### PR TITLE
feat(agents): publish an A2A agent card

### DIFF
--- a/brain-landing/__tests__/agent-card.test.ts
+++ b/brain-landing/__tests__/agent-card.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import { GET } from '../app/.well-known/agent-card.json/route'
+import { GET as manifest } from '../app/.well-known/agent-actions/route'
+
+/**
+ * A2A reached v1.0 under the Linux Foundation in 2026, and this path is what
+ * another vendor's agent looks for. Brain published `agent-actions` — INITE's
+ * own convention, read by nothing outside this company — and nothing at the
+ * standard one, so an agent following the discovery chain found a 404.
+ */
+
+async function card(): Promise<Record<string, unknown>> {
+  return JSON.parse(await GET().text()) as Record<string, unknown>
+}
+
+describe('the agent card', () => {
+  it('carries every field v1.0 requires', async () => {
+    const c = await card()
+    for (const field of [
+      'name', 'description', 'supportedInterfaces', 'version',
+      'capabilities', 'defaultInputModes', 'defaultOutputModes', 'skills',
+    ]) {
+      expect(c[field], `missing ${field}`).toBeDefined()
+    }
+    expect(Array.isArray(c.supportedInterfaces)).toBe(true)
+    expect((c.supportedInterfaces as unknown[]).length).toBeGreaterThan(0)
+  })
+
+  it('declares only the protocol it actually speaks', async () => {
+    /**
+     * Brain speaks REST and MCP. `HTTP+JSON` is an A2A core binding meaning
+     * A2A over HTTP, not "this service has a REST API" — declaring it would
+     * tell a client it can speak A2A here, which it cannot.
+     */
+    const interfaces = (await card()).supportedInterfaces as { protocolBinding: string; url: string }[]
+    expect(interfaces.map((i) => i.protocolBinding)).toEqual(['MCP'])
+    // Multi-tenant: a card naming one fixed URL would name one that works
+    // for nobody.
+    expect(interfaces[0].url).toContain('{companyId}')
+  })
+
+  it('lists the same operations the manifest does', async () => {
+    // Derived from one array rather than retyped. Two lists of the same nine
+    // operations disagree the first time one of them changes.
+    const actions = (JSON.parse(await manifest().text()) as { actions: { id: string }[] }).actions
+    const skills = (await card()).skills as { id: string }[]
+    expect(skills.map((s) => s.id)).toEqual(actions.map((a) => a.id))
+    expect(skills.length).toBeGreaterThan(5)
+  })
+
+  it('gives every skill the fields a client reads', async () => {
+    for (const skill of (await card()).skills as Record<string, unknown>[]) {
+      expect(typeof skill.name).toBe('string')
+      expect(String(skill.description).length).toBeGreaterThan(20)
+      expect(Array.isArray(skill.tags)).toBe(true)
+      expect((skill.tags as string[]).length).toBeGreaterThan(0)
+    }
+  })
+
+  it('names the writes as writes', async () => {
+    const skills = (await card()).skills as { id: string; tags: string[] }[]
+    const forget = skills.find((s) => s.id === 'forget-entity')!
+    expect(forget.tags).toContain('write')
+    expect(skills.find((s) => s.id === 'search')!.tags).toContain('retrieval')
+  })
+})

--- a/brain-landing/app/.well-known/agent-actions/route.ts
+++ b/brain-landing/app/.well-known/agent-actions/route.ts
@@ -9,7 +9,7 @@ export const dynamic = 'force-static'
  * instead of scraping. The MCP endpoint is the richer, typed path.
  */
 
-interface AgentAction {
+export interface AgentAction {
   id: string
   description: string
   url: string
@@ -21,7 +21,7 @@ interface AgentAction {
 
 const API = SITE_URL
 
-const ACTIONS: AgentAction[] = [
+export const ACTIONS: AgentAction[] = [
   {
     id: 'search',
     description:

--- a/brain-landing/app/.well-known/agent-card.json/route.ts
+++ b/brain-landing/app/.well-known/agent-card.json/route.ts
@@ -1,0 +1,104 @@
+import { SITE_URL, ORG, PARENT } from '../../../lib/seo'
+import { ACTIONS } from '../agent-actions/route'
+
+export const dynamic = 'force-static'
+
+/**
+ * GET /.well-known/agent-card.json — Brain's A2A Agent Card.
+ *
+ * A2A reached v1.0 under the Linux Foundation in 2026 and this is the path
+ * RFC 8615 reserves for it. Brain already published `/.well-known/
+ * agent-actions`, which is INITE's own convention and read by nothing outside
+ * this company; this is the one another vendor's agent will look for.
+ *
+ * The skills are derived from the same `ACTIONS` array the manifest serves,
+ * not retyped. Two lists of the same nine operations would disagree the first
+ * time one of them changed, and the audit that found this file missing is the
+ * same audit that would then report the wrong capabilities.
+ *
+ * ── One interface, and why not two ────────────────────────────────────────
+ *
+ * Brain speaks REST and MCP. Only MCP is declared. `HTTP+JSON` is one of
+ * A2A's core protocol bindings and means A2A carried over HTTP with JSON
+ * bodies — not "this service has a REST API". Declaring it would tell a
+ * client it can speak A2A here, which it cannot. The REST surface is
+ * described by OpenAPI at /openapi.json and by the agent-actions manifest,
+ * both of which say what they are.
+ *
+ * `protocolBinding` is defined by the specification as an open-form string,
+ * so `MCP` is conformant and true.
+ *
+ * The URL carries `{companyId}` because Brain is multi-tenant and the
+ * endpoint genuinely is per-tenant. A card that named a single URL would be
+ * naming one that works for nobody.
+ *
+ * Unsigned: v1.0 signatures are optional and signing means a private key in
+ * the build. That is a decision to take rather than one to assume.
+ */
+
+/** Ingest and deletion mutate; everything else reads. Tags follow that split. */
+function tagsFor(action: { id: string; mutation?: boolean }): string[] {
+  const base = ['knowledge-graph', 'memory']
+  if (action.mutation) return [...base, 'write']
+  return [...base, 'retrieval']
+}
+
+export function GET() {
+  const card = {
+    protocolVersion: '1.0',
+    name: ORG.name,
+    description: ORG.description,
+
+    supportedInterfaces: [
+      { url: `${SITE_URL}/mcp/{companyId}`, protocolBinding: 'MCP', protocolVersion: '1.0' },
+    ],
+
+    version: '1.0.0',
+    documentationUrl: `${SITE_URL}/en/docs`,
+    iconUrl: ORG.logo,
+
+    provider: {
+      organization: PARENT.legalName,
+      url: PARENT.url,
+    },
+
+    capabilities: {
+      streaming: false,
+      pushNotifications: false,
+      extendedAgentCard: false,
+    },
+
+    defaultInputModes: ['application/json'],
+    defaultOutputModes: ['application/json'],
+
+    skills: ACTIONS.map((action) => ({
+      id: action.id,
+      name: action.id
+        .split('-')
+        .map((word) => word[0].toUpperCase() + word.slice(1))
+        .join(' '),
+      description: action.description,
+      tags: tagsFor(action),
+      inputModes: ['application/json'],
+      outputModes: ['application/json'],
+    })),
+
+    securitySchemes: {
+      apiKey: {
+        type: 'http',
+        scheme: 'bearer',
+        description:
+          'Per-tenant API key in the Authorization header. The MCP endpoint at ' +
+          '/mcp/{companyId} exposes the same tools, typed.',
+      },
+    },
+    securityRequirements: [{ apiKey: [] }],
+  }
+
+  return new Response(JSON.stringify(card, null, 2), {
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Cache-Control': 'public, max-age=3600',
+    },
+  })
+}


### PR DESCRIPTION
A2A reached **v1.0 under the Linux Foundation** in 2026, and `/.well-known/agent-card.json` is the path RFC 8615 reserves for it — the one another vendor's agent looks for.

Brain published `/.well-known/agent-actions`, which is INITE's own convention and read by nothing outside this company, and answered **404** at the standard path. An agent following the discovery chain found nothing.

## Derived, not retyped

Skills come from the same `ACTIONS` array the manifest serves. Two lists of the same nine operations disagree the first time one of them changes — and then the card describes capabilities the service does not have.

## One interface, not two

Brain speaks REST and MCP. **Only MCP is declared.**

`HTTP+JSON` is one of A2A's core protocol bindings and means *A2A carried over HTTP with JSON bodies* — not "this service has a REST API". Declaring it would tell a client it can speak A2A here, which it cannot. The REST surface is described by OpenAPI at `/openapi.json` and by the agent-actions manifest, both of which say what they are.

`protocolBinding` is defined by the specification as an open-form string, so `MCP` is conformant and true.

The URL carries `{companyId}` because Brain is multi-tenant and the endpoint genuinely is per-tenant. A card naming one fixed URL would name one that works for nobody.

Unsigned: v1.0 signatures are optional and signing means a private key in the build — a decision to take rather than one to assume.

## How this was found

Auditing the whole INITE family with inite.ai's agent-surface check, which now looks for exactly this file. Brain scored **lowest of the properties that publish an MCP server**.

The same pass turned up two false negatives in that audit, both fixed upstream: it searched the registry by the host's first label (`brain`, not `inite`, among a hundred strangers' servers), and it read only the first 4 KB of an OpenAPI document — Brain's `/openapi.json` sorts `components` first, so its `"openapi": "3.1.0"` sits past that window. Brain's score went 0 → 40 → 65 as each was fixed.

## Verified

`tsc` clean · **43 tests** (5 new) · `next build` compiles the route as static

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014U8o8AqEtZq9DMGBzScu16