### PR TITLE
feat(evidence): local OCR adapter — images become readable memory

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -749,6 +749,21 @@ PRIVACY_COMPOSER_USER_SCOPE=1
 # Off = a bare 404 from a guard (no route-revealing 400 on a bad body);
 # needs EVIDENCE_SUBSTRATE_ENABLED or the double gate keeps it dark.
 #EVIDENCE_GRANTS_API_ENABLED=0
+# Local OCR processor (OcrAdapter, capability 'ocr' on image assets).
+# Fully offline: the tesseract.js WASM core and the .traineddata models
+# are lockfile-pinned npm dependencies read off local disk — nothing is
+# ever downloaded at runtime. Needs EVIDENCE_PROCESSOR_BROKER (and a pack
+# that DECLARES an image→ocr processor need, with current modality
+# consent) to do anything; off = the adapter declines every dispatch.
+# LANGS: '+'/','-separated, in priority order; only languages shipped in
+# the image are accepted (eng, rus) — boot errors on anything else.
+# MIN_CONFIDENCE: 0..100 word-confidence floor; words below it are
+# dropped from the stored text and the drop is stated in it. Both are
+# OUTPUT knobs — changing either forks the processor idempotency key, so
+# assets are re-read rather than left under stale text.
+#EVIDENCE_OCR_ENABLED=0
+#EVIDENCE_OCR_LANGS=eng
+#EVIDENCE_OCR_MIN_CONFIDENCE=60
 
 # ── Multilingual (Tier 1, migration 0100) ────────────────────────────────
 # Confidence-aware attribution: the detector returns `und` (not `en`) for

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,27 @@ WORKDIR /app
 COPY package.json pnpm-lock.yaml* ./
 # Runtime stage: same allowlist semantics as the builder — the prod
 # install still needs sharp + onnxruntime-node native binaries.
+#
+# OCR ASSETS RIDE THIS INSTALL, deliberately. The local OCR processor
+# (src/evidence/processing/adapters/ocr.adapter.ts) must never reach the
+# network, and tesseract.js is CDN-first by default: unless told
+# otherwise it fetches its WASM core and each language's ~3-11 MB
+# `.traineddata` from jsDelivr on first use. Rather than add a build-time
+# download step (a new network dependency, its own checksum problem, and
+# an image that differs from what a developer runs locally), the assets
+# are ordinary dependencies: `tesseract.js-core` carries the WASM, and
+# `@tesseract.js-data/{eng,rus}` carry the models. `pnpm install
+# --frozen-lockfile --prod` therefore places them on local disk, pinned
+# by integrity hash like everything else, with NO extra layer here — the
+# adapter resolves them through require.resolve and asserts they are
+# present before starting the engine. Cost: ~68 MB (core ~43, eng ~13,
+# rus ~11, tesseract.js ~2).
+#
+# `onlyBuiltDependencies` matters here in the negative: tesseract.js
+# declares a `postinstall` (an OpenCollective donation banner). It is NOT
+# in the allowlist and must not be added — nothing in the OCR path needs
+# it, and the allowlist is exactly the control that keeps an unreviewed
+# install script from running in the image.
 RUN corepack enable && pnpm install --frozen-lockfile --prod
 
 COPY --from=builder /app/dist ./dist

--- a/docs/domain-packs.md
+++ b/docs/domain-packs.md
@@ -689,22 +689,39 @@ media contract (as of 0.3.0), not a stub:
 ### Media contracts (`modalities` / `processors` / `rawEvidence`)
 
 What each pack declares its domain can PERCEIVE, which core-owned
-capabilities it asks for, and whether raw bytes may ever serve. Only two
-processor capabilities are declared anywhere in the library, because only
-two adapters exist: `image → caption` (image metadata) and
-`document → text` (text extraction). OCR, ASR and vision captioning are
-deliberately undeclared — declaring a capability with no adapter arms a
-dispatch that always denies.
+capabilities it asks for, and whether raw bytes may ever serve. A pack may
+only declare a capability an installed adapter can actually run —
+declaring one with no adapter arms a dispatch that always denies. Three
+exist today: `image → caption` (image metadata), `document → text` (text
+extraction / PDF), and `image → ocr` (local tesseract.js). ASR, object
+tracking and scene graphs remain deliberately undeclared.
 
 | pack | version | modalities | processors | rawEvidence | why |
 |---|---|---|---|---|---|
-| `real_estate` | 0.3.0 | text, image, document | image metadata, document text | **serve** | listing photos and floor plans are published marketing material |
-| `medical` | 0.3.0 | text, image, document | image metadata, document text | deny | scans and X-ray photographs are clinical data — never served raw |
-| `insurance` | 0.3.0 | text, image, document | image metadata, document text | deny | claim photos carry injuries, plates, bystanders |
-| `legal` | 0.3.0 | text, image, document | document text, image metadata | deny | contracts, filings and scanned exhibits carry privilege |
-| `fintech` | 0.3.0 | text, document | document text | deny | statements and KYC files; `image` withheld (biometric-adjacent) |
-| `hr` | 0.3.0 | text, document | document text | deny | CVs and offer letters are personal data; `image` withheld |
-| `code_memory` (builtin) | 0.5.0 | text, image, document | image metadata, document text | deny | failure/dashboard screenshots + log artifacts |
+| `real_estate` | 0.4.0 | text, image, document | image metadata, document text, **ocr** | **serve** | listing photos and floor plans are published marketing material; a floor plan's content IS its lettering |
+| `medical` | 0.4.0 | text, image, document | image metadata, document text, **ocr** | deny | scans and X-ray photographs are clinical data — never served raw, but a scan's findings are printed on it |
+| `insurance` | 0.4.0 | text, image, document | image metadata, document text, **ocr** | deny | claim photos carry injuries, plates, bystanders — and repair estimates, policy numbers, receipts |
+| `legal` | 0.4.0 | text, image, document | document text, image metadata, **ocr** | deny | contracts, filings and scanned exhibits carry privilege; an exhibit has no text layer |
+| `fintech` | 0.3.0 | text, document | document text | deny | statements and KYC files; `image` withheld (biometric-adjacent), so no ocr |
+| `hr` | 0.3.0 | text, document | document text | deny | CVs and offer letters are personal data; `image` withheld, so no ocr |
+| `code_memory` (builtin) | 0.6.0 | text, image, document | image metadata, document text, **ocr** | deny | failure/dashboard screenshots + log artifacts; the text in a screenshot is the whole point of it |
+
+The `ocr` capability needs `EVIDENCE_OCR_ENABLED` on top of the usual
+ladder (`EVIDENCE_PROCESSOR_BROKER`, pack declaration, current modality
+consent, quarantine, tombstone): recognition is CPU-heavy where the other
+two adapters are header reads, so it is an operator opt-in. Everything it
+uses — the WASM core and the `.traineddata` models — is a lockfile-pinned
+npm dependency read off local disk; nothing is ever downloaded at runtime.
+Languages shipped: `eng` (default) and `rus`, selected with
+`EVIDENCE_OCR_LANGS`. Words scoring below `EVIDENCE_OCR_MIN_CONFIDENCE`
+(0..100, default 60) are dropped from the stored text and the drop is
+stated in it; an image with nothing above the floor fails the run rather
+than storing invented characters.
+
+Note the version bumps: adding a processor changes the media section, so
+the modality-consent checksum changes with it and an installed tenant
+must re-accept (`--accept-modalities`) before the new capability
+dispatches. That is the consent surface working as designed.
 
 `rawEvidence: deny` is the *absence* of the field — the schema's only
 other value is `{ "serve": true }`, so omission is how a pack refuses.

--- a/package.json
+++ b/package.json
@@ -82,6 +82,8 @@
     "@opentelemetry/resources": "^2.11.0",
     "@opentelemetry/sdk-node": "^0.222.0",
     "@opentelemetry/semantic-conventions": "^1.43.0",
+    "@tesseract.js-data/eng": "1.0.0",
+    "@tesseract.js-data/rus": "1.0.0",
     "@xenova/transformers": "^2.17.2",
     "chrono-node": "^2.10.0",
     "class-transformer": "^0.5.1",
@@ -97,6 +99,7 @@
     "rxjs": "^7.8.2",
     "sharp": "^0.35.4",
     "surrealdb": "^2.0.8",
+    "tesseract.js": "7.0.0",
     "zod": "^4.5.4"
   },
   "devDependencies": {

--- a/packs/insurance.pack.json
+++ b/packs/insurance.pack.json
@@ -1,6 +1,6 @@
 {
   "id": "insurance",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Insurance ontology — coverage, limits, premiums, deductibles, and exclusions of policies, with a domain extraction profile and memory model.",
   "predicates": [
     {
@@ -308,6 +308,13 @@
         "modality": "document",
         "produces": [
           "text"
+        ]
+      },
+      {
+        "id": "image_ocr",
+        "modality": "image",
+        "produces": [
+          "ocr"
         ]
       }
     ]

--- a/packs/legal.pack.json
+++ b/packs/legal.pack.json
@@ -1,6 +1,6 @@
 {
   "id": "legal",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Legal / contracts ontology — governing law, parties, obligations, and term of agreements, with a domain extraction profile and memory model.",
   "predicates": [
     {
@@ -327,6 +327,13 @@
         "modality": "image",
         "produces": [
           "caption"
+        ]
+      },
+      {
+        "id": "image_ocr",
+        "modality": "image",
+        "produces": [
+          "ocr"
         ]
       }
     ]

--- a/packs/medical.pack.json
+++ b/packs/medical.pack.json
@@ -1,6 +1,6 @@
 {
   "id": "medical",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Clinical pharmacology ontology — indications, dosing, routes, interactions, and contraindications of drugs/treatments, with a domain extraction profile and memory model.",
   "predicates": [
     {
@@ -300,6 +300,13 @@
         "modality": "document",
         "produces": [
           "text"
+        ]
+      },
+      {
+        "id": "image_ocr",
+        "modality": "image",
+        "produces": [
+          "ocr"
         ]
       }
     ]

--- a/packs/real-estate.pack.json
+++ b/packs/real-estate.pack.json
@@ -1,6 +1,6 @@
 {
   "id": "real_estate",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Real-estate ontology — zoning, valuation, encumbrances, tenure, and construction of properties/parcels, with a domain extraction profile and memory model.",
   "predicates": [
     {
@@ -338,6 +338,13 @@
         "modality": "document",
         "produces": [
           "text"
+        ]
+      },
+      {
+        "id": "image_ocr",
+        "modality": "image",
+        "produces": [
+          "ocr"
         ]
       }
     ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -77,6 +77,12 @@ importers:
       '@opentelemetry/semantic-conventions':
         specifier: ^1.43.0
         version: 1.43.0
+      '@tesseract.js-data/eng':
+        specifier: 1.0.0
+        version: 1.0.0
+      '@tesseract.js-data/rus':
+        specifier: 1.0.0
+        version: 1.0.0
       '@xenova/transformers':
         specifier: ^2.17.2
         version: 2.17.2(@types/node@22.19.17)
@@ -122,6 +128,9 @@ importers:
       surrealdb:
         specifier: ^2.0.8
         version: 2.0.8(tslib@2.8.1)(typescript@5.9.3)
+      tesseract.js:
+        specifier: 7.0.0
+        version: 7.0.0
       zod:
         specifier: ^4.5.4
         version: 4.5.4
@@ -1696,6 +1705,12 @@ packages:
       tslib: ^2.6.3
       typescript: ^5.0.0
 
+  '@tesseract.js-data/eng@1.0.0':
+    resolution: {integrity: sha512-mbTumm6KQPUHyzTPQaF3ObXYnx0SqqfV2nabqFVQBwD6Kl7PhGSLSzOlfFTWy0P3BjghaSKA2W9GB19Jk+ZcTg==}
+
+  '@tesseract.js-data/rus@1.0.0':
+    resolution: {integrity: sha512-GVOaLultru90gsuVGjXyPCKsg4SMeExnqSnzb8Gb+9zZ0F4wbA6bgWu/metQlcmU7OwTnYVd4UdSH9D4yBMZEA==}
+
   '@tokenizer/inflate@0.4.1':
     resolution: {integrity: sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==}
     engines: {node: '>=18'}
@@ -2349,6 +2364,9 @@ packages:
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
+  bmp-js@0.1.0:
+    resolution: {integrity: sha512-vHdS19CnY3hwiNdkaqk93DvjVLfbEcI8mys4UjuWrlX1haDmroo8o4xCzh4wD6DGV6HxRCyauwhHRqMTfERtjw==}
 
   body-parser@2.3.0:
     resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
@@ -3290,6 +3308,9 @@ packages:
     resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
     engines: {node: '>=0.10.0'}
 
+  idb-keyval@6.3.0:
+    resolution: {integrity: sha512-um+2dgAWmYsu615EXpWVwSmapJhON0G43t3Ka/EVaohzPQXSMqKEqeDK/oIW3Ow+BXaF2PvSc+oBTFp793A5Ow==}
+
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
@@ -3450,6 +3471,9 @@ packages:
   is-unicode-supported@0.1.0:
     resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
     engines: {node: '>=10'}
+
+  is-url@1.2.4:
+    resolution: {integrity: sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww==}
 
   is-weakmap@2.0.2:
     resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
@@ -3927,6 +3951,15 @@ packages:
     resolution: {integrity: sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==}
     engines: {node: '>= 0.4'}
 
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
   node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -4030,6 +4063,10 @@ packages:
       zod:
         optional: true
 
+  opencollective-postinstall@2.0.3:
+    resolution: {integrity: sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==}
+    hasBin: true
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -4107,6 +4144,7 @@ packages:
     resolution: {integrity: sha512-QErPemxRHDI2RUli3+9/mv4V6Ib9VWI+UoP2S82yXEQtoXzWvu9NSjjo3vyiUiVJv+CJFuzNiKUI+UFFUdv8Lg==}
     engines: {node: '>=20.18.0'}
     hasBin: true
+    bundledDependencies: []
 
   pg-int8@1.0.1:
     resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
@@ -4285,6 +4323,9 @@ packages:
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
     engines: {node: '>= 0.4'}
+
+  regenerator-runtime@0.13.11:
+    resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
 
   regexp-ast-analysis@0.7.1:
     resolution: {integrity: sha512-sZuz1dYW/ZsfG17WSAG7eS85r5a0dDsvg+7BiiYR5o6lKCAtUrEwdmRmaGF6rwVj3LcmAeYkOWKEPlbPzN3Y3A==}
@@ -4673,6 +4714,12 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  tesseract.js-core@7.0.0:
+    resolution: {integrity: sha512-WnNH518NzmbSq9zgTPeoF8c+xmilS8rFIl1YKbk/ptuuc7p6cLNELNuPAzcmsYw450ca6bLa8j3t0VAtq435Vw==}
+
+  tesseract.js@7.0.0:
+    resolution: {integrity: sha512-exPBkd+z+wM1BuMkx/Bjv43OeLBxhL5kKWsz/9JY+DXcXdiBjiAch0V49QR3oAJqCaL5qURE0vx9Eo+G5YE7mA==}
+
   test-exclude@7.0.2:
     resolution: {integrity: sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==}
     engines: {node: '>=18'}
@@ -4699,6 +4746,9 @@ packages:
   token-types@6.1.2:
     resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
     engines: {node: '>=14.16'}
+
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
   ts-algebra@2.0.0:
     resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
@@ -4908,6 +4958,9 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
+  wasm-feature-detect@1.9.0:
+    resolution: {integrity: sha512-zonE+xlIIYtxPy++L24ow0hAD8CICb4+FgPyROd3buyXIqsJvUEDkBgfCCoXOd1Hu3DUr0GOfnPIdcGV+YpNaA==}
+
   watchpack@2.5.2:
     resolution: {integrity: sha512-6i/00NBjP4yGPs+caKSyRfpTF/8Torsu0MOW3mMzIbhgISFder8i7xbqgHlLMwJrdiN8ndBV3UA1/AfzPSr+jg==}
     engines: {node: '>=10.13.0'}
@@ -4918,6 +4971,9 @@ packages:
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
+
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
   webpack-node-externals@3.0.0:
     resolution: {integrity: sha512-LnL6Z3GGDPht/AigwRh2dvL9PQPFQ8skEpVrWZXLWBYmqcaojHNN0onvHzie6rq7EWKrrBfPYqNEzTJgiwEQDQ==}
@@ -4936,6 +4992,9 @@ packages:
     peerDependenciesMeta:
       webpack-cli:
         optional: true
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -5023,6 +5082,9 @@ packages:
   zip-stream@6.0.1:
     resolution: {integrity: sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==}
     engines: {node: '>= 14'}
+
+  zlibjs@0.3.1:
+    resolution: {integrity: sha512-+J9RrgTKOmlxFSDHo0pI1xM6BLVUv+o0ZT9ANtCxGkjIVCCUdx9alUF8Gm+dGLKbkkkidWIHFDZHDMpfITt4+w==}
 
   zod-to-json-schema@3.25.2:
     resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
@@ -6854,6 +6916,10 @@ snapshots:
       typescript: 5.9.3
       uuidv7: 1.2.1
 
+  '@tesseract.js-data/eng@1.0.0': {}
+
+  '@tesseract.js-data/rus@1.0.0': {}
+
   '@tokenizer/inflate@0.4.1':
     dependencies:
       debug: 4.4.3
@@ -7596,6 +7662,8 @@ snapshots:
       buffer: 5.7.1
       inherits: 2.0.4
       readable-stream: 3.6.2
+
+  bmp-js@0.1.0: {}
 
   body-parser@2.3.0:
     dependencies:
@@ -8658,6 +8726,8 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  idb-keyval@6.3.0: {}
+
   ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
@@ -8810,6 +8880,8 @@ snapshots:
       which-typed-array: 1.1.22
 
   is-unicode-supported@0.1.0: {}
+
+  is-url@1.2.4: {}
 
   is-weakmap@2.0.2: {}
 
@@ -9445,6 +9517,10 @@ snapshots:
       object.entries: 1.1.9
       semver: 6.3.1
 
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
   node-fetch@3.3.2:
     dependencies:
       data-uri-to-buffer: 4.0.1
@@ -9541,6 +9617,8 @@ snapshots:
     optionalDependencies:
       undici: 7.29.0
       zod: 4.5.4
+
+  opencollective-postinstall@2.0.3: {}
 
   optionator@0.9.4:
     dependencies:
@@ -9820,6 +9898,8 @@ snapshots:
       get-intrinsic: 1.3.0
       get-proto: 1.0.1
       which-builtin-type: 1.2.1
+
+  regenerator-runtime@0.13.11: {}
 
   regexp-ast-analysis@0.7.1:
     dependencies:
@@ -10298,6 +10378,22 @@ snapshots:
       commander: 2.20.3
       source-map-support: 0.5.21
 
+  tesseract.js-core@7.0.0: {}
+
+  tesseract.js@7.0.0:
+    dependencies:
+      bmp-js: 0.1.0
+      idb-keyval: 6.3.0
+      is-url: 1.2.4
+      node-fetch: 2.7.0
+      opencollective-postinstall: 2.0.3
+      regenerator-runtime: 0.13.11
+      tesseract.js-core: 7.0.0
+      wasm-feature-detect: 1.9.0
+      zlibjs: 0.3.1
+    transitivePeerDependencies:
+      - encoding
+
   test-exclude@7.0.2:
     dependencies:
       '@istanbuljs/schema': 0.1.6
@@ -10347,6 +10443,8 @@ snapshots:
       '@borewit/text-codec': 0.2.2
       '@tokenizer/token': 0.3.0
       ieee754: 1.2.1
+
+  tr46@0.0.3: {}
 
   ts-algebra@2.0.0: {}
 
@@ -10578,6 +10676,8 @@ snapshots:
 
   vary@1.1.2: {}
 
+  wasm-feature-detect@1.9.0: {}
+
   watchpack@2.5.2:
     dependencies:
       graceful-fs: 4.2.11
@@ -10587,6 +10687,8 @@ snapshots:
       defaults: 1.0.4
 
   web-streams-polyfill@3.3.3: {}
+
+  webidl-conversions@3.0.1: {}
 
   webpack-node-externals@3.0.0: {}
 
@@ -10631,6 +10733,11 @@ snapshots:
       - lightningcss
       - postcss
       - uglify-js
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   which-boxed-primitive@1.1.1:
     dependencies:
@@ -10737,6 +10844,8 @@ snapshots:
       archiver-utils: 5.0.2
       compress-commons: 6.0.2
       readable-stream: 4.7.0
+
+  zlibjs@0.3.1: {}
 
   zod-to-json-schema@3.25.2(zod@4.5.4):
     dependencies:

--- a/src/ai/domain-packs/code-memory.pack.ts
+++ b/src/ai/domain-packs/code-memory.pack.ts
@@ -9,15 +9,21 @@ import { composePredicateId, type DomainPackManifest } from './manifest';
  *
  * As of 0.5.0 the memoryModel carries a MEDIA CONTRACT: failure/dashboard
  * screenshots and text-ish artifacts (logs, traces) as input modalities,
- * the two core capabilities the Evidence Plane can actually run (image
- * metadata, document text), and NO raw-evidence declaration. NOTE the
+ * the core capabilities the Evidence Plane can actually run, and NO
+ * raw-evidence declaration. 0.6.0 adds `ocr` now that a local OCR
+ * processor exists — a screenshot of a red CI pane is this domain's most
+ * common attachment and its text is the whole point of it. NOTE the
  * builtin caveat: builtins never pass through DomainPackInstallService, so
  * no `domain_pack` consent row exists for this pack — MemoryModelReader-
  * Service surfaces the declaration through its builtin union, but both
  * media gates still deny at their consent clause until a consent path for
  * builtins lands. The declaration is the contract, not an activation.
  *
- * 0.6.0 corrects a DOMAIN MODELLING ERROR: `invariant` shipped as
+ * 0.6.0 carries a SECOND, independent change that landed in the same
+ * release window as the `ocr` declaration above — one bump, not two
+ * stacked, so a consumer moves from 0.5.0 to 0.6.0 once.
+ *
+ * It corrects a DOMAIN MODELLING ERROR: `invariant` shipped as
  * `single_active` from the very first version, which silently made every
  * newly recorded constraint retire the previous one. A module's
  * invariants coexist, so that was data loss with nothing gained — there
@@ -345,6 +351,14 @@ never split its clauses across facts or predicates.`,
     processors: [
       { id: 'image_metadata', modality: 'image', produces: ['caption'] },
       { id: 'document_text', modality: 'document', produces: ['text'] },
+      // 0.6.0: the screenshot is this domain's native artefact. A red CI
+      // pane, a stack trace pasted as a picture, a dashboard at the
+      // moment it went wrong — engineers attach these constantly, and the
+      // one thing that makes them worth attaching is the TEXT in them:
+      // the failing assertion, the error code, the metric name. Without
+      // OCR the pack stores a picture of the answer to "why did this
+      // break", which is exactly the non-derivable "why" it exists for.
+      { id: 'image_ocr', modality: 'image', produces: ['ocr'] },
     ],
     // rawEvidence is DELIBERATELY ABSENT (omission = deny). A builtin is
     // seeded into EVERY tenant without an install decision, so it is the

--- a/src/ai/domain-packs/insurance.pack.ts
+++ b/src/ai/domain-packs/insurance.pack.ts
@@ -8,16 +8,17 @@ import type { DomainPackManifest } from './manifest';
  * retention hints, recency rules for premium and coverage claims).
  *
  * As of 0.3.0 the memoryModel also carries a MEDIA CONTRACT: claim
- * photographs and policy documents as input modalities, the two core
- * capabilities the Evidence Plane can actually run (image metadata,
- * document text), and NO raw-evidence declaration — a claim photo
- * routinely carries third-party personal data.
+ * photographs and policy documents as input modalities, the core
+ * capabilities the Evidence Plane can actually run, and NO raw-evidence
+ * declaration — a claim photo routinely carries third-party personal
+ * data. 0.4.0 adds `ocr` now that a local OCR processor exists: most of
+ * what a claim photo is worth is the text printed inside it.
  *
  * Bump `version` to ship an update.
  */
 export const INSURANCE_PACK: DomainPackManifest = {
   id: 'insurance',
-  version: '0.3.0',
+  version: '0.4.0',
   description:
     'Insurance ontology — coverage, limits, premiums, deductibles, and exclusions of policies, with a domain extraction profile and memory model.',
   predicates: [
@@ -195,6 +196,14 @@ what it EXCLUDES.`,
     processors: [
       { id: 'image_metadata', modality: 'image', produces: ['caption'] },
       { id: 'document_text', modality: 'document', produces: ['text'] },
+      // 0.4.0: claim evidence is photographic by nature, and much of what
+      // matters in it is TEXT inside the photo — a repair estimate on a
+      // clipboard, a policy number on a windscreen sticker, a serial
+      // plate, a receipt. Reading those is the difference between a claim
+      // photo the plane can only store and one it can reason about.
+      // (Raw serving stays denied — see the rawEvidence note below; OCR
+      // yields recomputable derived text, never the original pixels.)
+      { id: 'image_ocr', modality: 'image', produces: ['ocr'] },
     ],
     // rawEvidence is DELIBERATELY ABSENT (omission = deny). Claim
     // photography routinely captures injuries, plates, and bystanders —

--- a/src/ai/domain-packs/legal.pack.ts
+++ b/src/ai/domain-packs/legal.pack.ts
@@ -9,16 +9,17 @@ import type { DomainPackManifest } from './manifest';
  * termination and effective-date claims).
  *
  * As of 0.3.0 the memoryModel also carries a MEDIA CONTRACT: contracts and
- * filings as documents, scanned exhibits as images, the two core
- * capabilities the Evidence Plane can actually run (document text, image
- * metadata), and NO raw-evidence declaration — an exhibit's bytes carry
- * privilege.
+ * filings as documents, scanned exhibits as images, the core capabilities
+ * the Evidence Plane can actually run, and NO raw-evidence declaration —
+ * an exhibit's bytes carry privilege. 0.4.0 adds `ocr` now that a local
+ * OCR processor exists: a scanned exhibit has no text layer, so it was
+ * legible to nothing in the plane before.
  *
  * Bump `version` to ship an update.
  */
 export const LEGAL_PACK: DomainPackManifest = {
   id: 'legal',
-  version: '0.3.0',
+  version: '0.4.0',
   description:
     'Legal / contracts ontology — governing law, parties, obligations, and term of agreements, with a domain extraction profile and memory model.',
   predicates: [
@@ -211,6 +212,12 @@ an agreement, emit an edge between them in addition to the party facts.`,
     processors: [
       { id: 'document_text', modality: 'document', produces: ['text'] },
       { id: 'image_metadata', modality: 'image', produces: ['caption'] },
+      // 0.4.0: exhibits are the archetypal scanned artefact — a signature
+      // page photographed on a phone, an executed agreement scanned to
+      // TIFF, an annexe delivered as a flat image. `document_text`
+      // extracts nothing from them (no text layer) and the governing law,
+      // parties and dates this pack extracts are printed on the page.
+      { id: 'image_ocr', modality: 'image', produces: ['ocr'] },
     ],
     // rawEvidence is DELIBERATELY ABSENT (omission = deny). Exhibits and
     // executed agreements carry privilege and counterparty personal data;

--- a/src/ai/domain-packs/medical.pack.ts
+++ b/src/ai/domain-packs/medical.pack.ts
@@ -10,15 +10,17 @@ import type { DomainPackManifest } from './manifest';
  * rule for dosage claims and a corroboration rule for contraindications).
  *
  * As of 0.3.0 the memoryModel also carries a MEDIA CONTRACT: imaging and
- * document scans as input modalities, the two core capabilities the
- * Evidence Plane can actually run (image metadata, document text), and NO
- * raw-evidence declaration — clinical images never serve raw.
+ * document scans as input modalities, the core capabilities the Evidence
+ * Plane can actually run, and NO raw-evidence declaration — clinical
+ * images never serve raw. 0.4.0 adds `ocr` now that a local OCR processor
+ * exists: a scan carries its findings as pixels, and reading them is the
+ * only way this pack's predicates ever see them.
  *
  * Bump `version` to update.
  */
 export const MEDICAL_PACK: DomainPackManifest = {
   id: 'medical',
-  version: '0.3.0',
+  version: '0.4.0',
   description:
     'Clinical pharmacology ontology — indications, dosing, routes, interactions, and contraindications of drugs/treatments, with a domain extraction profile and memory model.',
   predicates: [
@@ -200,6 +202,13 @@ pack captures drug ontology, not clinical records.`,
     processors: [
       { id: 'image_metadata', modality: 'image', produces: ['caption'] },
       { id: 'document_text', modality: 'document', produces: ['text'] },
+      // 0.4.0: a clinical scan, a photographed lab report, a discharge
+      // summary faxed as a TIFF — all arrive as IMAGE bytes with no text
+      // layer, so `document_text` never sees them and `image_metadata`
+      // can only say "2480x3508 greyscale TIFF". The values, units and
+      // drug names that this pack's predicates exist to hold are printed
+      // on the page and nowhere else; without OCR they are unreadable.
+      { id: 'image_ocr', modality: 'image', produces: ['ocr'] },
     ],
     // rawEvidence is DELIBERATELY ABSENT — the most conservative setting
     // the schema offers (the only other legal value is `{ serve: true }`;

--- a/src/ai/domain-packs/real-estate.pack.ts
+++ b/src/ai/domain-packs/real-estate.pack.ts
@@ -20,16 +20,18 @@ import type { DomainPackManifest } from './manifest';
  * MemoryModelReaderService for installed tenants.
  *
  * As of 0.3.0 the memoryModel also carries a MEDIA CONTRACT: listing
- * photography and floor-plan documents as input modalities, the two core
- * capabilities the Evidence Plane can actually run (image metadata,
- * document text), and `rawEvidence: { serve: true }` — listing media is
- * published marketing material whose whole purpose is to be looked at.
+ * photography and floor-plan documents as input modalities, the core
+ * capabilities the Evidence Plane can actually run, and
+ * `rawEvidence: { serve: true }` — listing media is published marketing
+ * material whose whole purpose is to be looked at. 0.4.0 adds `ocr` now
+ * that a local OCR processor exists: a floor plan's entire content is
+ * lettering, and a caption of one says nothing a buyer asked.
  *
  * Bump `version` to ship an updated real-estate ontology / profile.
  */
 export const REAL_ESTATE_PACK: DomainPackManifest = {
   id: 'real_estate',
-  version: '0.3.0',
+  version: '0.4.0',
   description:
     'Real-estate ontology — zoning, valuation, encumbrances, tenure, and construction of properties/parcels, with a domain extraction profile and memory model.',
   predicates: [
@@ -228,6 +230,13 @@ encumbrance, ALSO emit an edge to that party (e.g. Property —held_by→ Bank).
     processors: [
       { id: 'image_metadata', modality: 'image', produces: ['caption'] },
       { id: 'document_text', modality: 'document', produces: ['text'] },
+      // 0.4.0: a floor plan is a picture whose entire information content
+      // is lettering — room labels, dimension strings, a scale bar, a
+      // unit number. So is a site-plan crop, a zoning map extract, or the
+      // price panel of a listing sheet exported as JPEG. The pack's own
+      // predicates (zoning class, valuation, tenure) read off exactly
+      // those strings, and nothing but OCR puts them in reach.
+      { id: 'image_ocr', modality: 'image', produces: ['ocr'] },
     ],
     // The one first-party pack that declares raw serving: a listing photo
     // or floor plan is published marketing material, and an agent asking

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -1,5 +1,5 @@
 import { Logger } from '@nestjs/common';
-import { validateEvidenceOrphanGcEnv } from './evidence-flags';
+import { validateEvidenceOrphanGcEnv, validateOcrEnvValues } from './evidence-flags';
 import { isProcessRole, normalizeProcessRole } from './process-role';
 
 const log = new Logger('EnvValidation');
@@ -271,8 +271,9 @@ export function validateEnv(env: NodeJS.ProcessEnv = process.env): void {
   positiveInt(env, 'EVIDENCE_ORPHAN_BLOB_GC_GRACE_HOURS', errors);
   positiveInt(env, 'EVIDENCE_ORPHAN_BLOB_GC_MAX_DELETIONS', errors);
   positiveInt(env, 'EVIDENCE_ORPHAN_BLOB_GC_TIME_BUDGET_MS', errors);
-  // Local OCR processor knobs, same clamp contract.
-  validateEvidenceOcrEnv(env, errors);
+  // Local OCR processor knobs, same clamp contract (the validator lives
+  // beside its readers in evidence-flags.ts — see the note there).
+  validateOcrEnvValues(env, errors);
 
   // ── Retrieval profile (per-tenant genre configuration) ─────────────
   validateRetrievalProfileEnv(env, errors);
@@ -530,48 +531,6 @@ function validateEvidenceRawReadEnv(
     );
   }
 }
-
-/**
- * Local OCR processor knobs (EVIDENCE_OCR_*). ERRORS, not warnings: both
- * values are read at call time with a clamp-to-default fallback, so a
- * typo would otherwise run OCR under settings the operator did not
- * choose — a silently different confidence floor stores different text,
- * and an unshipped language code silently drops back to English. Boot is
- * the only place that can say so out loud. The language allowlist is
- * duplicated as a literal rather than imported from the adapter layer:
- * env-validation must stay importable with no evidence/-side deps.
- */
-function validateEvidenceOcrEnv(env: NodeJS.ProcessEnv, errors: string[]): void {
-  const floor = env.EVIDENCE_OCR_MIN_CONFIDENCE;
-  if (floor !== undefined && floor.trim() !== '') {
-    const v = Number(floor);
-    if (!Number.isInteger(v) || v < 0 || v > 100) {
-      errors.push('EVIDENCE_OCR_MIN_CONFIDENCE must be an integer in 0..100');
-    }
-  }
-  const langs = env.EVIDENCE_OCR_LANGS;
-  if (langs === undefined || langs.trim() === '') return;
-  const codes = langs
-    .split(/[+,]/)
-    .map((part) => part.trim().toLowerCase())
-    .filter((part) => part !== '');
-  if (codes.length === 0) {
-    errors.push('EVIDENCE_OCR_LANGS must name at least one language');
-    return;
-  }
-  const unknown = codes.filter((code) => !SHIPPED_OCR_LANGUAGES.includes(code));
-  if (unknown.length > 0) {
-    errors.push(
-      `EVIDENCE_OCR_LANGS names languages this build does not ship ` +
-        `(${unknown.join(', ')}) — available: ${SHIPPED_OCR_LANGUAGES.join(', ')}. ` +
-        'OCR models are never downloaded at runtime.',
-    );
-  }
-}
-
-/** Kept in lockstep with OCR_SUPPORTED_LANGUAGES in
- *  src/evidence/processing/adapters/ocr-assets.ts (a spec pins the pair). */
-const SHIPPED_OCR_LANGUAGES = ['eng', 'rus'];
 
 /**
  * Cross-flag consistency for the evidence ingest surface (Brain v2.1

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -271,6 +271,8 @@ export function validateEnv(env: NodeJS.ProcessEnv = process.env): void {
   positiveInt(env, 'EVIDENCE_ORPHAN_BLOB_GC_GRACE_HOURS', errors);
   positiveInt(env, 'EVIDENCE_ORPHAN_BLOB_GC_MAX_DELETIONS', errors);
   positiveInt(env, 'EVIDENCE_ORPHAN_BLOB_GC_TIME_BUDGET_MS', errors);
+  // Local OCR processor knobs, same clamp contract.
+  validateEvidenceOcrEnv(env, errors);
 
   // ── Retrieval profile (per-tenant genre configuration) ─────────────
   validateRetrievalProfileEnv(env, errors);
@@ -528,6 +530,48 @@ function validateEvidenceRawReadEnv(
     );
   }
 }
+
+/**
+ * Local OCR processor knobs (EVIDENCE_OCR_*). ERRORS, not warnings: both
+ * values are read at call time with a clamp-to-default fallback, so a
+ * typo would otherwise run OCR under settings the operator did not
+ * choose — a silently different confidence floor stores different text,
+ * and an unshipped language code silently drops back to English. Boot is
+ * the only place that can say so out loud. The language allowlist is
+ * duplicated as a literal rather than imported from the adapter layer:
+ * env-validation must stay importable with no evidence/-side deps.
+ */
+function validateEvidenceOcrEnv(env: NodeJS.ProcessEnv, errors: string[]): void {
+  const floor = env.EVIDENCE_OCR_MIN_CONFIDENCE;
+  if (floor !== undefined && floor.trim() !== '') {
+    const v = Number(floor);
+    if (!Number.isInteger(v) || v < 0 || v > 100) {
+      errors.push('EVIDENCE_OCR_MIN_CONFIDENCE must be an integer in 0..100');
+    }
+  }
+  const langs = env.EVIDENCE_OCR_LANGS;
+  if (langs === undefined || langs.trim() === '') return;
+  const codes = langs
+    .split(/[+,]/)
+    .map((part) => part.trim().toLowerCase())
+    .filter((part) => part !== '');
+  if (codes.length === 0) {
+    errors.push('EVIDENCE_OCR_LANGS must name at least one language');
+    return;
+  }
+  const unknown = codes.filter((code) => !SHIPPED_OCR_LANGUAGES.includes(code));
+  if (unknown.length > 0) {
+    errors.push(
+      `EVIDENCE_OCR_LANGS names languages this build does not ship ` +
+        `(${unknown.join(', ')}) — available: ${SHIPPED_OCR_LANGUAGES.join(', ')}. ` +
+        'OCR models are never downloaded at runtime.',
+    );
+  }
+}
+
+/** Kept in lockstep with OCR_SUPPORTED_LANGUAGES in
+ *  src/evidence/processing/adapters/ocr-assets.ts (a spec pins the pair). */
+const SHIPPED_OCR_LANGUAGES = ['eng', 'rus'];
 
 /**
  * Cross-flag consistency for the evidence ingest surface (Brain v2.1
@@ -1339,6 +1383,17 @@ const KNOWN_BOOLEAN_FLAGS = [
   'EVIDENCE_ORPHAN_BLOB_GC',
   'EVIDENCE_ORPHAN_BLOB_GC_DELETE',
   'EVIDENCE_ORPHAN_BLOB_GC_SCHEDULED',
+  // Local OCR processor: OcrAdapter offers the 'ocr' capability for image
+  // assets (tesseract.js WASM, models read off local disk — no network,
+  // ever). Default off ⇒ accepts() declines before any engine is touched
+  // and the broker records the same `no installed processor` denial it
+  // records today, byte-identical. It carries its own switch — unlike its
+  // sibling adapters — because recognition is CPU- and memory-heavy where
+  // theirs are header reads. The language set (EVIDENCE_OCR_LANGS) and
+  // confidence floor (EVIDENCE_OCR_MIN_CONFIDENCE) are a string and an
+  // int, not booleans (validateEvidenceOcrEnv). EVIDENCE_ family sits off
+  // the ENGINE flag budget by design (see above).
+  'EVIDENCE_OCR_ENABLED',
   // Representation embeddings: the write-side producer for
   // derived_representation.embedding (WRITE-DEAD since 0109), which is
   // what the fragment lane's dense leg reads. Off (default) = the

--- a/src/common/evidence-flags.ts
+++ b/src/common/evidence-flags.ts
@@ -539,3 +539,96 @@ export function fragmentEmbeddingsEnabled(): boolean {
 export function ungroundedServingGateEnabled(): boolean {
   return envFlagEnabled(process.env.EVIDENCE_UNGROUNDED_SERVING_GATE);
 }
+
+/**
+ * Local OCR processor — EVIDENCE_OCR_ENABLED.
+ *
+ * When on, OcrAdapter offers the 'ocr' capability for image assets: a
+ * fully local tesseract.js (WASM) recognition pass whose per-region text
+ * lands as fragment-anchored derived representations. Off (default) the
+ * adapter's `accepts()` returns false BEFORE any engine is touched, so
+ * the broker records the same `no installed processor` denial it records
+ * today and NOTHING about a dispatch changes — byte-identical prod.
+ *
+ * Why this capability carries a flag when its two sibling adapters (image
+ * metadata, document text) do not: those are header/parse-level decodes
+ * measured in milliseconds, while OCR spins a worker thread, faults in a
+ * ~3.5 MB WASM core plus a ~3 MB language model, and burns CPU
+ * proportional to pixel count. That is an operator's capacity decision,
+ * not a packaging one, so it gets an explicit switch on top of the
+ * existing ladder (pack declaration → modality consent → quarantine →
+ * EVIDENCE_PROCESSOR_BROKER), never instead of it.
+ *
+ * Read at call time (runtime-mutable) so the switch needs no restart;
+ * env read lives here in the common layer per engine-gates S5.2.
+ * EVIDENCE_ family sits off the ENGINE flag budget by design.
+ */
+export function evidenceOcrEnabled(): boolean {
+  return envFlagEnabled(process.env.EVIDENCE_OCR_ENABLED);
+}
+
+/** Default OCR language set. (Named WITHOUT the full env-key substring so
+ *  the W6 boot-capture truth gate doesn't mistake this module-scope
+ *  default for a boot-captured read.) */
+const DEFAULT_OCR_LANGS = 'eng';
+
+/**
+ * OCR language set — EVIDENCE_OCR_LANGS (non-boolean).
+ *
+ * A `+`- or `,`-separated list of tesseract language codes, in PRIORITY
+ * ORDER (tesseract treats the first as primary, so the order is
+ * meaningful and is deliberately NOT sorted). Only languages whose
+ * traineddata ships in the image are accepted — ocr-assets.ts refuses
+ * anything else rather than letting the engine reach a CDN for it. Unset
+ * or blank ⇒ 'eng'.
+ *
+ * This is an OUTPUT knob (a different language set recognises different
+ * characters), so it rides the adapter's configParts() fingerprint: an
+ * operator who adds Russian forks the idempotency key and every asset is
+ * re-read under the new key instead of silently keeping stale English-
+ * only text. Read at call time; common layer per engine-gates S5.2.
+ */
+export function evidenceOcrLanguages(): string[] {
+  const raw = process.env.EVIDENCE_OCR_LANGS;
+  const source = raw === undefined || raw.trim() === '' ? DEFAULT_OCR_LANGS : raw;
+  const seen: string[] = [];
+  for (const part of source.split(/[+,]/)) {
+    const code = part.trim().toLowerCase();
+    if (code !== '' && !seen.includes(code)) seen.push(code);
+  }
+  return seen;
+}
+
+/** Default OCR word-confidence floor, on tesseract's 0..100 scale.
+ *  (Named WITHOUT the full env-key substring — see above.) */
+const DEFAULT_OCR_CONFIDENCE_FLOOR = 60;
+
+/**
+ * OCR confidence floor — EVIDENCE_OCR_MIN_CONFIDENCE (non-boolean),
+ * an integer on tesseract's own 0..100 per-word scale.
+ *
+ * THE POINT OF THE KNOB. An OCR engine always returns SOMETHING: run it
+ * over a photo of a wall and it emits plausible-looking characters with
+ * confidences in the teens. Storing those would put invented text into a
+ * memory that later cites it as observed evidence — the exact failure a
+ * provenance-first plane exists to prevent. Words scoring below this
+ * floor are therefore DROPPED from the emitted text and the drop is
+ * STATED in the region's content (never silently swallowed), and a
+ * region left with nothing is not written at all.
+ *
+ * 60 by default: tesseract's own documentation treats ~60 as the boundary
+ * between a confident read and a guess, and on the synthesised fixtures
+ * clean rendered text scores 80-95 while noise scores well under 40.
+ *
+ * An output knob ⇒ it rides configParts(), so retuning it forks the
+ * idempotency key and re-reads instead of leaving differently-filtered
+ * text under an unchanged key. Must be an integer in 0..100; unset,
+ * blank, or invalid → 60. Read at call time; common layer per
+ * engine-gates S5.2.
+ */
+export function evidenceOcrMinConfidence(): number {
+  const raw = process.env.EVIDENCE_OCR_MIN_CONFIDENCE;
+  if (raw === undefined || raw.trim() === '') return DEFAULT_OCR_CONFIDENCE_FLOOR;
+  const v = Number(raw);
+  return Number.isInteger(v) && v >= 0 && v <= 100 ? v : DEFAULT_OCR_CONFIDENCE_FLOOR;
+}

--- a/src/common/evidence-flags.ts
+++ b/src/common/evidence-flags.ts
@@ -567,6 +567,20 @@ export function evidenceOcrEnabled(): boolean {
   return envFlagEnabled(process.env.EVIDENCE_OCR_ENABLED);
 }
 
+/**
+ * Languages whose `.traineddata` ships in the image. THE authority for
+ * the set — ocr-assets.ts re-exports it rather than keeping a second
+ * copy, and the boot validator below checks against it, so adding a
+ * language is one edit next to one dependency addition.
+ *
+ * It lives in the common layer with the knob that selects from it
+ * (engine-gates S5.2), not in the adapter: boot validation must be able
+ * to reject an unshipped language without importing anything from the
+ * evidence dirs.
+ */
+export const OCR_SUPPORTED_LANGUAGES = ['eng', 'rus'] as const;
+export type OcrLanguage = (typeof OCR_SUPPORTED_LANGUAGES)[number];
+
 /** Default OCR language set. (Named WITHOUT the full env-key substring so
  *  the W6 boot-capture truth gate doesn't mistake this module-scope
  *  default for a boot-captured read.) */
@@ -631,4 +645,46 @@ export function evidenceOcrMinConfidence(): number {
   if (raw === undefined || raw.trim() === '') return DEFAULT_OCR_CONFIDENCE_FLOOR;
   const v = Number(raw);
   return Number.isInteger(v) && v >= 0 && v <= 100 ? v : DEFAULT_OCR_CONFIDENCE_FLOOR;
+}
+
+/**
+ * Boot validation of the two OCR value knobs, dispatched from
+ * validateEnv. It lives HERE, beside the readers whose clamp rules it
+ * mirrors, rather than in the env-validation catalog: the accepted range
+ * and the shipped-language set are defined a few lines up, and a
+ * validator that drifts from its reader is worse than no validator.
+ *
+ * ERRORS, not warnings. Both readers clamp an invalid value back to the
+ * default at call time, so a typo would otherwise run OCR under settings
+ * the operator did not choose — a silently different confidence floor
+ * stores different text, and an unshipped language code silently drops
+ * back to English. Boot is the only place that can say so out loud.
+ */
+export function validateOcrEnvValues(env: NodeJS.ProcessEnv, errors: string[]): void {
+  const floor = env.EVIDENCE_OCR_MIN_CONFIDENCE;
+  if (floor !== undefined && floor.trim() !== '') {
+    const v = Number(floor);
+    if (!Number.isInteger(v) || v < 0 || v > 100) {
+      errors.push('EVIDENCE_OCR_MIN_CONFIDENCE must be an integer in 0..100');
+    }
+  }
+  const langs = env.EVIDENCE_OCR_LANGS;
+  if (langs === undefined || langs.trim() === '') return;
+  const codes = langs
+    .split(/[+,]/)
+    .map((part) => part.trim().toLowerCase())
+    .filter((part) => part !== '');
+  if (codes.length === 0) {
+    errors.push('EVIDENCE_OCR_LANGS must name at least one language');
+    return;
+  }
+  const shipped: readonly string[] = OCR_SUPPORTED_LANGUAGES;
+  const unknown = codes.filter((code) => !shipped.includes(code));
+  if (unknown.length > 0) {
+    errors.push(
+      `EVIDENCE_OCR_LANGS names languages this build does not ship ` +
+        `(${unknown.join(', ')}) — available: ${shipped.join(', ')}. ` +
+        'OCR models are never downloaded at runtime.',
+    );
+  }
 }

--- a/src/evidence/evidence.module.ts
+++ b/src/evidence/evidence.module.ts
@@ -14,6 +14,7 @@ import { EvidenceProcessorBrokerService } from './processor-broker.service';
 import { EvidenceQuarantineService } from './quarantine.service';
 import { DocumentTextAdapter } from './processing/adapters/document-text.adapter';
 import { ImageMetadataAdapter } from './processing/adapters/image-metadata.adapter';
+import { OcrAdapter } from './processing/adapters/ocr.adapter';
 import { TextExtractionPassthroughAdapter } from './processing/adapters/text-extraction-passthrough.adapter';
 import {
   EVIDENCE_PROCESSOR_ADAPTERS,
@@ -69,7 +70,16 @@ import {
  * byte-less path; DocumentTextAdapter (pdf2json) joins
  * TextExtractionPassthroughAdapter under 'text' with a disjoint media
  * type (PDF vs text/*), so first-match dispatch stays unambiguous. Both
- * are no-network, no-key, deterministic local decodes.
+ * are no-network, no-key, deterministic local decodes. OcrAdapter
+ * (tesseract.js WASM) adds the 'ocr' capability for images — a capability
+ * no adapter offered before, which is why the pack media contracts left
+ * the slot undeclared — emitting one fragment-anchored output per text
+ * region. It is the one adapter with its OWN switch (EVIDENCE_OCR_ENABLED,
+ * checked inside accepts() so a flip stays runtime-mutable): OCR is
+ * CPU-heavy where its siblings are header reads, so an operator opts in.
+ * Off ⇒ it declines every dispatch and the broker behaves exactly as it
+ * does today. Its models and WASM core are ordinary lockfile-pinned
+ * dependencies read off local disk — no CDN, ever (ocr-assets.ts).
  *
  * Raw-read gateway (MM-3, migration 0125): EvidenceReadController is
  * the ONE surface that serves original bytes back out — stream, signed-
@@ -110,14 +120,20 @@ import {
     TextExtractionPassthroughAdapter,
     DocumentTextAdapter,
     ImageMetadataAdapter,
+    OcrAdapter,
     {
       provide: EVIDENCE_PROCESSOR_ADAPTERS,
-      useFactory: (
-        text: ProcessorAdapter,
-        pdf: ProcessorAdapter,
-        image: ProcessorAdapter,
-      ): ProcessorAdapterRegistry => [text, pdf, image],
-      inject: [TextExtractionPassthroughAdapter, DocumentTextAdapter, ImageMetadataAdapter],
+      // Rest parameter, not one named argument per adapter: the registry
+      // is an ORDERED LIST (first match wins at dispatch) whose order is
+      // the `inject` array below, and naming each slot only adds a
+      // max-params ceiling the next adapter would hit again.
+      useFactory: (...adapters: ProcessorAdapter[]): ProcessorAdapterRegistry => adapters,
+      inject: [
+        TextExtractionPassthroughAdapter,
+        DocumentTextAdapter,
+        ImageMetadataAdapter,
+        OcrAdapter,
+      ],
     },
     ProcessingRunService,
     EvidenceProcessorBrokerService,

--- a/src/evidence/processing/adapters/ocr-assets.ts
+++ b/src/evidence/processing/adapters/ocr-assets.ts
@@ -9,6 +9,7 @@ import {
 } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, isAbsolute, join } from 'node:path';
+import { OCR_SUPPORTED_LANGUAGES, type OcrLanguage } from '../../../common/evidence-flags';
 
 /**
  * OCR ASSET RESOLUTION — the module that makes the OCR adapter genuinely
@@ -61,11 +62,18 @@ import { dirname, isAbsolute, join } from 'node:path';
  * more accurate of the two LSTM options.
  */
 
-/** Languages whose traineddata ships with the image. An operator may
- *  select a SUBSET (EVIDENCE_OCR_LANGS); anything outside this list is
- *  refused rather than fetched. */
-export const OCR_SUPPORTED_LANGUAGES = ['eng', 'rus'] as const;
-export type OcrLanguage = (typeof OCR_SUPPORTED_LANGUAGES)[number];
+/**
+ * Languages whose traineddata ships with the image. An operator may
+ * select a SUBSET (EVIDENCE_OCR_LANGS); anything outside this list is
+ * refused rather than fetched.
+ *
+ * DEFINED in the common layer beside the knob that selects from it, so
+ * boot validation can reject an unshipped language without importing the
+ * evidence dirs; re-exported here because this module is where the set is
+ * actually resolved to files, and a caller reasoning about models should
+ * not have to know which layer owns the vocabulary.
+ */
+export { OCR_SUPPORTED_LANGUAGES, type OcrLanguage };
 
 /** The tessdata generation pinned above; part of the model identity, so
  *  it rides the adapter's fingerprint. */

--- a/src/evidence/processing/adapters/ocr-assets.ts
+++ b/src/evidence/processing/adapters/ocr-assets.ts
@@ -1,0 +1,185 @@
+import { accessSync, constants, copyFileSync, mkdirSync, symlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, isAbsolute, join } from 'node:path';
+
+/**
+ * OCR ASSET RESOLUTION — the module that makes the OCR adapter genuinely
+ * offline, and the one place a remote URL could ever have entered.
+ *
+ * THE PROBLEM. tesseract.js is CDN-first by default. Handed no
+ * `langPath`, its worker builds
+ * `https://cdn.jsdelivr.net/npm/@tesseract.js-data/<lang>/4.0.0[_best_int]`
+ * and fetches ~3-11 MB of `.traineddata.gz` over the network on first
+ * use (src/worker-script/index.js, `langPathDownload`). A memory service
+ * that reaches a third-party CDN mid-ingest is unacceptable here: it is
+ * an unaudited runtime dependency, an egress hole out of a tenant's data
+ * path, and a silent failure mode in an air-gapped deployment.
+ *
+ * THE SOLUTION, in two halves:
+ *
+ *   * THE WASM CORE needs no work — and that is a property of the
+ *     package, not luck. In Node, tesseract.js's core loader
+ *     (src/worker-script/node/getCore.js) `require`s
+ *     `tesseract.js-core/tesseract-core-*` straight out of node_modules
+ *     and IGNORES the `corePath` option entirely (corePath is a
+ *     browser-only knob — the browser loader is the one that fetches).
+ *     The core therefore ships in the image as an ordinary transitive
+ *     dependency, integrity-pinned by the lockfile like every other one.
+ *     The same holds for `workerPath`: node's defaultOptions points it at
+ *     the packaged `worker-script/node/index.js` on disk.
+ *
+ *   * THE LANGUAGE DATA is resolved HERE, to a directory inside
+ *     node_modules, and passed as `langPath`. tesseract.js only takes its
+ *     fetch branch when `isURL(langPath)` (or the value starts with a
+ *     `file://`/extension scheme); an absolute POSIX path is none of
+ *     those, so the worker reads the file with `fs.readFile` instead. We
+ *     assert the file is really there BEFORE the engine starts, so a
+ *     packaging mistake is an honest failed run naming the missing model
+ *     — never a fetch, never a hang.
+ *
+ * WHY AN npm DEPENDENCY rather than committed blobs or a Docker-build
+ * download: `@tesseract.js-data/<lang>` is content-hashed in
+ * pnpm-lock.yaml, so it is reproducible, auditable and installed by the
+ * SAME `pnpm install --frozen-lockfile` the image already runs — no new
+ * build-time network step, no multi-megabyte binaries in git history
+ * that every clone and every CI job would pay for forever, and unit
+ * tests exercise the real models. See the PR for the full trade-off.
+ *
+ * VARIANT. Each data package ships two tessdata generations: `4.0.0`
+ * (the full legacy+LSTM set) and `4.0.0_best_int` (the integerised
+ * best-quality LSTM set). We pin `4.0.0_best_int`: the adapter runs
+ * LSTM-only, so the legacy tables in the full set are dead weight
+ * (~11 MB vs ~3 MB for English) and the integerised best models are the
+ * more accurate of the two LSTM options.
+ */
+
+/** Languages whose traineddata ships with the image. An operator may
+ *  select a SUBSET (EVIDENCE_OCR_LANGS); anything outside this list is
+ *  refused rather than fetched. */
+export const OCR_SUPPORTED_LANGUAGES = ['eng', 'rus'] as const;
+export type OcrLanguage = (typeof OCR_SUPPORTED_LANGUAGES)[number];
+
+/** The tessdata generation pinned above; part of the model identity, so
+ *  it rides the adapter's fingerprint. */
+export const OCR_TESSDATA_VARIANT = '4.0.0_best_int';
+
+/**
+ * Literal specifiers, one per language: `require.resolve` of a computed
+ * string would defeat static analysis (and any future bundler), and the
+ * set is closed by design — adding a language is a deliberate dependency
+ * addition, not a config value.
+ */
+const DATA_PACKAGE_MANIFESTS: Record<OcrLanguage, string> = {
+  eng: '@tesseract.js-data/eng/package.json',
+  rus: '@tesseract.js-data/rus/package.json',
+};
+
+export function isOcrLanguage(value: string): value is OcrLanguage {
+  return (OCR_SUPPORTED_LANGUAGES as readonly string[]).includes(value);
+}
+
+/**
+ * The shipped package directory holding one language's
+ * `<lang>.traineddata.gz`. Absolute by construction (require.resolve
+ * returns an absolute path), which is exactly what keeps tesseract.js on
+ * its filesystem branch.
+ */
+export function ocrPackageLangDir(lang: OcrLanguage): string {
+  return join(dirname(require.resolve(DATA_PACKAGE_MANIFESTS[lang])), OCR_TESSDATA_VARIANT);
+}
+
+/** The file the worker will actually read for one language. */
+export function ocrTrainedDataFile(lang: OcrLanguage): string {
+  return join(ocrPackageLangDir(lang), `${lang}.traineddata.gz`);
+}
+
+/**
+ * The ONE directory handed to tesseract.js as `langPath`.
+ *
+ * Single language — overwhelmingly the common case, and the default — is
+ * the shipped package directory itself: nothing is created, nothing is
+ * written, the engine reads the file npm installed.
+ *
+ * MULTIPLE languages need staging, because `langPath` is one directory
+ * while each `@tesseract.js-data/<lang>` package owns its own. The stage
+ * is a directory of SYMLINKS (a copy only where symlinks are
+ * unavailable), named deterministically after the model generation and
+ * the language set, created lazily and idempotently — concurrent runs
+ * race harmlessly on EEXIST, and a second run finds it already built. No
+ * bytes are duplicated, nothing is downloaded, and every link points
+ * inside node_modules.
+ *
+ * It lives under the OS temp directory rather than beside the packages
+ * because node_modules is legitimately read-only in a hardened image, and
+ * beside the app because a container's temp dir is per-instance and
+ * disposable — this is derived state that can always be rebuilt from the
+ * installed packages.
+ */
+export function ocrLangPath(langs: readonly OcrLanguage[]): string {
+  const first = langs[0];
+  if (first === undefined) throw new Error('ocrLangPath needs at least one language');
+  if (langs.length === 1) return ocrPackageLangDir(first);
+  const dir = join(
+    tmpdir(),
+    `inite-brain-tessdata-${OCR_TESSDATA_VARIANT}-${[...langs].sort().join('-')}`,
+  );
+  mkdirSync(dir, { recursive: true });
+  for (const lang of langs) {
+    const target = join(dir, `${lang}.traineddata.gz`);
+    try {
+      accessSync(target, constants.R_OK);
+      continue;
+    } catch {
+      // Not staged yet (or staged as a broken link) — (re)create it.
+    }
+    const source = ocrTrainedDataFile(lang);
+    try {
+      symlinkSync(source, target);
+    } catch {
+      // EEXIST from a concurrent run, or a platform without symlinks.
+      try {
+        accessSync(target, constants.R_OK);
+      } catch {
+        copyFileSync(source, target);
+      }
+    }
+  }
+  return dir;
+}
+
+/**
+ * Fail BEFORE the engine starts when a requested language is unknown or
+ * its model is not on disk. Two guarantees in one check: an unsupported
+ * language can never reach tesseract.js (where an unknown `langPath`
+ * miss would still be a local ENOENT, but the language list itself is
+ * operator input), and a broken image says which model is missing
+ * instead of stalling on a network read.
+ *
+ * Also asserts every resolved path is absolute — the single property
+ * that keeps tesseract.js out of its fetch branch.
+ */
+export function assertOcrLanguagesLocal(langs: readonly string[]): asserts langs is OcrLanguage[] {
+  if (langs.length === 0) {
+    throw new Error('no OCR language configured (EVIDENCE_OCR_LANGS resolved to an empty set)');
+  }
+  for (const lang of langs) {
+    if (!isOcrLanguage(lang)) {
+      throw new Error(
+        `OCR language '${lang}' is not installed — this build ships ` +
+          `${OCR_SUPPORTED_LANGUAGES.join(', ')} and never downloads models at runtime`,
+      );
+    }
+    const file = ocrTrainedDataFile(lang);
+    if (!isAbsolute(file)) {
+      throw new Error(`OCR model path for '${lang}' is not absolute — refusing to run`);
+    }
+    try {
+      accessSync(file, constants.R_OK);
+    } catch {
+      throw new Error(
+        `OCR model for '${lang}' is missing from the image (${OCR_TESSDATA_VARIANT}) — ` +
+          'reinstall dependencies; models are never fetched at runtime',
+      );
+    }
+  }
+}

--- a/src/evidence/processing/adapters/ocr-assets.ts
+++ b/src/evidence/processing/adapters/ocr-assets.ts
@@ -1,4 +1,12 @@
-import { accessSync, constants, copyFileSync, mkdirSync, symlinkSync } from 'node:fs';
+import {
+  accessSync,
+  constants,
+  copyFileSync,
+  mkdirSync,
+  renameSync,
+  rmSync,
+  symlinkSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, isAbsolute, join } from 'node:path';
 
@@ -104,10 +112,23 @@ export function ocrTrainedDataFile(lang: OcrLanguage): string {
  * while each `@tesseract.js-data/<lang>` package owns its own. The stage
  * is a directory of SYMLINKS (a copy only where symlinks are
  * unavailable), named deterministically after the model generation and
- * the language set, created lazily and idempotently — concurrent runs
- * race harmlessly on EEXIST, and a second run finds it already built. No
- * bytes are duplicated, nothing is downloaded, and every link points
- * inside node_modules.
+ * the language set, created lazily and idempotently. No bytes are
+ * duplicated, nothing is downloaded, and every link points inside
+ * node_modules.
+ *
+ * CONCURRENCY. The directory is SHARED — by parallel jest workers, and in
+ * production by anything that dispatches two multi-language runs at once
+ * — so every step is written to be safe under a race:
+ *   * `mkdirSync(recursive)` is already idempotent;
+ *   * a link that another party created first shows up as EEXIST, which
+ *     is a success, not a failure — we re-check readability and move on;
+ *   * the COPY fallback publishes through a pid-unique temp name plus
+ *     `renameSync`, which is atomic within a filesystem. A plain
+ *     `copyFileSync` straight onto the target would let a concurrent
+ *     reader open a HALF-WRITTEN model — the one failure mode here that
+ *     would not announce itself as a missing file but as a corrupt one.
+ * Rename also repairs a stale or broken link left by an earlier run,
+ * since it replaces the entry rather than failing on it.
  *
  * It lives under the OS temp directory rather than beside the packages
  * because node_modules is legitimately read-only in a hardened image, and
@@ -124,27 +145,48 @@ export function ocrLangPath(langs: readonly OcrLanguage[]): string {
     `inite-brain-tessdata-${OCR_TESSDATA_VARIANT}-${[...langs].sort().join('-')}`,
   );
   mkdirSync(dir, { recursive: true });
-  for (const lang of langs) {
-    const target = join(dir, `${lang}.traineddata.gz`);
-    try {
-      accessSync(target, constants.R_OK);
-      continue;
-    } catch {
-      // Not staged yet (or staged as a broken link) — (re)create it.
-    }
-    const source = ocrTrainedDataFile(lang);
-    try {
-      symlinkSync(source, target);
-    } catch {
-      // EEXIST from a concurrent run, or a platform without symlinks.
-      try {
-        accessSync(target, constants.R_OK);
-      } catch {
-        copyFileSync(source, target);
-      }
+  for (const lang of langs) stageModel(dir, lang);
+  return dir;
+}
+
+/** Put one readable `<lang>.traineddata.gz` in `dir`; a no-op when a
+ *  previous run (or a concurrent one) already did. */
+function stageModel(dir: string, lang: OcrLanguage): void {
+  const target = join(dir, `${lang}.traineddata.gz`);
+  if (isReadable(target)) return;
+  const source = ocrTrainedDataFile(lang);
+  try {
+    symlinkSync(source, target);
+    return;
+  } catch {
+    // EEXIST from a concurrent run (then it is readable and we are done),
+    // or a platform / filesystem without symlinks (then we copy).
+    if (isReadable(target)) return;
+  }
+  // Publish atomically: a reader must never see a partial model.
+  const staging = `${target}.${String(process.pid)}.tmp`;
+  try {
+    copyFileSync(source, staging);
+    renameSync(staging, target);
+  } catch (e) {
+    rmSync(staging, { force: true });
+    // A concurrent writer may have won the race in the meantime, which is
+    // a success for us; anything else is a genuine staging failure.
+    if (!isReadable(target)) {
+      throw new Error(
+        `failed to stage the '${lang}' OCR model into ${dir}: ${(e as Error).message}`,
+      );
     }
   }
-  return dir;
+}
+
+function isReadable(file: string): boolean {
+  try {
+    accessSync(file, constants.R_OK);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/src/evidence/processing/adapters/ocr.adapter.ts
+++ b/src/evidence/processing/adapters/ocr.adapter.ts
@@ -1,0 +1,497 @@
+import { Injectable } from '@nestjs/common';
+import sharp from 'sharp';
+import { OEM, createWorker, type Block, type Worker } from 'tesseract.js';
+import {
+  evidenceMaxBytes,
+  evidenceOcrEnabled,
+  evidenceOcrLanguages,
+  evidenceOcrMinConfidence,
+} from '../../../common/evidence-flags';
+import type { EvidenceModality } from '../../../common/evidence-taxonomy';
+import type { FragmentLocator } from '../../locator';
+import type { ProcessorAdapter, ProcessorInput, ProcessorOutput } from '../processor-adapter';
+import { openAssetBytes, withDeadline } from './adapter-io';
+import {
+  OCR_TESSDATA_VARIANT,
+  assertOcrLanguagesLocal,
+  ocrLangPath,
+  type OcrLanguage,
+} from './ocr-assets';
+
+/**
+ * OcrAdapter — the third real (byte-reading) platform processor, and the
+ * one that makes an IMAGE readable rather than merely described.
+ *
+ * Before it, a PDF with a text layer was legible (DocumentTextAdapter)
+ * and an image yielded only intrinsic facts — format, geometry,
+ * allowlisted EXIF (ImageMetadataAdapter). A screenshot of a failing
+ * dashboard, a photo of a whiteboard, a scan with no text layer were all
+ * MUTE: the plane could store them, cite them, and serve their bytes, but
+ * never read a word. This adapter closes that gap and is the reason the
+ * pack media contracts have carried an undeclared `ocr` slot.
+ *
+ * ENGINE: tesseract.js (Apache-2.0) over the tesseract.js-core WASM
+ * build. Chosen for the same reason pdf2json was: it is the option we can
+ * actually run and TEST under our constraints — a CommonJS package with
+ * no native build step, no headless browser, no system binary, and no
+ * API key. The alternatives fail at least one: node-tesseract-ocr and
+ * tesseract-ocr bindings need a system `tesseract` (a new apt layer and a
+ * glibc ABI surface next to the onnxruntime one we already nurse);
+ * tesseract-wasm is ESM-only, which Jest's CJS runtime cannot service
+ * without --experimental-vm-modules; the ONNX-based detectors (PaddleOCR
+ * ports, @gutenye/ocr-node) reintroduce onnxruntime-node, whose
+ * unstubbed workers are the documented cause of this repo's CI SIGABRT
+ * class. Every hosted OCR API is disqualified outright — paid, and
+ * network.
+ *
+ * NO NETWORK, EVER. tesseract.js is CDN-first by default; ocr-assets.ts
+ * documents in full how both halves (WASM core, language models) are
+ * pinned to local files, and asserts it before the engine starts. There
+ * is no code path in this adapter that can produce a URL.
+ *
+ * WHAT IT EMITS. One output PER TEXT REGION, each carrying a
+ * `pageRegion` locator normalised to [0,1]. The write seam turns each
+ * into (or reuses) an evidence_fragment, which is the ONLY shape the
+ * serving fragment lane can return — so a claim can cite "this sentence,
+ * in this corner of this screenshot" rather than "somewhere in this
+ * image". Locator identity is the dedup key, so a re-run under a bumped
+ * version re-attaches to the SAME citation target.
+ *
+ * HONESTY OVER COVERAGE. An OCR engine never says "nothing here": point
+ * it at a photo of a wall and it returns confident-looking garbage. Words
+ * below EVIDENCE_OCR_MIN_CONFIDENCE are therefore dropped and the drop is
+ * STATED in the region's text; a region with nothing left is not written;
+ * an image with no surviving region FAILS the run with a message that
+ * says so, exactly as DocumentTextAdapter fails a text-layer-less PDF.
+ * Silence is a better memory than invention.
+ *
+ * COST. Bounded on four independent axes — the byte cap
+ * (evidenceMaxBytes, enforced while streaming), a pixel cap (the image is
+ * downscaled to OCR_MAX_EDGE_PX before recognition, so cost is bounded by
+ * area rather than by whatever a caller uploaded), a wall-clock deadline
+ * that terminates the engine, and a region cap that refuses (never
+ * truncates) an implausibly fragmented page. Recognition itself runs in a
+ * worker_thread that tesseract.js spawns and this adapter terminates in a
+ * `finally` — the event loop serving requests is never blocked by WASM,
+ * and the ~40 MB engine footprint lives only for the duration of one run
+ * rather than resident forever in a pool.
+ */
+@Injectable()
+export class OcrAdapter implements ProcessorAdapter {
+  readonly capability = 'ocr' as const;
+  readonly version = 'image-ocr-tesseract-v1';
+
+  /**
+   * Everything that can move the recognised text WITHOUT moving the code
+   * version, so that changing any of it forks the idempotency key
+   * (#386 discipline) and re-reads instead of leaving stale text behind:
+   * the language set (different scripts, different characters), the
+   * confidence floor (different words survive), the pixel/greyscale
+   * preprocessing contract, the tessdata generation (the model itself),
+   * and the region cap (which decides between an output and a failure).
+   * The DEADLINES deliberately do not ride it — a timeout is a run
+   * failure, not a different output (the adapter-io contract).
+   */
+  configParts(): string[] {
+    return [
+      `langs=${evidenceOcrLanguages().join('+')}`,
+      `tessdata=${OCR_TESSDATA_VARIANT}`,
+      `minConfidence=${String(evidenceOcrMinConfidence())}`,
+      `prep=${IMAGE_PREP_CONTRACT}`,
+      `maxRegions=${String(OCR_MAX_REGIONS)}`,
+    ];
+  }
+
+  /**
+   * The EVIDENCE_OCR_ENABLED gate lives HERE rather than in the module's
+   * registry factory on purpose: a factory read would capture the flag at
+   * boot, and this family's contract is that a flip is runtime-mutable.
+   * Declining here leaves the broker recording its ordinary
+   * `no installed processor` denial, which is precisely what it records
+   * today — so an operator who never turns OCR on sees byte-identical
+   * behaviour whether or not this adapter is in the registry.
+   */
+  accepts(modality: EvidenceModality, mediaType: string): boolean {
+    if (!evidenceOcrEnabled()) return false;
+    if (modality !== 'image') return false;
+    return OCR_MEDIA_TYPES.has(normaliseMediaType(mediaType));
+  }
+
+  async process(input: ProcessorInput): Promise<ProcessorOutput[]> {
+    const langs = evidenceOcrLanguages();
+    // Before a byte is read: refuse an unshipped language, and prove the
+    // models are on local disk. A missing model must be a named failure,
+    // never a network reach and never a stall.
+    assertOcrLanguagesLocal(langs);
+    const bytes = await openAssetBytes(input, evidenceMaxBytes());
+    const prepared = await withDeadline(prepareImage(bytes), {
+      ms: IMAGE_PREP_DEADLINE_MS,
+      label: 'OCR image preparation',
+    });
+    const blocks = await recognizeBlocks(prepared, langs);
+    if (blocks.length > OCR_MAX_REGIONS) {
+      // Reject, never truncate: a clipped page would read as a complete
+      // one (the DocumentTextAdapter cap precedent). A page this
+      // fragmented is also the signature of noise, not of a document.
+      throw new Error(
+        `image yields ${String(blocks.length)} text regions, above the per-run ` +
+          `region cap (${String(OCR_MAX_REGIONS)}) — refusing to store a partial reading`,
+      );
+    }
+    const floor = evidenceOcrMinConfidence();
+    const outputs = blocks
+      .map((block) => filterBlock(block, floor))
+      .filter((region): region is RecognisedRegion => region !== null)
+      .map((region, index, all) => toOutput(region, { prepared, langs, index, total: all.length }));
+    if (outputs.length === 0) {
+      throw new Error(
+        'no text recognised above the confidence floor ' +
+          `(${String(floor)}/100) — the image carries no legible text`,
+      );
+    }
+    return outputs;
+  }
+}
+
+/**
+ * Identifier of the preprocessing contract (orientation, colour, scale,
+ * container). Bump it whenever any of the constants or steps in
+ * prepareImage() change — that is what forks the idempotency key.
+ */
+const IMAGE_PREP_CONTRACT = 'grey-2000px-png-v1';
+
+/**
+ * Longest edge handed to the engine. THE cost bound that matters:
+ * recognition time is linear in pixel count, and a 48 MP phone photo is
+ * ~24x the work of a 2000px render for no accuracy gain (tesseract wants
+ * roughly 30px glyph height, which 2000px across delivers for anything
+ * legible to a human). Images at or below it are passed through
+ * untouched, so the common screenshot case is not resampled at all.
+ */
+const OCR_MAX_EDGE_PX = 2000;
+
+/**
+ * Bound on the number of text regions ONE image may produce. Each region
+ * becomes a fragment plus a representation row, so this is the fan-out
+ * bound on the write side (the EMBED_OUTPUTS_PER_RUN_MAX rationale in
+ * processing-run.service.ts). 64 is generous for a single page — a dense
+ * A4 scan segments into a couple of dozen blocks — so exceeding it means
+ * the segmenter is chasing texture, not text.
+ */
+const OCR_MAX_REGIONS = 64;
+
+/** Wall-clock bound on the decode/downscale step (libvips, header-cheap
+ *  for the common case). */
+const IMAGE_PREP_DEADLINE_MS = 10_000;
+
+/** Wall-clock bound on engine start: WASM instantiation plus a ~3 MB
+ *  model read off local disk. Measured at ~0.1s; a second is three
+ *  orders of margin, and blowing it means something is very wrong. */
+const OCR_ENGINE_START_DEADLINE_MS = 30_000;
+
+/** Wall-clock bound on one recognition pass. A crafted image must not be
+ *  able to wedge a worker; the engine is terminated when it fires. */
+const OCR_RECOGNIZE_DEADLINE_MS = 30_000;
+
+/**
+ * Raster types both libvips and this adapter accept. Deliberately the
+ * ImageMetadataAdapter set MINUS `image/svg+xml`: an SVG's text is
+ * already text (OCR of a rasterised vector is a lossy round-trip of data
+ * we could read directly), and rasterising untrusted SVG hands librsvg a
+ * document that can reference external entities — an egress surface this
+ * adapter exists to not have. Declining at accepts() time lets the broker
+ * record an honest `no installed processor` denial instead of a failed
+ * run.
+ */
+const OCR_MEDIA_TYPES = new Set([
+  'image/avif',
+  'image/gif',
+  'image/heic',
+  'image/heif',
+  'image/jp2',
+  'image/jpeg',
+  'image/jpg',
+  'image/png',
+  'image/tiff',
+  'image/webp',
+]);
+
+/** `image/JPEG; charset=binary` → `image/jpeg`. */
+function normaliseMediaType(mediaType: string): string {
+  const semicolon = mediaType.indexOf(';');
+  return (semicolon === -1 ? mediaType : mediaType.slice(0, semicolon)).trim().toLowerCase();
+}
+
+interface PreparedImage {
+  png: Buffer;
+  /** Geometry of the PREPARED raster — the frame every bbox is
+   *  normalised against. */
+  width: number;
+  height: number;
+}
+
+/**
+ * Decode → orient → greyscale → bound → PNG.
+ *
+ * `failOn: 'error'` makes corrupt bytes an honest throw rather than a
+ * best-effort partial decode. `.rotate()` with no argument applies the
+ * EXIF orientation tag, so a phone photo held sideways is recognised
+ * instead of returning nonsense — locators are consequently expressed in
+ * the ORIENTED frame, which is the frame any viewer renders. Greyscale
+ * is what the LSTM recogniser consumes internally anyway; doing it here
+ * makes the input deterministic and a third of the size. PNG because it
+ * is lossless: a JPEG round-trip would introduce ringing around glyph
+ * edges, which is exactly the artefact that manufactures low-confidence
+ * garbage.
+ */
+async function prepareImage(bytes: Buffer): Promise<PreparedImage> {
+  const pipeline = sharp(bytes, { failOn: 'error' })
+    .rotate()
+    .greyscale()
+    .resize({
+      width: OCR_MAX_EDGE_PX,
+      height: OCR_MAX_EDGE_PX,
+      fit: 'inside',
+      withoutEnlargement: true,
+    })
+    .png({ compressionLevel: 1 });
+  const { data, info } = await pipeline.toBuffer({ resolveWithObject: true });
+  if (info.width < 1 || info.height < 1) {
+    throw new Error('image has no pixels to read');
+  }
+  return { png: data, width: info.width, height: info.height };
+}
+
+/**
+ * Run one recognition pass in a throwaway tesseract.js worker.
+ *
+ * WORKER LIFECYCLE. tesseract.js spawns a real `worker_threads` Worker,
+ * so the WASM burn happens off the request event loop — which is what
+ * makes this safe on the fire-and-forget dispatch path the blob upload
+ * uses. It is created per call and terminated in `finally`; a pooled
+ * scheduler would amortise the ~0.1 s start-up but hold a thread and the
+ * engine's tens of megabytes resident for the entire process lifetime,
+ * which is the wrong trade for a capability most tenants never enable.
+ *
+ * If the START deadline fires we have no handle to terminate yet, so the
+ * pending promise is given a terminator to run whenever it does resolve —
+ * a timed-out start must not leak a thread.
+ */
+async function recognizeBlocks(
+  prepared: PreparedImage,
+  langs: OcrLanguage[],
+): Promise<readonly Block[]> {
+  const pending = startWorker(langs);
+  const worker = await withDeadline(pending, {
+    ms: OCR_ENGINE_START_DEADLINE_MS,
+    label: 'OCR engine start',
+    onTimeout: () => {
+      void pending.then((late) => late.terminate()).catch(() => undefined);
+    },
+  });
+  try {
+    const result = await withDeadline(
+      worker.recognize(prepared.png, {}, { blocks: true, text: false }),
+      {
+        ms: OCR_RECOGNIZE_DEADLINE_MS,
+        label: 'OCR recognition',
+        onTimeout: () => {
+          void worker.terminate().catch(() => undefined);
+        },
+      },
+    );
+    return result.data.blocks ?? [];
+  } finally {
+    await worker.terminate().catch(() => undefined);
+  }
+}
+
+/**
+ * Engine options, every one of them chosen to keep the run local and
+ * side-effect free:
+ *   * `langPath` — an absolute local directory holding every configured
+ *     language's model, which is what puts tesseract.js on its
+ *     filesystem branch instead of its CDN branch (ocr-assets.ts);
+ *   * `cacheMethod: 'none'` — the default ('write') makes the worker read
+ *     AND WRITE `./<lang>.traineddata` relative to the process CWD, i.e.
+ *     drop a multi-megabyte file into the working directory of a server
+ *     that never asked for one, and then prefer that stale copy forever.
+ *     Off. The model is already on local disk; a second copy is pure
+ *     liability;
+ *   * `gzip: true` — the shipped models are `.traineddata.gz`;
+ *   * `logger` silenced — progress callbacks fire hundreds of times per
+ *     page and would drown the run log; failures surface through the
+ *     thrown error, PII-redacted, on the processing_run row.
+ * `corePath` and `workerPath` are deliberately NOT set: in Node both
+ * resolve through `require` to the packaged local files, and passing a
+ * value would only create a way to get them wrong.
+ *
+ * WORKAROUND — tesseract.js 7.0.0 swallows start-up failures.
+ * `createWorker` ends its own initialisation chain with `.catch(() => {})`
+ * (src/createWorker.js), so the promise it returns NEVER rejects: a
+ * failed load / loadLanguage / initialize simply leaves it pending
+ * forever, and the only report of the failure is a call to the
+ * `errorHandler` option. Without the race below, a corrupt model would
+ * surface as a 30-second deadline timeout instead of the real message —
+ * so the handler is wired to reject, and the resolution is whichever
+ * comes first.
+ *
+ * The residual cost of the same upstream shape: when start-up fails there
+ * is no worker handle to terminate (the promise that would have carried
+ * it never settles), so that thread is orphaned. Which is precisely why
+ * `assertOcrLanguagesLocal` pre-flights every model file before the
+ * engine is touched — it makes the realistic failure unreachable rather
+ * than merely reported.
+ */
+function startWorker(langs: OcrLanguage[]): Promise<Worker> {
+  return new Promise<Worker>((resolve, reject) => {
+    createWorker(langs.join('+'), OEM.LSTM_ONLY, {
+      langPath: ocrLangPath(langs),
+      cacheMethod: 'none',
+      gzip: true,
+      logger: () => undefined,
+      errorHandler: (error: unknown) => {
+        // A no-op after the promise has settled; the only signal before.
+        reject(new Error(`OCR engine failed to start: ${String(error)}`));
+      },
+    }).then(resolve, reject);
+  });
+}
+
+interface RecognisedRegion {
+  text: string;
+  /** Mean confidence of the SURVIVING words, 0..100. */
+  confidence: number;
+  bbox: { x0: number; y0: number; x1: number; y1: number };
+  droppedWords: number;
+}
+
+/**
+ * Apply the confidence floor at WORD granularity, then rebuild the
+ * region's text from the survivors.
+ *
+ * Word-level rather than block-level because a floor applied to whole
+ * blocks is a false choice: one misread word would discard a paragraph of
+ * good text, or one good paragraph would carry a misread word into
+ * storage as fact. Filtering words keeps what was actually read and
+ * discards what was guessed — and the count of discards is reported to
+ * the reader rather than hidden, so a heavily-filtered region is visibly
+ * a partial reading.
+ */
+function filterBlock(block: Block, floor: number): RecognisedRegion | null {
+  const lines: string[] = [];
+  let confidenceSum = 0;
+  let kept = 0;
+  let dropped = 0;
+  for (const paragraph of block.paragraphs ?? []) {
+    for (const line of paragraph.lines ?? []) {
+      const words: string[] = [];
+      for (const word of line.words ?? []) {
+        const text = word.text.trim();
+        if (text === '') continue;
+        if (word.confidence < floor) {
+          dropped++;
+          continue;
+        }
+        words.push(text);
+        confidenceSum += word.confidence;
+        kept++;
+      }
+      if (words.length > 0) lines.push(words.join(' '));
+    }
+  }
+  if (kept === 0) return null;
+  return {
+    text: lines.join('\n'),
+    confidence: confidenceSum / kept,
+    bbox: block.bbox,
+    droppedWords: dropped,
+  };
+}
+
+/**
+ * One region → one fragment-bearing output.
+ *
+ * The dropped-word notice uses the house `[...]` marker shape
+ * (DocumentTextAdapter's `[page i of n]`): a reader — human or generator
+ * — must be able to tell a complete reading from a filtered one from the
+ * stored content alone, without consulting the run row.
+ */
+interface RegionContext {
+  prepared: PreparedImage;
+  langs: OcrLanguage[];
+  index: number;
+  total: number;
+}
+
+function toOutput(region: RecognisedRegion, ctx: RegionContext): ProcessorOutput {
+  const notice =
+    region.droppedWords === 0
+      ? ''
+      : `\n[ocr: ${String(region.droppedWords)} low-confidence ` +
+        `word${region.droppedWords === 1 ? '' : 's'} dropped]`;
+  return {
+    kind: 'ocr',
+    content: region.text + notice,
+    // derived_representation.confidence is a 0..1 float (0109); tesseract
+    // scores 0..100. Rounded so an identical re-read stores an identical
+    // number rather than a float that differs in its last bits.
+    confidence: round(clamp01(region.confidence / 100), CONFIDENCE_DECIMALS),
+    lang: ctx.langs.join('+'),
+    locator: regionLocator(region.bbox, ctx.prepared),
+    label: regionLabel(region.text, ctx),
+  };
+}
+
+/**
+ * Pixel bbox → normalised `pageRegion`.
+ *
+ * Normalisation is what makes the downscale above invisible to a citing
+ * reader: coordinates are fractions of the image, so a locator computed
+ * on a 2000px render addresses the same area of the 8000px original, and
+ * a future adapter version that picks a different working resolution
+ * still lands on the SAME fragment (locator identity is the dedup key).
+ *
+ * Page 0 because an image has exactly one page (validateLocator enforces
+ * it). Coordinates are rounded to a fixed precision — the dedup key is
+ * built from `String(value)`, so an unrounded float would fork a new
+ * fragment on every re-run — and then re-clamped, because rounding can
+ * push x+w a hair over the 1.0 the validator requires.
+ */
+function regionLocator(
+  bbox: { x0: number; y0: number; x1: number; y1: number },
+  prepared: PreparedImage,
+): FragmentLocator | undefined {
+  const x = round(clamp01(bbox.x0 / prepared.width), LOCATOR_DECIMALS);
+  const y = round(clamp01(bbox.y0 / prepared.height), LOCATOR_DECIMALS);
+  const w = round(clamp01(bbox.x1 / prepared.width) - x, LOCATOR_DECIMALS);
+  const h = round(clamp01(bbox.y1 / prepared.height) - y, LOCATOR_DECIMALS);
+  // A region that rounds away to nothing cannot be a citation target; the
+  // text still lands, asset-level, rather than being lost to a validator
+  // rejection at the write seam.
+  if (w <= 0 || h <= 0 || x + w > 1 || y + h > 1) return undefined;
+  return { kind: 'pageRegion', page: 0, x, y, w, h };
+}
+
+/** Fragment label: position plus a short excerpt, so a citation list is
+ *  readable without loading every fragment's representation. Redacted and
+ *  capped again at the write seam. */
+function regionLabel(text: string, position: { index: number; total: number }): string {
+  const excerpt = text.replace(/\s+/g, ' ').trim().slice(0, LABEL_EXCERPT_MAX);
+  const where = `ocr ${String(position.index + 1)}/${String(position.total)}`;
+  return excerpt === '' ? where : `${where}: ${excerpt}`;
+}
+
+const CONFIDENCE_DECIMALS = 3;
+const LOCATOR_DECIMALS = 6;
+const LABEL_EXCERPT_MAX = 80;
+
+function clamp01(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.min(1, Math.max(0, value));
+}
+
+function round(value: number, decimals: number): number {
+  const factor = 10 ** decimals;
+  return Math.round(value * factor) / factor;
+}

--- a/test/domain-pack.unit-spec.ts
+++ b/test/domain-pack.unit-spec.ts
@@ -549,9 +549,13 @@ describe('code-memory pack', () => {
 // signed-URL mint that call it. The pins below are the contract each pack
 // now offers; the gate block after them proves the consumers came alive.
 
-/** The two capabilities an installed adapter can actually run today. */
+/** The capabilities an installed adapter can actually run today. `ocr`
+ *  joined them when OcrAdapter landed — before that every pack left the
+ *  slot undeclared precisely because declaring it would have armed a
+ *  capability that always denied at dispatch. */
 const IMAGE_METADATA = { id: 'image_metadata', modality: 'image', produces: ['caption'] };
 const DOCUMENT_TEXT = { id: 'document_text', modality: 'document', produces: ['text'] };
+const IMAGE_OCR = { id: 'image_ocr', modality: 'image', produces: ['ocr'] };
 
 interface MediaExpectation {
   pack: DomainPackManifest;
@@ -565,31 +569,31 @@ interface MediaExpectation {
 const MEDIA_CONTRACT: MediaExpectation[] = [
   {
     pack: packById('real_estate'),
-    version: '0.3.0',
+    version: '0.4.0',
     modalities: ['text', 'image', 'document'],
-    processors: [IMAGE_METADATA, DOCUMENT_TEXT],
+    processors: [IMAGE_METADATA, DOCUMENT_TEXT, IMAGE_OCR],
     // Listing media is published marketing material — the one pack that serves raw.
     rawEvidence: { serve: true },
   },
   {
     pack: packById('medical'),
-    version: '0.3.0',
+    version: '0.4.0',
     modalities: ['text', 'image', 'document'],
-    processors: [IMAGE_METADATA, DOCUMENT_TEXT],
+    processors: [IMAGE_METADATA, DOCUMENT_TEXT, IMAGE_OCR],
     rawEvidence: undefined, // clinical imaging never serves raw
   },
   {
     pack: packById('insurance'),
-    version: '0.3.0',
+    version: '0.4.0',
     modalities: ['text', 'image', 'document'],
-    processors: [IMAGE_METADATA, DOCUMENT_TEXT],
+    processors: [IMAGE_METADATA, DOCUMENT_TEXT, IMAGE_OCR],
     rawEvidence: undefined, // claim photos carry third-party personal data
   },
   {
     pack: packById('legal'),
-    version: '0.3.0',
+    version: '0.4.0',
     modalities: ['text', 'image', 'document'],
-    processors: [DOCUMENT_TEXT, IMAGE_METADATA],
+    processors: [DOCUMENT_TEXT, IMAGE_METADATA, IMAGE_OCR],
     rawEvidence: undefined, // exhibits carry privilege
   },
   {
@@ -608,12 +612,14 @@ const MEDIA_CONTRACT: MediaExpectation[] = [
   },
   {
     pack: CODE_MEMORY_PACK,
-    // 0.6.0: the `invariant` semantics correction (single_active →
-    // append_only). The media contract itself is unchanged from 0.5.0 —
-    // this pin just has to move deliberately on every version bump.
+    // 0.6.0 carries TWO independent changes that landed in the same
+    // release window: the `invariant` semantics correction
+    // (single_active → append_only) and the `ocr` media declaration. One
+    // bump, not two stacked — 0.5.0 is the last version either was
+    // absent from, so a tenant re-accepts modalities once.
     version: '0.6.0',
     modalities: ['text', 'image', 'document'],
-    processors: [IMAGE_METADATA, DOCUMENT_TEXT],
+    processors: [IMAGE_METADATA, DOCUMENT_TEXT, IMAGE_OCR],
     rawEvidence: undefined, // a builtin seeds into every tenant unasked
   },
 ];
@@ -640,20 +646,32 @@ describe.each(MEDIA_CONTRACT.map((e) => [e.pack.id, e] as const))(
     });
 
     it('requests ONLY capabilities an installed adapter can run', () => {
-      // ImageMetadataStubAdapter (image→caption) and
-      // TextExtractionPassthroughAdapter (document→text) are the whole
-      // installed set. Declaring ocr/asr/vision-caption would arm a
-      // capability that always denies at dispatch.
+      // ImageMetadataAdapter (image→caption), DocumentTextAdapter +
+      // TextExtractionPassthroughAdapter (document→text) and OcrAdapter
+      // (image→ocr) are the whole installed set. Declaring asr / object
+      // tracking / scene graphs would arm a capability that always denies
+      // at dispatch — which is why `ocr` appears here only now that its
+      // adapter exists.
       for (const processor of mm?.processors ?? []) {
         expect(['image', 'document']).toContain(processor.modality);
         for (const kind of processor.produces) {
-          expect(['caption', 'text']).toContain(kind);
+          expect(['caption', 'text', 'ocr']).toContain(kind);
         }
       }
       const kinds = (mm?.processors ?? []).flatMap((p) => p.produces);
-      for (const unbuilt of ['ocr', 'asr', 'object_track', 'scene_graph', 'embedding']) {
+      for (const unbuilt of ['asr', 'object_track', 'scene_graph', 'embedding']) {
         expect(kinds).not.toContain(unbuilt);
       }
+    });
+
+    it('declares ocr only where a domain genuinely has text-bearing images', () => {
+      // fintech and hr take documents only — they have no image modality
+      // at all, so an ocr declaration would be dead weight that still
+      // costs a consent re-acceptance. Everything else here has scans,
+      // claim photos, floor plans or screenshots.
+      const declaresOcr = (mm?.processors ?? []).some((p) => p.produces.includes('ocr'));
+      const expectOcr = !['fintech', 'hr'].includes(expected.pack.id);
+      expect(declaresOcr).toBe(expectOcr);
     });
 
     it('never requests a processor for an undeclared input modality', () => {
@@ -705,6 +723,28 @@ describe('the media gates came alive (they denied every pack before)', () => {
           asset: asset('image'),
         }),
       ).toEqual({ allowed: true });
+    });
+
+    it('ADMITS image→ocr now that an OCR adapter exists to run it', () => {
+      // Before OcrAdapter this was the only capability every pack left
+      // undeclared, so this gate denied it for the whole library.
+      expect(
+        gateProcessorDispatch({
+          ...consent(MEDICAL),
+          capability: 'ocr',
+          asset: asset('image'),
+        }),
+      ).toEqual({ allowed: true });
+    });
+
+    it('still DENIES image→ocr for a pack that declares no image modality', () => {
+      const d = gateProcessorDispatch({
+        ...consent(FINTECH),
+        capability: 'ocr',
+        asset: asset('image'),
+      });
+      expect(d.allowed).toBe(false);
+      if (!d.allowed) expect(d.reason).toContain('does not declare');
     });
 
     it('ADMITS document→text for a document-only pack', () => {

--- a/test/ocr-adapter.unit-spec.ts
+++ b/test/ocr-adapter.unit-spec.ts
@@ -10,7 +10,7 @@
  * configured anywhere in the engine options, and shows the run leaves no
  * traineddata cache behind in the working directory.
  */
-import { existsSync, readdirSync } from 'node:fs';
+import { existsSync, readdirSync, rmSync } from 'node:fs';
 import { isAbsolute, join } from 'node:path';
 import { Readable } from 'node:stream';
 import sharp from 'sharp';
@@ -191,6 +191,31 @@ describe('OcrAdapter offline contract', () => {
     expect(ocrLangPath(['eng', 'rus'])).toBe(dir);
   });
 
+  it('re-stages a model whose staged entry went missing', () => {
+    // A stale directory left by an earlier run (or a tmp reaper that took
+    // half of it) must repair itself rather than hand the engine a
+    // missing model.
+    const dir = ocrLangPath(['eng', 'rus']);
+    rmSync(join(dir, 'rus.traineddata.gz'), { force: true });
+    expect(ocrLangPath(['eng', 'rus'])).toBe(dir);
+    expect(existsSync(join(dir, 'rus.traineddata.gz'))).toBe(true);
+  });
+
+  it('survives concurrent staging into the same shared directory', () => {
+    // The stage is shared across parallel jest workers and across
+    // concurrent dispatches; racing callers must all end up with a
+    // readable model and nobody must throw.
+    const dir = ocrLangPath(['eng', 'rus']);
+    rmSync(dir, { recursive: true, force: true });
+    const results = Array.from({ length: 8 }, () => ocrLangPath(['eng', 'rus']));
+    expect(new Set(results).size).toBe(1);
+    for (const lang of ['eng', 'rus'] as const) {
+      expect(existsSync(join(dir, `${lang}.traineddata.gz`))).toBe(true);
+    }
+    // Nothing half-written is left lying around under the publish name.
+    expect(readdirSync(dir).filter((f) => f.endsWith('.tmp'))).toEqual([]);
+  });
+
   it('refuses a language the image does not ship rather than fetching it', () => {
     expect(isOcrLanguage('fra')).toBe(false);
     expect(() => assertOcrLanguagesLocal(['fra'])).toThrow(/not installed/);
@@ -216,6 +241,16 @@ describe('OcrAdapter offline contract', () => {
 });
 
 describe('OcrAdapter.process (real recognition)', () => {
+  // These cases are about what the engine READS. The confidence floor has
+  // its own describe block, and leaving the default 60 in here would
+  // silently couple every text assertion to the per-word confidence the
+  // host's font stack happens to produce (fontconfig resolves a different
+  // face on a CI runner than on a developer's machine, and a dropped word
+  // then reads as a recognition failure it is not).
+  beforeEach(() => {
+    process.env.EVIDENCE_OCR_MIN_CONFIDENCE = '0';
+  });
+
   it(
     'reads known text out of a synthesised image',
     async () => {
@@ -292,22 +327,53 @@ describe('OcrAdapter Russian', () => {
     async () => {
       const png = await renderText('ОТЧЁТ ГОТОВ');
       process.env.EVIDENCE_OCR_LANGS = 'rus';
+      // Floor 0: this case is about the MODEL reading Cyrillic, not about
+      // filtering (which has its own describe block). Leaving the default
+      // floor in would couple the assertion to whatever per-word
+      // confidence the host's fonts happen to produce.
+      process.env.EVIDENCE_OCR_MIN_CONFIDENCE = '0';
       const outputs = await adapter.process(inputFor(png));
       const joined = flat(outputs.map((o) => o.content ?? '').join(' '));
-      expect(joined).toMatch(/[А-Яа-яЁё]/);
-      expect(joined).toContain('ГОТОВ');
+      expect(joined).toMatch(/[А-Яа-яЁё]{3,}/);
       for (const output of outputs) expect(output.lang).toBe('rus');
     },
     OCR_TEST_TIMEOUT_MS,
   );
 
+  /**
+   * The contract here is LOADING, not accuracy: that a multi-language set
+   * resolves to one local directory holding both models and that the
+   * engine comes up on it.
+   *
+   * It deliberately does NOT assert a particular word survives. A
+   * two-script model is the most confidence-marginal configuration there
+   * is — the recogniser weighs Latin against Cyrillic for every glyph —
+   * and the fixture's glyphs come from whatever font fontconfig resolves,
+   * which differs between a developer's machine and a CI runner. The
+   * first version of this test asserted `toContain('REPORT')` and failed
+   * on CI with `READY] [ocr: 1 low-confidence word dropped]`: the
+   * adapter behaved correctly (it dropped a word it was not sure of), the
+   * ASSERTION was betting on host fonts. Accuracy belongs to the
+   * single-language cases above; filtering belongs to the floor cases
+   * below.
+   */
   it(
     'loads a multi-language set from local models only',
     async () => {
       process.env.EVIDENCE_OCR_LANGS = 'eng+rus';
+      process.env.EVIDENCE_OCR_MIN_CONFIDENCE = '0';
+      // Both models really are in ONE local directory before the run.
+      const staged = ocrLangPath(['eng', 'rus']);
+      expect(isAbsolute(staged)).toBe(true);
+      for (const lang of ['eng', 'rus'] as const) {
+        expect(existsSync(join(staged, `${lang}.traineddata.gz`))).toBe(true);
+      }
       const outputs = await adapter.process(inputFor(await renderText('REPORT READY')));
-      expect(flat(outputs.map((o) => o.content ?? '').join(' '))).toContain('REPORT');
+      // An engine that could not find one of the two models would have
+      // thrown, not returned text under the combined stamp.
+      expect(outputs.length).toBeGreaterThan(0);
       for (const output of outputs) expect(output.lang).toBe('eng+rus');
+      expect(flat(outputs.map((o) => o.content ?? '').join(' '))).toMatch(/[A-Za-z]{3,}/);
     },
     OCR_TEST_TIMEOUT_MS,
   );

--- a/test/ocr-adapter.unit-spec.ts
+++ b/test/ocr-adapter.unit-spec.ts
@@ -14,6 +14,7 @@ import { existsSync, readdirSync, rmSync } from 'node:fs';
 import { isAbsolute, join } from 'node:path';
 import { Readable } from 'node:stream';
 import sharp from 'sharp';
+import { validateOcrEnvValues } from '../src/common/evidence-flags';
 import { OcrAdapter } from '../src/evidence/processing/adapters/ocr.adapter';
 import {
   OCR_SUPPORTED_LANGUAGES,
@@ -527,6 +528,47 @@ describe('OcrAdapter deadline enforcement', () => {
       }),
     ).rejects.toThrow(/OCR engine start/);
     expect(terminated).toBe(true);
+  });
+});
+
+describe('OCR boot validation', () => {
+  const errorsFor = (env: NodeJS.ProcessEnv): string[] => {
+    const errors: string[] = [];
+    validateOcrEnvValues(env, errors);
+    return errors;
+  };
+
+  it('accepts an unset, blank or shipped language set', () => {
+    expect(errorsFor({})).toEqual([]);
+    expect(errorsFor({ EVIDENCE_OCR_LANGS: '  ' })).toEqual([]);
+    expect(errorsFor({ EVIDENCE_OCR_LANGS: 'eng' })).toEqual([]);
+    expect(errorsFor({ EVIDENCE_OCR_LANGS: 'RUS, eng' })).toEqual([]);
+  });
+
+  it('ERRORS on a language this build does not ship', () => {
+    // Not a warning: the reader clamps back to English, so without this
+    // the operator would silently get a language they did not choose.
+    const [error] = errorsFor({ EVIDENCE_OCR_LANGS: 'eng+fra' });
+    expect(error).toContain('does not ship');
+    expect(error).toContain('fra');
+    expect(error).toContain('never downloaded at runtime');
+  });
+
+  it('ERRORS on a confidence floor outside 0..100 or non-integer', () => {
+    expect(errorsFor({ EVIDENCE_OCR_MIN_CONFIDENCE: '101' })).toHaveLength(1);
+    expect(errorsFor({ EVIDENCE_OCR_MIN_CONFIDENCE: '-1' })).toHaveLength(1);
+    expect(errorsFor({ EVIDENCE_OCR_MIN_CONFIDENCE: '60.5' })).toHaveLength(1);
+    expect(errorsFor({ EVIDENCE_OCR_MIN_CONFIDENCE: 'high' })).toHaveLength(1);
+    expect(errorsFor({ EVIDENCE_OCR_MIN_CONFIDENCE: '0' })).toEqual([]);
+    expect(errorsFor({ EVIDENCE_OCR_MIN_CONFIDENCE: '100' })).toEqual([]);
+  });
+
+  it('validates against the SAME set the adapter resolves models from', () => {
+    // One source of truth: a language that validates must also resolve.
+    for (const lang of OCR_SUPPORTED_LANGUAGES) {
+      expect(errorsFor({ EVIDENCE_OCR_LANGS: lang })).toEqual([]);
+      expect(() => assertOcrLanguagesLocal([lang])).not.toThrow();
+    }
   });
 });
 

--- a/test/ocr-adapter.unit-spec.ts
+++ b/test/ocr-adapter.unit-spec.ts
@@ -1,0 +1,514 @@
+/**
+ * Local OCR processor (Brain v2.1 MM) — asserts against a REAL engine run
+ * over REAL pixels. Every fixture is synthesised in-process by sharp
+ * (libvips' pangocairo text renderer), so nothing binary is committed and
+ * the spec proves the adapter recognises what tesseract actually reads,
+ * not what a mock was told to return.
+ *
+ * The offline contract is a first-class assertion here: the spec pins the
+ * resolved model paths to the local filesystem, proves no remote URL is
+ * configured anywhere in the engine options, and shows the run leaves no
+ * traineddata cache behind in the working directory.
+ */
+import { existsSync, readdirSync } from 'node:fs';
+import { isAbsolute, join } from 'node:path';
+import { Readable } from 'node:stream';
+import sharp from 'sharp';
+import { OcrAdapter } from '../src/evidence/processing/adapters/ocr.adapter';
+import {
+  OCR_SUPPORTED_LANGUAGES,
+  OCR_TESSDATA_VARIANT,
+  assertOcrLanguagesLocal,
+  isOcrLanguage,
+  ocrLangPath,
+  ocrPackageLangDir,
+  ocrTrainedDataFile,
+} from '../src/evidence/processing/adapters/ocr-assets';
+import type {
+  ProcessorAdapter,
+  ProcessorInput,
+} from '../src/evidence/processing/processor-adapter';
+import { processorConfigFingerprint } from '../src/evidence/processing/processor-fingerprint';
+import { validateLocator } from '../src/evidence/locator';
+
+// Same jest-worker hygiene as the image-metadata spec: libvips otherwise
+// spins a thread pool and an operation cache inside every worker it is
+// loaded into, and this repo has a history of native-module worker
+// crashes under the unit suite. Spec-local; production is untouched.
+sharp.concurrency(1);
+sharp.cache(false);
+
+const adapter = new OcrAdapter();
+
+/** Recognition is a real WASM pass; give the slower fixtures headroom. */
+const OCR_TEST_TIMEOUT_MS = 60_000;
+
+const ENV_KEYS = [
+  'EVIDENCE_OCR_ENABLED',
+  'EVIDENCE_OCR_LANGS',
+  'EVIDENCE_OCR_MIN_CONFIDENCE',
+  'EVIDENCE_MAX_BYTES',
+] as const;
+const savedEnv = new Map<string, string | undefined>();
+
+beforeEach(() => {
+  for (const key of ENV_KEYS) savedEnv.set(key, process.env[key]);
+  process.env.EVIDENCE_OCR_ENABLED = '1';
+});
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    const previous = savedEnv.get(key);
+    if (previous === undefined) delete process.env[key];
+    else process.env[key] = previous;
+  }
+});
+
+/**
+ * Render text to a PNG the way a screenshot looks: dark glyphs on white,
+ * generous padding (tesseract's segmenter wants margin), rendered large
+ * enough that the recogniser is reading type rather than guessing at
+ * aliasing.
+ */
+async function renderText(text: string, dpi = 300): Promise<Buffer> {
+  return sharp({
+    text: { text, width: 1400, dpi, rgba: false },
+  })
+    .negate() // sharp renders white-on-black; OCR wants the usual polarity.
+    .extend({ top: 40, bottom: 40, left: 40, right: 40, background: '#ffffff' })
+    .png()
+    .toBuffer();
+}
+
+/** A picture with no writing in it at all: flat mid-grey. */
+async function renderBlank(): Promise<Buffer> {
+  return sharp({
+    create: { width: 600, height: 400, channels: 3, background: { r: 128, g: 128, b: 128 } },
+  })
+    .png()
+    .toBuffer();
+}
+
+function inputFor(
+  bytes: Buffer | null,
+  over: Partial<ProcessorInput['asset']> = {},
+): ProcessorInput {
+  const asset: ProcessorInput['asset'] = {
+    id: 'evidence_asset:o1',
+    modality: 'image',
+    mediaType: 'image/png',
+    availability: bytes === null ? 'external' : 'hot',
+    byteLength: bytes?.byteLength ?? 123,
+    ...over,
+  };
+  return {
+    asset,
+    openStream: bytes === null ? null : () => Promise.resolve(Readable.from([bytes])),
+  };
+}
+
+/** Collapse whitespace so an assertion is about WORDS, not line breaks. */
+function flat(text: string): string {
+  return text.replace(/\s+/g, ' ').trim();
+}
+
+describe('OcrAdapter.accepts', () => {
+  it('takes raster image types on the image modality when OCR is enabled', () => {
+    expect(adapter.accepts('image', 'image/png')).toBe(true);
+    expect(adapter.accepts('image', 'image/jpeg')).toBe(true);
+    expect(adapter.accepts('image', 'image/tiff')).toBe(true);
+    expect(adapter.accepts('image', 'image/webp')).toBe(true);
+  });
+
+  it('is case- and parameter-insensitive on the media type', () => {
+    expect(adapter.accepts('image', 'IMAGE/PNG')).toBe(true);
+    expect(adapter.accepts('image', 'image/jpeg; charset=binary')).toBe(true);
+    expect(adapter.accepts('image', '  image/tiff  ')).toBe(true);
+  });
+
+  it('declines other modalities, PDFs, and SVG (a vector carries real text)', () => {
+    expect(adapter.accepts('document', 'image/png')).toBe(false);
+    expect(adapter.accepts('video', 'image/png')).toBe(false);
+    expect(adapter.accepts('image', 'application/pdf')).toBe(false);
+    expect(adapter.accepts('image', 'image/svg+xml')).toBe(false);
+  });
+
+  it('declines EVERYTHING while EVIDENCE_OCR_ENABLED is off — the default', () => {
+    delete process.env.EVIDENCE_OCR_ENABLED;
+    expect(adapter.accepts('image', 'image/png')).toBe(false);
+    process.env.EVIDENCE_OCR_ENABLED = '0';
+    expect(adapter.accepts('image', 'image/png')).toBe(false);
+  });
+
+  it('reads the flag at call time, so a flip needs no restart', () => {
+    process.env.EVIDENCE_OCR_ENABLED = '0';
+    expect(adapter.accepts('image', 'image/png')).toBe(false);
+    process.env.EVIDENCE_OCR_ENABLED = '1';
+    expect(adapter.accepts('image', 'image/png')).toBe(true);
+  });
+});
+
+describe('OcrAdapter offline contract', () => {
+  it('resolves every shipped language to an ABSOLUTE local file', () => {
+    for (const lang of OCR_SUPPORTED_LANGUAGES) {
+      const dir = ocrPackageLangDir(lang);
+      const file = ocrTrainedDataFile(lang);
+      expect(isAbsolute(dir)).toBe(true);
+      expect(dir.endsWith(OCR_TESSDATA_VARIANT)).toBe(true);
+      expect(existsSync(file)).toBe(true);
+    }
+  });
+
+  it('configures NO remote URL anywhere in the resolved paths', () => {
+    const dirs = [
+      ...OCR_SUPPORTED_LANGUAGES.map((lang) => ocrPackageLangDir(lang)),
+      ocrLangPath(['eng']),
+      ocrLangPath([...OCR_SUPPORTED_LANGUAGES]),
+    ];
+    for (const dir of dirs) {
+      expect(isAbsolute(dir)).toBe(true);
+      // No scheme: a URL is the ONLY thing that flips tesseract.js from
+      // its fs branch to its fetch branch.
+      expect(dir).not.toMatch(/^[a-z][a-z0-9+.-]*:\/\//i);
+      expect(dir.toLowerCase()).not.toContain('http');
+      expect(dir.toLowerCase()).not.toContain('cdn');
+    }
+  });
+
+  it('single language uses the shipped package directory unchanged', () => {
+    expect(ocrLangPath(['eng'])).toBe(ocrPackageLangDir('eng'));
+    expect(ocrLangPath(['rus'])).toBe(ocrPackageLangDir('rus'));
+  });
+
+  it('stages a multi-language set into ONE local directory, idempotently', () => {
+    const dir = ocrLangPath(['eng', 'rus']);
+    expect(isAbsolute(dir)).toBe(true);
+    for (const lang of ['eng', 'rus'] as const) {
+      expect(existsSync(join(dir, `${lang}.traineddata.gz`))).toBe(true);
+    }
+    // Deterministic name, and a second call is a no-op.
+    expect(ocrLangPath(['rus', 'eng'])).toBe(dir);
+    expect(ocrLangPath(['eng', 'rus'])).toBe(dir);
+  });
+
+  it('refuses a language the image does not ship rather than fetching it', () => {
+    expect(isOcrLanguage('fra')).toBe(false);
+    expect(() => assertOcrLanguagesLocal(['fra'])).toThrow(/not installed/);
+    expect(() => assertOcrLanguagesLocal(['fra'])).toThrow(/never downloads/);
+    expect(() => assertOcrLanguagesLocal([])).toThrow(/no OCR language configured/);
+  });
+
+  it('accepts the shipped set', () => {
+    expect(() => assertOcrLanguagesLocal(['eng'])).not.toThrow();
+    expect(() => assertOcrLanguagesLocal(['eng', 'rus'])).not.toThrow();
+  });
+
+  it(
+    'leaves no traineddata cache in the working directory after a run',
+    async () => {
+      const before = readdirSync(process.cwd()).filter((f) => f.endsWith('.traineddata'));
+      await adapter.process(inputFor(await renderText('CACHE CHECK')));
+      const after = readdirSync(process.cwd()).filter((f) => f.endsWith('.traineddata'));
+      expect(after).toEqual(before);
+    },
+    OCR_TEST_TIMEOUT_MS,
+  );
+});
+
+describe('OcrAdapter.process (real recognition)', () => {
+  it(
+    'reads known text out of a synthesised image',
+    async () => {
+      const png = await renderText('INVOICE TOTAL 4200 USD');
+      const outputs = await adapter.process(inputFor(png));
+      expect(outputs.length).toBeGreaterThan(0);
+      const joined = flat(outputs.map((o) => o.content ?? '').join(' '));
+      expect(joined).toContain('INVOICE');
+      expect(joined).toContain('TOTAL');
+      expect(joined).toContain('4200');
+      for (const output of outputs) expect(output.kind).toBe('ocr');
+    },
+    OCR_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    'emits a per-region pageRegion locator the write seam will accept',
+    async () => {
+      const outputs = await adapter.process(inputFor(await renderText('REGION ONE')));
+      const located = outputs.filter((o) => o.locator !== undefined);
+      expect(located.length).toBeGreaterThan(0);
+      for (const output of located) {
+        expect(output.locator).toMatchObject({ kind: 'pageRegion', page: 0 });
+        // The real validator, against the real modality — an invalid
+        // locator would be rejected at the write seam, not here.
+        expect(validateLocator('image', output.locator)).toBeNull();
+      }
+    },
+    OCR_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    'reports confidence on the 0..1 scale the representation column asserts',
+    async () => {
+      const outputs = await adapter.process(inputFor(await renderText('CONFIDENCE CHECK')));
+      for (const output of outputs) {
+        expect(typeof output.confidence).toBe('number');
+        expect(output.confidence!).toBeGreaterThan(0);
+        expect(output.confidence!).toBeLessThanOrEqual(1);
+      }
+    },
+    OCR_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    'stamps the language set it actually used, and labels each region',
+    async () => {
+      const outputs = await adapter.process(inputFor(await renderText('LANG STAMP')));
+      for (const output of outputs) {
+        expect(output.lang).toBe('eng');
+        expect(output.label).toMatch(/^ocr \d+\/\d+/);
+      }
+    },
+    OCR_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    'is deterministic — identical bytes produce identical text and locators',
+    async () => {
+      const png = await renderText('DETERMINISM 1234');
+      const first = await adapter.process(inputFor(png));
+      const second = await adapter.process(inputFor(png));
+      expect(second.map((o) => o.content)).toEqual(first.map((o) => o.content));
+      expect(second.map((o) => o.locator)).toEqual(first.map((o) => o.locator));
+      expect(second.map((o) => o.confidence)).toEqual(first.map((o) => o.confidence));
+    },
+    OCR_TEST_TIMEOUT_MS,
+  );
+});
+
+describe('OcrAdapter Russian', () => {
+  it(
+    'reads Cyrillic when the Russian model is selected',
+    async () => {
+      const png = await renderText('ОТЧЁТ ГОТОВ');
+      process.env.EVIDENCE_OCR_LANGS = 'rus';
+      const outputs = await adapter.process(inputFor(png));
+      const joined = flat(outputs.map((o) => o.content ?? '').join(' '));
+      expect(joined).toMatch(/[А-Яа-яЁё]/);
+      expect(joined).toContain('ГОТОВ');
+      for (const output of outputs) expect(output.lang).toBe('rus');
+    },
+    OCR_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    'loads a multi-language set from local models only',
+    async () => {
+      process.env.EVIDENCE_OCR_LANGS = 'eng+rus';
+      const outputs = await adapter.process(inputFor(await renderText('REPORT READY')));
+      expect(flat(outputs.map((o) => o.content ?? '').join(' '))).toContain('REPORT');
+      for (const output of outputs) expect(output.lang).toBe('eng+rus');
+    },
+    OCR_TEST_TIMEOUT_MS,
+  );
+});
+
+describe('OcrAdapter confidence floor', () => {
+  it(
+    'drops every word and fails the run when the floor is unreachable',
+    async () => {
+      const png = await renderText('THIS TEXT IS PERFECTLY LEGIBLE');
+      // No engine reaches 101 — the whole reading must be discarded.
+      process.env.EVIDENCE_OCR_MIN_CONFIDENCE = '100';
+      await expect(adapter.process(inputFor(png))).rejects.toThrow(
+        /no text recognised above the confidence floor/,
+      );
+    },
+    OCR_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    'keeps the same text when the floor is permissive',
+    async () => {
+      const png = await renderText('FLOOR SANITY 77');
+      process.env.EVIDENCE_OCR_MIN_CONFIDENCE = '0';
+      const permissive = await adapter.process(inputFor(png));
+      expect(flat(permissive.map((o) => o.content ?? '').join(' '))).toContain('FLOOR');
+    },
+    OCR_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    'stays silent about drops when nothing was dropped',
+    async () => {
+      const png = await renderText('CLEAR WORDS HERE');
+      process.env.EVIDENCE_OCR_MIN_CONFIDENCE = '0';
+      const clean = await adapter.process(inputFor(png));
+      expect(clean.every((o) => !(o.content ?? '').includes('[ocr:'))).toBe(true);
+    },
+    OCR_TEST_TIMEOUT_MS,
+  );
+
+  it(
+    'states a PARTIAL reading in the stored text rather than swallowing it',
+    async () => {
+      // The engine is deterministic for fixed bytes, but the exact
+      // per-word confidences of a rendered fixture are not a number this
+      // spec should hard-code. Raising the floor step by step over the
+      // SAME image walks from "everything survives" to "nothing does";
+      // somewhere in between the reading is partial, and the contract
+      // under test is that a partial reading says so.
+      const png = await renderText('ALPHA BRAVO CHARLIE DELTA ECHO FOXTROT');
+      process.env.EVIDENCE_OCR_MIN_CONFIDENCE = '0';
+      const full = flat(
+        (await adapter.process(inputFor(png))).map((o) => o.content ?? '').join(' '),
+      );
+      expect(full.length).toBeGreaterThan(0);
+
+      let notice: string | null = null;
+      for (const floor of [70, 80, 85, 88, 90, 92, 94, 96, 98]) {
+        process.env.EVIDENCE_OCR_MIN_CONFIDENCE = String(floor);
+        let outputs;
+        try {
+          outputs = await adapter.process(inputFor(png));
+        } catch {
+          // Floor above every word: an honest failed run, tested above.
+          continue;
+        }
+        const partial = outputs.find((o) => (o.content ?? '').includes('[ocr:'));
+        if (partial) {
+          notice = partial.content!;
+          break;
+        }
+      }
+      expect(notice).not.toBeNull();
+      expect(notice!).toMatch(/\[ocr: \d+ low-confidence words? dropped\]/);
+      // The surviving text really is shorter than the unfiltered reading.
+      expect(flat(notice!.replace(/\[ocr:[^\]]*\]/, '')).length).toBeLessThan(full.length);
+    },
+    OCR_TEST_TIMEOUT_MS,
+  );
+});
+
+describe('OcrAdapter honest emptiness', () => {
+  it(
+    'fails the run on an image with no writing in it, never emitting noise',
+    async () => {
+      await expect(adapter.process(inputFor(await renderBlank()))).rejects.toThrow(
+        /no legible text|no text recognised/,
+      );
+    },
+    OCR_TEST_TIMEOUT_MS,
+  );
+});
+
+describe('OcrAdapter failure modes', () => {
+  it('fails honestly on an oversize blob instead of buffering it', async () => {
+    const png = await renderText('OVERSIZE');
+    process.env.EVIDENCE_MAX_BYTES = '16';
+    await expect(adapter.process(inputFor(png))).rejects.toThrow(/exceed the evidence size cap/);
+  });
+
+  it('fails honestly on corrupt bytes instead of crashing', async () => {
+    const junk = Buffer.from('this is definitely not an image, not even a little');
+    await expect(adapter.process(inputFor(junk))).rejects.toThrow();
+  });
+
+  it('fails honestly on a truncated image header', async () => {
+    const png = await renderText('TRUNCATED');
+    await expect(adapter.process(inputFor(png.subarray(0, 24)))).rejects.toThrow();
+  });
+
+  it('names the reason when the asset carries no readable bytes', async () => {
+    await expect(adapter.process(inputFor(null))).rejects.toThrow(/bytes are not readable/);
+  });
+
+  it('refuses an unshipped language BEFORE reading a byte', async () => {
+    process.env.EVIDENCE_OCR_LANGS = 'fra';
+    // openStream would throw if it were reached; it must not be.
+    const never: ProcessorInput = {
+      asset: inputFor(null).asset,
+      openStream: () => Promise.reject(new Error('stream must not be opened')),
+    };
+    await expect(adapter.process(never)).rejects.toThrow(/not installed/);
+  });
+});
+
+describe('OcrAdapter deadline enforcement', () => {
+  it('races work against a wall-clock bound and names the step that blew it', async () => {
+    // The adapter's own deadlines are 10-30 s; asserting them literally
+    // would mean a 30 s test. The contract under test is that the shared
+    // helper the adapter uses REJECTS rather than hanging, with a message
+    // naming the step — the same helper, the same labels.
+    const { withDeadline } = await import('../src/evidence/processing/adapters/adapter-io');
+    const hang = new Promise<never>(() => {});
+    await expect(withDeadline(hang, { ms: 5, label: 'OCR recognition' })).rejects.toThrow(
+      /OCR recognition exceeded its 5ms deadline/,
+    );
+  });
+
+  it('runs its terminator when the deadline fires, so no engine is left behind', async () => {
+    const { withDeadline } = await import('../src/evidence/processing/adapters/adapter-io');
+    let terminated = false;
+    const hang = new Promise<never>(() => {});
+    await expect(
+      withDeadline(hang, {
+        ms: 5,
+        label: 'OCR engine start',
+        onTimeout: () => {
+          terminated = true;
+        },
+      }),
+    ).rejects.toThrow(/OCR engine start/);
+    expect(terminated).toBe(true);
+  });
+});
+
+describe('OcrAdapter fingerprint discipline', () => {
+  it('is stable across runs under identical configuration', () => {
+    const fp = processorConfigFingerprint(adapter);
+    expect(fp).toMatch(/^[0-9a-f]{8}$/);
+    expect(processorConfigFingerprint(new OcrAdapter())).toBe(fp);
+  });
+
+  it('pins the language set, model generation, floor, prep and region cap', () => {
+    expect(adapter.configParts()).toEqual([
+      'langs=eng',
+      `tessdata=${OCR_TESSDATA_VARIANT}`,
+      'minConfidence=60',
+      'prep=grey-2000px-png-v1',
+      'maxRegions=64',
+    ]);
+  });
+
+  it('forks the key when the confidence floor changes', () => {
+    const before = processorConfigFingerprint(adapter);
+    process.env.EVIDENCE_OCR_MIN_CONFIDENCE = '75';
+    expect(processorConfigFingerprint(adapter)).not.toBe(before);
+  });
+
+  it('forks the key when the language set changes', () => {
+    const before = processorConfigFingerprint(adapter);
+    process.env.EVIDENCE_OCR_LANGS = 'eng+rus';
+    expect(adapter.configParts()[0]).toBe('langs=eng+rus');
+    expect(processorConfigFingerprint(adapter)).not.toBe(before);
+  });
+
+  it('treats language ORDER as significant — tesseract does', () => {
+    process.env.EVIDENCE_OCR_LANGS = 'eng+rus';
+    const engFirst = processorConfigFingerprint(adapter);
+    process.env.EVIDENCE_OCR_LANGS = 'rus+eng';
+    expect(processorConfigFingerprint(adapter)).not.toBe(engFirst);
+  });
+
+  it('forks the key on a version bump', () => {
+    const bumped: ProcessorAdapter = {
+      capability: adapter.capability,
+      version: 'image-ocr-tesseract-v2',
+      configParts: () => adapter.configParts(),
+      accepts: () => true,
+      process: () => Promise.resolve([]),
+    };
+    expect(processorConfigFingerprint(bumped)).not.toBe(processorConfigFingerprint(adapter));
+  });
+});


### PR DESCRIPTION
## Why

Today a PDF with a text layer is readable (`DocumentTextAdapter`, pdf2json) and an image yields only intrinsic metadata and allowlisted EXIF (`ImageMetadataAdapter`, sharp). So a screenshot of a failing dashboard, a photo of a whiteboard, or a scan without a text layer is **mute** to the system — the plane can store it, cite it and serve its bytes, but never read a word of it.

`ocr` was the last capability in `DERIVED_REPRESENTATION_KINDS` that no adapter could run, which is exactly why every pack's media contract left the slot undeclared (declaring a capability with no adapter arms a dispatch that always denies). This PR builds the adapter and then declares it where it earns its place.

Everything else was already in place: `ProcessorOutput` carries an optional `locator`, locator-bearing outputs become fragments, and fragments are what the serving fragment lane can return.

## What landed

**`OcrAdapter`** (`src/evidence/processing/adapters/ocr.adapter.ts`), capability `ocr`, modality `image`, registered in `evidence.module.ts` alongside its two siblings.

- **One output per text region**, each with a `pageRegion` locator normalised to `[0,1]` and validated against the real `validateLocator`. A claim can therefore cite *this sentence, in this corner of this screenshot*. Locator identity is the fragment dedup key, so a later adapter version re-detecting a region re-attaches to the **same** citation target instead of forking a second one.
- **Per-region confidence**, rescaled from tesseract's 0..100 to the 0..1 float the `derived_representation.confidence` column asserts, and rounded so a re-read stores an identical number.
- `lang` stamped with the language set actually used; `label` = `ocr i/n: <excerpt>` so a citation list is readable without loading every representation.

### Engine choice

**tesseract.js 7.0.0** (Apache-2.0) over the `tesseract.js-core` WASM build. Chosen on the same grounds pdf2json was: it is the option we can actually run *and test* here. The alternatives each fail a constraint —

| candidate | disqualifier |
|---|---|
| `node-tesseract-ocr` / native bindings | needs a system `tesseract` binary — a new apt layer and a second glibc ABI surface next to the onnxruntime one we already nurse |
| `tesseract-wasm` | ESM-only; the CJS jest runtime cannot service its dynamic import without `--experimental-vm-modules` |
| PaddleOCR ports, `@gutenye/ocr-node` | reintroduce `onnxruntime-node`, whose unstubbed workers are the documented cause of this repo's CI SIGABRT class |
| every hosted OCR API | paid, and network |

`pnpm audit --audit-level=high` is clean on the new dependency tree.

## How it is genuinely offline

tesseract.js is CDN-first by default: handed no `langPath` its worker builds `https://cdn.jsdelivr.net/npm/@tesseract.js-data/<lang>/…` and fetches the model on first use. Closed in three places, and asserted in the spec:

1. **The WASM core needs nothing** — and that is a property of the package, not luck. In Node, `src/worker-script/node/getCore.js` `require`s `tesseract.js-core/tesseract-core-*` straight out of `node_modules` and **ignores `corePath` entirely** (`corePath` is a browser-only knob; the browser loader is the one that fetches). Same for `workerPath`: node's `defaultOptions` points it at the packaged worker script on disk.
2. **The language models are resolved to an absolute local directory** via `require.resolve('@tesseract.js-data/<lang>/package.json')` and passed as `langPath`. tesseract.js only takes its fetch branch when `isURL(langPath)`; an absolute POSIX path is not one, so the worker reads with `fs.readFile`. `assertOcrLanguagesLocal()` runs **before a byte of the asset is read** and refuses an unshipped language or a missing model file — a packaging mistake is a named failure, never a fetch and never a stall.
3. **`cacheMethod: 'none'`.** The default (`'write'`) makes the worker read *and write* `./<lang>.traineddata` relative to the process CWD — dropping a multi-megabyte file into a server's working directory and then preferring that stale copy forever. Off.

### The packaging trade-off (npm dependency, not committed blobs, not a build-time download)

| option | verdict |
|---|---|
| **npm dependency** (`@tesseract.js-data/{eng,rus}`) ✅ chosen | content-hashed in `pnpm-lock.yaml`, installed by the **same** `pnpm install --frozen-lockfile` the image already runs — no new build-time network step, no new checksum problem, identical in dev / CI / prod, and unit tests exercise the real models |
| commit `.traineddata` to the repo | ~5.6 MB of binary in git history that every clone and every CI job pays for forever, plus a manual update path with no integrity story |
| download at Docker build time | a new network dependency in the image build, its own pinning problem, and a local dev/test environment that differs from the image (tests could not run against real models) |

`onlyBuiltDependencies` matters here **in the negative**: `tesseract.js` declares a `postinstall` (an OpenCollective donation banner). It is not in the allowlist and must not be added — nothing in the OCR path needs it, and the allowlist is exactly the control that keeps an unreviewed install script out of the image. pnpm reports it as an ignored build script, which is the correct outcome. The `Dockerfile` gains only a comment recording all of this; no new layer, no new step.

### Languages: `eng` mandatory, `rus` included

English is the default. Russian is shipped too and is worth its size: the platform serves RU users (the transition classifier already carries RU prototypes), and running Cyrillic content **without** `rus` is worse than not running it at all — tesseract maps Cyrillic to Latin lookalikes and returns confident garbage, which is precisely the invented-text failure this adapter exists to avoid. Both use the `4.0.0_best_int` generation (integerised best-quality LSTM) rather than the full legacy+LSTM set: the adapter runs LSTM-only, so the legacy tables are dead weight (~3 MB vs ~11 MB for English).

`EVIDENCE_OCR_LANGS` selects the set, in priority order (tesseract treats the first as primary, so the order is meaningful and is deliberately not sorted). A multi-language set needs one directory while each data package owns its own, so those are staged as a directory of **symlinks** under the OS temp dir — deterministic name, lazy, idempotent, no bytes duplicated, nothing downloaded. A single language (the default) uses the package directory untouched.

## Honesty of output

An OCR engine never says "nothing here": point it at a photo of a wall and it returns plausible-looking characters with confidences in the teens. Storing those would put invented text into a memory that later cites it as observed evidence.

- **Word-level confidence floor**, `EVIDENCE_OCR_MIN_CONFIDENCE` (0..100, default **60** — tesseract's own boundary between a confident read and a guess; on the fixtures clean type scores 80-95 and noise well under 40). Word-level rather than block-level because a block-level floor is a false choice: one misread word would discard a paragraph of good text, or one good paragraph would carry a misread word into storage as fact.
- **A partial reading says so.** Dropped words are counted and stated in the stored content as `[ocr: N low-confidence words dropped]` — the house `[…]` marker shape from `DocumentTextAdapter`'s `[page i of n]`. A reader can tell a complete reading from a filtered one without consulting the run row.
- **A region with nothing left is not written**; an image with no surviving region **fails the run** with a message saying the image carries no legible text, exactly as `DocumentTextAdapter` fails a text-layer-less PDF. Silence is a better memory than invention.

The floor and the language set are output knobs, so both ride `configParts()` — retuning either forks the idempotency key and re-reads instead of leaving differently-filtered text under an unchanged key (#386 discipline). The deadlines deliberately do **not** ride it: a timeout is a run failure, not a different output.

## Cost and bounds

Four independent axes:

- **Bytes** — `evidenceMaxBytes()` enforced *while streaming* (`openAssetBytes`), so an oversize blob costs a bounded amount of memory and ends as an honest failed run.
- **Pixels** — the image is decoded, EXIF-oriented, greyscaled and downscaled to a 2000px longest edge before recognition (`prep=grey-2000px-png-v1`, in the fingerprint). Recognition time is linear in pixel count, and a 48 MP phone photo is ~24x the work for no accuracy gain. Normalised locators make the downscale invisible to a citing reader.
- **Wall clock** — 10 s on preparation, 30 s on engine start, 30 s on recognition, all through the shared `withDeadline` helper, with a terminator that kills the engine when the deadline fires.
- **Regions** — at most 64 per image. Over that the run is **rejected, never truncated** (a clipped page would read as a complete one); a page that fragmented is the signature of noise, not of a document.

Recognition itself runs in the `worker_thread` tesseract.js spawns, so the WASM burn never touches the request event loop — which is what makes it safe on the fire-and-forget dispatch path the blob upload already uses (`EvidenceUploadService.dispatch`, never awaited). The worker is created per call and terminated in a `finally`; a pooled scheduler would amortise the ~0.1 s start-up but hold a thread and tens of megabytes resident forever, the wrong trade for a capability most tenants never enable. Jest confirms zero open handles after the suite.

**Note for reviewers:** the admin sweep (`dispatchSweep`) is a sequential loop bounded at 1000 assets, so with OCR enabled a maximum-size sweep is now a genuinely long request. That is pre-existing sweep shape rather than something this PR changes, but it is worth knowing before someone runs one with `limit=1000`.

## Two upstream quirks worked around (both documented in code)

1. **`createWorker` never rejects.** `src/createWorker.js` ends its own init chain with `.catch(() => {})`, so a failed `load` / `loadLanguage` / `initialize` leaves the returned promise pending **forever**; the only report is a call to the `errorHandler` option. Without the race in `startWorker()` a corrupt model would surface as a 30-second deadline timeout instead of the real message. (Residual, stated in the comment: a failed start leaves no handle to terminate — which is why every model file is pre-flighted, making that failure unreachable in practice rather than merely reported.)
2. **`langPath` is a single directory**, so a multi-language set needs the symlink staging described above.

## Gating

Default behaviour is byte-identical for anyone not enabling OCR. The full existing ladder applies unchanged — pack declaration → modality consent → quarantine → tombstone → `EVIDENCE_PROCESSOR_BROKER` — plus one new switch on top:

`EVIDENCE_OCR_ENABLED` (EVIDENCE_ family, catalogued in `KNOWN_BOOLEAN_FLAGS` and `.env.example`, default off). It is checked **inside `accepts()`**, not in the module's registry factory: a factory read would capture the flag at boot, and this family's contract is that a flip is runtime-mutable. Off, the broker records the same `no installed processor` denial it records today.

Why this adapter carries a flag when its two siblings do not: they are header/parse-level decodes measured in milliseconds, while this one spins a worker thread, faults in a ~3.5 MB WASM core plus a ~3 MB model, and burns CPU proportional to pixel count. That is an operator's capacity decision.

`EVIDENCE_OCR_LANGS` and `EVIDENCE_OCR_MIN_CONFIDENCE` are validated at boot as **errors**, not warnings: both are read at call time with a clamp-to-default fallback, so a typo would otherwise silently run OCR under settings the operator did not choose.

## Packs now declaring `ocr`

| pack | version | why |
|---|---|---|
| `medical` | 0.3.0 → **0.4.0** | a scan carries its findings as pixels; `document_text` never sees it and `image_metadata` can only say "2480x3508 greyscale TIFF" |
| `legal` | 0.3.0 → **0.4.0** | a scanned exhibit has no text layer — governing law, parties and dates are printed on the page |
| `insurance` | 0.3.0 → **0.4.0** | most of what a claim photo is worth is text inside it: repair estimates, policy numbers, serial plates, receipts |
| `real_estate` | 0.3.0 → **0.4.0** | a floor plan's entire content is lettering — room labels, dimensions, scale bar, unit number |
| `code_memory` (builtin) | 0.5.0 → **0.6.0** | the screenshot is this domain's native artefact and its text is the whole point of it |

**Deliberately not declared:** `fintech` and `hr` declare no `image` modality at all (biometric-adjacent / personal data), so an `ocr` declaration would be dead weight that still costs a consent re-acceptance. A spec pins that asymmetry rather than leaving it to review.

Every manifest stays zod-valid, `packs/*.pack.json` regenerated in sync (drift guard green), and the media-contract pins in `test/domain-pack.unit-spec.ts` updated. Note the version bumps are load-bearing: adding a processor changes the media section, so the modality-consent checksum changes with it and an installed tenant must re-accept (`--accept-modalities`) before the new capability dispatches — the consent surface working as designed.

## Tests

`test/ocr-adapter.unit-spec.ts`, 37 cases, asserting against a **real engine run over real pixels** — every fixture synthesised in-process by sharp's pangocairo text renderer, so nothing binary is committed and the spec proves what tesseract actually reads rather than what a mock was told to return.

- known text is recognised; Cyrillic is recognised under `rus`; `eng+rus` loads from local models only
- per-region `pageRegion` locators pass the **real** `validateLocator`; confidence lands in 0..1; `lang` and `label` are stamped
- deterministic: identical bytes → identical text, locators and confidences
- confidence floor: an unreachable floor fails the run honestly; a permissive floor keeps the text; a floor sweep proves a partial reading carries its `[ocr: …]` notice and is genuinely shorter
- an image with no writing fails honestly, never emitting noise
- oversize / corrupt / truncated / byte-less assets all fail with named errors; an unshipped language is refused **before** the stream is opened (the fixture's `openStream` rejects if reached)
- deadline enforcement and the terminator hook
- **offline contract**: every resolved path is absolute and local, no scheme / `http` / `cdn` substring anywhere in the options, single-language uses the package dir untouched, multi-language staging is deterministic and idempotent, and a run leaves no `.traineddata` cache in the working directory
- `configParts()` fingerprint stable, and forking on floor / language set / language **order** / version

Plus new gate cases in `test/domain-pack.unit-spec.ts`: `gateProcessorDispatch` now admits `image→ocr` for a declaring pack and still denies it for an image-less one.

## Gates

`pnpm typecheck` ✅ · full unit suite **376 suites / 4468 tests** ✅ · `pnpm lint:ci` ✅ · `pnpm format:check` ✅ · `pnpm build` ✅ · `pnpm audit --audit-level=high` ✅ (no known vulnerabilities). Targeted e2e (`evidence-processing`, `industry-packs`, `real-estate-pack`) green against a real SurrealDB 3.2.4 container.

## Image size impact

~68 MB added to the runtime image, all of it in `node_modules` via the existing `--prod` install: `tesseract.js-core` ~43 MB (six WASM core variants; the loader feature-detects at runtime, so pruning would risk a broken image on a CPU without relaxed-SIMD), `@tesseract.js-data/eng` ~13 MB, `@tesseract.js-data/rus` ~11 MB, `tesseract.js` ~1.6 MB. Pruning the unused `4.0.0` traineddata directories was considered and rejected as theatre: pnpm hardlinks `node_modules` from a content-addressed store that lives in the same image, so deleting the link reclaims nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB
