### PR TITLE
feat(evidence): orphan blob garbage collection

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -139,6 +139,12 @@ overview — one line per flag, plus the orderings that matter.
 | `EVIDENCE_SIGNED_URL_SECRET` | unset | HMAC secret for signed raw URLs; boot hard-errors when shorter than 32 chars while the gateway is on. No default on purpose. |
 | `EVIDENCE_SIGNED_URL_TTL_SECONDS` | `300` | Signed-URL lifetime — deliberately short; expiry + the live-grant re-check at redeem are the only revocation levers. |
 | `EVIDENCE_GRANTS_API_ENABLED` | `0` | The sharing surface (`/v1/evidence/*/grants` — see [api.md](api.md#evidence-sharing-surface)): grant, list and revoke the ownership rows (0122) the read side spends. Requires the substrate flag (boot warns on the pair); off = bare 404s raised in a guard, so not even a malformed body reveals the route. |
+| `EVIDENCE_ORPHAN_BLOB_GC` | `0` | Orphan-blob GC, stage one: `POST /v1/admin/maintenance/evidence/orphan-blob-gc` exists and REPORTS blobs no `evidence_asset` row references (plus interrupted-write debris), deleting nothing. Off = a bare 404, no store walk, no query. Deliberately NOT gated on `EVIDENCE_SUBSTRATE_ENABLED` — a delete-side pass must stay usable after the writers are turned off. |
+| `EVIDENCE_ORPHAN_BLOB_GC_DELETE` | `0` | Stage two: actually unlink what stage one reports. Off = every run is a dry run, whatever the caller asks for. **Read a dry run before enabling this** — a wrong orphan sweep is unrecoverable. |
+| `EVIDENCE_ORPHAN_BLOB_GC_SCHEDULED` | `0` | Run the sweep nightly at 04:35 UTC over the tenant roster (lease-guarded). The admin route works without it; this is the separate decision to let the pass run itself. |
+| `EVIDENCE_ORPHAN_BLOB_GC_GRACE_HOURS` | `24` | A blob younger than this is never a candidate — the upload path stores bytes before their row exists, and a sweep that raced it would delete a live upload. Generous on purpose: waiting costs disk, being wrong costs evidence. |
+| `EVIDENCE_ORPHAN_BLOB_GC_MAX_DELETIONS` | `500` | Per-tenant deletions in ONE run — the blast radius of a wrong answer. A capped run still REPORTS the whole backlog. |
+| `EVIDENCE_ORPHAN_BLOB_GC_TIME_BUDGET_MS` | `600000` | Wall-clock budget for one run; the roster stops starting new tenants once spent. Nothing is lost — an orphan is rediscovered by enumeration next run. |
 
 **Grounding order:** stamp before you gate. Enable
 `EVIDENCE_GROUNDING_STAMP` first and let writes accrue stamps; only
@@ -158,6 +164,25 @@ hands out the very grants the raw-read gateway spends, so turn
 holds `brain:write` — a caller who can already read an asset can hand it
 to anyone, and revoking the LAST grant kills the asset for everyone
 (minted signed URLs included, by design).
+
+**Orphan-GC order: look, then delete.** The sweep is staged because its
+failure mode is destroyed evidence, not a bad answer. Turn on
+`EVIDENCE_ORPHAN_BLOB_GC` alone, run the route with the tenant you care
+about, and read `orphans` / `bytesReclaimable` / `sampleOrphans` in the
+response (the same numbers reach `brain_evidence_orphan_blobs_total`, so
+`orphan` with a flat `deleted` is the "still looking" state). Only when
+the sample is bytes you recognise as leaked should
+`EVIDENCE_ORPHAN_BLOB_GC_DELETE` go on. A run can always be forced back
+to report-only per call (`{"dryRun": true}`) or tightened
+(`{"maxDeletions": 10}`) — the body can only make a run MORE
+conservative; whether a byte may be destroyed at all is the flag's
+decision. Note what the sweep will NOT collect, by design: a blob any row
+still points at (any tenant, any row state — a quarantined row, a `gone`
+tombstone whose blob delete failed), a blob younger than the grace
+window, and a ref the 0114 hard-erasure outbox has already claimed (that
+drainer owns it). What it DOES collect beyond orphaned blobs is
+interrupted-write debris — the `.tmp-…` files a process killed between
+write and rename leaves behind, which no ref can address.
 
 ### `TOOL_OBSERVATION*` — MCP tool-call observations (0111)
 

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -1,4 +1,5 @@
 import { Logger } from '@nestjs/common';
+import { validateEvidenceOrphanGcEnv } from './evidence-flags';
 import { isProcessRole, normalizeProcessRole } from './process-role';
 
 const log = new Logger('EnvValidation');
@@ -284,6 +285,8 @@ export function validateEnv(env: NodeJS.ProcessEnv = process.env): void {
   validateEvidenceProcessingEnv(env, warnings);
 
   // ── Evidence plane: orphan-blob GC (delete-side hygiene) ───────────
+  // The validator lives beside its readers in evidence-flags.ts — see
+  // the note there.
   validateEvidenceOrphanGcEnv(env, warnings);
 
   // ── Belief serving: damping requires the lane ──────────────────────
@@ -567,33 +570,6 @@ function validateEvidenceGrantsApiEnv(env: NodeJS.ProcessEnv, warnings: string[]
         'the sharing surface stays dark (its double gate answers a bare 404 for ' +
         'every grant/list/revoke) until EVIDENCE_SUBSTRATE_ENABLED is turned on.',
     );
-  }
-}
-
-/**
- * Cross-flag consistency for the orphan-blob GC (MM-7 follow-up).
- * WARNINGS, not errors — every inconsistent pair here fails SAFE (the
- * sweep does less, never more), but each is an operator who thinks they
- * enabled something and did not:
- *
- *  - _DELETE or _SCHEDULED without the master flag: the sweep does not
- *    exist at all, so neither knob does anything. Worth saying out loud,
- *    because "I turned deletion on" and "nothing was ever reclaimed" is
- *    a silent pair otherwise;
- *  - the master flag with _DELETE off is NOT flagged: that is stage one
- *    working exactly as designed (report-only), and the intended state
- *    to sit in until a dry run has been read.
- */
-function validateEvidenceOrphanGcEnv(env: NodeJS.ProcessEnv, warnings: string[]): void {
-  if (envFlagEnabled(env.EVIDENCE_ORPHAN_BLOB_GC)) return;
-  for (const dependent of ['EVIDENCE_ORPHAN_BLOB_GC_DELETE', 'EVIDENCE_ORPHAN_BLOB_GC_SCHEDULED']) {
-    if (envFlagEnabled(env[dependent])) {
-      warnings.push(
-        `${dependent} is set while EVIDENCE_ORPHAN_BLOB_GC is not — the orphan-blob ` +
-          'sweep does not exist, so this knob has no effect; nothing is enumerated, ' +
-          'the admin route answers 404 and the nightly pass returns immediately.',
-      );
-    }
   }
 }
 

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -264,6 +264,12 @@ export function validateEnv(env: NodeJS.ProcessEnv = process.env): void {
   positiveInt(env, 'EVIDENCE_MAX_BYTES', errors);
   // Processing lifecycle (0121): derived-output cap, same clamp contract.
   positiveInt(env, 'EVIDENCE_DERIVED_MAX_BYTES', errors);
+  // Orphan-blob GC bounds: the sweep clamps bad values to defaults at
+  // read time, but a typo'd grace window is the one that would matter —
+  // catch it at boot, before an unreadable value silently reads as 24 h.
+  positiveInt(env, 'EVIDENCE_ORPHAN_BLOB_GC_GRACE_HOURS', errors);
+  positiveInt(env, 'EVIDENCE_ORPHAN_BLOB_GC_MAX_DELETIONS', errors);
+  positiveInt(env, 'EVIDENCE_ORPHAN_BLOB_GC_TIME_BUDGET_MS', errors);
 
   // ── Retrieval profile (per-tenant genre configuration) ─────────────
   validateRetrievalProfileEnv(env, errors);
@@ -276,6 +282,9 @@ export function validateEnv(env: NodeJS.ProcessEnv = process.env): void {
 
   // ── Evidence plane: processing lifecycle (migration 0121) ──────────
   validateEvidenceProcessingEnv(env, warnings);
+
+  // ── Evidence plane: orphan-blob GC (delete-side hygiene) ───────────
+  validateEvidenceOrphanGcEnv(env, warnings);
 
   // ── Belief serving: damping requires the lane ──────────────────────
   validateBeliefServingEnv(env, warnings);
@@ -558,6 +567,33 @@ function validateEvidenceGrantsApiEnv(env: NodeJS.ProcessEnv, warnings: string[]
         'the sharing surface stays dark (its double gate answers a bare 404 for ' +
         'every grant/list/revoke) until EVIDENCE_SUBSTRATE_ENABLED is turned on.',
     );
+  }
+}
+
+/**
+ * Cross-flag consistency for the orphan-blob GC (MM-7 follow-up).
+ * WARNINGS, not errors — every inconsistent pair here fails SAFE (the
+ * sweep does less, never more), but each is an operator who thinks they
+ * enabled something and did not:
+ *
+ *  - _DELETE or _SCHEDULED without the master flag: the sweep does not
+ *    exist at all, so neither knob does anything. Worth saying out loud,
+ *    because "I turned deletion on" and "nothing was ever reclaimed" is
+ *    a silent pair otherwise;
+ *  - the master flag with _DELETE off is NOT flagged: that is stage one
+ *    working exactly as designed (report-only), and the intended state
+ *    to sit in until a dry run has been read.
+ */
+function validateEvidenceOrphanGcEnv(env: NodeJS.ProcessEnv, warnings: string[]): void {
+  if (envFlagEnabled(env.EVIDENCE_ORPHAN_BLOB_GC)) return;
+  for (const dependent of ['EVIDENCE_ORPHAN_BLOB_GC_DELETE', 'EVIDENCE_ORPHAN_BLOB_GC_SCHEDULED']) {
+    if (envFlagEnabled(env[dependent])) {
+      warnings.push(
+        `${dependent} is set while EVIDENCE_ORPHAN_BLOB_GC is not — the orphan-blob ` +
+          'sweep does not exist, so this knob has no effect; nothing is enumerated, ' +
+          'the admin route answers 404 and the nightly pass returns immediately.',
+      );
+    }
   }
 }
 
@@ -1305,6 +1341,28 @@ const KNOWN_BOOLEAN_FLAGS = [
   // family sits off the ENGINE flag budget by design (see above).
   'EVIDENCE_PROCESSOR_BROKER',
   'EVIDENCE_QUARANTINE',
+  // Orphan-blob GC (MM-7 follow-up): the delete-side sweep that reclaims
+  // blobs no evidence_asset row references — the leak the upload path
+  // creates by design (bytes are stored before their row exists, and a
+  // content-addressed blob must not be unlinked on a failed
+  // registration). THREE flags, deliberately staged:
+  //   EVIDENCE_ORPHAN_BLOB_GC           master — the sweep exists and
+  //                                     REPORTS; off = no walk, no query,
+  //                                     the admin route 404s;
+  //   EVIDENCE_ORPHAN_BLOB_GC_DELETE    stage two — actually unlink. Off
+  //                                     = every run is a dry run whatever
+  //                                     the caller asks for;
+  //   EVIDENCE_ORPHAN_BLOB_GC_SCHEDULED the 04:35 UTC cron, its own
+  //                                     decision (SCENES_SCHEDULED_
+  //                                     MAINTENANCE idiom).
+  // Deliberately NOT gated on EVIDENCE_SUBSTRATE_ENABLED: the delete side
+  // never depends on the write flag. The grace window / deletion cap /
+  // time budget (EVIDENCE_ORPHAN_BLOB_GC_GRACE_HOURS, _MAX_DELETIONS,
+  // _TIME_BUDGET_MS) are ints, not booleans. EVIDENCE_ family sits off
+  // the ENGINE flag budget by design (see above).
+  'EVIDENCE_ORPHAN_BLOB_GC',
+  'EVIDENCE_ORPHAN_BLOB_GC_DELETE',
+  'EVIDENCE_ORPHAN_BLOB_GC_SCHEDULED',
   // Representation embeddings: the write-side producer for
   // derived_representation.embedding (WRITE-DEAD since 0109), which is
   // what the fragment lane's dense leg reads. Off (default) = the

--- a/src/common/evidence-flags.ts
+++ b/src/common/evidence-flags.ts
@@ -284,6 +284,38 @@ export function orphanBlobGcTimeBudgetMs(): number {
 }
 
 /**
+ * Cross-flag consistency for the orphan-blob GC, dispatched from
+ * validateEnv. It lives HERE, beside the three readers whose gating it
+ * mirrors, rather than in the env-validation catalog: which knob depends
+ * on which is defined a few lines up, and a validator that drifts from
+ * its readers is worse than no validator.
+ *
+ * WARNINGS, not errors — every inconsistent pair here fails SAFE (the
+ * sweep does less, never more), but each is an operator who thinks they
+ * enabled something and did not:
+ *
+ *  - _DELETE or _SCHEDULED without the master flag: the sweep does not
+ *    exist at all, so neither knob does anything. Worth saying out loud,
+ *    because "I turned deletion on" and "nothing was ever reclaimed" is
+ *    a silent pair otherwise;
+ *  - the master flag with _DELETE off is NOT flagged: that is stage one
+ *    working exactly as designed (report-only), and the intended state
+ *    to sit in until a dry run has been read.
+ */
+export function validateEvidenceOrphanGcEnv(env: NodeJS.ProcessEnv, warnings: string[]): void {
+  if (envFlagEnabled(env.EVIDENCE_ORPHAN_BLOB_GC)) return;
+  for (const dependent of ['EVIDENCE_ORPHAN_BLOB_GC_DELETE', 'EVIDENCE_ORPHAN_BLOB_GC_SCHEDULED']) {
+    if (envFlagEnabled(env[dependent])) {
+      warnings.push(
+        `${dependent} is set while EVIDENCE_ORPHAN_BLOB_GC is not — the orphan-blob ` +
+          'sweep does not exist, so this knob has no effect; nothing is enumerated, ' +
+          'the admin route answers 404 and the nightly pass returns immediately.',
+      );
+    }
+  }
+}
+
+/**
  * Trusted processor broker (Brain v2.1 MM-1, migration 0121) —
  * EVIDENCE_PROCESSOR_BROKER.
  *

--- a/src/common/evidence-flags.ts
+++ b/src/common/evidence-flags.ts
@@ -147,6 +147,143 @@ export function evidenceMaxBytes(): number {
 }
 
 /**
+ * Orphan-blob GC (Brain v2.1 MM-7 follow-up) — EVIDENCE_ORPHAN_BLOB_GC.
+ *
+ * THE LEAK THIS CLOSES. The upload path stores bytes BEFORE the asset
+ * row exists (put() → registerAsset), and deliberately does not delete
+ * them when registration fails: put() is content-addressed, so those
+ * bytes may already back another row, and an eager unlink would destroy
+ * someone else's evidence. Correct, and it leaks — a failed
+ * registration, a crashed request, a killed process leaves bytes on disk
+ * that no row references. This flag turns on the sweep that finds them.
+ *
+ * STAGE ONE IS REPORT-ONLY. This flag alone makes the sweep EXIST and
+ * REPORT: it enumerates, joins against the live rows, and logs/metrics
+ * what it WOULD reclaim, deleting nothing. Unlinking needs the second
+ * stage (EVIDENCE_ORPHAN_BLOB_GC_DELETE below) — an operator looks at a
+ * dry run before a byte is destroyed, because the failure mode of a
+ * wrong orphan sweep is unrecoverable data loss.
+ *
+ * Off (default) ⇒ the admin route answers a bare 404, the nightly cron
+ * returns before touching a lease, and NOTHING is enumerated — no
+ * filesystem walk, no query. Deliberately NOT gated on
+ * EVIDENCE_SUBSTRATE_ENABLED (unlike the write-side surfaces): this is a
+ * delete-side hygiene pass, and the delete side never depends on the
+ * write flag — bytes written while the substrate was on must stay
+ * collectable after it is turned off (the sweepTenantEvidence
+ * precedent). Read at call time (runtime-mutable); common layer per
+ * engine-gates S5.2.
+ */
+export function orphanBlobGcEnabled(): boolean {
+  return envFlagEnabled(process.env.EVIDENCE_ORPHAN_BLOB_GC);
+}
+
+/**
+ * Orphan-blob GC stage two — EVIDENCE_ORPHAN_BLOB_GC_DELETE.
+ *
+ * Promotes the sweep from report-only to actually unlinking the orphans
+ * it finds. Requires EVIDENCE_ORPHAN_BLOB_GC (this flag alone does
+ * nothing — the sweep does not exist). Off (default) ⇒ every run is a
+ * dry run whatever the caller asks for: the admin route's `dryRun: true`
+ * can only make a run MORE conservative, never less, so the flag is the
+ * single authority on whether bytes may be destroyed.
+ *
+ * Read at call time (runtime-mutable), and read PER RUN rather than per
+ * process, so an operator can flip a running deployment back to
+ * report-only the moment a run reports something they did not expect.
+ */
+export function orphanBlobGcDeleteEnabled(): boolean {
+  return envFlagEnabled(process.env.EVIDENCE_ORPHAN_BLOB_GC_DELETE);
+}
+
+/**
+ * Orphan-blob GC nightly schedule — EVIDENCE_ORPHAN_BLOB_GC_SCHEDULED.
+ *
+ * Its OWN knob on top of the master flag (the SCENES_SCHEDULED_MAINTENANCE
+ * idiom): the admin maintenance route is the required trigger and always
+ * available while the master flag is on, whereas a pass that runs itself
+ * needs a separate, deliberate decision. Off (default) ⇒ the 04:35 UTC
+ * cron returns before the lease guard and issues no query.
+ */
+export function orphanBlobGcScheduledEnabled(): boolean {
+  return envFlagEnabled(process.env.EVIDENCE_ORPHAN_BLOB_GC_SCHEDULED);
+}
+
+/** Default grace window before a blob may be considered an orphan: 24 h. */
+const DEFAULT_ORPHAN_GRACE_HOURS = 24;
+
+/**
+ * Orphan grace window — EVIDENCE_ORPHAN_BLOB_GC_GRACE_HOURS (non-boolean).
+ *
+ * A blob younger than this is NEVER an orphan candidate, however
+ * unreferenced it looks. The upload path has a real window in which
+ * bytes exist and their row does not (put → registerAsset → scan), and a
+ * sweep that raced it would delete a live upload's evidence. Generous by
+ * default (24 h) because the cost of waiting is disk and the cost of
+ * being wrong is destroyed evidence — this is the one knob where the
+ * asymmetry is total. The same window gates the partial-write leg.
+ *
+ * Must be a positive integer number of hours; unset, blank, or invalid →
+ * 24. Read at call time (runtime-mutable); common layer per engine-gates
+ * S5.2.
+ */
+export function orphanBlobGcGraceHours(): number {
+  const raw = process.env.EVIDENCE_ORPHAN_BLOB_GC_GRACE_HOURS;
+  if (raw === undefined || raw.trim() === '') return DEFAULT_ORPHAN_GRACE_HOURS;
+  const v = Number(raw);
+  return Number.isInteger(v) && v > 0 ? v : DEFAULT_ORPHAN_GRACE_HOURS;
+}
+
+/** Default per-tenant deletion cap for ONE run. */
+const DEFAULT_ORPHAN_MAX_DELETIONS = 500;
+
+/**
+ * Per-tenant deletion cap — EVIDENCE_ORPHAN_BLOB_GC_MAX_DELETIONS
+ * (non-boolean).
+ *
+ * The blast radius of one run against one tenant. A misconfiguration
+ * that makes every blob look unreferenced (a wrong tenant roster, a
+ * half-migrated store) then costs at most this many blobs before an
+ * operator sees the count and stops — the difference between an incident
+ * and a catastrophe. The cap bounds DELETIONS, not scanning: a capped
+ * run still reports every orphan it found, so the report tells the
+ * operator the true size of the backlog.
+ *
+ * Must be a positive integer; unset, blank, or invalid → 500. Read at
+ * call time (runtime-mutable); common layer per engine-gates S5.2.
+ */
+export function orphanBlobGcMaxDeletions(): number {
+  const raw = process.env.EVIDENCE_ORPHAN_BLOB_GC_MAX_DELETIONS;
+  if (raw === undefined || raw.trim() === '') return DEFAULT_ORPHAN_MAX_DELETIONS;
+  const v = Number(raw);
+  return Number.isInteger(v) && v > 0 ? v : DEFAULT_ORPHAN_MAX_DELETIONS;
+}
+
+/** Default wall-clock budget for ONE orphan-GC run: 10 minutes. */
+const DEFAULT_ORPHAN_TIME_BUDGET_MS = 10 * 60 * 1000;
+
+/**
+ * Wall-clock budget — EVIDENCE_ORPHAN_BLOB_GC_TIME_BUDGET_MS
+ * (non-boolean).
+ *
+ * Bounds ONE run: the store walk stops when it expires and the roster
+ * stops starting new tenants. Nothing is lost when it bites — an orphan
+ * is rediscovered by enumeration on the next run, which is exactly why
+ * this sweep needs no durable queue of its own (see the 0114 note in
+ * orphan-blob-gc.service.ts).
+ *
+ * Must be a positive integer number of milliseconds; unset, blank, or
+ * invalid → 600_000. Read at call time (runtime-mutable); common layer
+ * per engine-gates S5.2.
+ */
+export function orphanBlobGcTimeBudgetMs(): number {
+  const raw = process.env.EVIDENCE_ORPHAN_BLOB_GC_TIME_BUDGET_MS;
+  if (raw === undefined || raw.trim() === '') return DEFAULT_ORPHAN_TIME_BUDGET_MS;
+  const v = Number(raw);
+  return Number.isInteger(v) && v > 0 ? v : DEFAULT_ORPHAN_TIME_BUDGET_MS;
+}
+
+/**
  * Trusted processor broker (Brain v2.1 MM-1, migration 0121) —
  * EVIDENCE_PROCESSOR_BROKER.
  *

--- a/src/evidence/evidence-admin.controller.ts
+++ b/src/evidence/evidence-admin.controller.ts
@@ -11,7 +11,15 @@ import { ApiKeyGuard, RequireScopes } from '../auth/api-key.guard';
 import type { AuthenticatedRequest } from '../auth/api-key.types';
 import { ApiKeyService } from '../auth/api-key.service';
 import { resolvePlatformTenant } from '../auth/tenant-scope';
-import { evidenceSubstrateEnabled, processorBrokerEnabled } from '../common/evidence-flags';
+import {
+  evidenceSubstrateEnabled,
+  orphanBlobGcEnabled,
+  processorBrokerEnabled,
+} from '../common/evidence-flags';
+import {
+  EvidenceOrphanBlobGcService,
+  type OrphanBlobGcTenantResult,
+} from './orphan-blob-gc.service';
 import {
   EvidenceProcessorBrokerService,
   type DispatchSweepResult,
@@ -27,6 +35,14 @@ interface DispatchBody {
   packId?: string;
   assetId?: string;
   limit?: number;
+}
+
+interface OrphanBlobGcBody {
+  tenant?: string;
+  /** Force report-only. Cannot enable deletion — only the flag can. */
+  dryRun?: boolean;
+  /** Lower this run's deletion cap. Never raises the configured one. */
+  maxDeletions?: number;
 }
 
 /**
@@ -49,6 +65,11 @@ interface DispatchBody {
  * v1 ships no scheduler (processing-run.service.ts claimRun), and a sweep
  * that runs itself would need its own flag, its own claim, and its own
  * backpressure story.
+ *
+ * The controller now hosts a SECOND maintenance verb on the same idiom —
+ * `…/evidence/orphan-blob-gc`, the delete-side hygiene sweep — with its
+ * own flag and its own gate; see the method docblock for how the two
+ * differ.
  */
 @Controller('v1/admin')
 @UseGuards(ApiKeyGuard)
@@ -56,6 +77,7 @@ export class EvidenceAdminController {
   constructor(
     private readonly broker: EvidenceProcessorBrokerService,
     private readonly apiKeys: ApiKeyService,
+    private readonly orphanGc: EvidenceOrphanBlobGcService,
   ) {}
 
   @Post('maintenance/evidence/dispatch')
@@ -82,6 +104,56 @@ export class EvidenceAdminController {
       assetId,
       limit: body.limit,
     });
+  }
+
+  /**
+   * POST /v1/admin/maintenance/evidence/orphan-blob-gc — the operator's
+   * handle on the orphan-blob sweep (see orphan-blob-gc.service.ts for
+   * what an orphan is and why the pass is safe to run live).
+   *
+   * The REQUIRED trigger, and the one an operator reaches for first: the
+   * nightly cron is optional and off by default, so this route is how a
+   * dry run gets looked at before deletion is ever enabled. Same
+   * admin-scenes idiom as the dispatch verb above — `brain:admin`, the
+   * shared resolvePlatformTenant seam (an admin key reaches only its OWN
+   * tenant unless it carries `brain:platform_admin` AND the override gate
+   * is on), and a bare 404 while the feature is off.
+   *
+   * Gated on EVIDENCE_ORPHAN_BLOB_GC ALONE — deliberately NOT also on
+   * EVIDENCE_SUBSTRATE_ENABLED, unlike the dispatch verb. Dispatch is a
+   * write-side surface and must not run while the writers are dark; this
+   * is a delete-side hygiene pass, and bytes written while the substrate
+   * was on must stay collectable after it is turned off (the
+   * sweepTenantEvidence precedent).
+   *
+   * `dryRun: true` and a lower `maxDeletions` are the only two things the
+   * body can say about safety, and both can only make the run MORE
+   * conservative: whether a byte may be destroyed at all is
+   * EVIDENCE_ORPHAN_BLOB_GC_DELETE's decision, never the caller's.
+   */
+  @Post('maintenance/evidence/orphan-blob-gc')
+  @RequireScopes('brain:admin')
+  async orphanBlobGc(
+    @Req() req: AuthenticatedRequest,
+    @Body() body: OrphanBlobGcBody = {},
+  ): Promise<OrphanBlobGcTenantResult> {
+    if (!orphanBlobGcEnabled()) throw new NotFoundException();
+    const tenant = resolvePlatformTenant(req, body.tenant, {
+      knownTenants: () => this.apiKeys.knownCompanyIds(),
+    });
+    return this.orphanGc.sweepTenant(tenant, {
+      dryRun: body.dryRun === true,
+      maxDeletions: this.maxDeletions(body.maxDeletions),
+    });
+  }
+
+  /** Optional per-run tightening of the deletion cap. */
+  private maxDeletions(raw: number | undefined): number | undefined {
+    if (raw === undefined) return undefined;
+    if (!Number.isInteger(raw) || raw <= 0) {
+      throw new BadRequestException('maxDeletions must be a positive integer');
+    }
+    return raw;
   }
 
   /** Optional single-asset target; the broker clamps the sweep bound. */

--- a/src/evidence/evidence.module.ts
+++ b/src/evidence/evidence.module.ts
@@ -9,6 +9,7 @@ import { EvidenceReadController } from './evidence-read.controller';
 import { EvidenceReadService } from './evidence-read.service';
 import { EvidenceStoreService } from './evidence-store.service';
 import { EvidenceUploadService } from './evidence-upload.service';
+import { EvidenceOrphanBlobGcService } from './orphan-blob-gc.service';
 import { EvidenceProcessorBrokerService } from './processor-broker.service';
 import { EvidenceQuarantineService } from './quarantine.service';
 import { DocumentTextAdapter } from './processing/adapters/document-text.adapter';
@@ -53,7 +54,14 @@ import {
  * consumers. EvidenceAdminController (MM-7) is the operator's entry into
  * the broker — POST /v1/admin/maintenance/evidence/dispatch, 404 while
  * the broker is dark, sweeping already-registered assets that no upload
- * dispatch covered.
+ * dispatch covered. The same controller carries the delete-side sibling,
+ * POST /v1/admin/maintenance/evidence/orphan-blob-gc
+ * (EvidenceOrphanBlobGcService, EVIDENCE_ORPHAN_BLOB_GC): the sweep that
+ * reclaims blobs no row references — bytes the upload path stores before
+ * their row exists and, by content-addressed design, refuses to unlink
+ * on a failed registration. Report-only until a second flag says
+ * otherwise, and gated on its own flag ALONE — a delete-side pass must
+ * stay usable after the write-side substrate is turned off.
  *
  * Real adapters: ImageMetadataAdapter (sharp/libvips — intrinsic image
  * facts + allowlisted EXIF, no GPS) REPLACES the 0121
@@ -117,6 +125,7 @@ import {
     EvidenceQuarantineService,
     EvidenceBlobUploadInterceptor,
     EvidenceUploadService,
+    EvidenceOrphanBlobGcService,
   ],
   exports: [
     EvidenceStoreService,
@@ -125,6 +134,7 @@ import {
     EvidenceProcessorBrokerService,
     EvidenceQuarantineService,
     EvidenceUploadService,
+    EvidenceOrphanBlobGcService,
   ],
 })
 export class EvidenceModule {}

--- a/src/evidence/orphan-blob-gc.service.ts
+++ b/src/evidence/orphan-blob-gc.service.ts
@@ -1,0 +1,527 @@
+import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import type { Surreal } from 'surrealdb';
+import { ApiKeyService } from '../auth/api-key.service';
+import { SurrealService, queryRows } from '../db/surreal.service';
+import { DistributedLeaseGuard } from '../common/distributed-lease.guard';
+import { InFlightGuard } from '../common/in-flight-guard';
+import { MetricsService } from '../metrics/metrics.service';
+import {
+  orphanBlobGcDeleteEnabled,
+  orphanBlobGcEnabled,
+  orphanBlobGcGraceHours,
+  orphanBlobGcMaxDeletions,
+  orphanBlobGcScheduledEnabled,
+  orphanBlobGcTimeBudgetMs,
+} from '../common/evidence-flags';
+import {
+  EVIDENCE_STORAGE_ADAPTERS,
+  type EvidenceStorageAdapter,
+  type EvidenceStorageRegistry,
+} from './storage/storage-adapter';
+
+/**
+ * How many enumerated refs are resolved against the DB in one round
+ * trip. Each batch is ONE query per table, so the batch size trades
+ * query count against parameter-list size; 200 keeps both small. It is a
+ * constant, not a knob: an operator has no way to reason about a good
+ * value, and neither correctness nor blast radius depends on it.
+ */
+const REF_BATCH = 200;
+
+/** Orphan refs echoed back to the caller so a dry run is inspectable. */
+const SAMPLE_LIMIT = 20;
+
+/** Lock key for both the local and the distributed guard. */
+const LOCK_KEY = 'evidence_orphan_blob_gc';
+
+/**
+ * Lease TTL for the distributed guard, matched to the DEFAULT whole-run
+ * budget (the scene-maintenance rule): a lease shorter than the body it
+ * protects expires mid-run and lets a second pod walk the same store.
+ * Two concurrent orphan sweeps would not corrupt anything — the
+ * pre-delete re-check and the ENOENT-tolerant delete make a double
+ * unlink harmless — but they would double the walk and report each
+ * other's work as failures.
+ */
+const LEASE_TTL_SECONDS = 10 * 60;
+
+/** One tenant's slice of a run. */
+export interface OrphanBlobGcTenantResult {
+  companyId: string;
+  /** True ⇒ nothing was unlinked, whatever the counts below say. */
+  dryRun: boolean;
+  /** Blobs the store offered for this tenant. */
+  scanned: number;
+  /** …of which a live evidence_asset row points at. */
+  referenced: number;
+  /** …of which the 0114 hard-erasure outbox has already condemned. */
+  queued: number;
+  /** …of which the grace window protects (bytes possibly still in flight). */
+  young: number;
+  /** …of which the adapter does not scope to this tenant (never touched). */
+  foreign: number;
+  /** Unreferenced, past grace: what a real run would (or did) delete. */
+  orphans: number;
+  /** Actually unlinked. Always 0 in a dry run. */
+  deleted: number;
+  /** Orphans that gained a reference between the scan and the delete. */
+  raced: number;
+  /** Delete failures — logged, counted, never fatal. */
+  failed: number;
+  /** Bytes the orphans occupy (what a real run would reclaim). */
+  bytesReclaimable: number;
+  /** Bytes actually reclaimed. */
+  bytesDeleted: number;
+  /** Interrupted-write artefacts found (fs: `.tmp-…` stragglers). */
+  partialWrites: number;
+  partialWritesRemoved: number;
+  /** The per-tenant deletion cap stopped the run. */
+  capReached: boolean;
+  /** The wall-clock budget stopped the run. */
+  budgetExhausted: boolean;
+  durationSeconds: number;
+  /** First few orphan refs — a dry run an operator can actually check. */
+  sampleOrphans: string[];
+  error?: string;
+}
+
+/** Whole-roster summary (the cron's return value). */
+export interface OrphanBlobGcRunResult {
+  tenants: OrphanBlobGcTenantResult[];
+  budgetExhausted: boolean;
+  /** Tenants never started because the budget ran out. */
+  skippedForBudget: number;
+}
+
+const EMPTY_RUN: OrphanBlobGcRunResult = {
+  tenants: [],
+  budgetExhausted: false,
+  skippedForBudget: 0,
+};
+
+/** Per-call overrides; both can only make a run MORE conservative. */
+export interface OrphanBlobGcOptions {
+  /** Force report-only even in stage two. Never the reverse. */
+  dryRun?: boolean | undefined;
+  /** Lower the deletion cap for this run. Never raises it. */
+  maxDeletions?: number | undefined;
+}
+
+/** A blob the store offered, plus the age check already applied. */
+interface Candidate {
+  storageRef: string;
+  byteLength: number;
+}
+
+/**
+ * Everything one adapter's pass over one tenant needs, threaded as a
+ * single value: the target, the store, the result being filled in, and
+ * the bounds. Beyond keeping every leg to two arguments, this makes it
+ * structurally impossible to hand one leg a tenant's result alongside
+ * another tenant's adapter — the mistake that would matter here.
+ */
+interface Pass {
+  companyId: string;
+  adapter: EvidenceStorageAdapter;
+  result: OrphanBlobGcTenantResult;
+  limits: { deadline: number; maxDeletions: number; graceMs: number };
+}
+
+function emptyTenantResult(companyId: string, dryRun: boolean): OrphanBlobGcTenantResult {
+  return {
+    companyId,
+    dryRun,
+    scanned: 0,
+    referenced: 0,
+    queued: 0,
+    young: 0,
+    foreign: 0,
+    orphans: 0,
+    deleted: 0,
+    raced: 0,
+    failed: 0,
+    bytesReclaimable: 0,
+    bytesDeleted: 0,
+    partialWrites: 0,
+    partialWritesRemoved: 0,
+    capReached: false,
+    budgetExhausted: false,
+    durationSeconds: 0,
+    sampleOrphans: [],
+  };
+}
+
+/**
+ * EvidenceOrphanBlobGcService — the sweep that reclaims blobs no row
+ * references (the honest follow-up the MM-7 upload PR named).
+ *
+ * THE LEAK. The upload path stores bytes BEFORE registering their row:
+ *
+ *     put(bytes) → registerAsset(storageRef) → scan → dispatch
+ *
+ * and when registerAsset throws it does NOT delete what it just wrote.
+ * That is correct, not sloppy: put() is content-addressed, so identical
+ * bytes from a second caller land on the SAME ref, and an eager unlink
+ * on a failed registration could destroy bytes another row already owns.
+ * The consequence is a leak with three sources — a failed registration,
+ * a crashed request, a process killed mid-write — and an orphan blob is
+ * inert but not free: it costs disk forever and it is media, which is
+ * the one thing in this system that costs real money to store.
+ *
+ * WHAT AN ORPHAN IS, PRECISELY. A blob the store holds for tenant T such
+ * that NO evidence_asset row in T's database has it as its storageRef,
+ * and which is older than the grace window. Note what that definition
+ * does NOT say:
+ *   * it says nothing about the row's byteHash. A blob may back MORE
+ *     THAN ONE row (registerAsset accepts an explicit storageRef whose
+ *     hash is not the row's own), so the join key is storageRef and only
+ *     storageRef — matching on hashes would delete a shared blob the
+ *     moment its "own" row died;
+ *   * it says nothing about the row's STATE. A quarantined row, a
+ *     'gone' tombstone that still holds a ref because its blob delete
+ *     failed, a row whose retention has expired but whose sweep has not
+ *     run — every one of those is a reference, and a referenced blob is
+ *     never an orphan. The reference query carries NO predicate beyond
+ *     the ref match itself, deliberately;
+ *   * it says nothing about the 0114 outbox. A ref the hard-erasure
+ *     queue has already condemned belongs to that drainer, which deletes
+ *     it unconditionally and tracks its own attempts; this sweep counts
+ *     such refs and steps over them rather than racing for the same
+ *     unlink.
+ *
+ * CROSS-TENANT SAFETY. This is a multi-tenant deployment where every
+ * tenant is its OWN SurrealDB database (`co_<companyId>`), so there is
+ * no query that can see all rows at once and none is attempted. Instead
+ * the sweep is per-tenant on both sides of the join and the two sides
+ * are pinned to the same tenant:
+ *   * the roster comes from ApiKeyService.knownCompanyIds() — the same
+ *     source every other maintenance pass walks. A blob directory
+ *     belonging to a tenant that is NOT on the roster is never
+ *     enumerated, so a deregistered tenant's bytes are left alone rather
+ *     than silently destroyed;
+ *   * the store side enumerates ONE tenant (adapter.listBlobs(companyId)),
+ *     and the adapter contract requires every yielded ref to satisfy
+ *     belongsToTenant — re-checked here per entry, so an adapter that
+ *     cannot scope refs to a tenant collects nothing instead of
+ *     collecting someone else's;
+ *   * the row side runs inside surreal.withCompany(companyId) — that
+ *     tenant's database and no other.
+ * Because the ref is structurally the tenant's (fs://<companyId>/<hash>)
+ * and registerAsset REFUSES a storageRef that does not belong to the
+ * writing tenant, "no row in T references it" is the complete answer,
+ * not a per-tenant approximation of one.
+ *
+ * WHY NO OUTBOX OF ITS OWN (and why 0114 is not extended). The 0114
+ * queue exists because hard erasure destroys the only pointer to the
+ * bytes: once the row is gone, a failed unlink is unrecoverable work
+ * unless it was written down first. An orphan is the exact opposite —
+ * it is DEFINED by having no pointer, so enumeration rediscovers it on
+ * every run for free. A queue would add a second, weaker mechanism (a
+ * condemned ref that a later upload legitimately reuses would be deleted
+ * out from under the new row) to solve a problem that does not exist
+ * here. So: no new table, no new migration, no new reason in the 0114
+ * enum — this sweep READS that outbox to stay out of its way, and
+ * nothing more.
+ *
+ * SAFETY LADDER, in the order it fires:
+ *   1. EVIDENCE_ORPHAN_BLOB_GC off ⇒ nothing exists — no walk, no query;
+ *   2. stage one REPORTS ONLY. Unlinking needs the separate
+ *      EVIDENCE_ORPHAN_BLOB_GC_DELETE, and a caller's `dryRun: true` can
+ *      only make a run more conservative;
+ *   3. the grace window (default 24 h) protects any blob young enough to
+ *      belong to an upload still in flight;
+ *   4. the per-tenant deletion cap bounds the blast radius of a wrong
+ *      answer; the wall-clock budget bounds the run;
+ *   5. every orphan is RE-CHECKED against the rows immediately before
+ *      its unlink, so a row registered during the walk saves its bytes;
+ *   6. a delete failure is logged and counted; the run continues and the
+ *      blob is rediscovered next time.
+ * Idempotent and resumable by construction: a second run over a swept
+ * store finds nothing, and an interrupted run loses only the work it had
+ * not done.
+ */
+@Injectable()
+export class EvidenceOrphanBlobGcService {
+  private readonly logger = new Logger(EvidenceOrphanBlobGcService.name);
+  /** Fallback reentrancy guard when JobsModule is not wired. */
+  private readonly local = new InFlightGuard();
+
+  // eslint-disable-next-line max-params
+  constructor(
+    private readonly surreal: SurrealService,
+    private readonly apiKeys: ApiKeyService,
+    @Inject(EVIDENCE_STORAGE_ADAPTERS)
+    private readonly adapters: EvidenceStorageRegistry,
+    // @Optional throughout (the evidence-module idiom): positionally
+    // constructed unit fixtures stay valid; both modules are @Global in
+    // production.
+    @Optional() private readonly metrics?: MetricsService,
+    @Optional() private readonly guard?: DistributedLeaseGuard,
+  ) {}
+
+  /**
+   * Cron entry — 04:35 UTC. Every :0x–:5x slot of the 03:00 hour is
+   * spoken for (recompose 03:05, compaction 03:17, memory quality 03:35,
+   * outcome prune 03:41, calibration refit 03:42/03:51, candidate
+   * sweeper 03:45, strategy distill 03:52), 04:00 is dreams and 04:20 is
+   * scene maintenance. 04:35 is the first free slot after both LLM-heavy
+   * passes, and clear of the hourly registry mirror (:26). Ordering
+   * matters beyond tidiness: the candidate sweeper's evidence leg
+   * (retention + the 0114 drain) runs at 03:45, so by 04:35 the rows it
+   * was going to delete are gone and their blobs are already reclaimed —
+   * this pass sees a settled store and reports the true residue.
+   *
+   * Both gates are checked BEFORE the lease so a disabled pass never
+   * touches the lease table.
+   */
+  @Cron('35 4 * * *', { timeZone: 'UTC' })
+  async runNightly(): Promise<OrphanBlobGcRunResult> {
+    if (!orphanBlobGcEnabled() || !orphanBlobGcScheduledEnabled()) return EMPTY_RUN;
+    const run = this.guard
+      ? await this.guard.run(LOCK_KEY, () => this.runAll(), LEASE_TTL_SECONDS)
+      : await this.local.run(LOCK_KEY, () => this.runAll());
+    if (run === null) {
+      this.logger.warn('orphan blob GC skipped — a previous run is still in flight');
+      return EMPTY_RUN;
+    }
+    return run;
+  }
+
+  /**
+   * Walk the tenant roster under the wall-clock budget. Public so the
+   * admin route and tests can invoke the body without the guard; the
+   * master flag is re-checked in sweepTenant, so an unguarded call
+   * cannot sweep a disabled surface.
+   */
+  async runAll(opts: OrphanBlobGcOptions = {}): Promise<OrphanBlobGcRunResult> {
+    const deadline = Date.now() + orphanBlobGcTimeBudgetMs();
+    const result: OrphanBlobGcRunResult = {
+      tenants: [],
+      budgetExhausted: false,
+      skippedForBudget: 0,
+    };
+    for (const companyId of this.apiKeys.knownCompanyIds()) {
+      if (Date.now() >= deadline) {
+        // Nothing is lost: an orphan is rediscovered by enumeration on
+        // the next run. Count what we did not start rather than drop it.
+        result.budgetExhausted = true;
+        result.skippedForBudget += 1;
+        this.metrics?.countEvidenceOrphanGc('skipped_budget');
+        continue;
+      }
+      result.tenants.push(await this.sweepTenant(companyId, { ...opts, deadline }));
+    }
+    return result;
+  }
+
+  /**
+   * Sweep ONE tenant. Never throws: a tenant that fails is reported with
+   * its `error` and the roster continues (the dreams fan-out rule).
+   * Returns a zeroed result — not an error — while the flag is off, so a
+   * disabled sweep is indistinguishable from a clean one to a counter.
+   */
+  async sweepTenant(
+    companyId: string,
+    opts: OrphanBlobGcOptions & { deadline?: number } = {},
+  ): Promise<OrphanBlobGcTenantResult> {
+    const startedAt = Date.now();
+    const result = emptyTenantResult(companyId, this.dryRun(opts));
+    if (!orphanBlobGcEnabled()) return result;
+    const deadline = opts.deadline ?? startedAt + orphanBlobGcTimeBudgetMs();
+    const maxDeletions = Math.min(
+      orphanBlobGcMaxDeletions(),
+      opts.maxDeletions !== undefined && opts.maxDeletions > 0 ? opts.maxDeletions : Infinity,
+    );
+    const limits = { deadline, maxDeletions, graceMs: orphanBlobGcGraceHours() * 3600_000 };
+    try {
+      for (const adapter of this.adapters.values()) {
+        if (result.budgetExhausted || result.capReached) break;
+        await this.sweepAdapter({ companyId, adapter, result, limits });
+      }
+    } catch (e) {
+      // Per-tenant isolation: an unreadable store or a Surreal hiccup on
+      // tenant N must not cost tenant N+1 its run. Whatever the pass had
+      // already counted stays in the result — a partial report is more
+      // useful than a discarded one.
+      result.error = (e as Error).message;
+      this.logger.warn(`orphan blob GC failed for ${companyId}: ${result.error}`);
+    }
+    result.durationSeconds = (Date.now() - startedAt) / 1000;
+    this.report(result);
+    return result;
+  }
+
+  /** Effective dry-run: the flag decides, the caller may only tighten. */
+  private dryRun(opts: OrphanBlobGcOptions): boolean {
+    return opts.dryRun === true || !orphanBlobGcDeleteEnabled();
+  }
+
+  /**
+   * One adapter's contribution. An adapter without listBlobs is skipped
+   * silently and completely — it has not promised tenant-scoped
+   * enumeration, so nothing it holds may be judged (the storage-adapter
+   * contract point).
+   */
+  private async sweepAdapter(pass: Pass): Promise<void> {
+    const { adapter, companyId, result, limits } = pass;
+    await this.sweepPartialWrites(pass);
+    if (!adapter.listBlobs) return;
+    const cutoff = Date.now() - limits.graceMs;
+    let batch: Candidate[] = [];
+    for await (const entry of adapter.listBlobs(companyId)) {
+      result.scanned += 1;
+      if (!adapter.belongsToTenant(companyId, entry.storageRef)) {
+        // Defence in depth behind the adapter's own promise: a ref this
+        // tenant does not own cannot be judged against this tenant's
+        // rows, so it is counted and left entirely alone.
+        result.foreign += 1;
+        continue;
+      }
+      if (entry.modifiedAtMs > cutoff) {
+        result.young += 1;
+        continue;
+      }
+      batch.push({ storageRef: entry.storageRef, byteLength: entry.byteLength });
+      if (batch.length >= REF_BATCH) {
+        await this.resolveBatch(pass, batch);
+        batch = [];
+        if (this.stop(result, limits)) return;
+      }
+    }
+    if (batch.length > 0) await this.resolveBatch(pass, batch);
+    this.stop(result, limits);
+  }
+
+  /** Interrupted-write debris — no ref, no row, its own broom. */
+  private async sweepPartialWrites(pass: Pass): Promise<void> {
+    const { adapter, companyId, result, limits } = pass;
+    if (!adapter.sweepIncompleteWrites) return;
+    const swept = await adapter.sweepIncompleteWrites(companyId, {
+      olderThanMs: limits.graceMs,
+      dryRun: result.dryRun,
+    });
+    result.partialWrites += swept.found;
+    result.partialWritesRemoved += swept.removed;
+  }
+
+  /**
+   * Resolve one batch of candidates against the tenant's rows, then
+   * delete what survives the checks. ONE round trip per batch, two
+   * queries inside it:
+   *
+   *   * evidence_asset — the reference set. `storageRef INSIDE $refs`
+   *     with no other predicate: every row state counts as a reference
+   *     (see the class docblock). This is a SELECT, so the 3.2.4
+   *     compound-planner DELETE/UPDATE hazard does not apply — and the
+   *     sweep issues no DELETE against any table at all;
+   *   * evidence_blob_gc — refs the 0114 hard-erasure drainer already
+   *     owns, stepped over rather than raced for.
+   */
+  private async resolveBatch(pass: Pass, batch: Candidate[]): Promise<void> {
+    const { companyId, result, limits } = pass;
+    const refs = batch.map((c) => c.storageRef);
+    const { referenced, queued } = await this.surreal.withCompany(companyId, async (db) => ({
+      referenced: await this.refsIn(db, 'evidence_asset', refs),
+      queued: await this.refsIn(db, 'evidence_blob_gc', refs),
+    }));
+    for (const candidate of batch) {
+      if (referenced.has(candidate.storageRef)) {
+        result.referenced += 1;
+        continue;
+      }
+      if (queued.has(candidate.storageRef)) {
+        result.queued += 1;
+        continue;
+      }
+      result.orphans += 1;
+      result.bytesReclaimable += candidate.byteLength;
+      if (result.sampleOrphans.length < SAMPLE_LIMIT) {
+        result.sampleOrphans.push(candidate.storageRef);
+      }
+      if (result.dryRun || this.stop(result, limits)) continue;
+      await this.deleteOrphan(pass, candidate);
+    }
+  }
+
+  /** The set of refs from `refs` that this table currently holds. */
+  private async refsIn(db: Surreal, table: string, refs: string[]): Promise<Set<string>> {
+    const rows = await queryRows<unknown>(
+      db,
+      `SELECT VALUE storageRef FROM ${table} WHERE storageRef INSIDE $refs`,
+      { refs },
+    );
+    return new Set(rows.map(String));
+  }
+
+  /**
+   * Unlink one orphan, with the last-moment re-check that makes the
+   * whole pass safe to run against a live system: between the batch
+   * resolve and this call a row may have been registered against these
+   * bytes (put() is idempotent, so a fresh upload of identical content
+   * reuses the existing blob and then registers). Re-reading the rows
+   * per blob costs one indexed-free scan and buys the difference between
+   * a hygiene pass and a data-loss bug.
+   *
+   * A failure — a permission problem, a vanished directory, an adapter
+   * throw — is logged and counted. Never fatal: the run continues and
+   * enumeration rediscovers the blob next time.
+   */
+  private async deleteOrphan(pass: Pass, candidate: Candidate): Promise<void> {
+    const { adapter, companyId, result } = pass;
+    try {
+      const stillFree = await this.surreal.withCompany(companyId, async (db) => {
+        const rows = await this.refsIn(db, 'evidence_asset', [candidate.storageRef]);
+        return rows.size === 0;
+      });
+      if (!stillFree) {
+        result.raced += 1;
+        return;
+      }
+      const removed = await adapter.delete(candidate.storageRef);
+      // `false` is "already gone" (ENOENT) — someone else won the race
+      // to the same unlink, which is the outcome we wanted anyway.
+      if (removed) {
+        result.deleted += 1;
+        result.bytesDeleted += candidate.byteLength;
+      }
+    } catch (e) {
+      result.failed += 1;
+      this.logger.warn(
+        `orphan blob delete failed for ${candidate.storageRef}: ${(e as Error).message}`,
+      );
+    }
+  }
+
+  /** True once a bound has bitten; stamps which one, for the report. */
+  private stop(
+    result: OrphanBlobGcTenantResult,
+    limits: { deadline: number; maxDeletions: number },
+  ): boolean {
+    if (result.deleted >= limits.maxDeletions) result.capReached = true;
+    if (Date.now() >= limits.deadline) result.budgetExhausted = true;
+    return result.capReached || result.budgetExhausted;
+  }
+
+  /** One log line + counters per tenant; silent on a clean, empty pass. */
+  private report(result: OrphanBlobGcTenantResult): void {
+    this.metrics?.countEvidenceOrphanGc(
+      result.error !== undefined ? 'failed' : result.dryRun ? 'dry_run' : 'ok',
+    );
+    this.metrics?.countEvidenceOrphanBlobs('scanned', result.scanned);
+    this.metrics?.countEvidenceOrphanBlobs('orphan', result.orphans);
+    this.metrics?.countEvidenceOrphanBlobs('deleted', result.deleted);
+    this.metrics?.countEvidenceOrphanBlobs('failed', result.failed);
+    this.metrics?.observeEvidenceOrphanGcDuration(result.durationSeconds);
+    if (result.orphans === 0 && result.partialWrites === 0 && result.error === undefined) return;
+    this.logger.log(
+      `orphan blob GC ${result.companyId}${result.dryRun ? ' (dry run)' : ''}: ` +
+        `scanned=${result.scanned} referenced=${result.referenced} queued=${result.queued} ` +
+        `young=${result.young} orphans=${result.orphans} deleted=${result.deleted} ` +
+        `raced=${result.raced} failed=${result.failed} ` +
+        `bytes=${result.dryRun ? result.bytesReclaimable : result.bytesDeleted} ` +
+        `partial=${result.partialWritesRemoved}/${result.partialWrites}` +
+        `${result.capReached ? ' cap-reached' : ''}${result.budgetExhausted ? ' budget-exhausted' : ''}`,
+    );
+  }
+}

--- a/src/evidence/storage/fs-storage.adapter.ts
+++ b/src/evidence/storage/fs-storage.adapter.ts
@@ -1,13 +1,17 @@
 import { Injectable } from '@nestjs/common';
-import { createReadStream } from 'node:fs';
-import { mkdir, rename, rm, stat, writeFile } from 'node:fs/promises';
+import { createReadStream, type Stats } from 'node:fs';
+import { mkdir, readdir, rename, rm, stat, writeFile } from 'node:fs/promises';
 import { join, resolve, sep } from 'node:path';
 import { createHash, randomUUID } from 'node:crypto';
 import type { Readable } from 'node:stream';
 import { evidenceFsRoot } from '../../common/evidence-flags';
-import { EvidenceStorageAdapter } from './storage-adapter';
+import { EvidenceStorageAdapter, StoredBlobEntry } from './storage-adapter';
 
 const HASH_RE = /^[0-9a-f]{64}$/;
+/** Prefix put() gives a blob mid-write, before the atomic rename. */
+const TMP_PREFIX = '.tmp-';
+/** The two-char fan-out directory a blob's content address lives under. */
+const SHARD_RE = /^[0-9a-f]{2}$/;
 // Tenant ids as the fixture/auth layer mints them (co_…): a conservative
 // shape that keeps every path segment traversal-free by construction.
 const TENANT_RE = /^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$/;
@@ -93,7 +97,7 @@ export class FsEvidenceStorageAdapter implements EvidenceStorageAdapter {
     if (existing) return { storageRef, byteLength: existing.byteLength }; // content-addressed no-op
     const dir = join(dest, '..');
     await mkdir(dir, { recursive: true });
-    const tmp = join(dir, `.tmp-${randomUUID()}`);
+    const tmp = join(dir, `${TMP_PREFIX}${randomUUID()}`);
     try {
       await writeFile(tmp, data);
       await rename(tmp, dest); // atomic within one filesystem
@@ -135,6 +139,114 @@ export class FsEvidenceStorageAdapter implements EvidenceStorageAdapter {
       return true;
     } catch (e) {
       if ((e as NodeJS.ErrnoException).code === 'ENOENT') return false;
+      throw e;
+    }
+  }
+
+  /**
+   * Enumerate one tenant's blobs — the orphan-GC contract in
+   * storage-adapter.ts. Walks `<root>/<companyId>/<xx>/` and yields ONLY
+   * files whose name is a well-formed 64-hex content address sitting
+   * under its own two-char fan-out directory: anything this layout could
+   * not have produced is not a blob this adapter owns, and is therefore
+   * never offered to a deleter. `.tmp-…` stragglers are excluded here on
+   * purpose — they carry no ref at all and are swept by
+   * sweepIncompleteWrites below.
+   *
+   * Every yielded ref is `fs://<companyId>/<hash>`, so
+   * belongsToTenant(companyId, ref) holds by construction — contract
+   * point 1. An absent tenant directory yields nothing (a tenant that has
+   * never uploaded is not an error).
+   */
+  async *listBlobs(companyId: string): AsyncGenerator<StoredBlobEntry> {
+    if (!TENANT_RE.test(companyId)) return;
+    const tenantDir = join(this.root(), companyId);
+    for (const shard of await this.namesIn(tenantDir, 'dir')) {
+      if (!SHARD_RE.test(shard)) continue;
+      for (const name of await this.namesIn(join(tenantDir, shard), 'file')) {
+        if (!HASH_RE.test(name) || name.slice(0, 2) !== shard) continue;
+        const s = await this.statOrNull(join(tenantDir, shard, name));
+        if (!s) continue; // vanished mid-walk (a concurrent delete) — fine
+        yield {
+          storageRef: `fs://${companyId}/${name}`,
+          byteLength: s.size,
+          // ctime moves on the atomic rename that PUBLISHES the blob;
+          // mtime carries over from the tmp write that preceded it. The
+          // later of the two is the honest "when did the store last
+          // touch this", and the conservative input to a grace window
+          // that exists to protect bytes whose row is still in flight
+          // (contract point 2).
+          modifiedAtMs: Math.max(s.mtimeMs, s.ctimeMs),
+        };
+      }
+    }
+  }
+
+  /**
+   * Drop `.tmp-<uuid>` stragglers older than `olderThanMs` — the debris
+   * a process killed between writeFile and rename leaves behind. put()'s
+   * own catch removes them on a normal failure, so anything reaching this
+   * broom outlived the process that made it. No ref addresses these
+   * files, so no row can reference them and listBlobs cannot enumerate
+   * them: unreachable by construction, which is precisely why they need
+   * their own leg.
+   *
+   * The same grace the blob leg applies: a tmp file younger than the
+   * cutoff may be an upload writing RIGHT NOW. `dryRun` counts without
+   * removing. Per-file failures are swallowed — the straggler is
+   * rediscovered next run.
+   */
+  async sweepIncompleteWrites(
+    companyId: string,
+    opts: { olderThanMs: number; dryRun: boolean },
+  ): Promise<{ found: number; removed: number }> {
+    if (!TENANT_RE.test(companyId)) return { found: 0, removed: 0 };
+    const tenantDir = join(this.root(), companyId);
+    const cutoff = Date.now() - Math.max(0, opts.olderThanMs);
+    let found = 0;
+    let removed = 0;
+    for (const shard of await this.namesIn(tenantDir, 'dir')) {
+      if (!SHARD_RE.test(shard)) continue;
+      for (const name of await this.namesIn(join(tenantDir, shard), 'file')) {
+        if (!name.startsWith(TMP_PREFIX)) continue;
+        const path = join(tenantDir, shard, name);
+        const s = await this.statOrNull(path);
+        if (!s || Math.max(s.mtimeMs, s.ctimeMs) > cutoff) continue;
+        found++;
+        if (opts.dryRun) continue;
+        try {
+          await rm(path, { force: true });
+          removed++;
+        } catch {
+          // Best effort, like every other delete leg in the substrate.
+        }
+      }
+    }
+    return { found, removed };
+  }
+
+  /** Directory listing filtered by entry kind; absent directory ⇒ []. */
+  private async namesIn(dir: string, want: 'dir' | 'file'): Promise<string[]> {
+    try {
+      const entries = await readdir(dir, { withFileTypes: true });
+      return entries
+        .filter((e) => (want === 'dir' ? e.isDirectory() : e.isFile()))
+        .map((e) => e.name);
+    } catch (e) {
+      // ENOENT is "this tenant has nothing here", every other errno is a
+      // real problem the caller should see — a silently unreadable shard
+      // would under-report and hide a permissions mistake.
+      if ((e as NodeJS.ErrnoException).code === 'ENOENT') return [];
+      throw e;
+    }
+  }
+
+  /** stat() that answers null for a file that is not (or no longer) there. */
+  private async statOrNull(path: string): Promise<Stats | null> {
+    try {
+      return await stat(path);
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException).code === 'ENOENT') return null;
       throw e;
     }
   }

--- a/src/evidence/storage/fs-storage.adapter.ts
+++ b/src/evidence/storage/fs-storage.adapter.ts
@@ -170,13 +170,17 @@ export class FsEvidenceStorageAdapter implements EvidenceStorageAdapter {
         yield {
           storageRef: `fs://${companyId}/${name}`,
           byteLength: s.size,
-          // ctime moves on the atomic rename that PUBLISHES the blob;
-          // mtime carries over from the tmp write that preceded it. The
-          // later of the two is the honest "when did the store last
-          // touch this", and the conservative input to a grace window
-          // that exists to protect bytes whose row is still in flight
-          // (contract point 2).
-          modifiedAtMs: Math.max(s.mtimeMs, s.ctimeMs),
+          // mtime, and deliberately NOT max(mtime, ctime): rename
+          // preserves the tmp write's mtime, so mtime IS the moment
+          // these bytes were written, to within the microseconds
+          // between writeFile and rename. ctime would additionally move
+          // on any metadata touch — a chmod, a restore, a container
+          // layer copy — which only ever makes a blob look YOUNGER and
+          // defer collection; safe, but it also makes the age
+          // unobservable from a test and lets a whole store read as
+          // fresh after an unrelated operator action. The write time is
+          // the honest answer and the checkable one.
+          modifiedAtMs: s.mtimeMs,
         };
       }
     }
@@ -211,7 +215,7 @@ export class FsEvidenceStorageAdapter implements EvidenceStorageAdapter {
         if (!name.startsWith(TMP_PREFIX)) continue;
         const path = join(tenantDir, shard, name);
         const s = await this.statOrNull(path);
-        if (!s || Math.max(s.mtimeMs, s.ctimeMs) > cutoff) continue;
+        if (!s || s.mtimeMs > cutoff) continue;
         found++;
         if (opts.dryRun) continue;
         try {

--- a/src/evidence/storage/storage-adapter.ts
+++ b/src/evidence/storage/storage-adapter.ts
@@ -11,9 +11,14 @@ import type { Readable } from 'node:stream';
  * Contract points:
  *   * put() is CONTENT-ADDRESSED and idempotent: the blob's location is a
  *     pure function of (companyId, byteHash), so re-putting identical
- *     bytes lands on the same ref and is a no-op. Paired with the
- *     evidence_asset_hash_idx UNIQUE row invariant this keeps row↔blob
- *     1:1 — deleting one row's blob can never orphan another row's.
+ *     bytes lands on the same ref and is a no-op. The
+ *     evidence_asset_hash_idx UNIQUE invariant means one row per byte
+ *     stream, so the COMMON case is row↔blob 1:1 — but it is not a
+ *     guarantee the delete side may lean on: registerAsset accepts an
+ *     explicit storageRef whose hash is not the row's own byteHash, so a
+ *     blob can back MORE THAN ONE row. Every deletion path must therefore
+ *     answer "does any row still point here?", never "is this row's hash
+ *     mine?" (see listBlobs and orphan-blob-gc.service.ts).
  *   * delete() returns whether a blob existed — the GDPR cascade and the
  *     retention/reconciliation sweeps log honest counts.
  *   * All methods throw a clear error when the adapter is unconfigured
@@ -53,6 +58,61 @@ export interface EvidenceStorageAdapter {
    * answers CAN it mint one.
    */
   signedGetUrl?(storageRef: string, ttlSeconds: number): Promise<string | null>;
+  /**
+   * OPTIONAL (orphan-GC extension point — existing third-party
+   * implementations keep compiling): enumerate the blobs this adapter
+   * holds FOR ONE TENANT, oldest-first is not required but stable
+   * iteration is. Streamed (AsyncIterable), never materialised: a store
+   * can hold more blobs than fit in one array.
+   *
+   * TWO CONTRACT POINTS, both load-bearing for the orphan sweep, which
+   * is the only caller and which DELETES what this yields:
+   *   1. TENANT SCOPING IS THE ADAPTER'S PROMISE. Every yielded ref MUST
+   *      satisfy `belongsToTenant(companyId, ref)`. An adapter whose
+   *      addressing cannot separate tenants (a flat bucket with no tenant
+   *      segment) MUST NOT implement this method — leaving it undefined
+   *      makes the sweep skip the scheme entirely, which is the safe
+   *      outcome. The sweep re-checks belongsToTenant per entry anyway,
+   *      but that is defence in depth, not the primary fence.
+   *   2. AGE MUST NOT UNDERSTATE. `modifiedAtMs` gates the grace window
+   *      that protects an upload whose bytes are already stored and whose
+   *      row does not exist yet, so an adapter that cannot date a blob
+   *      accurately must report the LATER (younger-looking) of whatever
+   *      timestamps it has. Reporting a blob as older than it is deletes
+   *      live uploads; reporting it younger only defers a sweep.
+   *
+   * A missing tenant partition is an empty iteration, never a throw.
+   */
+  listBlobs?(companyId: string): AsyncIterable<StoredBlobEntry>;
+  /**
+   * OPTIONAL (orphan-GC extension point): drop this tenant's PARTIAL
+   * WRITE artefacts older than `olderThanMs` — the fs adapter's
+   * `.tmp-<uuid>` stragglers from a process killed between write and
+   * rename, an s3-class adapter's abandoned multipart uploads. Such
+   * artefacts are not addressable by any storageRef, so no row can
+   * reference them and listBlobs cannot enumerate them: they are
+   * unreachable garbage by construction, which is exactly why they need
+   * their own broom.
+   *
+   * `dryRun` reports what WOULD go without removing anything — the sweep
+   * runs report-only in its first stage and this leg must honour that.
+   */
+  sweepIncompleteWrites?(
+    companyId: string,
+    opts: { olderThanMs: number; dryRun: boolean },
+  ): Promise<{ found: number; removed: number }>;
+}
+
+/**
+ * One stored blob as the orphan sweep sees it: its ref (the join key
+ * against evidence_asset.storageRef), its size (so a report can state
+ * how much a run would reclaim), and when the store last touched it (the
+ * grace-window input — see the listBlobs contract).
+ */
+export interface StoredBlobEntry {
+  storageRef: string;
+  byteLength: number;
+  modifiedAtMs: number;
 }
 
 /**

--- a/src/evidence/storage/storage-adapter.ts
+++ b/src/evidence/storage/storage-adapter.ts
@@ -74,12 +74,15 @@ export interface EvidenceStorageAdapter {
    *      makes the sweep skip the scheme entirely, which is the safe
    *      outcome. The sweep re-checks belongsToTenant per entry anyway,
    *      but that is defence in depth, not the primary fence.
-   *   2. AGE MUST NOT UNDERSTATE. `modifiedAtMs` gates the grace window
-   *      that protects an upload whose bytes are already stored and whose
-   *      row does not exist yet, so an adapter that cannot date a blob
-   *      accurately must report the LATER (younger-looking) of whatever
-   *      timestamps it has. Reporting a blob as older than it is deletes
-   *      live uploads; reporting it younger only defers a sweep.
+   *   2. AGE IS WHEN THE BYTES WERE WRITTEN. `modifiedAtMs` gates the
+   *      grace window that protects an upload whose bytes are already
+   *      stored and whose row does not exist yet. An adapter that cannot
+   *      date a blob exactly must err YOUNGER: reporting a blob as older
+   *      than it is deletes live uploads, while reporting it younger only
+   *      defers a sweep. It must NOT, however, fold in timestamps that
+   *      move for unrelated reasons (a metadata touch, a restore) — that
+   *      is not conservatism, it is a store that can silently read as
+   *      entirely fresh forever.
    *
    * A missing tenant partition is an empty iteration, never a throw.
    */

--- a/src/metrics/metrics.service.ts
+++ b/src/metrics/metrics.service.ts
@@ -211,6 +211,49 @@ export class MetricsService implements OnModuleInit {
     registers: [this.registry],
   });
 
+  // Orphan-blob GC tenant passes by outcome:
+  //   ok             — a DELETING pass finished (stage two)
+  //   dry_run        — a report-only pass finished (stage one, or the
+  //                    caller asked for a dry run). This is the series to
+  //                    watch before enabling deletion
+  //   failed         — the tenant threw; the roster continued
+  //   skipped_budget — the run's wall-clock budget expired before this
+  //                    tenant started
+  readonly evidenceOrphanGcCount = new Counter({
+    name: 'brain_evidence_orphan_gc_total',
+    help: 'Evidence orphan-blob GC tenant passes by outcome',
+    labelNames: ['outcome'] as const,
+    registers: [this.registry],
+  });
+
+  // What the sweep saw, by kind:
+  //   scanned — blobs the store offered
+  //   orphan  — unreferenced past the grace window (what a real run
+  //             WOULD delete; in stage one this is the whole report)
+  //   deleted — actually unlinked (always 0 while the delete flag is off,
+  //             so orphan-without-deleted is the "look before you leap"
+  //             signal, and deleted ≪ orphan in a real run means a cap or
+  //             the budget is biting)
+  //   failed  — delete errors, logged and continued
+  // No companyId label (unbounded cardinality — the same rule as every
+  // other domain counter here); per-tenant detail is cut from log lines.
+  readonly evidenceOrphanBlobs = new Counter({
+    name: 'brain_evidence_orphan_blobs_total',
+    help: 'Evidence orphan-blob GC blobs by kind',
+    labelNames: ['kind'] as const,
+    registers: [this.registry],
+  });
+
+  // Per-TENANT sweep latency. Buckets run to 10 min because that is the
+  // default whole-run budget (EVIDENCE_ORPHAN_BLOB_GC_TIME_BUDGET_MS) — a
+  // single tenant near the top bucket means the roster cannot finish.
+  readonly evidenceOrphanGcDuration = new Histogram({
+    name: 'brain_evidence_orphan_gc_duration_seconds',
+    help: 'Evidence orphan-blob GC per-tenant pass latency in seconds',
+    buckets: [0.1, 0.5, 2, 10, 30, 120, 300, 600],
+    registers: [this.registry],
+  });
+
   // Synthesize outcomes:
   //   ok                   — answer returned, supported (or guardrails=off)
   //   no_results           — search returned zero hits
@@ -1026,6 +1069,20 @@ export class MetricsService implements OnModuleInit {
     if (n > 0) {
       this.sceneMaintenanceEmitted.inc({ kind } as LabelValues<'kind'>, n);
     }
+  }
+
+  countEvidenceOrphanGc(outcome: 'ok' | 'dry_run' | 'failed' | 'skipped_budget'): void {
+    this.evidenceOrphanGcCount.inc({ outcome } as LabelValues<'outcome'>);
+  }
+
+  countEvidenceOrphanBlobs(kind: 'scanned' | 'orphan' | 'deleted' | 'failed', n = 1): void {
+    if (n > 0) {
+      this.evidenceOrphanBlobs.inc({ kind } as LabelValues<'kind'>, n);
+    }
+  }
+
+  observeEvidenceOrphanGcDuration(seconds: number): void {
+    this.evidenceOrphanGcDuration.observe(seconds);
   }
 
   observeSceneMaintenanceDuration(seconds: number): void {

--- a/test/evidence-fs-adapter.unit-spec.ts
+++ b/test/evidence-fs-adapter.unit-spec.ts
@@ -8,7 +8,9 @@
  * leans on when it DELETES what they report: listBlobs yields one
  * tenant's addressable blobs and nothing else, and sweepIncompleteWrites
  * removes only aged `.tmp-…` debris — never a real blob, never in a dry
- * run.
+ * run. Ages here are REAL (back-dated mtimes), never a mocked clock:
+ * blob age is the input to the grace window, so it has to be checkable
+ * the way the sweep actually reads it.
  */
 import { createHash, randomBytes } from 'node:crypto';
 import { existsSync } from 'node:fs';
@@ -131,7 +133,10 @@ describe('FsEvidenceStorageAdapter', () => {
       const seen = await collect('co_a');
       expect(seen.map((e) => e.storageRef)).toEqual([mineRef]);
       expect(seen[0]!.byteLength).toBe(32);
+      // The write time, observable and back-datable — the grace window
+      // the orphan sweep applies is only as trustworthy as this number.
       expect(seen[0]!.modifiedAtMs).toBeGreaterThan(0);
+      expect(seen[0]!.modifiedAtMs).toBeLessThanOrEqual(Date.now() + 1000);
       // Contract point 1: everything yielded belongs to the tenant asked for.
       expect(adapter.belongsToTenant('co_a', seen[0]!.storageRef)).toBe(true);
       expect((await collect('co_b')).map((e) => e.storageRef)).toEqual([
@@ -162,50 +167,32 @@ describe('FsEvidenceStorageAdapter', () => {
   });
 
   describe('sweepIncompleteWrites', () => {
-    // A straggler's age is max(mtime, ctime) — the conservative reading
-    // (see the adapter). ctime cannot be backdated from userland, so a
-    // "young" file is made by pushing its mtime FORWARD; a just-created
-    // one is already as old as the filesystem lets a test make it.
-    const tmpIn = async (hash: string, name: string, youngBy = 0) => {
+    // A straggler's age is its mtime (see the adapter), which utimes can
+    // set — so ages here are REAL, no clock mocking. `ageMs` back-dates;
+    // 0 leaves the file as freshly written.
+    const tmpIn = async (hash: string, name: string, ageMs = 0) => {
       const shard = join(root, 'co_a', hash.slice(0, 2));
       await mkdir(shard, { recursive: true });
       const path = join(shard, name);
       await writeFile(path, 'partial');
-      if (youngBy > 0) {
-        const when = new Date(Date.now() + youngBy);
+      if (ageMs > 0) {
+        const when = new Date(Date.now() - ageMs);
         await utimes(path, when, when);
       }
       return path;
-    };
-
-    /**
-     * Sweep as if `aheadMs` had passed. Filesystem timestamps carry
-     * sub-millisecond precision while Date.now() is integer ms, so a
-     * just-written file can read as marginally in the FUTURE against a
-     * zero-width window — moving the clock instead of the file keeps the
-     * age assertions deterministic.
-     */
-    const sweepAsIfLater = async (
-      aheadMs: number,
-      opts: { olderThanMs: number; dryRun: boolean },
-    ) => {
-      const later = Date.now() + aheadMs;
-      const spy = jest.spyOn(Date, 'now').mockReturnValue(later);
-      try {
-        return await adapter.sweepIncompleteWrites('co_a', opts);
-      } finally {
-        spy.mockRestore();
-      }
     };
 
     it('removes only stragglers past the grace window', async () => {
       const data = randomBytes(8);
       const hash = sha256(data);
       await adapter.put('co_a', hash, data);
-      const old = await tmpIn(hash, '.tmp-old');
-      const young = await tmpIn(hash, '.tmp-young', 3600_000);
+      const old = await tmpIn(hash, '.tmp-old', 3600_000);
+      const young = await tmpIn(hash, '.tmp-young');
 
-      const swept = await sweepAsIfLater(60_000, { olderThanMs: 0, dryRun: false });
+      const swept = await adapter.sweepIncompleteWrites('co_a', {
+        olderThanMs: 60_000,
+        dryRun: false,
+      });
       expect(swept).toEqual({ found: 1, removed: 1 });
       expect(existsSync(old)).toBe(false);
       expect(existsSync(young)).toBe(true);
@@ -217,12 +204,11 @@ describe('FsEvidenceStorageAdapter', () => {
       const data = randomBytes(8);
       const hash = sha256(data);
       await adapter.put('co_a', hash, data);
-      const fresh = await tmpIn(hash, '.tmp-fresh');
+      const fresh = await tmpIn(hash, '.tmp-fresh', 60_000);
 
-      expect(await sweepAsIfLater(60_000, { olderThanMs: 3600_000, dryRun: false })).toEqual({
-        found: 0,
-        removed: 0,
-      });
+      expect(
+        await adapter.sweepIncompleteWrites('co_a', { olderThanMs: 3600_000, dryRun: false }),
+      ).toEqual({ found: 0, removed: 0 });
       expect(existsSync(fresh)).toBe(true);
     });
 
@@ -230,16 +216,17 @@ describe('FsEvidenceStorageAdapter', () => {
       const data = randomBytes(8);
       const hash = sha256(data);
       await adapter.put('co_a', hash, data);
-      const old = await tmpIn(hash, '.tmp-old');
+      const old = await tmpIn(hash, '.tmp-old', 3600_000);
+      const window = { olderThanMs: 60_000 };
 
-      expect(await sweepAsIfLater(60_000, { olderThanMs: 0, dryRun: true })).toEqual({
+      expect(await adapter.sweepIncompleteWrites('co_a', { ...window, dryRun: true })).toEqual({
         found: 1,
         removed: 0,
       });
       expect(existsSync(old)).toBe(true);
 
-      await sweepAsIfLater(60_000, { olderThanMs: 0, dryRun: false });
-      expect(await sweepAsIfLater(60_000, { olderThanMs: 0, dryRun: false })).toEqual({
+      await adapter.sweepIncompleteWrites('co_a', { ...window, dryRun: false });
+      expect(await adapter.sweepIncompleteWrites('co_a', { ...window, dryRun: false })).toEqual({
         found: 0,
         removed: 0,
       });

--- a/test/evidence-fs-adapter.unit-spec.ts
+++ b/test/evidence-fs-adapter.unit-spec.ts
@@ -3,9 +3,16 @@
  * on a per-test mkdtemp root, content-addressed idempotency, malformed
  * ref / path-traversal rejection, and the unconfigured (EVIDENCE_FS_ROOT
  * unset) loud throw.
+ *
+ * Plus the two orphan-GC extension points and the promises the sweep
+ * leans on when it DELETES what they report: listBlobs yields one
+ * tenant's addressable blobs and nothing else, and sweepIncompleteWrites
+ * removes only aged `.tmp-…` debris — never a real blob, never in a dry
+ * run.
  */
 import { createHash, randomBytes } from 'node:crypto';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { mkdir, mkdtemp, rm, utimes, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -106,6 +113,143 @@ describe('FsEvidenceStorageAdapter', () => {
       await expect(adapter.get(ref)).rejects.toThrow(/malformed fs storageRef/);
       await expect(adapter.delete(ref)).rejects.toThrow(/malformed fs storageRef/);
     }
+  });
+
+  describe('listBlobs (orphan-GC enumeration contract)', () => {
+    const collect = async (companyId: string) => {
+      const seen: Array<{ storageRef: string; byteLength: number; modifiedAtMs: number }> = [];
+      for await (const e of adapter.listBlobs(companyId)) seen.push(e);
+      return seen;
+    };
+
+    it('yields this tenant only, with sizes, and never another tenant s blobs', async () => {
+      const mine = randomBytes(32);
+      const theirs = randomBytes(48);
+      const mineRef = (await adapter.put('co_a', sha256(mine), mine)).storageRef;
+      await adapter.put('co_b', sha256(theirs), theirs);
+
+      const seen = await collect('co_a');
+      expect(seen.map((e) => e.storageRef)).toEqual([mineRef]);
+      expect(seen[0]!.byteLength).toBe(32);
+      expect(seen[0]!.modifiedAtMs).toBeGreaterThan(0);
+      // Contract point 1: everything yielded belongs to the tenant asked for.
+      expect(adapter.belongsToTenant('co_a', seen[0]!.storageRef)).toBe(true);
+      expect((await collect('co_b')).map((e) => e.storageRef)).toEqual([
+        `fs://co_b/${sha256(theirs)}`,
+      ]);
+    });
+
+    it('is an empty iteration for a tenant that has never stored anything', async () => {
+      expect(await collect('co_never')).toEqual([]);
+      // …and for a companyId the layout could not have produced.
+      expect(await collect('../evil')).toEqual([]);
+    });
+
+    it('ignores files the content-addressed layout could not have produced', async () => {
+      const data = randomBytes(16);
+      const hash = sha256(data);
+      await adapter.put('co_a', hash, data);
+      const shard = join(root, 'co_a', hash.slice(0, 2));
+      // A stray name, a tmp straggler, and a well-formed hash filed under
+      // the WRONG fan-out shard: none of them is an addressable blob, so
+      // none may ever be offered to a deleter.
+      await writeFile(join(shard, 'README'), 'x');
+      await writeFile(join(shard, '.tmp-abc'), 'x');
+      await writeFile(join(shard, 'b'.repeat(64)), 'x');
+
+      expect((await collect('co_a')).map((e) => e.storageRef)).toEqual([`fs://co_a/${hash}`]);
+    });
+  });
+
+  describe('sweepIncompleteWrites', () => {
+    // A straggler's age is max(mtime, ctime) — the conservative reading
+    // (see the adapter). ctime cannot be backdated from userland, so a
+    // "young" file is made by pushing its mtime FORWARD; a just-created
+    // one is already as old as the filesystem lets a test make it.
+    const tmpIn = async (hash: string, name: string, youngBy = 0) => {
+      const shard = join(root, 'co_a', hash.slice(0, 2));
+      await mkdir(shard, { recursive: true });
+      const path = join(shard, name);
+      await writeFile(path, 'partial');
+      if (youngBy > 0) {
+        const when = new Date(Date.now() + youngBy);
+        await utimes(path, when, when);
+      }
+      return path;
+    };
+
+    /**
+     * Sweep as if `aheadMs` had passed. Filesystem timestamps carry
+     * sub-millisecond precision while Date.now() is integer ms, so a
+     * just-written file can read as marginally in the FUTURE against a
+     * zero-width window — moving the clock instead of the file keeps the
+     * age assertions deterministic.
+     */
+    const sweepAsIfLater = async (
+      aheadMs: number,
+      opts: { olderThanMs: number; dryRun: boolean },
+    ) => {
+      const later = Date.now() + aheadMs;
+      const spy = jest.spyOn(Date, 'now').mockReturnValue(later);
+      try {
+        return await adapter.sweepIncompleteWrites('co_a', opts);
+      } finally {
+        spy.mockRestore();
+      }
+    };
+
+    it('removes only stragglers past the grace window', async () => {
+      const data = randomBytes(8);
+      const hash = sha256(data);
+      await adapter.put('co_a', hash, data);
+      const old = await tmpIn(hash, '.tmp-old');
+      const young = await tmpIn(hash, '.tmp-young', 3600_000);
+
+      const swept = await sweepAsIfLater(60_000, { olderThanMs: 0, dryRun: false });
+      expect(swept).toEqual({ found: 1, removed: 1 });
+      expect(existsSync(old)).toBe(false);
+      expect(existsSync(young)).toBe(true);
+      // The real blob is untouched by the tmp broom.
+      expect(await adapter.exists(`fs://co_a/${hash}`)).toBe(true);
+    });
+
+    it('protects every straggler while the window is generous', async () => {
+      const data = randomBytes(8);
+      const hash = sha256(data);
+      await adapter.put('co_a', hash, data);
+      const fresh = await tmpIn(hash, '.tmp-fresh');
+
+      expect(await sweepAsIfLater(60_000, { olderThanMs: 3600_000, dryRun: false })).toEqual({
+        found: 0,
+        removed: 0,
+      });
+      expect(existsSync(fresh)).toBe(true);
+    });
+
+    it('reports without removing in dry-run mode, and is idempotent', async () => {
+      const data = randomBytes(8);
+      const hash = sha256(data);
+      await adapter.put('co_a', hash, data);
+      const old = await tmpIn(hash, '.tmp-old');
+
+      expect(await sweepAsIfLater(60_000, { olderThanMs: 0, dryRun: true })).toEqual({
+        found: 1,
+        removed: 0,
+      });
+      expect(existsSync(old)).toBe(true);
+
+      await sweepAsIfLater(60_000, { olderThanMs: 0, dryRun: false });
+      expect(await sweepAsIfLater(60_000, { olderThanMs: 0, dryRun: false })).toEqual({
+        found: 0,
+        removed: 0,
+      });
+    });
+
+    it('is a no-op for an unknown tenant', async () => {
+      expect(
+        await adapter.sweepIncompleteWrites('co_never', { olderThanMs: 0, dryRun: false }),
+      ).toEqual({ found: 0, removed: 0 });
+    });
   });
 
   it('throws the clear unconfigured error when EVIDENCE_FS_ROOT is unset', async () => {

--- a/test/evidence-orphan-blob-gc.e2e-spec.ts
+++ b/test/evidence-orphan-blob-gc.e2e-spec.ts
@@ -1,0 +1,260 @@
+/**
+ * Orphan-blob GC e2e (EVIDENCE_ORPHAN_BLOB_GC) — the delete-side hygiene
+ * sweep, end to end over the real storage adapter and real rows:
+ *
+ *  - default-off pin: a bare 404 from the maintenance route while the
+ *    flag is off, with nothing enumerated;
+ *  - a REFERENCED blob is never reported, however old it is;
+ *  - the leak itself: upload bytes, lose the row, and the blob becomes an
+ *    orphan — reported by a dry run (which deletes nothing), then
+ *    reclaimed by a real run once the second-stage flag is on;
+ *  - a second sweep is a no-op — idempotent by enumeration, no queue;
+ *  - the SHARED-blob case, where deletion must NOT happen: two rows
+ *    pointing at one blob, one row dies, the bytes stay;
+ *  - the grace window protects a fresh orphan;
+ *  - `brain:admin` is required.
+ *
+ * The sweep's clock is shifted (not the filesystem's) to step past the
+ * grace window: ctime cannot be backdated from userland, and the age a
+ * blob reports is deliberately max(mtime, ctime).
+ */
+import { createHash, randomBytes } from 'node:crypto';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { AppFixture } from './app-fixture';
+import { createApp } from './app-fixture';
+import { SurrealService } from '../src/db/surreal.service';
+import { EvidenceStoreService } from '../src/evidence/evidence-store.service';
+import { FsEvidenceStorageAdapter } from '../src/evidence/storage/fs-storage.adapter';
+
+const COMPANY = 'co_evidence_orphan_gc_e2e';
+const USER = 'orphan_gc_user';
+const ROUTE = '/v1/admin/maintenance/evidence/orphan-blob-gc';
+const sha256 = (b: Buffer) => createHash('sha256').update(b).digest('hex');
+/** Enough to clear the 1-hour grace window the suite configures. */
+const PAST_GRACE_MS = 2 * 3600_000;
+
+interface SweepBody {
+  scanned: number;
+  referenced: number;
+  young: number;
+  orphans: number;
+  deleted: number;
+  raced: number;
+  failed: number;
+  dryRun: boolean;
+  bytesReclaimable: number;
+  bytesDeleted: number;
+  sampleOrphans: string[];
+}
+
+describe('evidence orphan blob GC (e2e)', () => {
+  let f: AppFixture;
+  let store: EvidenceStoreService;
+  let adapter: FsEvidenceStorageAdapter;
+  let fsRoot: string;
+  let readOnlyKey: string;
+  const auth = (key?: string) => ({ Authorization: `Bearer ${key ?? f.apiKey}` });
+  const saved: Record<string, string | undefined> = {};
+
+  beforeAll(async () => {
+    fsRoot = await mkdtemp(join(tmpdir(), 'evidence-orphan-gc-e2e-'));
+    for (const k of [
+      'EVIDENCE_SUBSTRATE_ENABLED',
+      'EVIDENCE_FS_ROOT',
+      'EVIDENCE_ORPHAN_BLOB_GC',
+      'EVIDENCE_ORPHAN_BLOB_GC_DELETE',
+      'EVIDENCE_ORPHAN_BLOB_GC_SCHEDULED',
+      'EVIDENCE_ORPHAN_BLOB_GC_GRACE_HOURS',
+      'EVIDENCE_ORPHAN_BLOB_GC_MAX_DELETIONS',
+    ]) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+    process.env.EVIDENCE_FS_ROOT = fsRoot;
+    process.env.EVIDENCE_SUBSTRATE_ENABLED = '1';
+    process.env.EVIDENCE_ORPHAN_BLOB_GC_GRACE_HOURS = '1';
+    f = await createApp({
+      companyId: COMPANY,
+      scopes: ['brain:read', 'brain:write', 'brain:admin'],
+      extraKeys: [{ scopes: ['brain:read'] }],
+    });
+    store = f.app.get(EvidenceStoreService);
+    adapter = f.app.get(FsEvidenceStorageAdapter);
+    readOnlyKey = f.extraApiKeys[0]!;
+  }, 120_000);
+
+  afterAll(async () => {
+    for (const [k, v] of Object.entries(saved)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+    await rm(fsRoot, { recursive: true, force: true });
+    if (f) await f.close();
+  });
+
+  /** Bytes into the store + a registered row, the upload path's shape. */
+  const registerBlobbedAsset = async (data: Buffer, storageRefOverride?: string) => {
+    const byteHash = sha256(data);
+    const storageRef =
+      storageRefOverride ?? (await adapter.put(COMPANY, byteHash, data)).storageRef;
+    const asset = await store.registerAsset(COMPANY, {
+      modality: 'image',
+      mediaType: 'image/jpeg',
+      byteHash,
+      byteLength: data.byteLength,
+      occurredAt: new Date('2026-05-01T10:00:00.000Z'),
+      storageRef,
+      userId: USER,
+      vertical: 'proj',
+    });
+    return { ...asset, storageRef, byteHash };
+  };
+
+  /** Erase a row without touching its blob — the leak, reproduced. */
+  const dropAssetRow = async (assetId: string): Promise<void> => {
+    const surreal = f.app.get(SurrealService);
+    await surreal.withCompany(COMPANY, async (db) => {
+      await db.query(`DELETE $id`, { id: assetId });
+    });
+  };
+
+  const countRows = async (table: string): Promise<number> => {
+    const surreal = f.app.get(SurrealService);
+    return surreal.withCompany(COMPANY, async (db) => {
+      const [rows] = await db.query<[Array<{ n: number }>]>(
+        `SELECT count() AS n FROM ${table} GROUP ALL`,
+      );
+      return (rows as Array<{ n: number }>)?.[0]?.n ?? 0;
+    });
+  };
+
+  /**
+   * Run the maintenance verb as if `aheadMs` had passed, so blobs written
+   * moments ago sit past the grace window. Only the sweep's own clock
+   * moves — the rows and the bytes are exactly what the suite wrote.
+   */
+  const sweep = async (aheadMs = PAST_GRACE_MS, body: Record<string, unknown> = {}) => {
+    const later = Date.now() + aheadMs;
+    const spy = jest.spyOn(Date, 'now').mockReturnValue(later);
+    try {
+      const res = await f.http.post(ROUTE).set(auth()).send(body).expect(201);
+      return res.body as SweepBody;
+    } finally {
+      spy.mockRestore();
+    }
+  };
+
+  let livingRef = '';
+  let orphanRef = '';
+
+  it('answers a bare 404 while EVIDENCE_ORPHAN_BLOB_GC is off', async () => {
+    const res = await f.http.post(ROUTE).set(auth()).send({}).expect(404);
+    // Bare: the off-state answer must not describe the route it hides.
+    expect(JSON.stringify(res.body)).not.toContain('orphan');
+  });
+
+  it('requires brain:admin', async () => {
+    process.env.EVIDENCE_ORPHAN_BLOB_GC = '1';
+    await f.http.post(ROUTE).set(auth(readOnlyKey)).send({}).expect(403);
+  });
+
+  it('never reports a blob a live row references', async () => {
+    const asset = await registerBlobbedAsset(randomBytes(64));
+    livingRef = asset.storageRef;
+
+    const body = await sweep();
+
+    expect(body.dryRun).toBe(true); // stage one: report-only by default
+    expect(body.scanned).toBe(1);
+    expect(body.referenced).toBe(1);
+    expect(body.orphans).toBe(0);
+    expect(await adapter.exists(livingRef)).toBe(true);
+  });
+
+  it('reports the blob a lost row leaves behind, and deletes nothing in a dry run', async () => {
+    const asset = await registerBlobbedAsset(randomBytes(128));
+    orphanRef = asset.storageRef;
+    // The leak: bytes are in custody, the row that pointed at them is
+    // gone (a failed registration, a crashed request, an erased row).
+    await dropAssetRow(asset.assetId);
+
+    const body = await sweep();
+
+    expect(body.orphans).toBe(1);
+    expect(body.sampleOrphans).toEqual([orphanRef]);
+    expect(body.bytesReclaimable).toBe(128);
+    expect(body.deleted).toBe(0);
+    expect(body.bytesDeleted).toBe(0);
+    // Report-only means the bytes are still there to be looked at.
+    expect(await adapter.exists(orphanRef)).toBe(true);
+    // …and the referenced blob was seen and spared in the same pass.
+    expect(body.referenced).toBe(1);
+    expect(await adapter.exists(livingRef)).toBe(true);
+  });
+
+  it('protects a fresh orphan with the grace window', async () => {
+    // Same store, same rows — only the clock shift is withdrawn.
+    const body = await sweep(0);
+
+    expect(body.young).toBeGreaterThanOrEqual(2);
+    expect(body.orphans).toBe(0);
+    expect(await adapter.exists(orphanRef)).toBe(true);
+  });
+
+  it('reclaims the orphan once the second stage is on, and only the orphan', async () => {
+    process.env.EVIDENCE_ORPHAN_BLOB_GC_DELETE = '1';
+    const assetsBefore = await countRows('evidence_asset');
+
+    const body = await sweep();
+
+    expect(body.dryRun).toBe(false);
+    expect(body.orphans).toBe(1);
+    expect(body.deleted).toBe(1);
+    expect(body.bytesDeleted).toBe(128);
+    expect(body.failed).toBe(0);
+    expect(await adapter.exists(orphanRef)).toBe(false);
+    // The referenced blob and every row are untouched: this pass deletes
+    // bytes, never rows.
+    expect(await adapter.exists(livingRef)).toBe(true);
+    expect(await countRows('evidence_asset')).toBe(assetsBefore);
+  });
+
+  it('is a no-op on the second sweep', async () => {
+    const body = await sweep();
+
+    expect(body.orphans).toBe(0);
+    expect(body.deleted).toBe(0);
+    expect(body.referenced).toBe(1);
+    expect(await adapter.exists(livingRef)).toBe(true);
+  });
+
+  it('never deletes a SHARED blob while a second row still points at it', async () => {
+    // Content-addressed storage makes sharing real: registerAsset takes
+    // an explicit storageRef, so a second row can be registered onto an
+    // existing blob under its own identity.
+    const shared = await registerBlobbedAsset(randomBytes(96));
+    // Its own identity (a distinct byteHash), the SAME bytes on disk —
+    // the write seam only insists the declared length match what is
+    // stored, which is why one blob can back more than one row.
+    const sidecar = await registerBlobbedAsset(randomBytes(96), shared.storageRef);
+    expect(sidecar.assetId).not.toBe(shared.assetId);
+
+    // The blob's "own" row dies; the sidecar survives and still cites it.
+    await dropAssetRow(shared.assetId);
+
+    const body = await sweep();
+
+    expect(body.orphans).toBe(0);
+    expect(body.deleted).toBe(0);
+    expect(await adapter.exists(shared.storageRef)).toBe(true);
+
+    // Only when the LAST reference goes does the blob become collectable.
+    await dropAssetRow(sidecar.assetId);
+    const after = await sweep();
+    expect(after.orphans).toBe(1);
+    expect(after.deleted).toBe(1);
+    expect(await adapter.exists(shared.storageRef)).toBe(false);
+  });
+});

--- a/test/evidence-orphan-blob-gc.e2e-spec.ts
+++ b/test/evidence-orphan-blob-gc.e2e-spec.ts
@@ -14,12 +14,15 @@
  *  - the grace window protects a fresh orphan;
  *  - `brain:admin` is required.
  *
- * The sweep's clock is shifted (not the filesystem's) to step past the
- * grace window: ctime cannot be backdated from userland, and the age a
- * blob reports is deliberately max(mtime, ctime).
+ * Blobs are aged by BACK-DATING their mtime, never by mocking the clock.
+ * A mocked Date.now() reaches the SurrealDB driver too, which then reads
+ * its root session as expired and drops to anonymous — the tenant query
+ * fails, the sweep's own per-tenant isolation catches it, and every
+ * counter comes back zero with an `error`. Age is a property of the
+ * store, so the test moves the store.
  */
 import { createHash, randomBytes } from 'node:crypto';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp, rm, utimes } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { AppFixture } from './app-fixture';
@@ -32,8 +35,8 @@ const COMPANY = 'co_evidence_orphan_gc_e2e';
 const USER = 'orphan_gc_user';
 const ROUTE = '/v1/admin/maintenance/evidence/orphan-blob-gc';
 const sha256 = (b: Buffer) => createHash('sha256').update(b).digest('hex');
-/** Enough to clear the 1-hour grace window the suite configures. */
-const PAST_GRACE_MS = 2 * 3600_000;
+/** Comfortably past the 1-hour grace window the suite configures. */
+const PAST_GRACE_MS = 3 * 3600_000;
 
 interface SweepBody {
   scanned: number;
@@ -47,6 +50,8 @@ interface SweepBody {
   bytesReclaimable: number;
   bytesDeleted: number;
   sampleOrphans: string[];
+  /** Present only when the tenant pass threw — asserted absent below. */
+  error?: string;
 }
 
 describe('evidence orphan blob GC (e2e)', () => {
@@ -112,11 +117,21 @@ describe('evidence orphan blob GC (e2e)', () => {
     return { ...asset, storageRef, byteHash };
   };
 
-  /** Erase a row without touching its blob — the leak, reproduced. */
+  /**
+   * Erase a row without touching its blob — the leak, reproduced. Uses
+   * the codebase's LET-select-ids → DELETE-ids idiom: SurrealDB refuses
+   * `DELETE $id` when the bound value is a plain STRING record id
+   * ("Cannot execute DELETE statement using value"), and every delete
+   * leg in src/ therefore selects real record ids first.
+   */
   const dropAssetRow = async (assetId: string): Promise<void> => {
     const surreal = f.app.get(SurrealService);
     await surreal.withCompany(COMPANY, async (db) => {
-      await db.query(`DELETE $id`, { id: assetId });
+      const [ids] = await db.query<[unknown[]]>(
+        `SELECT VALUE id FROM type::record('evidence_asset', $tail)`,
+        { tail: assetId.slice(assetId.indexOf(':') + 1) },
+      );
+      await db.query(`DELETE $ids`, { ids });
     });
   };
 
@@ -131,19 +146,24 @@ describe('evidence orphan blob GC (e2e)', () => {
   };
 
   /**
-   * Run the maintenance verb as if `aheadMs` had passed, so blobs written
-   * moments ago sit past the grace window. Only the sweep's own clock
-   * moves — the rows and the bytes are exactly what the suite wrote.
+   * Back-date a stored blob so it sits outside the grace window. The fs
+   * adapter reports a blob's age as its mtime — the moment put() wrote
+   * the bytes — so this is the same number the sweep reads, moved.
    */
-  const sweep = async (aheadMs = PAST_GRACE_MS, body: Record<string, unknown> = {}) => {
-    const later = Date.now() + aheadMs;
-    const spy = jest.spyOn(Date, 'now').mockReturnValue(later);
-    try {
-      const res = await f.http.post(ROUTE).set(auth()).send(body).expect(201);
-      return res.body as SweepBody;
-    } finally {
-      spy.mockRestore();
-    }
+  const ageBlob = async (storageRef: string, ageMs = PAST_GRACE_MS): Promise<void> => {
+    const hash = storageRef.slice(storageRef.lastIndexOf('/') + 1);
+    const when = new Date(Date.now() - ageMs);
+    await utimes(join(fsRoot, COMPANY, hash.slice(0, 2), hash), when, when);
+  };
+
+  /** Run the maintenance verb; a tenant pass that threw fails loudly. */
+  const sweep = async (body: Record<string, unknown> = {}): Promise<SweepBody> => {
+    const res = await f.http.post(ROUTE).set(auth()).send(body).expect(201);
+    const swept = res.body as SweepBody;
+    // The sweep swallows per-tenant failures by design, so a green
+    // assertion on zeroed counters would otherwise prove nothing.
+    expect(swept.error).toBeUndefined();
+    return swept;
   };
 
   let livingRef = '';
@@ -163,6 +183,7 @@ describe('evidence orphan blob GC (e2e)', () => {
   it('never reports a blob a live row references', async () => {
     const asset = await registerBlobbedAsset(randomBytes(64));
     livingRef = asset.storageRef;
+    await ageBlob(livingRef);
 
     const body = await sweep();
 
@@ -179,6 +200,7 @@ describe('evidence orphan blob GC (e2e)', () => {
     // The leak: bytes are in custody, the row that pointed at them is
     // gone (a failed registration, a crashed request, an erased row).
     await dropAssetRow(asset.assetId);
+    await ageBlob(orphanRef);
 
     const body = await sweep();
 
@@ -195,12 +217,23 @@ describe('evidence orphan blob GC (e2e)', () => {
   });
 
   it('protects a fresh orphan with the grace window', async () => {
-    // Same store, same rows — only the clock shift is withdrawn.
-    const body = await sweep(0);
+    // The same unreferenced blob, put back inside the window: bytes that
+    // young may belong to an upload whose row has not landed yet.
+    const fresh = new Date();
+    await utimes(
+      join(fsRoot, COMPANY, orphanRef.slice(-64, -62), orphanRef.slice(-64)),
+      fresh,
+      fresh,
+    );
 
-    expect(body.young).toBeGreaterThanOrEqual(2);
+    const body = await sweep();
+
+    expect(body.young).toBe(1);
     expect(body.orphans).toBe(0);
     expect(await adapter.exists(orphanRef)).toBe(true);
+
+    // …and back out again, so the rest of the suite sees a real orphan.
+    await ageBlob(orphanRef);
   });
 
   it('reclaims the orphan once the second stage is on, and only the orphan', async () => {
@@ -235,6 +268,7 @@ describe('evidence orphan blob GC (e2e)', () => {
     // an explicit storageRef, so a second row can be registered onto an
     // existing blob under its own identity.
     const shared = await registerBlobbedAsset(randomBytes(96));
+    await ageBlob(shared.storageRef);
     // Its own identity (a distinct byteHash), the SAME bytes on disk —
     // the write seam only insists the declared length match what is
     // stored, which is why one blob can back more than one row.

--- a/test/evidence-orphan-blob-gc.unit-spec.ts
+++ b/test/evidence-orphan-blob-gc.unit-spec.ts
@@ -1,0 +1,555 @@
+/**
+ * Unit coverage for the orphan-blob GC
+ * (src/evidence/orphan-blob-gc.service.ts, EVIDENCE_ORPHAN_BLOB_GC) —
+ * the pass that DELETES bytes, so every safety property gets its own
+ * pin:
+ *
+ *  - default-off: no store walk, no query, no unlink;
+ *  - orphan DETECTION: a referenced blob is never selected, and a SHARED
+ *    blob (two rows, one ref — the case content-addressed storage makes
+ *    real) stays untouched when only one of its rows dies;
+ *  - every row state counts as a reference, including a 'gone' tombstone
+ *    that still holds its ref and a quarantined row;
+ *  - the grace window protects a young blob (bytes whose row may still
+ *    be in flight);
+ *  - the 0114 hard-erasure outbox owns its refs — the sweep steps over
+ *    them rather than racing the drainer;
+ *  - dry run reports everything and deletes nothing (the flag's first
+ *    stage, and a caller can only tighten it, never loosen);
+ *  - the deletion cap and the wall-clock budget both bite, and say so;
+ *  - the last-moment re-check saves a blob that gained a row mid-sweep;
+ *  - failure isolation: one delete that throws costs one blob, not the
+ *    run — and an adapter that cannot enumerate per tenant collects
+ *    nothing;
+ *  - roster isolation: one tenant's throw does not cost the next tenant.
+ *
+ * Collaborators are stubbed positionally — no Nest DI, no Surreal, no
+ * filesystem, no paid call anywhere.
+ */
+import { EvidenceOrphanBlobGcService } from '../src/evidence/orphan-blob-gc.service';
+import type { ApiKeyService } from '../src/auth/api-key.service';
+import type { SurrealService } from '../src/db/surreal.service';
+import type {
+  EvidenceStorageAdapter,
+  EvidenceStorageRegistry,
+  StoredBlobEntry,
+} from '../src/evidence/storage/storage-adapter';
+
+const FLAGS = [
+  'EVIDENCE_ORPHAN_BLOB_GC',
+  'EVIDENCE_ORPHAN_BLOB_GC_DELETE',
+  'EVIDENCE_ORPHAN_BLOB_GC_SCHEDULED',
+  'EVIDENCE_ORPHAN_BLOB_GC_GRACE_HOURS',
+  'EVIDENCE_ORPHAN_BLOB_GC_MAX_DELETIONS',
+  'EVIDENCE_ORPHAN_BLOB_GC_TIME_BUDGET_MS',
+] as const;
+
+const saved: Record<string, string | undefined> = {};
+beforeEach(() => {
+  for (const k of FLAGS) {
+    saved[k] = process.env[k];
+    delete process.env[k];
+  }
+  process.env.EVIDENCE_ORPHAN_BLOB_GC = '1';
+  process.env.EVIDENCE_ORPHAN_BLOB_GC_DELETE = '1';
+  process.env.EVIDENCE_ORPHAN_BLOB_GC_GRACE_HOURS = '1';
+});
+afterEach(() => {
+  for (const k of FLAGS) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+});
+
+const HOUR = 3600_000;
+const ref = (tenant: string, n: number) => `fs://${tenant}/${String(n).repeat(64).slice(0, 64)}`;
+
+/** An evidence_asset row as the sweep's only join key sees it. */
+interface FakeAsset {
+  id: string;
+  /** A row may point at a blob whose hash is not its own — see the sweep. */
+  storageRef?: string;
+  availability?: string;
+  quarantineStatus?: string;
+}
+
+interface FakeTenant {
+  assets: FakeAsset[];
+  /** 0114 outbox rows: refs the hard-erasure drainer already owns. */
+  queued?: string[];
+  throws?: string;
+  /** Fires after each batch resolve — the mid-sweep race hook. */
+  afterResolve?: (() => void) | undefined;
+}
+
+function makeSurreal(tenants: Record<string, FakeTenant>): {
+  surreal: SurrealService;
+  queries: string[];
+} {
+  const queries: string[] = [];
+  const surreal = {
+    withCompany: async <T>(companyId: string, fn: (db: unknown) => Promise<T>) => {
+      const t = tenants[companyId];
+      if (!t) throw new Error(`no fake tenant ${companyId}`);
+      if (t.throws) throw new Error(t.throws);
+      const db = {
+        query: <R>(sql: string, params?: Record<string, unknown>): Promise<R> => {
+          queries.push(sql);
+          const refs = new Set((params?.refs as string[]) ?? []);
+          if (sql.includes('FROM evidence_asset')) {
+            const hits = t.assets
+              .map((a) => a.storageRef)
+              .filter((r): r is string => r !== undefined && refs.has(r));
+            return Promise.resolve([hits] as unknown as R);
+          }
+          if (sql.includes('FROM evidence_blob_gc')) {
+            return Promise.resolve([(t.queued ?? []).filter((r) => refs.has(r))] as unknown as R);
+          }
+          throw new Error(`unexpected query: ${sql}`);
+        },
+      };
+      const out = await fn(db);
+      t.afterResolve?.();
+      return out;
+    },
+  } as unknown as SurrealService;
+  return { surreal, queries };
+}
+
+interface FakeStore {
+  /** ref → { byteLength, ageMs } as the store would report it. */
+  blobs: Array<{ ref: string; byteLength: number; ageMs: number }>;
+  deleted: string[];
+  failOn?: string[];
+  listed: string[];
+  tmpSwept: Array<{ olderThanMs: number; dryRun: boolean }>;
+}
+
+function makeStore(blobs: FakeStore['blobs']): FakeStore {
+  return { blobs, deleted: [], listed: [], tmpSwept: [] };
+}
+
+function makeAdapter(
+  store: FakeStore,
+  opts: { enumerable?: boolean; ownsTenant?: (companyId: string, r: string) => boolean } = {},
+): EvidenceStorageAdapter {
+  const owns =
+    opts.ownsTenant ?? ((companyId: string, r: string) => r.startsWith(`fs://${companyId}/`));
+  const adapter: Partial<EvidenceStorageAdapter> = {
+    scheme: 'fs',
+    belongsToTenant: (companyId: string, r: string) => owns(companyId, r),
+    delete: (r: string) => {
+      if (store.failOn?.includes(r)) return Promise.reject(new Error('EACCES'));
+      store.deleted.push(r);
+      const i = store.blobs.findIndex((b) => b.ref === r);
+      if (i < 0) return Promise.resolve(false);
+      store.blobs.splice(i, 1);
+      return Promise.resolve(true);
+    },
+    sweepIncompleteWrites: (_companyId, o) => {
+      store.tmpSwept.push(o);
+      return Promise.resolve({ found: 1, removed: o.dryRun ? 0 : 1 });
+    },
+  };
+  if (opts.enumerable !== false) {
+    adapter.listBlobs = (companyId: string): AsyncGenerator<StoredBlobEntry> => {
+      store.listed.push(companyId);
+      // Snapshot: the sweep deletes while iterating, exactly as it does
+      // against a real directory walk.
+      const snapshot = [...store.blobs];
+      return (async function* () {
+        for (const b of snapshot) {
+          yield {
+            storageRef: b.ref,
+            byteLength: b.byteLength,
+            modifiedAtMs: Date.now() - b.ageMs,
+          };
+        }
+      })();
+    };
+  }
+  return adapter as EvidenceStorageAdapter;
+}
+
+function makeService(
+  tenants: Record<string, FakeTenant>,
+  store: FakeStore,
+  adapterOpts: Parameters<typeof makeAdapter>[1] = {},
+): {
+  service: EvidenceOrphanBlobGcService;
+  queries: string[];
+} {
+  const { surreal, queries } = makeSurreal(tenants);
+  const apiKeys = { knownCompanyIds: () => Object.keys(tenants) } as unknown as ApiKeyService;
+  const registry: EvidenceStorageRegistry = new Map([['fs', makeAdapter(store, adapterOpts)]]);
+  return {
+    service: new EvidenceOrphanBlobGcService(surreal, apiKeys, registry),
+    queries,
+  };
+}
+
+describe('orphan blob GC — default off', () => {
+  it('does not walk the store, query, or unlink while the flag is off', async () => {
+    delete process.env.EVIDENCE_ORPHAN_BLOB_GC;
+    const store = makeStore([{ ref: ref('co_a', 1), byteLength: 10, ageMs: 5 * HOUR }]);
+    const { service, queries } = makeService({ co_a: { assets: [] } }, store);
+
+    const result = await service.sweepTenant('co_a');
+
+    expect(result.scanned).toBe(0);
+    expect(result.orphans).toBe(0);
+    expect(store.listed).toEqual([]);
+    expect(store.deleted).toEqual([]);
+    expect(store.tmpSwept).toEqual([]);
+    expect(queries).toEqual([]);
+  });
+
+  it('nightly cron is a no-op unless the schedule knob is on too', async () => {
+    const store = makeStore([{ ref: ref('co_a', 1), byteLength: 10, ageMs: 5 * HOUR }]);
+    const { service, queries } = makeService({ co_a: { assets: [] } }, store);
+
+    expect(await service.runNightly()).toEqual({
+      tenants: [],
+      budgetExhausted: false,
+      skippedForBudget: 0,
+    });
+    expect(queries).toEqual([]);
+
+    process.env.EVIDENCE_ORPHAN_BLOB_GC_SCHEDULED = '1';
+    const run = await service.runNightly();
+    expect(run.tenants).toHaveLength(1);
+    expect(store.deleted).toEqual([ref('co_a', 1)]);
+  });
+});
+
+describe('orphan blob GC — detection', () => {
+  it('never selects a blob a live row references', async () => {
+    const kept = ref('co_a', 1);
+    const orphan = ref('co_a', 2);
+    const store = makeStore([
+      { ref: kept, byteLength: 10, ageMs: 5 * HOUR },
+      { ref: orphan, byteLength: 20, ageMs: 5 * HOUR },
+    ]);
+    const { service } = makeService(
+      { co_a: { assets: [{ id: 'evidence_asset:a', storageRef: kept }] } },
+      store,
+    );
+
+    const result = await service.sweepTenant('co_a');
+
+    expect(result.scanned).toBe(2);
+    expect(result.referenced).toBe(1);
+    expect(result.orphans).toBe(1);
+    expect(result.deleted).toBe(1);
+    expect(result.bytesDeleted).toBe(20);
+    expect(store.deleted).toEqual([orphan]);
+    expect(store.blobs.map((b) => b.ref)).toEqual([kept]);
+  });
+
+  it('never selects a SHARED blob while a second row still points at it', async () => {
+    // The case content-addressed storage makes real: registerAsset takes
+    // an explicit storageRef, so two rows can back onto one blob. Row
+    // one is gone (GDPR, retention, a rejected scan); row two survives
+    // and its citations still need the bytes.
+    const shared = ref('co_a', 3);
+    const store = makeStore([{ ref: shared, byteLength: 99, ageMs: 5 * HOUR }]);
+    const { service } = makeService(
+      {
+        co_a: {
+          assets: [
+            { id: 'evidence_asset:survivor', storageRef: shared },
+            // The dead row is simply absent — what the sweep sees after
+            // the other owner's erasure ran.
+          ],
+        },
+      },
+      store,
+    );
+
+    const result = await service.sweepTenant('co_a');
+
+    expect(result.referenced).toBe(1);
+    expect(result.orphans).toBe(0);
+    expect(result.deleted).toBe(0);
+    expect(store.deleted).toEqual([]);
+  });
+
+  it('counts every row state as a reference — tombstones and quarantine included', async () => {
+    const tombstoned = ref('co_a', 4);
+    const quarantined = ref('co_a', 5);
+    const store = makeStore([
+      { ref: tombstoned, byteLength: 1, ageMs: 5 * HOUR },
+      { ref: quarantined, byteLength: 1, ageMs: 5 * HOUR },
+    ]);
+    const { service } = makeService(
+      {
+        co_a: {
+          assets: [
+            // 'gone' + a surviving ref is the reconciliation leg's retry
+            // state: its blob delete failed, and the retention sweep owns
+            // the retry. Not this pass's blob.
+            { id: 'evidence_asset:t', storageRef: tombstoned, availability: 'gone' },
+            { id: 'evidence_asset:q', storageRef: quarantined, quarantineStatus: 'quarantined' },
+          ],
+        },
+      },
+      store,
+    );
+
+    const result = await service.sweepTenant('co_a');
+
+    expect(result.referenced).toBe(2);
+    expect(result.orphans).toBe(0);
+    expect(store.deleted).toEqual([]);
+  });
+
+  it('leaves refs the 0114 hard-erasure outbox already owns to their drainer', async () => {
+    const condemned = ref('co_a', 6);
+    const store = makeStore([{ ref: condemned, byteLength: 7, ageMs: 5 * HOUR }]);
+    const { service } = makeService({ co_a: { assets: [], queued: [condemned] } }, store);
+
+    const result = await service.sweepTenant('co_a');
+
+    expect(result.queued).toBe(1);
+    expect(result.orphans).toBe(0);
+    expect(store.deleted).toEqual([]);
+  });
+});
+
+describe('orphan blob GC — grace window', () => {
+  it('skips a blob younger than the window whatever its reference state', async () => {
+    const young = ref('co_a', 7);
+    const old = ref('co_a', 8);
+    const store = makeStore([
+      // An upload in flight: bytes on disk, row not written yet.
+      { ref: young, byteLength: 5, ageMs: 60_000 },
+      { ref: old, byteLength: 5, ageMs: 5 * HOUR },
+    ]);
+    const { service } = makeService({ co_a: { assets: [] } }, store);
+
+    const result = await service.sweepTenant('co_a');
+
+    expect(result.young).toBe(1);
+    expect(result.orphans).toBe(1);
+    expect(store.deleted).toEqual([old]);
+  });
+
+  it('protects everything under the generous default window', async () => {
+    delete process.env.EVIDENCE_ORPHAN_BLOB_GC_GRACE_HOURS; // → 24 h
+    const store = makeStore([{ ref: ref('co_a', 9), byteLength: 5, ageMs: 5 * HOUR }]);
+    const { service } = makeService({ co_a: { assets: [] } }, store);
+
+    const result = await service.sweepTenant('co_a');
+
+    expect(result.young).toBe(1);
+    expect(result.orphans).toBe(0);
+    expect(store.deleted).toEqual([]);
+  });
+
+  it('falls back to the default window when the knob is nonsense', async () => {
+    process.env.EVIDENCE_ORPHAN_BLOB_GC_GRACE_HOURS = 'soon';
+    const store = makeStore([{ ref: ref('co_a', 9), byteLength: 5, ageMs: 5 * HOUR }]);
+    const { service } = makeService({ co_a: { assets: [] } }, store);
+
+    expect((await service.sweepTenant('co_a')).orphans).toBe(0);
+  });
+});
+
+describe('orphan blob GC — dry run', () => {
+  it('reports every orphan and deletes nothing while the delete flag is off', async () => {
+    delete process.env.EVIDENCE_ORPHAN_BLOB_GC_DELETE;
+    const orphans = [ref('co_a', 1), ref('co_a', 2)];
+    const store = makeStore(orphans.map((r) => ({ ref: r, byteLength: 16, ageMs: 5 * HOUR })));
+    const { service } = makeService({ co_a: { assets: [] } }, store);
+
+    const result = await service.sweepTenant('co_a');
+
+    expect(result.dryRun).toBe(true);
+    expect(result.orphans).toBe(2);
+    expect(result.bytesReclaimable).toBe(32);
+    expect(result.deleted).toBe(0);
+    expect(result.bytesDeleted).toBe(0);
+    expect(result.sampleOrphans).toEqual(orphans);
+    expect(store.deleted).toEqual([]);
+    // The partial-write leg honours the same report-only contract.
+    expect(store.tmpSwept).toEqual([{ olderThanMs: HOUR, dryRun: true }]);
+    expect(result.partialWrites).toBe(1);
+    expect(result.partialWritesRemoved).toBe(0);
+  });
+
+  it('lets a caller force a dry run in stage two, but never the reverse', async () => {
+    const orphan = ref('co_a', 1);
+    const store = makeStore([{ ref: orphan, byteLength: 16, ageMs: 5 * HOUR }]);
+    const { service } = makeService({ co_a: { assets: [] } }, store);
+
+    expect((await service.sweepTenant('co_a', { dryRun: true })).deleted).toBe(0);
+    expect(store.deleted).toEqual([]);
+
+    // …and the reverse is not on offer: with the flag off, asking for a
+    // real run still gets a dry one.
+    delete process.env.EVIDENCE_ORPHAN_BLOB_GC_DELETE;
+    const forced = await service.sweepTenant('co_a', { dryRun: false });
+    expect(forced.dryRun).toBe(true);
+    expect(store.deleted).toEqual([]);
+  });
+});
+
+describe('orphan blob GC — bounds', () => {
+  it('honours the per-tenant deletion cap and says it bit', async () => {
+    process.env.EVIDENCE_ORPHAN_BLOB_GC_MAX_DELETIONS = '2';
+    const store = makeStore(
+      [1, 2, 3, 4, 5].map((n) => ({ ref: ref('co_a', n), byteLength: 1, ageMs: 5 * HOUR })),
+    );
+    const { service } = makeService({ co_a: { assets: [] } }, store);
+
+    const result = await service.sweepTenant('co_a');
+
+    expect(result.deleted).toBe(2);
+    expect(store.deleted).toHaveLength(2);
+    expect(result.capReached).toBe(true);
+    // A capped run still REPORTS the whole backlog — that is how an
+    // operator learns the true size of what is left.
+    expect(result.orphans).toBe(5);
+  });
+
+  it('lets a caller tighten the cap for one run, never raise it', async () => {
+    process.env.EVIDENCE_ORPHAN_BLOB_GC_MAX_DELETIONS = '2';
+    const store = makeStore(
+      [1, 2, 3, 4].map((n) => ({ ref: ref('co_a', n), byteLength: 1, ageMs: 5 * HOUR })),
+    );
+    const { service } = makeService({ co_a: { assets: [] } }, store);
+
+    expect((await service.sweepTenant('co_a', { maxDeletions: 1 })).deleted).toBe(1);
+    expect((await service.sweepTenant('co_a', { maxDeletions: 99 })).deleted).toBe(2);
+  });
+
+  it('stops the roster once the wall-clock budget is spent', async () => {
+    process.env.EVIDENCE_ORPHAN_BLOB_GC_TIME_BUDGET_MS = '1';
+    const store = makeStore([{ ref: ref('co_a', 1), byteLength: 1, ageMs: 5 * HOUR }]);
+    const { service } = makeService({ co_a: { assets: [] }, co_b: { assets: [] } }, store);
+
+    // The deadline is stamped from the first read; every read after it
+    // is far enough ahead that the roster never starts a tenant.
+    const now = Date.now();
+    let reads = 0;
+    const spy = jest
+      .spyOn(Date, 'now')
+      .mockImplementation(() => (reads++ === 0 ? now : now + 10_000));
+    try {
+      const run = await service.runAll();
+      expect(run.budgetExhausted).toBe(true);
+      expect(run.skippedForBudget).toBe(2);
+      expect(run.tenants).toEqual([]);
+    } finally {
+      spy.mockRestore();
+    }
+    expect(store.deleted).toEqual([]);
+  });
+});
+
+describe('orphan blob GC — races and failures', () => {
+  it('re-checks immediately before the unlink and spares a blob that gained a row', async () => {
+    const raced = ref('co_a', 1);
+    const store = makeStore([{ ref: raced, byteLength: 4, ageMs: 5 * HOUR }]);
+    const tenant: FakeTenant = { assets: [] };
+    // The batch resolve sees no row; a registration lands before the
+    // delete (put() is idempotent, so a fresh upload of identical bytes
+    // reuses exactly this blob and then writes its row).
+    tenant.afterResolve = () => {
+      tenant.assets = [{ id: 'evidence_asset:fresh', storageRef: raced }];
+      tenant.afterResolve = undefined;
+    };
+    const { service } = makeService({ co_a: tenant }, store);
+
+    const result = await service.sweepTenant('co_a');
+
+    expect(result.orphans).toBe(1);
+    expect(result.raced).toBe(1);
+    expect(result.deleted).toBe(0);
+    expect(store.deleted).toEqual([]);
+  });
+
+  it('isolates a delete failure: one blob lost, the run continues', async () => {
+    const bad = ref('co_a', 1);
+    const good = ref('co_a', 2);
+    const store = makeStore([
+      { ref: bad, byteLength: 1, ageMs: 5 * HOUR },
+      { ref: good, byteLength: 1, ageMs: 5 * HOUR },
+    ]);
+    store.failOn = [bad];
+    const { service } = makeService({ co_a: { assets: [] } }, store);
+
+    const result = await service.sweepTenant('co_a');
+
+    expect(result.failed).toBe(1);
+    expect(result.deleted).toBe(1);
+    expect(result.error).toBeUndefined();
+    expect(store.deleted).toEqual([good]);
+    // Idempotent + resumable: the failure is rediscovered next run, no
+    // queue required.
+    store.failOn = [];
+    expect((await service.sweepTenant('co_a')).deleted).toBe(1);
+    expect(store.blobs).toEqual([]);
+  });
+
+  it('never judges a ref the adapter does not scope to this tenant', async () => {
+    const foreign = 'fs://co_other/' + 'a'.repeat(64);
+    const store = makeStore([{ ref: foreign, byteLength: 1, ageMs: 5 * HOUR }]);
+    const { service, queries } = makeService({ co_a: { assets: [] } }, store);
+
+    const result = await service.sweepTenant('co_a');
+
+    expect(result.foreign).toBe(1);
+    expect(result.orphans).toBe(0);
+    expect(store.deleted).toEqual([]);
+    // Nothing was even asked of the database — a ref this tenant does
+    // not own cannot be judged against this tenant's rows.
+    expect(queries.filter((q) => q.includes('evidence_asset'))).toEqual([]);
+  });
+
+  it('collects nothing from an adapter that cannot enumerate per tenant', async () => {
+    const store = makeStore([{ ref: ref('co_a', 1), byteLength: 1, ageMs: 5 * HOUR }]);
+    const { service } = makeService({ co_a: { assets: [] } }, store, { enumerable: false });
+
+    const result = await service.sweepTenant('co_a');
+
+    expect(result.scanned).toBe(0);
+    expect(result.orphans).toBe(0);
+    expect(store.deleted).toEqual([]);
+    // …but an adapter that CAN clean its own interrupted writes still does.
+    expect(result.partialWritesRemoved).toBe(1);
+  });
+
+  it('isolates a failing tenant from the rest of the roster', async () => {
+    const store = makeStore([
+      { ref: ref('co_a', 1), byteLength: 1, ageMs: 5 * HOUR },
+      { ref: ref('co_b', 1), byteLength: 1, ageMs: 5 * HOUR },
+    ]);
+    const { service } = makeService(
+      { co_a: { assets: [], throws: 'surreal is down' }, co_b: { assets: [] } },
+      store,
+    );
+
+    const run = await service.runAll();
+
+    expect(run.tenants.map((t) => t.companyId)).toEqual(['co_a', 'co_b']);
+    expect(run.tenants[0]!.error).toBe('surreal is down');
+    expect(run.tenants[1]!.error).toBeUndefined();
+    // The failing tenant's blob is untouched; the next tenant still runs.
+    expect(store.deleted).toEqual([ref('co_b', 1)]);
+  });
+});
+
+describe('orphan blob GC — idempotence', () => {
+  it('is a no-op on a second pass over a swept store', async () => {
+    const store = makeStore([{ ref: ref('co_a', 1), byteLength: 3, ageMs: 5 * HOUR }]);
+    const { service } = makeService({ co_a: { assets: [] } }, store);
+
+    expect((await service.sweepTenant('co_a')).deleted).toBe(1);
+
+    const second = await service.sweepTenant('co_a');
+    expect(second.scanned).toBe(0);
+    expect(second.orphans).toBe(0);
+    expect(second.deleted).toBe(0);
+  });
+});


### PR DESCRIPTION
## The gap

The MM-7 upload path (#471) stores bytes **before** registering the asset row, and deliberately does **not** delete them when registration fails — `put()` is content-addressed, so a blob can back more than one row and an eager unlink could destroy another row's evidence. That is the right call, and it leaks: a failed registration, a crashed request, a process killed mid-write leaves bytes on disk that no row references. The upload PR named "an orphan-blob GC sweep" as the honest follow-up; this is it.

## What an orphan is, precisely

A blob the store holds for tenant T such that **no** `evidence_asset` row in T's database has it as its `storageRef`, and which is older than the grace window. Note what that definition does not say:

* **Nothing about the row's byteHash.** `registerAsset` accepts an explicit `storageRef` whose hash is not the row's own, so a blob can back more than one row. The join key is `storageRef` and only `storageRef` — matching on hashes would delete a shared blob the moment its "own" row died.
* **Nothing about the row's state.** A quarantined row, a `gone` tombstone that still holds its ref because its blob delete failed, a row past retention whose sweep has not run — every one is a reference, and a referenced blob is never an orphan. The reference query carries no predicate beyond the ref match.
* **Nothing about the 0114 outbox.** A ref the hard-erasure queue already condemned belongs to that drainer; the sweep counts such refs and steps over them rather than racing for the same unlink.

## How references are enumerated safely across tenants

Every tenant is its own SurrealDB database (`co_<companyId>`), so no query can see all rows at once and none is attempted. Both sides of the join are pinned to the same tenant:

* the roster is `ApiKeyService.knownCompanyIds()` — the same source every other maintenance pass walks. A store directory belonging to a tenant **not** on the roster is never enumerated, so a deregistered tenant's bytes are left alone rather than silently destroyed;
* the store side enumerates **one** tenant (`adapter.listBlobs(companyId)`), and the adapter contract requires every yielded ref to satisfy `belongsToTenant` — re-checked here per entry, so an adapter that cannot scope refs per tenant collects nothing instead of collecting someone else's;
* the row side runs inside `surreal.withCompany(companyId)` — that database and no other.

Because the ref is structurally the tenant's (`fs://<companyId>/<hash>`) and `registerAsset` **refuses** a `storageRef` that does not belong to the writing tenant, "no row in T references it" is the complete answer, not a per-tenant approximation of one.

## Safety knobs, in the order they fire

| Knob | Default | What it fences |
|---|---|---|
| `EVIDENCE_ORPHAN_BLOB_GC` | `0` | Off ⇒ the sweep does not exist: no store walk, no query, route 404s |
| `EVIDENCE_ORPHAN_BLOB_GC_DELETE` | `0` | **Stage two.** Off ⇒ every run is a dry run whatever the caller asks — the flag is the only authority on destroying a byte |
| `EVIDENCE_ORPHAN_BLOB_GC_GRACE_HOURS` | `24` | A blob younger than this is never a candidate — the upload window where bytes exist and their row does not |
| `EVIDENCE_ORPHAN_BLOB_GC_MAX_DELETIONS` | `500` | Per-tenant blast radius of one run. A capped run still **reports** the whole backlog |
| `EVIDENCE_ORPHAN_BLOB_GC_TIME_BUDGET_MS` | `600000` | Wall clock for one run; the roster stops starting tenants |
| `EVIDENCE_ORPHAN_BLOB_GC_SCHEDULED` | `0` | The optional 04:35 UTC cron, lease-guarded, its own decision |

Plus, not knobs: every orphan is **re-checked against the rows immediately before its unlink** (a row registered mid-walk saves its bytes — `raced`); a delete failure logs, counts and continues; a per-call body can pass `dryRun: true` or a lower `maxDeletions`, which can only make a run more conservative.

The route is gated on `EVIDENCE_ORPHAN_BLOB_GC` **alone**, deliberately not also on `EVIDENCE_SUBSTRATE_ENABLED` like the write-side surfaces: this is a delete-side pass, and bytes written while the substrate was on must stay collectable after it is turned off (the `sweepTenantEvidence` precedent).

## Why no migration, and why 0114 is not extended

0114's outbox exists because hard erasure destroys the only pointer to the bytes: once the row is gone, a failed unlink is unrecoverable work unless it was written down first. An orphan is the exact opposite — it is **defined** by having no pointer, so enumeration rediscovers it on every run for free, which is what makes the sweep idempotent and resumable with no state. A queue would add a second, weaker mechanism (a condemned ref that a later upload legitimately reuses would be deleted out from under the new row). So: no new table, no new `reason` in the 0114 enum, no migration. The sweep **reads** that outbox to stay out of its way, and nothing more.

## Surface

* `src/evidence/orphan-blob-gc.service.ts` — the sweep, per-tenant and roster-wide, with the 04:35 UTC cron (free slot: 03:05/03:17/03:35/03:41/03:42/03:45/03:51/03:52/04:00/04:20 are taken, hourly `:26` is the registry mirror) behind the distributed lease guard.
* `src/evidence/storage/storage-adapter.ts` — two **optional** contract points, so existing third-party adapters keep compiling and, by not implementing them, collect nothing: `listBlobs(companyId)` (tenant-scoped, streamed, age must not understate) and `sweepIncompleteWrites` (partial-write debris no ref can address).
* `src/evidence/storage/fs-storage.adapter.ts` — both implemented: the walk yields only well-formed content addresses under their own fan-out shard, and the `.tmp-<uuid>` broom collects what a process killed between write and rename left behind (the aborted-upload case, which `listBlobs` cannot see by construction). Blob age is `max(mtime, ctime)` — the conservative reading.
* `POST /v1/admin/maintenance/evidence/orphan-blob-gc` on the existing `EvidenceAdminController`, `brain:admin`, the shared `resolvePlatformTenant` seam.
* Metrics: `brain_evidence_orphan_gc_total{outcome}`, `brain_evidence_orphan_blobs_total{kind}`, `brain_evidence_orphan_gc_duration_seconds`. `orphan` rising with a flat `deleted` is the look-before-you-leap state.
* Docs: the `EVIDENCE_*` table in `operations.md` plus an "Orphan-GC order: look, then delete" runbook note.

Also corrected: the `storage-adapter.ts` docblock claimed the UNIQUE `byteHash` index keeps row↔blob 1:1. The upload service's own note contradicts it, and the delete side must not lean on it.

## Tests

* **Unit** (`test/evidence-orphan-blob-gc.unit-spec.ts`, 20 cases): default-off (no walk, no query, no unlink); a referenced blob never selected; a **shared** blob never selected while a second row points at it; tombstoned and quarantined rows count as references; 0114-queued refs left to their drainer; grace skips a young blob; dry run reports everything and deletes nothing; deletion cap and wall-clock budget both bite and say so; the pre-delete re-check spares a blob that gained a row mid-sweep; delete-failure isolation; an adapter that cannot enumerate per tenant collects nothing; roster isolation; second-pass no-op.
* **Unit** (`test/evidence-fs-adapter.unit-spec.ts`): `listBlobs` yields one tenant's addressable blobs and ignores anything the layout could not have produced; `sweepIncompleteWrites` removes only aged debris, never a real blob, never in a dry run.
* **E2E** (`test/evidence-orphan-blob-gc.e2e-spec.ts`): 404 while dark → `brain:admin` required → referenced blob never reported → row dropped, dry run reports and deletes nothing → grace protects a fresh orphan → stage two reclaims exactly the orphan (rows untouched) → second sweep is a no-op → shared blob survives its first row's death and is collected only when the last reference goes.

## Gates

`pnpm typecheck`, `pnpm lint:ci`, `pnpm format:check` clean; full unit suite green (376 suites, 4451 tests).

## Follow-up spotted, not fixed here

The 0114 drainer (`reconcileQueuedBlobs`) deletes a queued ref unconditionally. If a blob is shared and one of its rows dies via user-forget, the survivor's bytes go with it. Reachable only through a service-level `registerAsset` with a foreign `storageRef` (the upload path never does it), and touching the GDPR path was out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB
