### PR TITLE
docs(openapi): publish the core ingest, search and synthesize paths

### DIFF
--- a/brain-landing/public/openapi.json
+++ b/brain-landing/public/openapi.json
@@ -347,6 +347,37 @@
         ],
         "type": "object"
       },
+      "Citation": {
+        "additionalProperties": false,
+        "properties": {
+          "canonicalName": {
+            "type": "string"
+          },
+          "entityId": {
+            "type": "string"
+          },
+          "factId": {
+            "type": "string"
+          },
+          "object": {
+            "type": "string"
+          },
+          "predicate": {
+            "type": "string"
+          },
+          "sourceKey": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "factId",
+          "entityId",
+          "canonicalName",
+          "predicate",
+          "object"
+        ],
+        "type": "object"
+      },
       "ClaimWorkResponse": {
         "additionalProperties": false,
         "properties": {
@@ -413,6 +444,78 @@
         ],
         "type": "object"
       },
+      "ConflictExplanation": {
+        "additionalProperties": {},
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "ConnectionEdge": {
+        "additionalProperties": false,
+        "properties": {
+          "createdAt": {
+            "type": "string"
+          },
+          "direction": {
+            "enum": [
+              "outbound",
+              "inbound"
+            ],
+            "type": "string"
+          },
+          "edgeId": {
+            "type": "string"
+          },
+          "from": {
+            "type": "string"
+          },
+          "kind": {
+            "type": "string"
+          },
+          "neighbour": {
+            "$ref": "#/components/schemas/ConnectionNeighbour"
+          },
+          "source": {},
+          "to": {
+            "type": "string"
+          },
+          "weight": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "edgeId",
+          "from",
+          "to",
+          "kind",
+          "weight",
+          "source",
+          "createdAt",
+          "direction"
+        ],
+        "type": "object"
+      },
+      "ConnectionNeighbour": {
+        "additionalProperties": false,
+        "properties": {
+          "canonicalName": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "type",
+          "canonicalName"
+        ],
+        "type": "object"
+      },
       "CreateEpisodeSubscriptionRequest": {
         "additionalProperties": false,
         "properties": {
@@ -443,6 +546,13 @@
           "secret",
           "watermark"
         ],
+        "type": "object"
+      },
+      "DecisionLogEntry": {
+        "additionalProperties": {},
+        "propertyNames": {
+          "type": "string"
+        },
         "type": "object"
       },
       "DeleteEpisodeSubscriptionResponse": {
@@ -730,6 +840,183 @@
         ],
         "type": "object"
       },
+      "EntityAutocompleteResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "suggestions": {
+            "items": {
+              "$ref": "#/components/schemas/EntityAutocompleteSuggestion"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "suggestions"
+        ],
+        "type": "object"
+      },
+      "EntityAutocompleteSuggestion": {
+        "additionalProperties": false,
+        "properties": {
+          "canonicalName": {
+            "type": "string"
+          },
+          "entityId": {
+            "type": "string"
+          },
+          "score": {
+            "type": "number"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "entityId",
+          "canonicalName",
+          "type",
+          "score"
+        ],
+        "type": "object"
+      },
+      "EntityConnectionsResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "edges": {
+            "items": {
+              "$ref": "#/components/schemas/ConnectionEdge"
+            },
+            "type": "array"
+          },
+          "entityId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "entityId",
+          "edges"
+        ],
+        "type": "object"
+      },
+      "EntityProfileFact": {
+        "additionalProperties": false,
+        "properties": {
+          "confidence": {
+            "type": "number"
+          },
+          "factId": {
+            "type": "string"
+          },
+          "object": {
+            "type": "string"
+          },
+          "predicate": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "validFrom": {
+            "type": "string"
+          },
+          "validUntil": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "factId",
+          "predicate",
+          "object",
+          "confidence",
+          "validFrom",
+          "status"
+        ],
+        "type": "object"
+      },
+      "EntityProfileResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "canonicalName": {
+            "type": "string"
+          },
+          "entityId": {
+            "type": "string"
+          },
+          "externalRefs": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "facts": {
+            "items": {
+              "$ref": "#/components/schemas/EntityProfileFact"
+            },
+            "type": "array"
+          },
+          "mergedAt": {
+            "type": "string"
+          },
+          "mergedInto": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "entityId",
+          "type",
+          "canonicalName",
+          "externalRefs",
+          "facts"
+        ],
+        "type": "object"
+      },
+      "EntityRef": {
+        "additionalProperties": {},
+        "properties": {
+          "entityId": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "vertical": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "EntityTimelineResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "entityId": {
+            "type": "string"
+          },
+          "events": {
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/TimelineRecordedEvent"
+                },
+                {
+                  "$ref": "#/components/schemas/TimelineRetractedEvent"
+                }
+              ]
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "entityId",
+          "events"
+        ],
+        "type": "object"
+      },
       "EpisodeSubscriptionRow": {
         "additionalProperties": false,
         "properties": {
@@ -942,6 +1229,65 @@
           "statusCode",
           "message"
         ],
+        "type": "object"
+      },
+      "EvidenceCitation": {
+        "additionalProperties": false,
+        "properties": {
+          "assetId": {
+            "type": "string"
+          },
+          "beliefId": {
+            "type": "string"
+          },
+          "capability": {
+            "enum": [
+              "text",
+              "visual",
+              "audio",
+              "document_region"
+            ],
+            "type": "string"
+          },
+          "conversationId": {
+            "type": "string"
+          },
+          "episodeId": {
+            "type": "string"
+          },
+          "excerpt": {
+            "type": "string"
+          },
+          "fragmentId": {
+            "type": "string"
+          },
+          "occurredAt": {
+            "type": "string"
+          },
+          "sceneId": {
+            "type": "string"
+          },
+          "span": {
+            "additionalProperties": false,
+            "properties": {
+              "end": {
+                "type": "number"
+              },
+              "exact": {
+                "type": "string"
+              },
+              "start": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "start",
+              "end",
+              "exact"
+            ],
+            "type": "object"
+          }
+        },
         "type": "object"
       },
       "EvidenceFragmentLocator": {
@@ -1375,6 +1721,42 @@
         ],
         "type": "object"
       },
+      "FactSource": {
+        "additionalProperties": {},
+        "properties": {
+          "conversationId": {
+            "type": "string"
+          },
+          "episodeIds": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "eventId": {
+            "type": "string"
+          },
+          "evidence": {
+            "items": {
+              "$ref": "#/components/schemas/SourceEvidence"
+            },
+            "type": "array"
+          },
+          "messageId": {
+            "type": "string"
+          },
+          "recorder": {
+            "type": "string"
+          },
+          "vertical": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "vertical"
+        ],
+        "type": "object"
+      },
       "FailWorkRequest": {
         "additionalProperties": false,
         "properties": {
@@ -1567,6 +1949,93 @@
         "required": [
           "runId",
           "leaseSeconds"
+        ],
+        "type": "object"
+      },
+      "HopOutcome": {
+        "additionalProperties": false,
+        "properties": {
+          "hits": {
+            "items": {
+              "$ref": "#/components/schemas/SearchHit"
+            },
+            "type": "array"
+          },
+          "hop": {
+            "$ref": "#/components/schemas/HopPlan"
+          },
+          "hopEntityIds": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "runningEntityIds": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "supportingFactIds": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "hop",
+          "hopEntityIds",
+          "runningEntityIds",
+          "hits",
+          "supportingFactIds"
+        ],
+        "type": "object"
+      },
+      "HopPlan": {
+        "additionalProperties": false,
+        "properties": {
+          "asOf": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "combination": {
+            "enum": [
+              "seed",
+              "subset_of_previous",
+              "intersect",
+              "union"
+            ],
+            "type": "string"
+          },
+          "predicates": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "rationale": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subQuery": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "subQuery",
+          "combination"
         ],
         "type": "object"
       },
@@ -2045,6 +2514,109 @@
         ],
         "type": "object"
       },
+      "IngestFactRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "confidence": {
+            "maximum": 1,
+            "minimum": 0,
+            "type": "number"
+          },
+          "entityRef": {
+            "$ref": "#/components/schemas/EntityRef"
+          },
+          "explain": {
+            "type": "boolean"
+          },
+          "metadata": {
+            "additionalProperties": {},
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "object": {
+            "maxLength": 2000,
+            "type": "string"
+          },
+          "predicate": {
+            "maxLength": 256,
+            "type": "string"
+          },
+          "source": {
+            "$ref": "#/components/schemas/FactSource"
+          },
+          "userId": {
+            "maxLength": 200,
+            "type": "string"
+          },
+          "validFrom": {
+            "type": "string"
+          },
+          "validUntil": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "entityRef",
+          "predicate",
+          "object",
+          "validFrom",
+          "source"
+        ],
+        "type": "object"
+      },
+      "IngestFactResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "competingFactIds": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "conflictExplanation": {
+            "$ref": "#/components/schemas/ConflictExplanation"
+          },
+          "corroboratedFactId": {
+            "type": "string"
+          },
+          "factId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "outcome": {
+            "enum": [
+              "INSERTED",
+              "INSERTED_HISTORICAL",
+              "CORROBORATED",
+              "SUPERSEDED",
+              "COMPETING",
+              "REJECTED"
+            ],
+            "type": "string"
+          },
+          "reason": {
+            "type": "string"
+          },
+          "supersededByFactId": {
+            "type": "string"
+          },
+          "supersededFactIds": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "factId",
+          "outcome"
+        ],
+        "type": "object"
+      },
       "InstallFromRegistryRequest": {
         "additionalProperties": false,
         "properties": {
@@ -2187,6 +2759,186 @@
           "predicateCount",
           "checksum",
           "memoryModel"
+        ],
+        "type": "object"
+      },
+      "MultiHopRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "asOf": {
+            "type": "string"
+          },
+          "confidenceFloor": {
+            "maximum": 1,
+            "minimum": 0,
+            "type": "number"
+          },
+          "disableLangFilter": {
+            "type": "boolean"
+          },
+          "entityIds": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "entityTypes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "includeContested": {
+            "type": "boolean"
+          },
+          "includeRetracted": {
+            "type": "boolean"
+          },
+          "includeStale": {
+            "type": "boolean"
+          },
+          "limit": {
+            "maximum": 100,
+            "minimum": 1,
+            "type": "number"
+          },
+          "maxHops": {
+            "maximum": 5,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "minConfidence": {
+            "maximum": 1,
+            "minimum": 0,
+            "type": "number"
+          },
+          "outputShape": {
+            "enum": [
+              "full",
+              "compact",
+              "ids"
+            ],
+            "type": "string"
+          },
+          "predicates": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "query": {
+            "maxLength": 8000,
+            "type": "string"
+          },
+          "queryLang": {
+            "type": "string"
+          },
+          "requireProvenance": {
+            "type": "boolean"
+          },
+          "searchMode": {
+            "enum": [
+              "vector",
+              "lexical",
+              "hybrid"
+            ],
+            "type": "string"
+          },
+          "synthesisGuardrails": {
+            "enum": [
+              "strict",
+              "lenient",
+              "off",
+              "answer"
+            ],
+            "type": "string"
+          },
+          "synthesisModel": {
+            "type": "string"
+          },
+          "synthesize": {
+            "type": "boolean"
+          },
+          "tokenBudget": {
+            "maximum": 50000,
+            "minimum": 50,
+            "type": "number"
+          },
+          "userId": {
+            "maxLength": 200,
+            "type": "string"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "type": "object"
+      },
+      "MultiHopResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "finalEntityIds": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "finalHits": {
+            "items": {
+              "$ref": "#/components/schemas/SearchHit"
+            },
+            "type": "array"
+          },
+          "hops": {
+            "items": {
+              "$ref": "#/components/schemas/HopOutcome"
+            },
+            "type": "array"
+          },
+          "isMultiHop": {
+            "type": "boolean"
+          },
+          "supportingFactIds": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "synthesis": {
+            "additionalProperties": false,
+            "properties": {
+              "answer": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "citations": {
+                "items": {
+                  "$ref": "#/components/schemas/Citation"
+                },
+                "type": "array"
+              },
+              "reason": {
+                "$ref": "#/components/schemas/SynthesisReason"
+              },
+              "tokenUsage": {
+                "$ref": "#/components/schemas/TokenUsage"
+              }
+            },
+            "required": [
+              "answer",
+              "citations"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "isMultiHop",
+          "hops",
+          "finalEntityIds",
+          "finalHits",
+          "supportingFactIds"
         ],
         "type": "object"
       },
@@ -3046,6 +3798,71 @@
         ],
         "type": "object"
       },
+      "RetractFactRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "reason": {
+            "type": "string"
+          },
+          "retractedBy": {
+            "$ref": "#/components/schemas/RetractedBy"
+          }
+        },
+        "required": [
+          "reason",
+          "retractedBy"
+        ],
+        "type": "object"
+      },
+      "RetractFactResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "cascadedFactIds": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "factId": {
+            "type": "string"
+          },
+          "retractedAt": {
+            "type": "string"
+          },
+          "revivedFactIds": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "factId",
+          "retractedAt",
+          "cascadedFactIds",
+          "revivedFactIds"
+        ],
+        "type": "object"
+      },
+      "RetractedBy": {
+        "additionalProperties": {},
+        "properties": {
+          "source": {
+            "enum": [
+              "human",
+              "system"
+            ],
+            "type": "string"
+          },
+          "userId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "source"
+        ],
+        "type": "object"
+      },
       "RevokeEvidenceGrantResponse": {
         "additionalProperties": false,
         "properties": {
@@ -3060,6 +3877,215 @@
         "required": [
           "grantId",
           "revoked"
+        ],
+        "type": "object"
+      },
+      "ScoreBreakdown": {
+        "additionalProperties": {},
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "SearchFact": {
+        "additionalProperties": false,
+        "properties": {
+          "breakdown": {
+            "$ref": "#/components/schemas/ScoreBreakdown"
+          },
+          "confidence": {
+            "type": "number"
+          },
+          "factId": {
+            "type": "string"
+          },
+          "highlight": {
+            "type": "string"
+          },
+          "mentionedAt": {
+            "type": "string"
+          },
+          "object": {
+            "type": "string"
+          },
+          "predicate": {
+            "type": "string"
+          },
+          "scene": {
+            "type": "string"
+          },
+          "score": {
+            "type": "number"
+          },
+          "sourceKey": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "validFrom": {
+            "type": "string"
+          },
+          "validUntil": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "factId",
+          "predicate",
+          "object",
+          "confidence",
+          "validFrom",
+          "status",
+          "score"
+        ],
+        "type": "object"
+      },
+      "SearchHit": {
+        "additionalProperties": false,
+        "properties": {
+          "canonicalName": {
+            "type": "string"
+          },
+          "entityId": {
+            "type": "string"
+          },
+          "entityType": {
+            "type": "string"
+          },
+          "externalRefs": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "facts": {
+            "items": {
+              "$ref": "#/components/schemas/SearchFact"
+            },
+            "type": "array"
+          },
+          "score": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "entityId",
+          "entityType",
+          "canonicalName",
+          "externalRefs",
+          "facts",
+          "score"
+        ],
+        "type": "object"
+      },
+      "SearchRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "asOf": {
+            "type": "string"
+          },
+          "confidenceFloor": {
+            "maximum": 1,
+            "minimum": 0,
+            "type": "number"
+          },
+          "disableLangFilter": {
+            "type": "boolean"
+          },
+          "entityIds": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "entityTypes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "includeContested": {
+            "type": "boolean"
+          },
+          "includeRetracted": {
+            "type": "boolean"
+          },
+          "includeStale": {
+            "type": "boolean"
+          },
+          "limit": {
+            "maximum": 100,
+            "minimum": 1,
+            "type": "number"
+          },
+          "minConfidence": {
+            "maximum": 1,
+            "minimum": 0,
+            "type": "number"
+          },
+          "outputShape": {
+            "enum": [
+              "full",
+              "compact",
+              "ids"
+            ],
+            "type": "string"
+          },
+          "predicates": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "query": {
+            "maxLength": 8000,
+            "type": "string"
+          },
+          "queryLang": {
+            "type": "string"
+          },
+          "requireProvenance": {
+            "type": "boolean"
+          },
+          "searchMode": {
+            "enum": [
+              "vector",
+              "lexical",
+              "hybrid"
+            ],
+            "type": "string"
+          },
+          "tokenBudget": {
+            "maximum": 50000,
+            "minimum": 50,
+            "type": "number"
+          },
+          "userId": {
+            "maxLength": 200,
+            "type": "string"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "type": "object"
+      },
+      "SearchResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "results": {
+            "items": {
+              "$ref": "#/components/schemas/SearchHit"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "results"
         ],
         "type": "object"
       },
@@ -3080,6 +4106,34 @@
         "required": [
           "amount",
           "currency"
+        ],
+        "type": "object"
+      },
+      "SourceEvidence": {
+        "additionalProperties": false,
+        "properties": {
+          "kind": {
+            "enum": [
+              "event",
+              "message",
+              "conversation",
+              "url",
+              "document",
+              "commit",
+              "other"
+            ],
+            "type": "string"
+          },
+          "note": {
+            "type": "string"
+          },
+          "ref": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "ref"
         ],
         "type": "object"
       },
@@ -3410,6 +4464,259 @@
         ],
         "type": "object"
       },
+      "SynthesisReason": {
+        "enum": [
+          "no_results",
+          "no_grounded_evidence",
+          "low_coverage",
+          "evidence_capability_unmet",
+          "ungrounded_evidence",
+          "verifier_failed",
+          "verifier_partial",
+          "generator_error",
+          "verifier_error"
+        ],
+        "type": "string"
+      },
+      "SynthesizeRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "answerLang": {
+            "type": "string"
+          },
+          "asOf": {
+            "type": "string"
+          },
+          "confidenceFloor": {
+            "maximum": 1,
+            "minimum": 0,
+            "type": "number"
+          },
+          "disableLangFilter": {
+            "type": "boolean"
+          },
+          "entityIds": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "entityTypes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "explain": {
+            "type": "boolean"
+          },
+          "includeContested": {
+            "type": "boolean"
+          },
+          "includeRetracted": {
+            "type": "boolean"
+          },
+          "includeStale": {
+            "type": "boolean"
+          },
+          "limit": {
+            "maximum": 100,
+            "minimum": 1,
+            "type": "number"
+          },
+          "minConfidence": {
+            "maximum": 1,
+            "minimum": 0,
+            "type": "number"
+          },
+          "outputShape": {
+            "enum": [
+              "full",
+              "compact",
+              "ids"
+            ],
+            "type": "string"
+          },
+          "predicates": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "query": {
+            "maxLength": 8000,
+            "type": "string"
+          },
+          "queryLang": {
+            "type": "string"
+          },
+          "requireProvenance": {
+            "type": "boolean"
+          },
+          "searchMode": {
+            "enum": [
+              "vector",
+              "lexical",
+              "hybrid"
+            ],
+            "type": "string"
+          },
+          "synthesisGuardrails": {
+            "enum": [
+              "strict",
+              "lenient",
+              "off",
+              "answer"
+            ],
+            "type": "string"
+          },
+          "synthesisModel": {
+            "type": "string"
+          },
+          "tokenBudget": {
+            "maximum": 50000,
+            "minimum": 50,
+            "type": "number"
+          },
+          "userId": {
+            "maxLength": 200,
+            "type": "string"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "type": "object"
+      },
+      "SynthesizeResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "answer": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "cached": {
+            "type": "boolean"
+          },
+          "citations": {
+            "items": {
+              "$ref": "#/components/schemas/Citation"
+            },
+            "type": "array"
+          },
+          "decisionLog": {
+            "items": {
+              "$ref": "#/components/schemas/DecisionLogEntry"
+            },
+            "type": "array"
+          },
+          "evidenceCitations": {
+            "items": {
+              "$ref": "#/components/schemas/EvidenceCitation"
+            },
+            "type": "array"
+          },
+          "reason": {
+            "$ref": "#/components/schemas/SynthesisReason"
+          },
+          "results": {
+            "items": {
+              "$ref": "#/components/schemas/SearchHit"
+            },
+            "type": "array"
+          },
+          "tokenUsage": {
+            "$ref": "#/components/schemas/TokenUsage"
+          }
+        },
+        "required": [
+          "answer",
+          "citations",
+          "results"
+        ],
+        "type": "object"
+      },
+      "TimelineRecordedEvent": {
+        "additionalProperties": false,
+        "properties": {
+          "at": {
+            "type": "string"
+          },
+          "confidence": {
+            "type": "number"
+          },
+          "factId": {
+            "type": "string"
+          },
+          "object": {
+            "type": "string"
+          },
+          "predicate": {
+            "type": "string"
+          },
+          "source": {},
+          "type": {
+            "const": "fact.recorded",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "at",
+          "factId",
+          "predicate",
+          "object",
+          "source",
+          "confidence"
+        ],
+        "type": "object"
+      },
+      "TimelineRetractedEvent": {
+        "additionalProperties": false,
+        "properties": {
+          "at": {
+            "type": "string"
+          },
+          "factId": {
+            "type": "string"
+          },
+          "reason": {},
+          "retractedBy": {},
+          "supersededBy": {
+            "type": "string"
+          },
+          "type": {
+            "const": "fact.retracted",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "at",
+          "factId",
+          "retractedBy",
+          "reason"
+        ],
+        "type": "object"
+      },
+      "TokenUsage": {
+        "additionalProperties": false,
+        "properties": {
+          "completionTokens": {
+            "type": "number"
+          },
+          "promptTokens": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "promptTokens",
+          "completionTokens"
+        ],
+        "type": "object"
+      },
       "TrustScopeRow": {
         "additionalProperties": false,
         "properties": {
@@ -3680,12 +4987,12 @@
     }
   },
   "info": {
-    "description": "Generated from the zod wire contracts (`pnpm openapi:build` — scripts/build-openapi.ts); do not edit by hand. The admin/ops surface (jobs, leases, policy, stats, maintenance) is documented in docs/api.md instead. Scopes are plain bearer-key grants, not OAuth flows — each operation states its required scope.",
+    "description": "Generated from the zod wire contracts (`pnpm openapi:build` — scripts/build-openapi.ts); do not edit by hand. Excluded on purpose: the operator/ops surface (jobs, leases, policy, stats, maintenance, GDPR cascades), which is indexed in docs/api.md, and the MCP transport `ALL /mcp/{companyId}`, which is JSON-RPC over Streamable HTTP rather than REST — MCP clients discover it through `tools/list` (docs/mcp.md). Scopes are plain bearer-key grants, not OAuth flows — each operation states its required scope.",
     "license": {
       "identifier": "AGPL-3.0-or-later",
       "name": "AGPL-3.0-or-later"
     },
-    "summary": "The community-facing platform surface: Domain Pack registry, tenant pack admin, document ingest, the external-indexer work protocol, and source reputation reads.",
+    "summary": "The community-facing platform surface: the memory core (fact ingest, search, multi-hop, synthesize, entity and fact reads), the Domain Pack registry and tenant pack admin, the document pipeline, the external-indexer work protocol, the raw-substrate driver, the evidence substrate, and source reputation reads.",
     "title": "INITE Brain — Platform API",
     "version": "2.2.0"
   },
@@ -4659,6 +5966,261 @@
         ]
       }
     },
+    "/v1/entities/autocomplete": {
+      "get": {
+        "description": "Word-start match over the edge-ngram `prefix` fulltext index, BM25-ranked via `search::score`. A query under 2 characters returns nothing (the tokenizer produces no grams). Live, tenant-global entities only — merged-away redirects and personal-scoped entities are excluded. Source: src/entities/entities.controller.ts.\n\nRequired scope: `brain:read`.",
+        "operationId": "autocompleteEntities",
+        "parameters": [
+          {
+            "description": "The prefix to complete (under 2 chars → empty result).",
+            "in": "query",
+            "name": "q",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Page size, 1–25 (default 10).",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityAutocompleteResponse"
+                }
+              }
+            },
+            "description": "Ranked suggestions."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        },
+        "summary": "Entity-name typeahead",
+        "tags": [
+          "Entities"
+        ]
+      }
+    },
+    "/v1/entities/{id}": {
+      "get": {
+        "description": "The entity plus the facts currently held about it, filtered by the row policy (a fact whose predicate requires a scope the caller lacks never appears). `asOf` slices WORLD time (what was true at T); `recordedAt` slices TRANSACTION time (what the graph believed at T — a later retract or supersede is ignored). A merged entity answers with `mergedInto` set: treat it as a redirect.\n\nRequired scope: `brain:read`.",
+        "operationId": "getEntityProfile",
+        "parameters": [
+          {
+            "description": "Entity id — short (`cuid_abc`) or full (`knowledge_entity:cuid_abc`).",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "ISO-8601 world-time slice.",
+            "in": "query",
+            "name": "asOf",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "ISO-8601 transaction-time slice.",
+            "in": "query",
+            "name": "recordedAt",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityProfileResponse"
+                }
+              }
+            },
+            "description": "The profile."
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "summary": "Entity profile and its active facts",
+        "tags": [
+          "Entities"
+        ]
+      }
+    },
+    "/v1/entities/{id}/connections": {
+      "get": {
+        "description": "The entity’s 1-hop neighbourhood over `knowledge_edge`, in both directions (`direction` says which). `kind` filters to one edge type; `asOf` restricts to edges live at that instant. `neighbour` is absent when the far end could not be projected.\n\nRequired scope: `brain:read`.",
+        "operationId": "getEntityConnections",
+        "parameters": [
+          {
+            "description": "Entity id — short or fully-qualified.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Only edges of this kind.",
+            "in": "query",
+            "name": "kind",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "ISO-8601 instant the edge must be live at.",
+            "in": "query",
+            "name": "asOf",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityConnectionsResponse"
+                }
+              }
+            },
+            "description": "The typed edges."
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "summary": "Typed edges and direct neighbours",
+        "tags": [
+          "Entities"
+        ]
+      }
+    },
+    "/v1/entities/{id}/timeline": {
+      "get": {
+        "description": "`fact.recorded` / `fact.retracted` events on the TRANSACTION-time axis — when the graph learned and unlearned things, not when they were true. `since` / `until` page the window; `recordedAt` cuts to events known by T. `userId` is honoured only while READ_SURFACE_USER_SCOPE is on (this surface predates migration 0055 and otherwise pins `userId IS NONE`); a user-bound token is pinned to its own end user, and a mismatch is 403.\n\nRequired scope: `brain:read`.",
+        "operationId": "getEntityTimeline",
+        "parameters": [
+          {
+            "description": "Entity id — short or fully-qualified.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "ISO-8601 lower bound on recordedAt.",
+            "in": "query",
+            "name": "since",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "ISO-8601 upper bound on recordedAt.",
+            "in": "query",
+            "name": "until",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Only events known by this instant.",
+            "in": "query",
+            "name": "recordedAt",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Per-user scope (READ_SURFACE_USER_SCOPE only).",
+            "in": "query",
+            "name": "userId",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityTimelineResponse"
+                }
+              }
+            },
+            "description": "The event sweep."
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "summary": "Bitemporal sweep over an entity’s memory",
+        "tags": [
+          "Entities"
+        ]
+      }
+    },
     "/v1/episodes": {
       "get": {
         "description": "Verbatim pre-extraction dialogue turns in stable (occurredAt, id) order — the raw layer any consumer can build its own projection from. Callers without `brain:read_pii` see only episodes whose piiClass is empty. 404 until EPISODES_API_ENABLED=1. Source: src/episodes/episodes.controller.ts.\n\nRequired scope: `brain:read`.",
@@ -5373,6 +6935,61 @@
         ]
       }
     },
+    "/v1/facts/{id}/retract": {
+      "post": {
+        "description": "Marks the fact retracted and writes the audit trail. Two cascades follow: facts DERIVED from it are retracted too (`cascadedFactIds`), and facts this one had SUPERSEDED come back to active (`revivedFactIds`) unless they were separately retracted on their own merits. Deliberately NOT gated by FACTS_API_ENABLED — the read routes above are, but a tenant must always be able to remove a fact. `brain:write` is the floor; FactsService elevates the requirement to `brain:admin` for billing_event / human_declared / legal-source facts once it has read the row (403 from there, not from the guard). For erasure rather than retraction, see the GDPR cascade on the admin surface (docs/api.md).\n\nRequired scope: `brain:write`.",
+        "operationId": "retractFact",
+        "parameters": [
+          {
+            "description": "Fact record id (`knowledge_fact:…`).",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RetractFactRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RetractFactResponse"
+                }
+              }
+            },
+            "description": "What the retraction changed."
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "summary": "Retract a fact",
+        "tags": [
+          "Facts"
+        ]
+      }
+    },
     "/v1/indexer/work": {
       "get": {
         "description": "Pending indexer runs routed to this tenant’s installed external packs. Protocol: docs/indexer-protocol.md. Part of the document pipeline — answers `503 feature_disabled` until `DOCUMENT_INGEST_ENABLED=1`. Source: src/documents/indexer-work.controller.ts.\n\nRequired scope: `indexer:write`.",
@@ -5876,6 +7493,47 @@
         ]
       }
     },
+    "/v1/ingest/fact": {
+      "post": {
+        "description": "The headline write. Resolves the entity, embeds the claim and runs bitemporal conflict resolution against the standing timeline: the response `outcome` says what the resolver decided (INSERTED / INSERTED_HISTORICAL / CORROBORATED / SUPERSEDED / COMPETING / REJECTED), never just \"ok\". `userId` stamps a per-user memory scope (migration 0055) — scope-local conflict resolution, invisible to every other user of the tenant and to requests that don't assert one. `explain: true` adds the deterministic conflict narrative on a SUPERSEDED / COMPETING outcome. Source: src/ingest/ingest.controller.ts.\n\nRequired scope: `brain:write`.",
+        "operationId": "ingestFact",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IngestFactRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IngestFactResponse"
+                }
+              }
+            },
+            "description": "The resolver's decision."
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        },
+        "summary": "Record a declared structured fact",
+        "tags": [
+          "Ingest"
+        ]
+      }
+    },
     "/v1/projections": {
       "get": {
         "description": "Every derived world (facts@version, …) with its lifecycle status (building/built/live/residual/failed), watermark, builder identity and stats, plus the process-local read pin (RETRIEVAL_DERIVED_VERSION). A registry row promises a queryable world. 404 until PROJECTIONS_API_ENABLED=1. Source: src/admin/projections.controller.ts.\n\nRequired scope: `brain:read`.",
@@ -6169,6 +7827,94 @@
         ]
       }
     },
+    "/v1/search": {
+      "post": {
+        "description": "The headline read. Hybrid retrieval by default (vector + BM25 fused by reciprocal rank), router-boosted, listwise-reranked, then backfilled with each hit entity’s facts. Default semantics is Datomic-style \"actual now\" — only facts whose validity window contains the query moment; `asOf` slices world-time and `includeStale` reverts to the audit shape. `userId` widens the fence from tenant-global memory to tenant-global PLUS that user's personal rows (fail-closed: omitted means global only). Facts whose predicate requires a scope the caller lacks never enter the result. Fans out to the shared embedding / LLM budget, so it sits in the per-credential `expensive` throttle bucket — 10 requests/min, not the 120/min default. Source: src/search/search.controller.ts.\n\nRequired scope: `brain:read`.",
+        "operationId": "searchKnowledge",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchResponse"
+                }
+              }
+            },
+            "description": "Scored entity hits with their facts."
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          }
+        },
+        "summary": "Search the knowledge graph",
+        "tags": [
+          "Search"
+        ]
+      }
+    },
+    "/v1/search/multi-hop": {
+      "post": {
+        "description": "A planner LLM decomposes the query into at most `maxHops` anchored sub-queries; each later hop is scoped to the running entity set, so the engine never spends compute on candidates already disqualified. Answers questions that join evidence across turns or entities. `supportingFactIds` is the evidence chain (HotpotQA-style) — the caller can audit exactly which facts drove the answer. `synthesize: true` adds a grounded answer with citations alongside the per-hop trace. Fans out to the shared embedding / LLM budget, so it sits in the per-credential `expensive` throttle bucket — 10 requests/min, not the 120/min default. Source: src/multi-hop/multi-hop.controller.ts.\n\nRequired scope: `brain:read`.",
+        "operationId": "searchMultiHop",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MultiHopRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MultiHopResponse"
+                }
+              }
+            },
+            "description": "The hop trace and the final entity set."
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          }
+        },
+        "summary": "Chained multi-hop search",
+        "tags": [
+          "Search"
+        ]
+      }
+    },
     "/v1/sources": {
       "get": {
         "description": "Catalogue of everything brain knows ABOUT its fact sources: the operator-declared identity (type, authLevel) joined with the learned agreement rates, one row per sourceKey. Public projection — operator annotations (owner/note) are served only on the brain:admin surface. `domain` additionally captures that domain's learned rate into `domainTrust` and makes `minSamples` judge it (falling back to the global row). Source: src/sources/public-sources.controller.ts.\n\nRequired scope: `brain:read`.",
@@ -6298,6 +8044,50 @@
         ]
       }
     },
+    "/v1/synthesize": {
+      "post": {
+        "description": "Corrective RAG over the same retrieval stack as /v1/search: generate an answer, then verify each claim against the facts it cites. The pipeline ABSTAINS rather than guess — `answer` is null and `reason` names the gate that fired (no results, thin coverage, ungrounded support, a failed verifier…). `synthesisGuardrails` picks the policy: `strict` closes to null on a partial verdict, `lenient` returns the answer with the verdict attached, `off` skips the verifier. Cited facts are always the caller’s own visible memory. Fans out to the shared embedding / LLM budget, so it sits in the per-credential `expensive` throttle bucket — 10 requests/min, not the 120/min default. Source: src/synthesize/synthesize.controller.ts.\n\nRequired scope: `brain:read`.",
+        "operationId": "synthesizeAnswer",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SynthesizeRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SynthesizeResponse"
+                }
+              }
+            },
+            "description": "The answer (or a reasoned abstention)."
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          }
+        },
+        "summary": "Answer a question from memory, with citations",
+        "tags": [
+          "Search"
+        ]
+      }
+    },
     "/v1/users/{userId}/profile": {
       "get": {
         "description": "Query-time assembly of what the platform knows about a user: active user-scoped facts grouped by aspect (persona-first), plus `profileText` shaped for direct prompt injection. Deterministic — no model calls. A user-bound token may only fetch its own profile (mismatch 403); M2M tokens any. 404 until USER_PROFILE_API_ENABLED=1. Source: src/users/user-profile.controller.ts.\n\nRequired scope: `brain:read`.",
@@ -6374,6 +8164,18 @@
     }
   ],
   "tags": [
+    {
+      "description": "Writing memory: the declared-fact path (scope `brain:write`). Every write goes through bitemporal conflict resolution, so the response reports a decision, not an acknowledgement.",
+      "name": "Ingest"
+    },
+    {
+      "description": "Reading memory (scope `brain:read`): hybrid search, chained multi-hop search, and cited synthesis over the same retrieval stack. All three share the per-credential `expensive` throttle bucket (10 req/min).",
+      "name": "Search"
+    },
+    {
+      "description": "The entity read surface (scope `brain:read`): typeahead, profile, bitemporal timeline and typed connections. The GDPR cascade on the same controller is an operator action and lives on the admin surface (docs/api.md).",
+      "name": "Entities"
+    },
     {
       "description": "Discovery reads over the global Domain Pack registry (shared across all tenants).",
       "name": "Registry"

--- a/docs/api.md
+++ b/docs/api.md
@@ -3,9 +3,14 @@
 An index of every HTTP endpoint Brain serves, grouped by area, with
 auth scopes — for anyone calling Brain over REST or wiring an admin UI.
 A generated [OpenAPI 3.1 document](openapi.json) covers the platform
-surface (registry, packs, documents, indexer work) with full request /
-response schemas — regenerate with `pnpm openapi:build`; this page
-stays an index, not a second spec.
+surface — the memory core (fact ingest, search, multi-hop, synthesize,
+entity and fact reads), registry, packs, documents, indexer work,
+episodes and evidence — with full request / response schemas.
+Regenerate with `pnpm openapi:build`; this page stays an index, not a
+second spec. Deliberately outside that document: the operator/ops
+surface below, and the MCP transport, which is JSON-RPC over
+Streamable HTTP rather than REST (clients discover it through
+`tools/list`).
 
 All v1 endpoints are live; MCP transport is mounted per tenant. Every
 v1 call requires `Authorization: Bearer <credential>` — an

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -347,6 +347,37 @@
         ],
         "type": "object"
       },
+      "Citation": {
+        "additionalProperties": false,
+        "properties": {
+          "canonicalName": {
+            "type": "string"
+          },
+          "entityId": {
+            "type": "string"
+          },
+          "factId": {
+            "type": "string"
+          },
+          "object": {
+            "type": "string"
+          },
+          "predicate": {
+            "type": "string"
+          },
+          "sourceKey": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "factId",
+          "entityId",
+          "canonicalName",
+          "predicate",
+          "object"
+        ],
+        "type": "object"
+      },
       "ClaimWorkResponse": {
         "additionalProperties": false,
         "properties": {
@@ -413,6 +444,78 @@
         ],
         "type": "object"
       },
+      "ConflictExplanation": {
+        "additionalProperties": {},
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "ConnectionEdge": {
+        "additionalProperties": false,
+        "properties": {
+          "createdAt": {
+            "type": "string"
+          },
+          "direction": {
+            "enum": [
+              "outbound",
+              "inbound"
+            ],
+            "type": "string"
+          },
+          "edgeId": {
+            "type": "string"
+          },
+          "from": {
+            "type": "string"
+          },
+          "kind": {
+            "type": "string"
+          },
+          "neighbour": {
+            "$ref": "#/components/schemas/ConnectionNeighbour"
+          },
+          "source": {},
+          "to": {
+            "type": "string"
+          },
+          "weight": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "edgeId",
+          "from",
+          "to",
+          "kind",
+          "weight",
+          "source",
+          "createdAt",
+          "direction"
+        ],
+        "type": "object"
+      },
+      "ConnectionNeighbour": {
+        "additionalProperties": false,
+        "properties": {
+          "canonicalName": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "type",
+          "canonicalName"
+        ],
+        "type": "object"
+      },
       "CreateEpisodeSubscriptionRequest": {
         "additionalProperties": false,
         "properties": {
@@ -443,6 +546,13 @@
           "secret",
           "watermark"
         ],
+        "type": "object"
+      },
+      "DecisionLogEntry": {
+        "additionalProperties": {},
+        "propertyNames": {
+          "type": "string"
+        },
         "type": "object"
       },
       "DeleteEpisodeSubscriptionResponse": {
@@ -730,6 +840,183 @@
         ],
         "type": "object"
       },
+      "EntityAutocompleteResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "suggestions": {
+            "items": {
+              "$ref": "#/components/schemas/EntityAutocompleteSuggestion"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "suggestions"
+        ],
+        "type": "object"
+      },
+      "EntityAutocompleteSuggestion": {
+        "additionalProperties": false,
+        "properties": {
+          "canonicalName": {
+            "type": "string"
+          },
+          "entityId": {
+            "type": "string"
+          },
+          "score": {
+            "type": "number"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "entityId",
+          "canonicalName",
+          "type",
+          "score"
+        ],
+        "type": "object"
+      },
+      "EntityConnectionsResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "edges": {
+            "items": {
+              "$ref": "#/components/schemas/ConnectionEdge"
+            },
+            "type": "array"
+          },
+          "entityId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "entityId",
+          "edges"
+        ],
+        "type": "object"
+      },
+      "EntityProfileFact": {
+        "additionalProperties": false,
+        "properties": {
+          "confidence": {
+            "type": "number"
+          },
+          "factId": {
+            "type": "string"
+          },
+          "object": {
+            "type": "string"
+          },
+          "predicate": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "validFrom": {
+            "type": "string"
+          },
+          "validUntil": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "factId",
+          "predicate",
+          "object",
+          "confidence",
+          "validFrom",
+          "status"
+        ],
+        "type": "object"
+      },
+      "EntityProfileResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "canonicalName": {
+            "type": "string"
+          },
+          "entityId": {
+            "type": "string"
+          },
+          "externalRefs": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "facts": {
+            "items": {
+              "$ref": "#/components/schemas/EntityProfileFact"
+            },
+            "type": "array"
+          },
+          "mergedAt": {
+            "type": "string"
+          },
+          "mergedInto": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "entityId",
+          "type",
+          "canonicalName",
+          "externalRefs",
+          "facts"
+        ],
+        "type": "object"
+      },
+      "EntityRef": {
+        "additionalProperties": {},
+        "properties": {
+          "entityId": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "vertical": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "EntityTimelineResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "entityId": {
+            "type": "string"
+          },
+          "events": {
+            "items": {
+              "anyOf": [
+                {
+                  "$ref": "#/components/schemas/TimelineRecordedEvent"
+                },
+                {
+                  "$ref": "#/components/schemas/TimelineRetractedEvent"
+                }
+              ]
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "entityId",
+          "events"
+        ],
+        "type": "object"
+      },
       "EpisodeSubscriptionRow": {
         "additionalProperties": false,
         "properties": {
@@ -942,6 +1229,65 @@
           "statusCode",
           "message"
         ],
+        "type": "object"
+      },
+      "EvidenceCitation": {
+        "additionalProperties": false,
+        "properties": {
+          "assetId": {
+            "type": "string"
+          },
+          "beliefId": {
+            "type": "string"
+          },
+          "capability": {
+            "enum": [
+              "text",
+              "visual",
+              "audio",
+              "document_region"
+            ],
+            "type": "string"
+          },
+          "conversationId": {
+            "type": "string"
+          },
+          "episodeId": {
+            "type": "string"
+          },
+          "excerpt": {
+            "type": "string"
+          },
+          "fragmentId": {
+            "type": "string"
+          },
+          "occurredAt": {
+            "type": "string"
+          },
+          "sceneId": {
+            "type": "string"
+          },
+          "span": {
+            "additionalProperties": false,
+            "properties": {
+              "end": {
+                "type": "number"
+              },
+              "exact": {
+                "type": "string"
+              },
+              "start": {
+                "type": "number"
+              }
+            },
+            "required": [
+              "start",
+              "end",
+              "exact"
+            ],
+            "type": "object"
+          }
+        },
         "type": "object"
       },
       "EvidenceFragmentLocator": {
@@ -1375,6 +1721,42 @@
         ],
         "type": "object"
       },
+      "FactSource": {
+        "additionalProperties": {},
+        "properties": {
+          "conversationId": {
+            "type": "string"
+          },
+          "episodeIds": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "eventId": {
+            "type": "string"
+          },
+          "evidence": {
+            "items": {
+              "$ref": "#/components/schemas/SourceEvidence"
+            },
+            "type": "array"
+          },
+          "messageId": {
+            "type": "string"
+          },
+          "recorder": {
+            "type": "string"
+          },
+          "vertical": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "vertical"
+        ],
+        "type": "object"
+      },
       "FailWorkRequest": {
         "additionalProperties": false,
         "properties": {
@@ -1567,6 +1949,93 @@
         "required": [
           "runId",
           "leaseSeconds"
+        ],
+        "type": "object"
+      },
+      "HopOutcome": {
+        "additionalProperties": false,
+        "properties": {
+          "hits": {
+            "items": {
+              "$ref": "#/components/schemas/SearchHit"
+            },
+            "type": "array"
+          },
+          "hop": {
+            "$ref": "#/components/schemas/HopPlan"
+          },
+          "hopEntityIds": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "runningEntityIds": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "supportingFactIds": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "hop",
+          "hopEntityIds",
+          "runningEntityIds",
+          "hits",
+          "supportingFactIds"
+        ],
+        "type": "object"
+      },
+      "HopPlan": {
+        "additionalProperties": false,
+        "properties": {
+          "asOf": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "combination": {
+            "enum": [
+              "seed",
+              "subset_of_previous",
+              "intersect",
+              "union"
+            ],
+            "type": "string"
+          },
+          "predicates": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "rationale": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "subQuery": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "subQuery",
+          "combination"
         ],
         "type": "object"
       },
@@ -2045,6 +2514,109 @@
         ],
         "type": "object"
       },
+      "IngestFactRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "confidence": {
+            "maximum": 1,
+            "minimum": 0,
+            "type": "number"
+          },
+          "entityRef": {
+            "$ref": "#/components/schemas/EntityRef"
+          },
+          "explain": {
+            "type": "boolean"
+          },
+          "metadata": {
+            "additionalProperties": {},
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "object": {
+            "maxLength": 2000,
+            "type": "string"
+          },
+          "predicate": {
+            "maxLength": 256,
+            "type": "string"
+          },
+          "source": {
+            "$ref": "#/components/schemas/FactSource"
+          },
+          "userId": {
+            "maxLength": 200,
+            "type": "string"
+          },
+          "validFrom": {
+            "type": "string"
+          },
+          "validUntil": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "entityRef",
+          "predicate",
+          "object",
+          "validFrom",
+          "source"
+        ],
+        "type": "object"
+      },
+      "IngestFactResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "competingFactIds": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "conflictExplanation": {
+            "$ref": "#/components/schemas/ConflictExplanation"
+          },
+          "corroboratedFactId": {
+            "type": "string"
+          },
+          "factId": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "outcome": {
+            "enum": [
+              "INSERTED",
+              "INSERTED_HISTORICAL",
+              "CORROBORATED",
+              "SUPERSEDED",
+              "COMPETING",
+              "REJECTED"
+            ],
+            "type": "string"
+          },
+          "reason": {
+            "type": "string"
+          },
+          "supersededByFactId": {
+            "type": "string"
+          },
+          "supersededFactIds": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "factId",
+          "outcome"
+        ],
+        "type": "object"
+      },
       "InstallFromRegistryRequest": {
         "additionalProperties": false,
         "properties": {
@@ -2187,6 +2759,186 @@
           "predicateCount",
           "checksum",
           "memoryModel"
+        ],
+        "type": "object"
+      },
+      "MultiHopRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "asOf": {
+            "type": "string"
+          },
+          "confidenceFloor": {
+            "maximum": 1,
+            "minimum": 0,
+            "type": "number"
+          },
+          "disableLangFilter": {
+            "type": "boolean"
+          },
+          "entityIds": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "entityTypes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "includeContested": {
+            "type": "boolean"
+          },
+          "includeRetracted": {
+            "type": "boolean"
+          },
+          "includeStale": {
+            "type": "boolean"
+          },
+          "limit": {
+            "maximum": 100,
+            "minimum": 1,
+            "type": "number"
+          },
+          "maxHops": {
+            "maximum": 5,
+            "minimum": 1,
+            "type": "integer"
+          },
+          "minConfidence": {
+            "maximum": 1,
+            "minimum": 0,
+            "type": "number"
+          },
+          "outputShape": {
+            "enum": [
+              "full",
+              "compact",
+              "ids"
+            ],
+            "type": "string"
+          },
+          "predicates": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "query": {
+            "maxLength": 8000,
+            "type": "string"
+          },
+          "queryLang": {
+            "type": "string"
+          },
+          "requireProvenance": {
+            "type": "boolean"
+          },
+          "searchMode": {
+            "enum": [
+              "vector",
+              "lexical",
+              "hybrid"
+            ],
+            "type": "string"
+          },
+          "synthesisGuardrails": {
+            "enum": [
+              "strict",
+              "lenient",
+              "off",
+              "answer"
+            ],
+            "type": "string"
+          },
+          "synthesisModel": {
+            "type": "string"
+          },
+          "synthesize": {
+            "type": "boolean"
+          },
+          "tokenBudget": {
+            "maximum": 50000,
+            "minimum": 50,
+            "type": "number"
+          },
+          "userId": {
+            "maxLength": 200,
+            "type": "string"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "type": "object"
+      },
+      "MultiHopResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "finalEntityIds": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "finalHits": {
+            "items": {
+              "$ref": "#/components/schemas/SearchHit"
+            },
+            "type": "array"
+          },
+          "hops": {
+            "items": {
+              "$ref": "#/components/schemas/HopOutcome"
+            },
+            "type": "array"
+          },
+          "isMultiHop": {
+            "type": "boolean"
+          },
+          "supportingFactIds": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "synthesis": {
+            "additionalProperties": false,
+            "properties": {
+              "answer": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "citations": {
+                "items": {
+                  "$ref": "#/components/schemas/Citation"
+                },
+                "type": "array"
+              },
+              "reason": {
+                "$ref": "#/components/schemas/SynthesisReason"
+              },
+              "tokenUsage": {
+                "$ref": "#/components/schemas/TokenUsage"
+              }
+            },
+            "required": [
+              "answer",
+              "citations"
+            ],
+            "type": "object"
+          }
+        },
+        "required": [
+          "isMultiHop",
+          "hops",
+          "finalEntityIds",
+          "finalHits",
+          "supportingFactIds"
         ],
         "type": "object"
       },
@@ -3046,6 +3798,71 @@
         ],
         "type": "object"
       },
+      "RetractFactRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "reason": {
+            "type": "string"
+          },
+          "retractedBy": {
+            "$ref": "#/components/schemas/RetractedBy"
+          }
+        },
+        "required": [
+          "reason",
+          "retractedBy"
+        ],
+        "type": "object"
+      },
+      "RetractFactResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "cascadedFactIds": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "factId": {
+            "type": "string"
+          },
+          "retractedAt": {
+            "type": "string"
+          },
+          "revivedFactIds": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "factId",
+          "retractedAt",
+          "cascadedFactIds",
+          "revivedFactIds"
+        ],
+        "type": "object"
+      },
+      "RetractedBy": {
+        "additionalProperties": {},
+        "properties": {
+          "source": {
+            "enum": [
+              "human",
+              "system"
+            ],
+            "type": "string"
+          },
+          "userId": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "source"
+        ],
+        "type": "object"
+      },
       "RevokeEvidenceGrantResponse": {
         "additionalProperties": false,
         "properties": {
@@ -3060,6 +3877,215 @@
         "required": [
           "grantId",
           "revoked"
+        ],
+        "type": "object"
+      },
+      "ScoreBreakdown": {
+        "additionalProperties": {},
+        "propertyNames": {
+          "type": "string"
+        },
+        "type": "object"
+      },
+      "SearchFact": {
+        "additionalProperties": false,
+        "properties": {
+          "breakdown": {
+            "$ref": "#/components/schemas/ScoreBreakdown"
+          },
+          "confidence": {
+            "type": "number"
+          },
+          "factId": {
+            "type": "string"
+          },
+          "highlight": {
+            "type": "string"
+          },
+          "mentionedAt": {
+            "type": "string"
+          },
+          "object": {
+            "type": "string"
+          },
+          "predicate": {
+            "type": "string"
+          },
+          "scene": {
+            "type": "string"
+          },
+          "score": {
+            "type": "number"
+          },
+          "sourceKey": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "validFrom": {
+            "type": "string"
+          },
+          "validUntil": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "factId",
+          "predicate",
+          "object",
+          "confidence",
+          "validFrom",
+          "status",
+          "score"
+        ],
+        "type": "object"
+      },
+      "SearchHit": {
+        "additionalProperties": false,
+        "properties": {
+          "canonicalName": {
+            "type": "string"
+          },
+          "entityId": {
+            "type": "string"
+          },
+          "entityType": {
+            "type": "string"
+          },
+          "externalRefs": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "facts": {
+            "items": {
+              "$ref": "#/components/schemas/SearchFact"
+            },
+            "type": "array"
+          },
+          "score": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "entityId",
+          "entityType",
+          "canonicalName",
+          "externalRefs",
+          "facts",
+          "score"
+        ],
+        "type": "object"
+      },
+      "SearchRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "asOf": {
+            "type": "string"
+          },
+          "confidenceFloor": {
+            "maximum": 1,
+            "minimum": 0,
+            "type": "number"
+          },
+          "disableLangFilter": {
+            "type": "boolean"
+          },
+          "entityIds": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "entityTypes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "includeContested": {
+            "type": "boolean"
+          },
+          "includeRetracted": {
+            "type": "boolean"
+          },
+          "includeStale": {
+            "type": "boolean"
+          },
+          "limit": {
+            "maximum": 100,
+            "minimum": 1,
+            "type": "number"
+          },
+          "minConfidence": {
+            "maximum": 1,
+            "minimum": 0,
+            "type": "number"
+          },
+          "outputShape": {
+            "enum": [
+              "full",
+              "compact",
+              "ids"
+            ],
+            "type": "string"
+          },
+          "predicates": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "query": {
+            "maxLength": 8000,
+            "type": "string"
+          },
+          "queryLang": {
+            "type": "string"
+          },
+          "requireProvenance": {
+            "type": "boolean"
+          },
+          "searchMode": {
+            "enum": [
+              "vector",
+              "lexical",
+              "hybrid"
+            ],
+            "type": "string"
+          },
+          "tokenBudget": {
+            "maximum": 50000,
+            "minimum": 50,
+            "type": "number"
+          },
+          "userId": {
+            "maxLength": 200,
+            "type": "string"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "type": "object"
+      },
+      "SearchResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "results": {
+            "items": {
+              "$ref": "#/components/schemas/SearchHit"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "results"
         ],
         "type": "object"
       },
@@ -3080,6 +4106,34 @@
         "required": [
           "amount",
           "currency"
+        ],
+        "type": "object"
+      },
+      "SourceEvidence": {
+        "additionalProperties": false,
+        "properties": {
+          "kind": {
+            "enum": [
+              "event",
+              "message",
+              "conversation",
+              "url",
+              "document",
+              "commit",
+              "other"
+            ],
+            "type": "string"
+          },
+          "note": {
+            "type": "string"
+          },
+          "ref": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "kind",
+          "ref"
         ],
         "type": "object"
       },
@@ -3410,6 +4464,259 @@
         ],
         "type": "object"
       },
+      "SynthesisReason": {
+        "enum": [
+          "no_results",
+          "no_grounded_evidence",
+          "low_coverage",
+          "evidence_capability_unmet",
+          "ungrounded_evidence",
+          "verifier_failed",
+          "verifier_partial",
+          "generator_error",
+          "verifier_error"
+        ],
+        "type": "string"
+      },
+      "SynthesizeRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "answerLang": {
+            "type": "string"
+          },
+          "asOf": {
+            "type": "string"
+          },
+          "confidenceFloor": {
+            "maximum": 1,
+            "minimum": 0,
+            "type": "number"
+          },
+          "disableLangFilter": {
+            "type": "boolean"
+          },
+          "entityIds": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "entityTypes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "explain": {
+            "type": "boolean"
+          },
+          "includeContested": {
+            "type": "boolean"
+          },
+          "includeRetracted": {
+            "type": "boolean"
+          },
+          "includeStale": {
+            "type": "boolean"
+          },
+          "limit": {
+            "maximum": 100,
+            "minimum": 1,
+            "type": "number"
+          },
+          "minConfidence": {
+            "maximum": 1,
+            "minimum": 0,
+            "type": "number"
+          },
+          "outputShape": {
+            "enum": [
+              "full",
+              "compact",
+              "ids"
+            ],
+            "type": "string"
+          },
+          "predicates": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "query": {
+            "maxLength": 8000,
+            "type": "string"
+          },
+          "queryLang": {
+            "type": "string"
+          },
+          "requireProvenance": {
+            "type": "boolean"
+          },
+          "searchMode": {
+            "enum": [
+              "vector",
+              "lexical",
+              "hybrid"
+            ],
+            "type": "string"
+          },
+          "synthesisGuardrails": {
+            "enum": [
+              "strict",
+              "lenient",
+              "off",
+              "answer"
+            ],
+            "type": "string"
+          },
+          "synthesisModel": {
+            "type": "string"
+          },
+          "tokenBudget": {
+            "maximum": 50000,
+            "minimum": 50,
+            "type": "number"
+          },
+          "userId": {
+            "maxLength": 200,
+            "type": "string"
+          }
+        },
+        "required": [
+          "query"
+        ],
+        "type": "object"
+      },
+      "SynthesizeResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "answer": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "cached": {
+            "type": "boolean"
+          },
+          "citations": {
+            "items": {
+              "$ref": "#/components/schemas/Citation"
+            },
+            "type": "array"
+          },
+          "decisionLog": {
+            "items": {
+              "$ref": "#/components/schemas/DecisionLogEntry"
+            },
+            "type": "array"
+          },
+          "evidenceCitations": {
+            "items": {
+              "$ref": "#/components/schemas/EvidenceCitation"
+            },
+            "type": "array"
+          },
+          "reason": {
+            "$ref": "#/components/schemas/SynthesisReason"
+          },
+          "results": {
+            "items": {
+              "$ref": "#/components/schemas/SearchHit"
+            },
+            "type": "array"
+          },
+          "tokenUsage": {
+            "$ref": "#/components/schemas/TokenUsage"
+          }
+        },
+        "required": [
+          "answer",
+          "citations",
+          "results"
+        ],
+        "type": "object"
+      },
+      "TimelineRecordedEvent": {
+        "additionalProperties": false,
+        "properties": {
+          "at": {
+            "type": "string"
+          },
+          "confidence": {
+            "type": "number"
+          },
+          "factId": {
+            "type": "string"
+          },
+          "object": {
+            "type": "string"
+          },
+          "predicate": {
+            "type": "string"
+          },
+          "source": {},
+          "type": {
+            "const": "fact.recorded",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "at",
+          "factId",
+          "predicate",
+          "object",
+          "source",
+          "confidence"
+        ],
+        "type": "object"
+      },
+      "TimelineRetractedEvent": {
+        "additionalProperties": false,
+        "properties": {
+          "at": {
+            "type": "string"
+          },
+          "factId": {
+            "type": "string"
+          },
+          "reason": {},
+          "retractedBy": {},
+          "supersededBy": {
+            "type": "string"
+          },
+          "type": {
+            "const": "fact.retracted",
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "at",
+          "factId",
+          "retractedBy",
+          "reason"
+        ],
+        "type": "object"
+      },
+      "TokenUsage": {
+        "additionalProperties": false,
+        "properties": {
+          "completionTokens": {
+            "type": "number"
+          },
+          "promptTokens": {
+            "type": "number"
+          }
+        },
+        "required": [
+          "promptTokens",
+          "completionTokens"
+        ],
+        "type": "object"
+      },
       "TrustScopeRow": {
         "additionalProperties": false,
         "properties": {
@@ -3680,12 +4987,12 @@
     }
   },
   "info": {
-    "description": "Generated from the zod wire contracts (`pnpm openapi:build` — scripts/build-openapi.ts); do not edit by hand. The admin/ops surface (jobs, leases, policy, stats, maintenance) is documented in docs/api.md instead. Scopes are plain bearer-key grants, not OAuth flows — each operation states its required scope.",
+    "description": "Generated from the zod wire contracts (`pnpm openapi:build` — scripts/build-openapi.ts); do not edit by hand. Excluded on purpose: the operator/ops surface (jobs, leases, policy, stats, maintenance, GDPR cascades), which is indexed in docs/api.md, and the MCP transport `ALL /mcp/{companyId}`, which is JSON-RPC over Streamable HTTP rather than REST — MCP clients discover it through `tools/list` (docs/mcp.md). Scopes are plain bearer-key grants, not OAuth flows — each operation states its required scope.",
     "license": {
       "identifier": "AGPL-3.0-or-later",
       "name": "AGPL-3.0-or-later"
     },
-    "summary": "The community-facing platform surface: Domain Pack registry, tenant pack admin, document ingest, the external-indexer work protocol, and source reputation reads.",
+    "summary": "The community-facing platform surface: the memory core (fact ingest, search, multi-hop, synthesize, entity and fact reads), the Domain Pack registry and tenant pack admin, the document pipeline, the external-indexer work protocol, the raw-substrate driver, the evidence substrate, and source reputation reads.",
     "title": "INITE Brain — Platform API",
     "version": "2.2.0"
   },
@@ -4659,6 +5966,261 @@
         ]
       }
     },
+    "/v1/entities/autocomplete": {
+      "get": {
+        "description": "Word-start match over the edge-ngram `prefix` fulltext index, BM25-ranked via `search::score`. A query under 2 characters returns nothing (the tokenizer produces no grams). Live, tenant-global entities only — merged-away redirects and personal-scoped entities are excluded. Source: src/entities/entities.controller.ts.\n\nRequired scope: `brain:read`.",
+        "operationId": "autocompleteEntities",
+        "parameters": [
+          {
+            "description": "The prefix to complete (under 2 chars → empty result).",
+            "in": "query",
+            "name": "q",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Page size, 1–25 (default 10).",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityAutocompleteResponse"
+                }
+              }
+            },
+            "description": "Ranked suggestions."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        },
+        "summary": "Entity-name typeahead",
+        "tags": [
+          "Entities"
+        ]
+      }
+    },
+    "/v1/entities/{id}": {
+      "get": {
+        "description": "The entity plus the facts currently held about it, filtered by the row policy (a fact whose predicate requires a scope the caller lacks never appears). `asOf` slices WORLD time (what was true at T); `recordedAt` slices TRANSACTION time (what the graph believed at T — a later retract or supersede is ignored). A merged entity answers with `mergedInto` set: treat it as a redirect.\n\nRequired scope: `brain:read`.",
+        "operationId": "getEntityProfile",
+        "parameters": [
+          {
+            "description": "Entity id — short (`cuid_abc`) or full (`knowledge_entity:cuid_abc`).",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "ISO-8601 world-time slice.",
+            "in": "query",
+            "name": "asOf",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "ISO-8601 transaction-time slice.",
+            "in": "query",
+            "name": "recordedAt",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityProfileResponse"
+                }
+              }
+            },
+            "description": "The profile."
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "summary": "Entity profile and its active facts",
+        "tags": [
+          "Entities"
+        ]
+      }
+    },
+    "/v1/entities/{id}/connections": {
+      "get": {
+        "description": "The entity’s 1-hop neighbourhood over `knowledge_edge`, in both directions (`direction` says which). `kind` filters to one edge type; `asOf` restricts to edges live at that instant. `neighbour` is absent when the far end could not be projected.\n\nRequired scope: `brain:read`.",
+        "operationId": "getEntityConnections",
+        "parameters": [
+          {
+            "description": "Entity id — short or fully-qualified.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Only edges of this kind.",
+            "in": "query",
+            "name": "kind",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "ISO-8601 instant the edge must be live at.",
+            "in": "query",
+            "name": "asOf",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityConnectionsResponse"
+                }
+              }
+            },
+            "description": "The typed edges."
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "summary": "Typed edges and direct neighbours",
+        "tags": [
+          "Entities"
+        ]
+      }
+    },
+    "/v1/entities/{id}/timeline": {
+      "get": {
+        "description": "`fact.recorded` / `fact.retracted` events on the TRANSACTION-time axis — when the graph learned and unlearned things, not when they were true. `since` / `until` page the window; `recordedAt` cuts to events known by T. `userId` is honoured only while READ_SURFACE_USER_SCOPE is on (this surface predates migration 0055 and otherwise pins `userId IS NONE`); a user-bound token is pinned to its own end user, and a mismatch is 403.\n\nRequired scope: `brain:read`.",
+        "operationId": "getEntityTimeline",
+        "parameters": [
+          {
+            "description": "Entity id — short or fully-qualified.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "ISO-8601 lower bound on recordedAt.",
+            "in": "query",
+            "name": "since",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "ISO-8601 upper bound on recordedAt.",
+            "in": "query",
+            "name": "until",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Only events known by this instant.",
+            "in": "query",
+            "name": "recordedAt",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Per-user scope (READ_SURFACE_USER_SCOPE only).",
+            "in": "query",
+            "name": "userId",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EntityTimelineResponse"
+                }
+              }
+            },
+            "description": "The event sweep."
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "summary": "Bitemporal sweep over an entity’s memory",
+        "tags": [
+          "Entities"
+        ]
+      }
+    },
     "/v1/episodes": {
       "get": {
         "description": "Verbatim pre-extraction dialogue turns in stable (occurredAt, id) order — the raw layer any consumer can build its own projection from. Callers without `brain:read_pii` see only episodes whose piiClass is empty. 404 until EPISODES_API_ENABLED=1. Source: src/episodes/episodes.controller.ts.\n\nRequired scope: `brain:read`.",
@@ -5373,6 +6935,61 @@
         ]
       }
     },
+    "/v1/facts/{id}/retract": {
+      "post": {
+        "description": "Marks the fact retracted and writes the audit trail. Two cascades follow: facts DERIVED from it are retracted too (`cascadedFactIds`), and facts this one had SUPERSEDED come back to active (`revivedFactIds`) unless they were separately retracted on their own merits. Deliberately NOT gated by FACTS_API_ENABLED — the read routes above are, but a tenant must always be able to remove a fact. `brain:write` is the floor; FactsService elevates the requirement to `brain:admin` for billing_event / human_declared / legal-source facts once it has read the row (403 from there, not from the guard). For erasure rather than retraction, see the GDPR cascade on the admin surface (docs/api.md).\n\nRequired scope: `brain:write`.",
+        "operationId": "retractFact",
+        "parameters": [
+          {
+            "description": "Fact record id (`knowledge_fact:…`).",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RetractFactRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RetractFactResponse"
+                }
+              }
+            },
+            "description": "What the retraction changed."
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "summary": "Retract a fact",
+        "tags": [
+          "Facts"
+        ]
+      }
+    },
     "/v1/indexer/work": {
       "get": {
         "description": "Pending indexer runs routed to this tenant’s installed external packs. Protocol: docs/indexer-protocol.md. Part of the document pipeline — answers `503 feature_disabled` until `DOCUMENT_INGEST_ENABLED=1`. Source: src/documents/indexer-work.controller.ts.\n\nRequired scope: `indexer:write`.",
@@ -5876,6 +7493,47 @@
         ]
       }
     },
+    "/v1/ingest/fact": {
+      "post": {
+        "description": "The headline write. Resolves the entity, embeds the claim and runs bitemporal conflict resolution against the standing timeline: the response `outcome` says what the resolver decided (INSERTED / INSERTED_HISTORICAL / CORROBORATED / SUPERSEDED / COMPETING / REJECTED), never just \"ok\". `userId` stamps a per-user memory scope (migration 0055) — scope-local conflict resolution, invisible to every other user of the tenant and to requests that don't assert one. `explain: true` adds the deterministic conflict narrative on a SUPERSEDED / COMPETING outcome. Source: src/ingest/ingest.controller.ts.\n\nRequired scope: `brain:write`.",
+        "operationId": "ingestFact",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IngestFactRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IngestFactResponse"
+                }
+              }
+            },
+            "description": "The resolver's decision."
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        },
+        "summary": "Record a declared structured fact",
+        "tags": [
+          "Ingest"
+        ]
+      }
+    },
     "/v1/projections": {
       "get": {
         "description": "Every derived world (facts@version, …) with its lifecycle status (building/built/live/residual/failed), watermark, builder identity and stats, plus the process-local read pin (RETRIEVAL_DERIVED_VERSION). A registry row promises a queryable world. 404 until PROJECTIONS_API_ENABLED=1. Source: src/admin/projections.controller.ts.\n\nRequired scope: `brain:read`.",
@@ -6169,6 +7827,94 @@
         ]
       }
     },
+    "/v1/search": {
+      "post": {
+        "description": "The headline read. Hybrid retrieval by default (vector + BM25 fused by reciprocal rank), router-boosted, listwise-reranked, then backfilled with each hit entity’s facts. Default semantics is Datomic-style \"actual now\" — only facts whose validity window contains the query moment; `asOf` slices world-time and `includeStale` reverts to the audit shape. `userId` widens the fence from tenant-global memory to tenant-global PLUS that user's personal rows (fail-closed: omitted means global only). Facts whose predicate requires a scope the caller lacks never enter the result. Fans out to the shared embedding / LLM budget, so it sits in the per-credential `expensive` throttle bucket — 10 requests/min, not the 120/min default. Source: src/search/search.controller.ts.\n\nRequired scope: `brain:read`.",
+        "operationId": "searchKnowledge",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SearchRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchResponse"
+                }
+              }
+            },
+            "description": "Scored entity hits with their facts."
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          }
+        },
+        "summary": "Search the knowledge graph",
+        "tags": [
+          "Search"
+        ]
+      }
+    },
+    "/v1/search/multi-hop": {
+      "post": {
+        "description": "A planner LLM decomposes the query into at most `maxHops` anchored sub-queries; each later hop is scoped to the running entity set, so the engine never spends compute on candidates already disqualified. Answers questions that join evidence across turns or entities. `supportingFactIds` is the evidence chain (HotpotQA-style) — the caller can audit exactly which facts drove the answer. `synthesize: true` adds a grounded answer with citations alongside the per-hop trace. Fans out to the shared embedding / LLM budget, so it sits in the per-credential `expensive` throttle bucket — 10 requests/min, not the 120/min default. Source: src/multi-hop/multi-hop.controller.ts.\n\nRequired scope: `brain:read`.",
+        "operationId": "searchMultiHop",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MultiHopRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MultiHopResponse"
+                }
+              }
+            },
+            "description": "The hop trace and the final entity set."
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          }
+        },
+        "summary": "Chained multi-hop search",
+        "tags": [
+          "Search"
+        ]
+      }
+    },
     "/v1/sources": {
       "get": {
         "description": "Catalogue of everything brain knows ABOUT its fact sources: the operator-declared identity (type, authLevel) joined with the learned agreement rates, one row per sourceKey. Public projection — operator annotations (owner/note) are served only on the brain:admin surface. `domain` additionally captures that domain's learned rate into `domainTrust` and makes `minSamples` judge it (falling back to the global row). Source: src/sources/public-sources.controller.ts.\n\nRequired scope: `brain:read`.",
@@ -6298,6 +8044,50 @@
         ]
       }
     },
+    "/v1/synthesize": {
+      "post": {
+        "description": "Corrective RAG over the same retrieval stack as /v1/search: generate an answer, then verify each claim against the facts it cites. The pipeline ABSTAINS rather than guess — `answer` is null and `reason` names the gate that fired (no results, thin coverage, ungrounded support, a failed verifier…). `synthesisGuardrails` picks the policy: `strict` closes to null on a partial verdict, `lenient` returns the answer with the verdict attached, `off` skips the verifier. Cited facts are always the caller’s own visible memory. Fans out to the shared embedding / LLM budget, so it sits in the per-credential `expensive` throttle bucket — 10 requests/min, not the 120/min default. Source: src/synthesize/synthesize.controller.ts.\n\nRequired scope: `brain:read`.",
+        "operationId": "synthesizeAnswer",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SynthesizeRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SynthesizeResponse"
+                }
+              }
+            },
+            "description": "The answer (or a reasoned abstention)."
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "429": {
+            "$ref": "#/components/responses/TooManyRequests"
+          }
+        },
+        "summary": "Answer a question from memory, with citations",
+        "tags": [
+          "Search"
+        ]
+      }
+    },
     "/v1/users/{userId}/profile": {
       "get": {
         "description": "Query-time assembly of what the platform knows about a user: active user-scoped facts grouped by aspect (persona-first), plus `profileText` shaped for direct prompt injection. Deterministic — no model calls. A user-bound token may only fetch its own profile (mismatch 403); M2M tokens any. 404 until USER_PROFILE_API_ENABLED=1. Source: src/users/user-profile.controller.ts.\n\nRequired scope: `brain:read`.",
@@ -6374,6 +8164,18 @@
     }
   ],
   "tags": [
+    {
+      "description": "Writing memory: the declared-fact path (scope `brain:write`). Every write goes through bitemporal conflict resolution, so the response reports a decision, not an acknowledgement.",
+      "name": "Ingest"
+    },
+    {
+      "description": "Reading memory (scope `brain:read`): hybrid search, chained multi-hop search, and cited synthesis over the same retrieval stack. All three share the per-credential `expensive` throttle bucket (10 req/min).",
+      "name": "Search"
+    },
+    {
+      "description": "The entity read surface (scope `brain:read`): typeahead, profile, bitemporal timeline and typed connections. The GDPR cascade on the same controller is an operator action and lives on the admin surface (docs/api.md).",
+      "name": "Entities"
+    },
     {
       "description": "Discovery reads over the global Domain Pack registry (shared across all tenants).",
       "name": "Registry"

--- a/scripts/build-openapi.ts
+++ b/scripts/build-openapi.ts
@@ -1,16 +1,58 @@
 #!/usr/bin/env -S npx ts-node -T
 /**
  * build-openapi — assemble the OpenAPI 3.1 document for the PLATFORM
- * surface (the community-facing API: pack registry, pack admin, document
- * ingest/read, external-indexer candidates + work discovery, source
- * reputation reads). The admin/ops surface (jobs, leases, policy, stats,
- * maintenance) is out of scope on purpose.
+ * surface.
  *
+ * ── THE SELECTION RULE ────────────────────────────────────────────────
+ * The service serves ~192 route handlers across ~59 controllers; this
+ * document publishes far fewer, and the cut is deliberate. A route is
+ * PUBLISHED when it is part of the contract an integrator codes
+ * against:
+ *
+ *   • the memory core — declared-fact ingest, search, multi-hop search,
+ *     synthesize, the entity read surface, fact reads + provenance +
+ *     retraction, belief reads, the rolling user profile;
+ *   • the Domain Pack registry, its marketplace, and tenant pack admin
+ *     (`/v1/admin/packs*`, `/v1/admin/registry/*`) — "admin" in the
+ *     PATH, but tenant self-service, not operator ops;
+ *   • the document pipeline and the external-indexer work protocol;
+ *   • the raw-substrate driver (episodes, subscriptions, projections);
+ *   • the evidence substrate (ingest, raw reads, sharing grants);
+ *   • source-reputation reads.
+ *
+ * A route is EXCLUDED when it is not that:
+ *
+ *   • operator/ops surfaces — jobs, leases, DLQ, policy, predicates,
+ *     stats, traces, calibration, migrations, scheduler, maintenance,
+ *     GDPR cascades (POST /v1/entities/:id/forget) and everything else
+ *     behind `brain:platform_admin`. These are indexed in docs/api.md
+ *     and change with the operator playbook, not with an integration.
+ *   • the admin BFF and its dynamic UI paths, the internal poller /
+ *     changefeed surfaces, and health/metrics endpoints.
+ *   • the MCP transport, `ALL /mcp/:companyId`. NOT AN OVERSIGHT, and
+ *     please do not "fix" it: that route is JSON-RPC 2.0 over MCP
+ *     Streamable HTTP, one URL carrying `initialize` / `tools/list` /
+ *     `tools/call` messages whose shapes live in the MCP tool
+ *     registrations (src/mcp/*-tools.ts), not in an HTTP method+path
+ *     matrix. An OpenAPI `paths` block can only lie about it. MCP
+ *     clients discover the surface through `tools/list`; humans read
+ *     docs/mcp.md.
+ *
+ * ── SCHEMAS ───────────────────────────────────────────────────────────
  * components.schemas are GENERATED from the zod wire contracts under
  * src/contracts/ (zod v4 z.toJSONSchema over a registry, so nested
  * contracts become $refs). zod's default output is JSON Schema 2020-12,
  * which OpenAPI 3.1 accepts natively — no down-conversion. paths are
- * hand-written below against the controllers they document.
+ * hand-written below against the controllers they document, but a
+ * request/response BODY is never hand-written: it always $refs a zod
+ * contract, and each contract is pinned to the DTO / service result
+ * type it mirrors by a test/contracts-*.unit-spec.ts parity guard.
+ *
+ * The one sanctioned exception: `explain`-mode debug payloads (a search
+ * hit's `breakdown`, a synthesis `decisionLog` entry, an ingest
+ * `conflictExplanation`) are published as OPEN objects. They mirror
+ * scorer/resolver internals that move with every retrieval lever, and
+ * pinning them would publish a promise the engine never made.
  *
  * Output: docs/openapi.json (committed artifact, keys sorted so
  * regenerate-and-diff is deterministic).
@@ -19,7 +61,8 @@
  *   pnpm openapi:build
  *
  * Drift gate: test/openapi-doc.unit-spec.ts re-builds the document and
- * asserts deep-equality with the committed file.
+ * asserts deep-equality with BOTH committed copies (docs/ and
+ * brain-landing/public/ — see OUT_PATHS).
  */
 import { readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
@@ -114,7 +157,52 @@ import {
   FactProvenanceEpisodeSchema,
   FactProvenanceResponseSchema,
   FactReadResponseSchema,
+  RetractedBySchema,
+  RetractFactRequestSchema,
+  RetractFactResponseSchema,
 } from '../src/contracts/facts/facts.schema';
+import {
+  ConflictExplanationSchema,
+  EntityRefSchema,
+  FactSourceSchema,
+  IngestFactRequestSchema,
+  IngestFactResponseSchema,
+  SourceEvidenceSchema,
+} from '../src/contracts/ingest/ingest.schema';
+import {
+  ScoreBreakdownSchema,
+  SearchFactSchema,
+  SearchHitSchema,
+  SearchRequestSchema,
+  SearchResponseSchema,
+} from '../src/contracts/search/search.schema';
+import {
+  HopOutcomeSchema,
+  HopPlanSchema,
+  MultiHopRequestSchema,
+  MultiHopResponseSchema,
+} from '../src/contracts/search/multi-hop.schema';
+import {
+  CitationSchema,
+  DecisionLogEntrySchema,
+  EvidenceCitationSchema,
+  SynthesisReasonSchema,
+  SynthesizeRequestSchema,
+  SynthesizeResponseSchema,
+  TokenUsageSchema,
+} from '../src/contracts/synthesize/synthesize.schema';
+import {
+  ConnectionEdgeSchema,
+  ConnectionNeighbourSchema,
+  EntityAutocompleteResponseSchema,
+  EntityAutocompleteSuggestionSchema,
+  EntityConnectionsResponseSchema,
+  EntityProfileFactSchema,
+  EntityProfileResponseSchema,
+  EntityTimelineResponseSchema,
+  TimelineRecordedEventSchema,
+  TimelineRetractedEventSchema,
+} from '../src/contracts/entities/entities.schema';
 import {
   BeliefReadResponseSchema,
   BeliefsListResponseSchema,
@@ -234,10 +322,50 @@ const ZOD_COMPONENTS: Record<string, z.ZodType> = {
   EpisodeSubscriptionsListResponse: EpisodeSubscriptionsListResponseSchema,
   DeleteEpisodeSubscriptionResponse: DeleteEpisodeSubscriptionResponseSchema,
   EpisodesAvailableEvent: EpisodesAvailableEventSchema,
-  // --- fact read + provenance (src/contracts/facts/facts.schema.ts)
+  // --- fact read + provenance + retraction (src/contracts/facts/…)
   FactReadResponse: FactReadResponseSchema,
   FactProvenanceEpisode: FactProvenanceEpisodeSchema,
   FactProvenanceResponse: FactProvenanceResponseSchema,
+  RetractedBy: RetractedBySchema,
+  RetractFactRequest: RetractFactRequestSchema,
+  RetractFactResponse: RetractFactResponseSchema,
+  // --- declared-fact ingest (src/contracts/ingest/ingest.schema.ts)
+  EntityRef: EntityRefSchema,
+  SourceEvidence: SourceEvidenceSchema,
+  FactSource: FactSourceSchema,
+  IngestFactRequest: IngestFactRequestSchema,
+  IngestFactResponse: IngestFactResponseSchema,
+  ConflictExplanation: ConflictExplanationSchema,
+  // --- search (src/contracts/search/search.schema.ts)
+  SearchRequest: SearchRequestSchema,
+  SearchFact: SearchFactSchema,
+  SearchHit: SearchHitSchema,
+  SearchResponse: SearchResponseSchema,
+  ScoreBreakdown: ScoreBreakdownSchema,
+  // --- multi-hop search (src/contracts/search/multi-hop.schema.ts)
+  MultiHopRequest: MultiHopRequestSchema,
+  HopPlan: HopPlanSchema,
+  HopOutcome: HopOutcomeSchema,
+  MultiHopResponse: MultiHopResponseSchema,
+  // --- synthesize (src/contracts/synthesize/synthesize.schema.ts)
+  SynthesizeRequest: SynthesizeRequestSchema,
+  SynthesizeResponse: SynthesizeResponseSchema,
+  SynthesisReason: SynthesisReasonSchema,
+  Citation: CitationSchema,
+  EvidenceCitation: EvidenceCitationSchema,
+  TokenUsage: TokenUsageSchema,
+  DecisionLogEntry: DecisionLogEntrySchema,
+  // --- entity read surface (src/contracts/entities/entities.schema.ts)
+  EntityAutocompleteSuggestion: EntityAutocompleteSuggestionSchema,
+  EntityAutocompleteResponse: EntityAutocompleteResponseSchema,
+  EntityProfileFact: EntityProfileFactSchema,
+  EntityProfileResponse: EntityProfileResponseSchema,
+  TimelineRecordedEvent: TimelineRecordedEventSchema,
+  TimelineRetractedEvent: TimelineRetractedEventSchema,
+  EntityTimelineResponse: EntityTimelineResponseSchema,
+  ConnectionNeighbour: ConnectionNeighbourSchema,
+  ConnectionEdge: ConnectionEdgeSchema,
+  EntityConnectionsResponse: EntityConnectionsResponseSchema,
   // --- belief reads (src/contracts/beliefs/beliefs.schema.ts)
   BeliefReadResponse: BeliefReadResponseSchema,
   BeliefsListResponse: BeliefsListResponseSchema,
@@ -768,6 +896,246 @@ function packsAdminPaths(): Json {
   };
 }
 
+/**
+ * The memory core — the two calls the README's quick start makes
+ * (declared-fact ingest, search) plus the two reasoning surfaces built
+ * on the same retrieval stack (multi-hop, synthesize). Always mounted:
+ * no feature flag gates these, so there is no 404-until-on arm.
+ *
+ * `search`, `search/multi-hop` and `synthesize` all fan out to the
+ * shared embedding / generator budget, so all three sit in the tight
+ * per-credential `expensive` throttle bucket (10 req/min) rather than
+ * the 120/min default.
+ */
+const EXPENSIVE_NOTE =
+  'Fans out to the shared embedding / LLM budget, so it sits in the ' +
+  'per-credential `expensive` throttle bucket — 10 requests/min, not ' +
+  'the 120/min default.';
+
+function memoryCorePaths(): Json {
+  return {
+    '/v1/ingest/fact': {
+      post: operation({
+        operationId: 'ingestFact',
+        tag: 'Ingest',
+        summary: 'Record a declared structured fact',
+        description:
+          'The headline write. Resolves the entity, embeds the claim and ' +
+          'runs bitemporal conflict resolution against the standing ' +
+          'timeline: the response `outcome` says what the resolver ' +
+          'decided (INSERTED / INSERTED_HISTORICAL / CORROBORATED / ' +
+          'SUPERSEDED / COMPETING / REJECTED), never just "ok". ' +
+          '`userId` stamps a per-user memory scope (migration 0055) — ' +
+          'scope-local conflict resolution, invisible to every other ' +
+          "user of the tenant and to requests that don't assert one. " +
+          '`explain: true` adds the deterministic conflict narrative on ' +
+          'a SUPERSEDED / COMPETING outcome. ' +
+          'Source: src/ingest/ingest.controller.ts.',
+        scope: 'brain:write',
+        requestBody: jsonBody(ref('IngestFactRequest')),
+        responses: {
+          '201': jsonResponse("The resolver's decision.", ref('IngestFactResponse')),
+          '400': errorRef('BadRequest'),
+          ...AUTH_ERRORS,
+        },
+      }),
+    },
+    '/v1/search': {
+      post: operation({
+        operationId: 'searchKnowledge',
+        tag: 'Search',
+        summary: 'Search the knowledge graph',
+        description:
+          'The headline read. Hybrid retrieval by default (vector + BM25 ' +
+          'fused by reciprocal rank), router-boosted, listwise-reranked, ' +
+          'then backfilled with each hit entity’s facts. Default ' +
+          'semantics is Datomic-style "actual now" — only facts whose ' +
+          'validity window contains the query moment; `asOf` slices ' +
+          'world-time and `includeStale` reverts to the audit shape. ' +
+          '`userId` widens the fence from tenant-global memory to ' +
+          "tenant-global PLUS that user's personal rows (fail-closed: " +
+          'omitted means global only). Facts whose predicate requires a ' +
+          `scope the caller lacks never enter the result. ${EXPENSIVE_NOTE} ` +
+          'Source: src/search/search.controller.ts.',
+        scope: 'brain:read',
+        requestBody: jsonBody(ref('SearchRequest')),
+        responses: {
+          '201': jsonResponse('Scored entity hits with their facts.', ref('SearchResponse')),
+          '400': errorRef('BadRequest'),
+          ...AUTH_ERRORS,
+          '429': errorRef('TooManyRequests'),
+        },
+      }),
+    },
+    '/v1/search/multi-hop': {
+      post: operation({
+        operationId: 'searchMultiHop',
+        tag: 'Search',
+        summary: 'Chained multi-hop search',
+        description:
+          'A planner LLM decomposes the query into at most `maxHops` ' +
+          'anchored sub-queries; each later hop is scoped to the running ' +
+          'entity set, so the engine never spends compute on candidates ' +
+          'already disqualified. Answers questions that join evidence ' +
+          'across turns or entities. `supportingFactIds` is the evidence ' +
+          'chain (HotpotQA-style) — the caller can audit exactly which ' +
+          'facts drove the answer. `synthesize: true` adds a grounded ' +
+          `answer with citations alongside the per-hop trace. ${EXPENSIVE_NOTE} ` +
+          'Source: src/multi-hop/multi-hop.controller.ts.',
+        scope: 'brain:read',
+        requestBody: jsonBody(ref('MultiHopRequest')),
+        responses: {
+          '201': jsonResponse('The hop trace and the final entity set.', ref('MultiHopResponse')),
+          '400': errorRef('BadRequest'),
+          ...AUTH_ERRORS,
+          '429': errorRef('TooManyRequests'),
+        },
+      }),
+    },
+    '/v1/synthesize': {
+      post: operation({
+        operationId: 'synthesizeAnswer',
+        tag: 'Search',
+        summary: 'Answer a question from memory, with citations',
+        description:
+          'Corrective RAG over the same retrieval stack as /v1/search: ' +
+          'generate an answer, then verify each claim against the facts ' +
+          'it cites. The pipeline ABSTAINS rather than guess — `answer` ' +
+          'is null and `reason` names the gate that fired (no results, ' +
+          'thin coverage, ungrounded support, a failed verifier…). ' +
+          '`synthesisGuardrails` picks the policy: `strict` closes to ' +
+          'null on a partial verdict, `lenient` returns the answer with ' +
+          'the verdict attached, `off` skips the verifier. Cited facts ' +
+          'are always the caller’s own visible memory. ' +
+          `${EXPENSIVE_NOTE} Source: src/synthesize/synthesize.controller.ts.`,
+        scope: 'brain:read',
+        requestBody: jsonBody(ref('SynthesizeRequest')),
+        responses: {
+          '201': jsonResponse('The answer (or a reasoned abstention).', ref('SynthesizeResponse')),
+          '400': errorRef('BadRequest'),
+          ...AUTH_ERRORS,
+          '429': errorRef('TooManyRequests'),
+        },
+      }),
+    },
+  };
+}
+
+/**
+ * The entity READ surface. The GDPR cascade on the same controller
+ * (POST /v1/entities/{id}/forget, `brain:admin`) is an operator action
+ * and stays on the docs/api.md admin index — see the selection rule.
+ */
+function entitiesPaths(): Json {
+  return {
+    '/v1/entities/autocomplete': {
+      get: operation({
+        operationId: 'autocompleteEntities',
+        tag: 'Entities',
+        summary: 'Entity-name typeahead',
+        description:
+          'Word-start match over the edge-ngram `prefix` fulltext index, ' +
+          'BM25-ranked via `search::score`. A query under 2 characters ' +
+          'returns nothing (the tokenizer produces no grams). Live, ' +
+          'tenant-global entities only — merged-away redirects and ' +
+          'personal-scoped entities are excluded. ' +
+          'Source: src/entities/entities.controller.ts.',
+        scope: 'brain:read',
+        parameters: [
+          queryParam('q', 'The prefix to complete (under 2 chars → empty result).'),
+          queryParam('limit', 'Page size, 1–25 (default 10).', { type: 'integer' }),
+        ],
+        responses: {
+          '200': jsonResponse('Ranked suggestions.', ref('EntityAutocompleteResponse')),
+          ...AUTH_ERRORS,
+        },
+      }),
+    },
+    '/v1/entities/{id}': {
+      get: operation({
+        operationId: 'getEntityProfile',
+        tag: 'Entities',
+        summary: 'Entity profile and its active facts',
+        description:
+          'The entity plus the facts currently held about it, filtered ' +
+          'by the row policy (a fact whose predicate requires a scope the ' +
+          'caller lacks never appears). `asOf` slices WORLD time (what ' +
+          'was true at T); `recordedAt` slices TRANSACTION time (what the ' +
+          'graph believed at T — a later retract or supersede is ' +
+          'ignored). A merged entity answers with `mergedInto` set: ' +
+          'treat it as a redirect.',
+        scope: 'brain:read',
+        parameters: [
+          pathParam('id', 'Entity id — short (`cuid_abc`) or full (`knowledge_entity:cuid_abc`).'),
+          queryParam('asOf', 'ISO-8601 world-time slice.'),
+          queryParam('recordedAt', 'ISO-8601 transaction-time slice.'),
+        ],
+        responses: {
+          '200': jsonResponse('The profile.', ref('EntityProfileResponse')),
+          '400': errorRef('BadRequest'),
+          ...AUTH_ERRORS,
+          '404': errorRef('NotFound'),
+        },
+      }),
+    },
+    '/v1/entities/{id}/timeline': {
+      get: operation({
+        operationId: 'getEntityTimeline',
+        tag: 'Entities',
+        summary: 'Bitemporal sweep over an entity’s memory',
+        description:
+          '`fact.recorded` / `fact.retracted` events on the ' +
+          'TRANSACTION-time axis — when the graph learned and unlearned ' +
+          'things, not when they were true. `since` / `until` page the ' +
+          'window; `recordedAt` cuts to events known by T. `userId` is ' +
+          'honoured only while READ_SURFACE_USER_SCOPE is on (this ' +
+          'surface predates migration 0055 and otherwise pins ' +
+          '`userId IS NONE`); a user-bound token is pinned to its own ' +
+          'end user, and a mismatch is 403.',
+        scope: 'brain:read',
+        parameters: [
+          pathParam('id', 'Entity id — short or fully-qualified.'),
+          queryParam('since', 'ISO-8601 lower bound on recordedAt.'),
+          queryParam('until', 'ISO-8601 upper bound on recordedAt.'),
+          queryParam('recordedAt', 'Only events known by this instant.'),
+          queryParam('userId', 'Per-user scope (READ_SURFACE_USER_SCOPE only).'),
+        ],
+        responses: {
+          '200': jsonResponse('The event sweep.', ref('EntityTimelineResponse')),
+          '400': errorRef('BadRequest'),
+          ...AUTH_ERRORS,
+          '404': errorRef('NotFound'),
+        },
+      }),
+    },
+    '/v1/entities/{id}/connections': {
+      get: operation({
+        operationId: 'getEntityConnections',
+        tag: 'Entities',
+        summary: 'Typed edges and direct neighbours',
+        description:
+          'The entity’s 1-hop neighbourhood over `knowledge_edge`, in ' +
+          'both directions (`direction` says which). `kind` filters to ' +
+          'one edge type; `asOf` restricts to edges live at that ' +
+          'instant. `neighbour` is absent when the far end could not be ' +
+          'projected.',
+        scope: 'brain:read',
+        parameters: [
+          pathParam('id', 'Entity id — short or fully-qualified.'),
+          queryParam('kind', 'Only edges of this kind.'),
+          queryParam('asOf', 'ISO-8601 instant the edge must be live at.'),
+        ],
+        responses: {
+          '200': jsonResponse('The typed edges.', ref('EntityConnectionsResponse')),
+          '400': errorRef('BadRequest'),
+          ...AUTH_ERRORS,
+          '404': errorRef('NotFound'),
+        },
+      }),
+    },
+  };
+}
+
 function documentsPaths(): Json {
   return {
     '/v1/ingest/document': {
@@ -1110,10 +1478,11 @@ function driverPaths(): Json {
 }
 
 /**
- * Memory read surface: fact-by-id + provenance ("show me why I
- * remember this"), belief reads (semantic_belief) and the rolling user
- * profile. Dark behind default-off flags with 404 (an absent surface
- * is indistinguishable from a disabled one).
+ * Fact-level memory surface: fact-by-id + provenance ("show me why I
+ * remember this"), retraction, belief reads (semantic_belief) and the
+ * rolling user profile. The READS are dark behind default-off flags
+ * with 404 (an absent surface is indistinguishable from a disabled
+ * one); retraction is deliberately flag-independent.
  */
 function memoryReadPaths(): Json {
   return {
@@ -1152,6 +1521,35 @@ function memoryReadPaths(): Json {
         responses: {
           '200': jsonResponse('The grounding episodes.', ref('FactProvenanceResponse')),
           ...DRIVER_404,
+        },
+      }),
+    },
+    '/v1/facts/{id}/retract': {
+      post: operation({
+        operationId: 'retractFact',
+        tag: 'Facts',
+        summary: 'Retract a fact',
+        description:
+          'Marks the fact retracted and writes the audit trail. Two ' +
+          'cascades follow: facts DERIVED from it are retracted too ' +
+          '(`cascadedFactIds`), and facts this one had SUPERSEDED come ' +
+          'back to active (`revivedFactIds`) unless they were separately ' +
+          'retracted on their own merits. Deliberately NOT gated by ' +
+          'FACTS_API_ENABLED — the read routes above are, but a tenant ' +
+          'must always be able to remove a fact. `brain:write` is the ' +
+          'floor; FactsService elevates the requirement to `brain:admin` ' +
+          'for billing_event / human_declared / legal-source facts once ' +
+          'it has read the row (403 from there, not from the guard). ' +
+          'For erasure rather than retraction, see the GDPR cascade on ' +
+          'the admin surface (docs/api.md).',
+        scope: 'brain:write',
+        parameters: [pathParam('id', 'Fact record id (`knowledge_fact:…`).')],
+        requestBody: jsonBody(ref('RetractFactRequest')),
+        responses: {
+          '201': jsonResponse('What the retraction changed.', ref('RetractFactResponse')),
+          '400': errorRef('BadRequest'),
+          ...AUTH_ERRORS,
+          '404': errorRef('NotFound'),
         },
       }),
     },
@@ -1800,15 +2198,22 @@ export function buildOpenApiDocument(): Json {
       title: 'INITE Brain — Platform API',
       version: pkg.version,
       summary:
-        'The community-facing platform surface: Domain Pack registry, ' +
-        'tenant pack admin, document ingest, the external-indexer ' +
-        'work protocol, and source reputation reads.',
+        'The community-facing platform surface: the memory core ' +
+        '(fact ingest, search, multi-hop, synthesize, entity and fact ' +
+        'reads), the Domain Pack registry and tenant pack admin, the ' +
+        'document pipeline, the external-indexer work protocol, the ' +
+        'raw-substrate driver, the evidence substrate, and source ' +
+        'reputation reads.',
       description:
         'Generated from the zod wire contracts (`pnpm openapi:build` — ' +
-        'scripts/build-openapi.ts); do not edit by hand. The admin/ops ' +
-        'surface (jobs, leases, policy, stats, maintenance) is documented ' +
-        'in docs/api.md instead. Scopes are plain bearer-key grants, not ' +
-        'OAuth flows — each operation states its required scope.',
+        'scripts/build-openapi.ts); do not edit by hand. Excluded on ' +
+        'purpose: the operator/ops surface (jobs, leases, policy, stats, ' +
+        'maintenance, GDPR cascades), which is indexed in docs/api.md, ' +
+        'and the MCP transport `ALL /mcp/{companyId}`, which is JSON-RPC ' +
+        'over Streamable HTTP rather than REST — MCP clients discover it ' +
+        'through `tools/list` (docs/mcp.md). Scopes are plain bearer-key ' +
+        'grants, not OAuth flows — each operation states its required ' +
+        'scope.',
       license: {
         name: 'AGPL-3.0-or-later',
         identifier: 'AGPL-3.0-or-later',
@@ -1824,6 +2229,29 @@ export function buildOpenApiDocument(): Json {
     ],
     security: [{ bearerAuth: [] }],
     tags: [
+      {
+        name: 'Ingest',
+        description:
+          'Writing memory: the declared-fact path (scope `brain:write`). ' +
+          'Every write goes through bitemporal conflict resolution, so ' +
+          'the response reports a decision, not an acknowledgement.',
+      },
+      {
+        name: 'Search',
+        description:
+          'Reading memory (scope `brain:read`): hybrid search, chained ' +
+          'multi-hop search, and cited synthesis over the same retrieval ' +
+          'stack. All three share the per-credential `expensive` ' +
+          'throttle bucket (10 req/min).',
+      },
+      {
+        name: 'Entities',
+        description:
+          'The entity read surface (scope `brain:read`): typeahead, ' +
+          'profile, bitemporal timeline and typed connections. The GDPR ' +
+          'cascade on the same controller is an operator action and ' +
+          'lives on the admin surface (docs/api.md).',
+      },
       {
         name: 'Registry',
         description:
@@ -1934,6 +2362,8 @@ export function buildOpenApiDocument(): Json {
       },
     ],
     paths: {
+      ...memoryCorePaths(),
+      ...entitiesPaths(),
       ...registryPaths(),
       ...marketplacePaths(),
       ...packsAdminPaths(),

--- a/src/contracts/entities/entities.schema.ts
+++ b/src/contracts/entities/entities.schema.ts
@@ -1,0 +1,114 @@
+import { z } from 'zod';
+
+/**
+ * Wire contracts for the entity READ surface — autocomplete, profile,
+ * bitemporal timeline and typed connections
+ * (src/entities/entities.controller.ts). Parity with the service result
+ * types is pinned by test/contracts-entities.unit-spec.ts.
+ *
+ * The GDPR cascade (POST /v1/entities/:id/forget, scope `brain:admin`)
+ * is NOT part of this file — it is an operator action, documented on the
+ * admin surface in docs/api.md.
+ */
+
+export const EntityAutocompleteSuggestionSchema = z.object({
+  entityId: z.string(),
+  canonicalName: z.string(),
+  type: z.string(),
+  /** BM25 relevance from `search::score` over the edge-ngram prefix index. */
+  score: z.number(),
+});
+
+export const EntityAutocompleteResponseSchema = z.object({
+  suggestions: z.array(EntityAutocompleteSuggestionSchema),
+});
+
+export const EntityProfileFactSchema = z.object({
+  factId: z.string(),
+  predicate: z.string(),
+  object: z.string(),
+  confidence: z.number(),
+  validFrom: z.string(),
+  validUntil: z.string().optional(),
+  status: z.string(),
+});
+
+export const EntityProfileResponseSchema = z.object({
+  entityId: z.string(),
+  type: z.string(),
+  canonicalName: z.string(),
+  externalRefs: z.record(z.string(), z.string()),
+  /**
+   * Set when the entity was merged into another (identity_of cascade):
+   * treat it as a redirect and fetch `mergedInto`. Both absent on live
+   * entities.
+   */
+  mergedAt: z.string().optional(),
+  mergedInto: z.string().optional(),
+  facts: z.array(EntityProfileFactSchema),
+});
+
+/** A fact entered the graph. */
+export const TimelineRecordedEventSchema = z.object({
+  type: z.literal('fact.recorded'),
+  /** Transaction-time instant (ISO-8601). */
+  at: z.string(),
+  factId: z.string(),
+  predicate: z.string(),
+  object: z.string(),
+  /** The stored FLEXIBLE `source` object, verbatim. */
+  source: z.unknown(),
+  confidence: z.number(),
+});
+
+/** A fact left the graph — retracted, or superseded by a newer claim. */
+export const TimelineRetractedEventSchema = z.object({
+  type: z.literal('fact.retracted'),
+  at: z.string(),
+  factId: z.string(),
+  /** The stored retractedBy object, verbatim. */
+  retractedBy: z.unknown(),
+  reason: z.unknown(),
+  supersededBy: z.string().optional(),
+});
+
+export const TimelineEventSchema = z.union([
+  TimelineRecordedEventSchema,
+  TimelineRetractedEventSchema,
+]);
+
+export const EntityTimelineResponseSchema = z.object({
+  entityId: z.string(),
+  /** Transaction-time sweep, oldest first within the requested window. */
+  events: z.array(TimelineEventSchema),
+});
+
+export const ConnectionNeighbourSchema = z.object({
+  id: z.string(),
+  type: z.string(),
+  canonicalName: z.string(),
+});
+
+export const ConnectionEdgeSchema = z.object({
+  edgeId: z.string(),
+  from: z.string(),
+  to: z.string(),
+  kind: z.string(),
+  weight: z.number(),
+  /** The stored FLEXIBLE edge `source` object, verbatim. */
+  source: z.unknown(),
+  createdAt: z.string(),
+  /** The entity on the far end; absent when the projection could not resolve it. */
+  neighbour: ConnectionNeighbourSchema.optional(),
+  direction: z.enum(['outbound', 'inbound']),
+});
+
+export const EntityConnectionsResponseSchema = z.object({
+  entityId: z.string(),
+  edges: z.array(ConnectionEdgeSchema),
+});
+
+export type EntityAutocompleteResponse = z.infer<typeof EntityAutocompleteResponseSchema>;
+export type EntityProfileResponse = z.infer<typeof EntityProfileResponseSchema>;
+export type EntityTimelineResponse = z.infer<typeof EntityTimelineResponseSchema>;
+export type EntityConnectionsResponse = z.infer<typeof EntityConnectionsResponseSchema>;

--- a/src/contracts/facts/facts.schema.ts
+++ b/src/contracts/facts/facts.schema.ts
@@ -125,5 +125,36 @@ export const FactProvenanceResponseSchema = z.object({
     .optional(),
 });
 
+/**
+ * Who asked for the retraction. `@IsObject()` on the DTO — the pipe
+ * treats it as opaque (an extra key inside is not a 400), so the
+ * schema is loose and says so.
+ */
+export const RetractedBySchema = z.looseObject({
+  userId: z.string().optional(),
+  source: z.enum(['human', 'system']),
+});
+
+export const RetractFactRequestSchema = z.strictObject({
+  /** Free-text justification, written into the audit trail. */
+  reason: z.string(),
+  retractedBy: RetractedBySchema,
+});
+
+export const RetractFactResponseSchema = z.object({
+  factId: z.string(),
+  retractedAt: z.string(),
+  /** Facts retracted along with this one (derived-from cascade). */
+  cascadedFactIds: z.array(z.string()),
+  /**
+   * Facts the retracted one had superseded that are now active again.
+   * Empty when it superseded nothing, or when every predecessor was
+   * itself separately retracted (never revived on someone else's merits).
+   */
+  revivedFactIds: z.array(z.string()),
+});
+
 export type FactReadResponse = z.infer<typeof FactReadResponseSchema>;
 export type FactProvenanceResponse = z.infer<typeof FactProvenanceResponseSchema>;
+export type RetractFactRequest = z.infer<typeof RetractFactRequestSchema>;
+export type RetractFactResponse = z.infer<typeof RetractFactResponseSchema>;

--- a/src/contracts/ingest/ingest.schema.ts
+++ b/src/contracts/ingest/ingest.schema.ts
@@ -1,0 +1,114 @@
+import { z } from 'zod';
+
+/**
+ * Wire contracts for the headline write — POST /v1/ingest/fact.
+ *
+ * Request mirrors IngestFactDto (src/ingest/dto/ingest-fact.dto.ts) and
+ * the interfaces it carries (EntityRef, FactSource, SourceEvidence);
+ * response mirrors IngestResult (src/ingest/ingest-result.ts). Parity is
+ * pinned by test/contracts-ingest.unit-spec.ts.
+ *
+ * `entityRef`, `source` and `metadata` are LOOSE objects on purpose:
+ * class-validator sees them as opaque `@IsObject()` fields (a union /
+ * open shape can't survive `forbidNonWhitelisted` nesting), so their
+ * inner keys are shape-checked by FactIngestService rather than the
+ * pipe — an extra key inside them is not a 400. The published schema
+ * says exactly that.
+ */
+
+/** One supporting observation behind a fact — ≤10 per source. */
+export const SourceEvidenceSchema = z.object({
+  kind: z.enum(['event', 'message', 'conversation', 'url', 'document', 'commit', 'other']),
+  /** The pointer itself — id, URL, path, sha… ≤512 chars. */
+  ref: z.string(),
+  note: z.string().optional(),
+});
+
+/**
+ * Which entity the fact is about. Either a (vertical, id) pair — the
+ * dedup key, which a `userId` additionally scopes to that end user — or
+ * a bare `entityId` naming an existing row.
+ */
+export const EntityRefSchema = z.looseObject({
+  vertical: z.string().optional(),
+  id: z.string().optional(),
+  entityId: z.string().optional(),
+});
+
+/**
+ * Where the claim came from. Stored verbatim inside the FLEXIBLE
+ * `knowledge_fact.source`. `originKey` is NOT part of this contract —
+ * FactIngestService strips any client-supplied value.
+ */
+export const FactSourceSchema = z.looseObject({
+  vertical: z.string(),
+  eventId: z.string().optional(),
+  conversationId: z.string().optional(),
+  messageId: z.string().optional(),
+  recorder: z.string().optional(),
+  /** Supporting observations behind the claim — ≤10 entries. */
+  evidence: z.array(SourceEvidenceSchema).optional(),
+  /**
+   * Grounding episode record ids (`episode:…`) — ≤64 entries, validated
+   * only while EVIDENCE_GROUNDING_STAMP is on, so a caller cannot spoof
+   * grounded status with garbage.
+   */
+  episodeIds: z.array(z.string()).optional(),
+});
+
+export const IngestFactRequestSchema = z.strictObject({
+  entityRef: EntityRefSchema,
+  predicate: z.string().max(256),
+  /** A single fact value (price, address, name…). Prose belongs in mention text. */
+  object: z.string().max(2_000),
+  /** ISO-8601 start of the fact's validity window. */
+  validFrom: z.string(),
+  validUntil: z.string().optional(),
+  confidence: z.number().min(0).max(1).optional(),
+  source: FactSourceSchema,
+  /**
+   * Per-user memory scope (migration 0055): the fact — and, for a
+   * (vertical, id) ref, the entity dedup key — is stamped with this end
+   * user, invisible to every other user of the tenant. Conflict
+   * resolution is scope-local.
+   */
+  userId: z.string().max(200).optional(),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+  /** Emit `conflictExplanation` when the outcome is SUPERSEDED or COMPETING. */
+  explain: z.boolean().optional(),
+});
+
+/**
+ * The deterministic conflict narrative (src/ingest/conflict-explainer.ts).
+ * Deliberately NOT field-level contracted — like `breakdown` on a search
+ * hit and `decisionLog` on a synthesis, this is an `explain`-mode DEBUG
+ * payload built from the resolver's internal score dimensions, and
+ * pinning it here would publish a promise the resolver never made.
+ */
+export const ConflictExplanationSchema = z.record(z.string(), z.unknown());
+
+export const IngestFactResponseSchema = z.object({
+  /** null when the resolver REJECTED the claim. */
+  factId: z.string().nullable(),
+  outcome: z.enum([
+    'INSERTED',
+    /** Backdated insert: recorded as an already-superseded historical row (0043). */
+    'INSERTED_HISTORICAL',
+    /** Same claim from a DIFFERENT source — kept as audit, incumbent's counter grew (0047). */
+    'CORROBORATED',
+    'SUPERSEDED',
+    'COMPETING',
+    'REJECTED',
+  ]),
+  supersededFactIds: z.array(z.string()).optional(),
+  competingFactIds: z.array(z.string()).optional(),
+  /** INSERTED_HISTORICAL only: the newer fact the backdated row was slotted behind. */
+  supersededByFactId: z.string().optional(),
+  /** CORROBORATED only: the incumbent this claim confirmed. */
+  corroboratedFactId: z.string().optional(),
+  reason: z.string().optional(),
+  conflictExplanation: ConflictExplanationSchema.optional(),
+});
+
+export type IngestFactRequest = z.infer<typeof IngestFactRequestSchema>;
+export type IngestFactResponse = z.infer<typeof IngestFactResponseSchema>;

--- a/src/contracts/search/multi-hop.schema.ts
+++ b/src/contracts/search/multi-hop.schema.ts
@@ -1,0 +1,81 @@
+import { z } from 'zod';
+import { SearchHitSchema, SearchRequestSchema } from './search.schema';
+import {
+  CitationSchema,
+  SYNTHESIS_GUARDRAILS,
+  SynthesisReasonSchema,
+  TokenUsageSchema,
+} from '../synthesize/synthesize.schema';
+
+/**
+ * Wire contracts for POST /v1/search/multi-hop — a planner LLM
+ * decomposes the query into ≤ maxHops anchored sub-queries and the
+ * executor chains them.
+ *
+ * Request mirrors MultiHopDto (which extends SearchDto); response
+ * mirrors MultiHopResult (src/multi-hop/multi-hop.types.ts). Parity is
+ * pinned by test/contracts-multi-hop.unit-spec.ts.
+ */
+
+export const MultiHopRequestSchema = SearchRequestSchema.extend({
+  /** Planner budget, 1–5 hops. */
+  maxHops: z.number().int().min(1).max(5).optional(),
+  /** Run the synthesizer over the final entity set and return a grounded answer. */
+  synthesize: z.boolean().optional(),
+  synthesisGuardrails: z.enum(SYNTHESIS_GUARDRAILS).optional(),
+  synthesisModel: z.string().optional(),
+});
+
+/** One planned hop, as the planner emitted it. */
+export const HopPlanSchema = z.object({
+  /** Natural-language sub-query — becomes the `query` of this hop's search. */
+  subQuery: z.string(),
+  /** Predicate filter; `null` / omitted = no filter. */
+  predicates: z.array(z.string()).nullable().optional(),
+  /**
+   * How the hop combines with the running entity set: `seed` (first
+   * hop), `subset_of_previous` (search scoped to the prior set),
+   * `intersect` (unconstrained, intersected after) or `union`.
+   */
+  combination: z.enum(['seed', 'subset_of_previous', 'intersect', 'union']),
+  /** Per-hop bitemporal anchor (ISO-8601); the request-level asOf is honoured separately. */
+  asOf: z.string().nullable().optional(),
+  /** Planner rationale for ops debugging — never affects execution. */
+  rationale: z.string().nullable().optional(),
+});
+
+export const HopOutcomeSchema = z.object({
+  hop: HopPlanSchema,
+  /** Entity ids from this hop alone (pre-combination). */
+  hopEntityIds: z.array(z.string()),
+  /** Running entity set AFTER combining with the prior hop. */
+  runningEntityIds: z.array(z.string()),
+  hits: z.array(SearchHitSchema),
+  /** The SCORED facts this hop returned — no need to walk hits[].facts[]. */
+  supportingFactIds: z.array(z.string()),
+});
+
+export const MultiHopResponseSchema = z.object({
+  /** false when the planner produced a degenerate chain and a single search ran. */
+  isMultiHop: z.boolean(),
+  hops: z.array(HopOutcomeSchema),
+  finalEntityIds: z.array(z.string()),
+  finalHits: z.array(SearchHitSchema),
+  /**
+   * The evidence chain — de-duplicated union of every hop's
+   * supportingFactIds in execution order (HotpotQA-style joint-F1 input).
+   */
+  supportingFactIds: z.array(z.string()),
+  /** Present only when the request asked for `synthesize: true`. */
+  synthesis: z
+    .object({
+      answer: z.string().nullable(),
+      reason: SynthesisReasonSchema.optional(),
+      citations: z.array(CitationSchema),
+      tokenUsage: TokenUsageSchema.optional(),
+    })
+    .optional(),
+});
+
+export type MultiHopRequest = z.infer<typeof MultiHopRequestSchema>;
+export type MultiHopResponse = z.infer<typeof MultiHopResponseSchema>;

--- a/src/contracts/search/search.schema.ts
+++ b/src/contracts/search/search.schema.ts
@@ -1,0 +1,108 @@
+import { z } from 'zod';
+
+/**
+ * Wire contracts for the headline read — POST /v1/search.
+ *
+ * Request mirrors SearchDto (src/search/dto/search.dto.ts); response
+ * mirrors SearchService.search's envelope and SearchHit
+ * (src/search/search.types.ts). Compile-time parity (samples typed
+ * against the DTO / service types) and runtime parity (the samples
+ * parse, key-for-key) are pinned by test/contracts-search.unit-spec.ts,
+ * so a field added on one side without the other fails loudly.
+ *
+ * The request object is STRICT because the global ValidationPipe runs
+ * with `forbidNonWhitelisted: true` (src/main.ts) — an unknown body key
+ * is a 400, not a silent strip.
+ */
+
+/**
+ * Per-fact score provenance, returned only for callers that asked for
+ * it. Deliberately NOT field-level contracted: `breakdown` is an
+ * `explain`-mode DEBUG payload whose components track the retrieval
+ * pipeline's internals (ScoreBreakdown, src/search/internals/types.ts)
+ * and change with every scoring lever. Pinning it here would publish a
+ * promise the engine never made.
+ */
+export const ScoreBreakdownSchema = z.record(z.string(), z.unknown());
+
+export const SearchRequestSchema = z.strictObject({
+  /** Free-text query. Capped at 8 KB (SearchService re-clamps server-side). */
+  query: z.string().max(8_000),
+  /** Page size, 1–100. */
+  limit: z.number().min(1).max(100).optional(),
+  entityTypes: z.array(z.string()).optional(),
+  predicates: z.array(z.string()).optional(),
+  /**
+   * Restrict to facts owned by these entities. Short (`cuid_abc`) and
+   * fully-qualified (`knowledge_entity:cuid_abc`) forms are both
+   * accepted — multi-hop anchors later hops with this.
+   */
+  entityIds: z.array(z.string()).optional(),
+  /** ISO-8601 world-time anchor (bitemporal slice). */
+  asOf: z.string().optional(),
+  /**
+   * Per-user memory scope (migration 0055): results become
+   * tenant-global PLUS this user's personal rows. Omitted =
+   * tenant-global only (fail-closed).
+   */
+  userId: z.string().max(200).optional(),
+  /** Floor on the raw stored `confidence` field. */
+  minConfidence: z.number().min(0).max(1).optional(),
+  includeContested: z.boolean().optional(),
+  includeRetracted: z.boolean().optional(),
+  /**
+   * Revert to the audit shape — every active-status fact ever ingested,
+   * including ones whose validity window has passed. Default search is
+   * Datomic-style "actual now".
+   */
+  includeStale: z.boolean().optional(),
+  /** `hybrid` (default) fuses vector + BM25; `vector` / `lexical` run one leg. */
+  searchMode: z.enum(['vector', 'lexical', 'hybrid']).optional(),
+  /** Floor applied AFTER decay + source-trust weighting (stricter than minConfidence). */
+  confidenceFloor: z.number().min(0).max(1).optional(),
+  /** Drop facts whose ingest path preserved no source trail. */
+  requireProvenance: z.boolean().optional(),
+  /** Response cap in tokens (cl100k_base), 50–50000. */
+  tokenBudget: z.number().min(50).max(50_000).optional(),
+  outputShape: z.enum(['full', 'compact', 'ids']).optional(),
+  /** ISO 639-1 hint; drives the lang-filtered pass + cross-lingual backoff. */
+  queryLang: z.string().optional(),
+  /** Debug escape hatch: skip the language-aware pass entirely. */
+  disableLangFilter: z.boolean().optional(),
+});
+
+export const SearchFactSchema = z.object({
+  factId: z.string(),
+  predicate: z.string(),
+  object: z.string(),
+  confidence: z.number(),
+  validFrom: z.string(),
+  validUntil: z.string().optional(),
+  status: z.string(),
+  /** Write-time source key (trustSnapshot, 0044) — chase a citation to its claimer. */
+  sourceKey: z.string().optional(),
+  /** Event time of the fact's first grounding turn (DERIVER_MENTION_STAMP). */
+  mentionedAt: z.string().optional(),
+  /** One clause of encoding context — the situation the fact was learned in (V13). */
+  scene: z.string().optional(),
+  /** BM25 snippet with `<em>` around matched terms (SEARCH_HIGHLIGHT_ENABLED). */
+  highlight: z.string().optional(),
+  score: z.number(),
+  breakdown: ScoreBreakdownSchema.optional(),
+});
+
+export const SearchHitSchema = z.object({
+  entityId: z.string(),
+  entityType: z.string(),
+  canonicalName: z.string(),
+  externalRefs: z.record(z.string(), z.string()),
+  facts: z.array(SearchFactSchema),
+  score: z.number(),
+});
+
+export const SearchResponseSchema = z.object({
+  results: z.array(SearchHitSchema),
+});
+
+export type SearchRequest = z.infer<typeof SearchRequestSchema>;
+export type SearchResponse = z.infer<typeof SearchResponseSchema>;

--- a/src/contracts/synthesize/synthesize.schema.ts
+++ b/src/contracts/synthesize/synthesize.schema.ts
@@ -1,0 +1,114 @@
+import { z } from 'zod';
+import { EVIDENCE_CAPABILITIES } from '../../common/evidence-taxonomy';
+import { SearchHitSchema, SearchRequestSchema } from '../search/search.schema';
+
+/**
+ * Wire contracts for POST /v1/synthesize — corrective-RAG over the
+ * retrieved facts, with a verifier gate.
+ *
+ * Request mirrors SynthesizeDto (which extends SearchDto); response
+ * mirrors SynthesizeResult (src/synthesize/synthesize.types.ts). Parity
+ * is pinned by test/contracts-synthesize.unit-spec.ts.
+ */
+
+export const SYNTHESIS_GUARDRAILS = ['strict', 'lenient', 'off', 'answer'] as const;
+
+export const SynthesizeRequestSchema = SearchRequestSchema.extend({
+  /** Override the generator model for this call. */
+  synthesisModel: z.string().optional(),
+  /**
+   * `strict` closes to a null answer on a partial verdict; `lenient`
+   * returns the answer with the verdict attached; `off` skips the
+   * verifier; `answer` is the answer-shaped router lane.
+   */
+  synthesisGuardrails: z.enum(SYNTHESIS_GUARDRAILS).optional(),
+  /** Emit `decisionLog` — one entry per retrieved fact. */
+  explain: z.boolean().optional(),
+  /** Preferred answer language (free-text hint; not format-validated). */
+  answerLang: z.string().optional(),
+});
+
+/** Prompt/completion cost of one LLM call, surfaced for token accounting. */
+export const TokenUsageSchema = z.object({
+  promptTokens: z.number(),
+  completionTokens: z.number(),
+});
+
+/** A claim's reference to the fact it rests on. */
+export const CitationSchema = z.object({
+  factId: z.string(),
+  entityId: z.string(),
+  canonicalName: z.string(),
+  predicate: z.string(),
+  object: z.string(),
+  /** Write-time sourceKey (trustSnapshot) — absent on pre-0044 facts. */
+  sourceKey: z.string().optional(),
+});
+
+/** Why the pipeline declined to answer (absent on a served answer). */
+export const SynthesisReasonSchema = z.enum([
+  'no_results',
+  'no_grounded_evidence',
+  'low_coverage',
+  /** A supported answer cites a predicate needing non-text evidence it lacks (0113). */
+  'evidence_capability_unmet',
+  /** Every cited fact carries groundingStatus='ungrounded' (0115). */
+  'ungrounded_evidence',
+  'verifier_failed',
+  'verifier_partial',
+  'generator_error',
+  'verifier_error',
+]);
+
+/**
+ * Non-fact evidence citation. Four arms behind a ONE-OF invariant —
+ * episode (transcript), fragment (media), belief (current state) and
+ * scene (episodic gist); exactly one id field is present.
+ */
+export const EvidenceCitationSchema = z.object({
+  episodeId: z.string().optional(),
+  conversationId: z.string().optional(),
+  occurredAt: z.string().optional(),
+  /**
+   * W3C-style VERIFIED span over the NFC-normalized stored turn text,
+   * in Unicode code points: `start` inclusive, `end` exclusive, `exact`
+   * the verbatim quote. Absent = episodeId-only (never a guessed highlight).
+   */
+  span: z.object({ start: z.number(), end: z.number(), exact: z.string() }).optional(),
+  fragmentId: z.string().optional(),
+  assetId: z.string().optional(),
+  capability: z.enum(EVIDENCE_CAPABILITIES).optional(),
+  /** The RENDERED excerpt the generator actually saw — never generator-authored. */
+  excerpt: z.string().optional(),
+  beliefId: z.string().optional(),
+  sceneId: z.string().optional(),
+});
+
+/**
+ * Per-fact retrieval + verdict trace. Deliberately NOT field-level
+ * contracted (the `breakdown` / `conflictExplanation` rule): an
+ * `explain`-mode DEBUG payload over pipeline internals
+ * (src/synthesize/decision-log.ts).
+ */
+export const DecisionLogEntrySchema = z.record(z.string(), z.unknown());
+
+export const SynthesizeResponseSchema = z.object({
+  /** null when the pipeline abstained — `reason` says why. */
+  answer: z.string().nullable(),
+  reason: SynthesisReasonSchema.optional(),
+  citations: z.array(CitationSchema),
+  results: z.array(SearchHitSchema),
+  /** Episode/fragment/belief/scene refs for an L3-escalated answer. */
+  evidenceCitations: z.array(EvidenceCitationSchema).optional(),
+  decisionLog: z.array(DecisionLogEntrySchema).optional(),
+  tokenUsage: TokenUsageSchema.optional(),
+  /**
+   * Served from the fact-lifecycle-gated answer cache
+   * (SYNTHESIZE_ANSWER_CACHE): citations were re-validated against the
+   * live rows, and `results` is empty because retrieval never ran.
+   */
+  cached: z.boolean().optional(),
+});
+
+export type SynthesizeRequest = z.infer<typeof SynthesizeRequestSchema>;
+export type SynthesizeResponse = z.infer<typeof SynthesizeResponseSchema>;

--- a/test/contracts-entities.unit-spec.ts
+++ b/test/contracts-entities.unit-spec.ts
@@ -1,0 +1,141 @@
+/**
+ * Wire-contract drift guard for the entity read surface — autocomplete,
+ * profile, timeline and connections.
+ *
+ * Fully-populated samples are typed against the SERVICE result
+ * interfaces (compile-time parity), then parsed against the zod wire
+ * contracts (runtime parity), then pinned key-for-key.
+ */
+import {
+  ConnectionEdgeSchema,
+  ConnectionNeighbourSchema,
+  EntityAutocompleteResponseSchema,
+  EntityAutocompleteSuggestionSchema,
+  EntityConnectionsResponseSchema,
+  EntityProfileFactSchema,
+  EntityProfileResponseSchema,
+  EntityTimelineResponseSchema,
+  TimelineRecordedEventSchema,
+  TimelineRetractedEventSchema,
+} from '../src/contracts/entities/entities.schema';
+import type {
+  AutocompleteSuggestion,
+  ConnectionEdge,
+  ConnectionNeighbour,
+  EntityProfile,
+  TimelineRecordedEvent,
+  TimelineRetractedEvent,
+} from '../src/entities/entities.service';
+
+const expectKeys = (shape: Record<string, unknown>, sample: Record<string, unknown>) =>
+  expect(Object.keys(shape).sort()).toEqual(Object.keys(sample).sort());
+
+const fullSuggestion: Required<AutocompleteSuggestion> = {
+  entityId: 'knowledge_entity:cuid_abc',
+  canonicalName: 'Customer 42',
+  type: 'person',
+  score: 3.4,
+};
+
+const fullProfileFact: Required<EntityProfile['facts'][number]> = {
+  factId: 'knowledge_fact:abc',
+  predicate: 'complained_about',
+  object: 'late maintenance',
+  confidence: 0.85,
+  validFrom: '2026-09-01T10:00:00.000Z',
+  validUntil: '2026-10-01T00:00:00.000Z',
+  status: 'active',
+};
+
+const fullProfile: Required<EntityProfile> = {
+  entityId: 'knowledge_entity:cuid_abc',
+  type: 'person',
+  canonicalName: 'Customer 42',
+  externalRefs: { rent: 'cust_42' },
+  mergedAt: '2026-08-01T00:00:00.000Z',
+  mergedInto: 'knowledge_entity:cuid_survivor',
+  facts: [fullProfileFact],
+};
+
+const fullRecorded: Required<TimelineRecordedEvent> = {
+  type: 'fact.recorded',
+  at: '2026-09-01T10:00:00.000Z',
+  factId: 'knowledge_fact:abc',
+  predicate: 'complained_about',
+  object: 'late maintenance',
+  source: { vertical: 'rent', recorder: 'tenant_bot' },
+  confidence: 0.85,
+};
+
+const fullRetracted: Required<TimelineRetractedEvent> = {
+  type: 'fact.retracted',
+  at: '2026-09-02T10:00:00.000Z',
+  factId: 'knowledge_fact:abc',
+  retractedBy: { source: 'human', userId: 'ops_1' },
+  reason: 'entered in error',
+  supersededBy: 'knowledge_fact:newer',
+};
+
+const fullNeighbour: Required<ConnectionNeighbour> = {
+  id: 'knowledge_entity:cuid_other',
+  type: 'organisation',
+  canonicalName: 'Acme',
+};
+
+const fullEdge: Required<ConnectionEdge> = {
+  edgeId: 'knowledge_edge:e1',
+  from: 'knowledge_entity:cuid_abc',
+  to: 'knowledge_entity:cuid_other',
+  kind: 'works_at',
+  weight: 1,
+  source: { vertical: 'rent' },
+  createdAt: '2026-09-01T10:00:00.000Z',
+  neighbour: fullNeighbour,
+  direction: 'outbound',
+};
+
+describe('entities wire contracts', () => {
+  it('parses fully-populated service results', () => {
+    expect(() =>
+      EntityAutocompleteResponseSchema.parse({ suggestions: [fullSuggestion] }),
+    ).not.toThrow();
+    expect(() => EntityProfileResponseSchema.parse(fullProfile)).not.toThrow();
+    expect(() =>
+      EntityTimelineResponseSchema.parse({
+        entityId: fullProfile.entityId,
+        events: [fullRecorded, fullRetracted],
+      }),
+    ).not.toThrow();
+    expect(() =>
+      EntityConnectionsResponseSchema.parse({
+        entityId: fullProfile.entityId,
+        edges: [fullEdge],
+      }),
+    ).not.toThrow();
+  });
+
+  it('pins every response key on both sides', () => {
+    expectKeys(EntityAutocompleteSuggestionSchema.shape, fullSuggestion);
+    expectKeys(EntityProfileResponseSchema.shape, fullProfile);
+    expectKeys(EntityProfileFactSchema.shape, fullProfileFact);
+    expectKeys(TimelineRecordedEventSchema.shape, fullRecorded);
+    expectKeys(TimelineRetractedEventSchema.shape, fullRetracted);
+    expectKeys(ConnectionEdgeSchema.shape, fullEdge);
+    expectKeys(ConnectionNeighbourSchema.shape, fullNeighbour);
+    expect(Object.keys(EntityAutocompleteResponseSchema.shape)).toEqual(['suggestions']);
+    expect(Object.keys(EntityTimelineResponseSchema.shape).sort()).toEqual(['entityId', 'events']);
+    expect(Object.keys(EntityConnectionsResponseSchema.shape).sort()).toEqual([
+      'edges',
+      'entityId',
+    ]);
+  });
+
+  it('keeps the timeline event union discriminated by `type`', () => {
+    expect(() =>
+      EntityTimelineResponseSchema.parse({
+        entityId: fullProfile.entityId,
+        events: [{ ...fullRecorded, type: 'fact.exploded' }],
+      }),
+    ).toThrow();
+  });
+});

--- a/test/contracts-facts.unit-spec.ts
+++ b/test/contracts-facts.unit-spec.ts
@@ -11,12 +11,17 @@ import {
   FactProvenanceEpisodeSchema,
   FactProvenanceResponseSchema,
   FactReadResponseSchema,
+  RetractedBySchema,
+  RetractFactRequestSchema,
+  RetractFactResponseSchema,
 } from '../src/contracts/facts/facts.schema';
 import type {
   FactProvenanceEpisode,
   FactProvenanceResult,
   FactReadResult,
+  RetractResult,
 } from '../src/facts/facts.service';
+import type { RetractedBy, RetractFactDto } from '../src/facts/dto/retract.dto';
 
 const expectKeys = (shape: Record<string, unknown>, sample: Record<string, unknown>) =>
   expect(Object.keys(shape).sort()).toEqual(Object.keys(sample).sort());
@@ -76,6 +81,20 @@ const fullProvenance: Required<FactProvenanceResult> = {
   ],
 };
 
+const fullRetractedBy: Required<RetractedBy> = { userId: 'ops_1', source: 'human' };
+
+const fullRetractRequest: Required<RetractFactDto> = {
+  reason: 'entered in error',
+  retractedBy: fullRetractedBy,
+};
+
+const fullRetractResult: Required<RetractResult> = {
+  factId: 'knowledge_fact:abc',
+  retractedAt: '2026-09-02T10:00:00.000Z',
+  cascadedFactIds: ['knowledge_fact:derived'],
+  revivedFactIds: ['knowledge_fact:predecessor'],
+};
+
 describe('facts wire contracts', () => {
   it('FactReadResponseSchema parses a fully-populated service result', () => {
     const parsed = FactReadResponseSchema.safeParse(fullFact);
@@ -105,5 +124,31 @@ describe('facts wire contracts', () => {
 
   it('FactProvenanceEpisodeSchema covers every episode field — both directions', () => {
     expectKeys(FactProvenanceEpisodeSchema.shape, fullEpisode);
+  });
+
+  it('RetractFactRequestSchema parses a fully-populated DTO', () => {
+    expect(RetractFactRequestSchema.safeParse(fullRetractRequest).success).toBe(true);
+    expectKeys(RetractFactRequestSchema.shape, fullRetractRequest);
+    expectKeys(RetractedBySchema.shape, fullRetractedBy);
+  });
+
+  it('RetractFactRequestSchema rejects an unknown key but not one inside retractedBy', () => {
+    // The pipe runs forbidNonWhitelisted, so a stray body key is a 400 —
+    // but `retractedBy` is an opaque @IsObject() field the pipe never
+    // walks into.
+    expect(RetractFactRequestSchema.safeParse({ ...fullRetractRequest, nope: 1 }).success).toBe(
+      false,
+    );
+    expect(
+      RetractFactRequestSchema.safeParse({
+        ...fullRetractRequest,
+        retractedBy: { ...fullRetractedBy, ticket: 'OPS-1' },
+      }).success,
+    ).toBe(true);
+  });
+
+  it('RetractFactResponseSchema covers every service field — both directions', () => {
+    expect(RetractFactResponseSchema.safeParse(fullRetractResult).success).toBe(true);
+    expectKeys(RetractFactResponseSchema.shape, fullRetractResult);
   });
 });

--- a/test/contracts-ingest.unit-spec.ts
+++ b/test/contracts-ingest.unit-spec.ts
@@ -1,0 +1,118 @@
+/**
+ * Wire-contract drift guard for POST /v1/ingest/fact.
+ *
+ * Fully-populated samples are typed against the REQUEST DTO and the
+ * SERVICE result interface (compile-time parity), then parsed against
+ * the zod wire contracts (runtime parity), then pinned key-for-key — a
+ * field added to one side without the other fails loudly.
+ */
+import {
+  EntityRefSchema,
+  FactSourceSchema,
+  IngestFactRequestSchema,
+  IngestFactResponseSchema,
+  SourceEvidenceSchema,
+} from '../src/contracts/ingest/ingest.schema';
+import type {
+  EntityRef,
+  FactSource,
+  IngestFactDto,
+  SourceEvidence,
+} from '../src/ingest/dto/ingest-fact.dto';
+import type { ConflictExplanation } from '../src/ingest/conflict-explainer';
+import type { IngestResult } from '../src/ingest/ingest-result';
+
+const expectKeys = (shape: Record<string, unknown>, sample: Record<string, unknown>) =>
+  expect(Object.keys(shape).sort()).toEqual(Object.keys(sample).sort());
+
+/**
+ * The `explain`-mode debug payloads are published as OPEN objects (see
+ * the schema docblocks): their internals track resolver/scorer
+ * internals and are deliberately not part of the wire contract, so a
+ * sample only has to BE an object of the right type.
+ */
+const debugPayload = <T>(): T => ({}) as T;
+
+const fullEvidence: Required<SourceEvidence> = {
+  kind: 'message',
+  ref: 'msg_1',
+  note: 'tenant chat',
+};
+
+const fullEntityRef: Required<EntityRef> = {
+  vertical: 'rent',
+  id: 'cust_42',
+  entityId: 'knowledge_entity:cuid_abc',
+};
+
+const fullSource: Required<FactSource> = {
+  vertical: 'rent',
+  eventId: 'evt_1',
+  conversationId: 'conv_1',
+  messageId: 'msg_1',
+  recorder: 'tenant_bot',
+  evidence: [fullEvidence],
+  episodeIds: ['episode:e1'],
+};
+
+const fullRequest: Required<IngestFactDto> = {
+  entityRef: fullEntityRef,
+  predicate: 'complained_about',
+  object: 'late maintenance',
+  validFrom: '2026-09-01T10:00:00.000Z',
+  validUntil: '2026-10-01T00:00:00.000Z',
+  confidence: 0.9,
+  source: fullSource,
+  userId: 'user_42',
+  metadata: { channel: 'sms' },
+  explain: true,
+};
+
+const fullResponse: Required<IngestResult> = {
+  factId: 'knowledge_fact:abc',
+  outcome: 'SUPERSEDED',
+  supersededFactIds: ['knowledge_fact:old'],
+  competingFactIds: ['knowledge_fact:rival'],
+  supersededByFactId: 'knowledge_fact:newer',
+  corroboratedFactId: 'knowledge_fact:incumbent',
+  reason: 'newer validFrom wins the single_active slot',
+  conflictExplanation: debugPayload<ConflictExplanation>(),
+};
+
+describe('ingest wire contracts', () => {
+  it('IngestFactRequestSchema parses a fully-populated DTO', () => {
+    expect(() => IngestFactRequestSchema.parse(fullRequest)).not.toThrow();
+  });
+
+  it('IngestFactResponseSchema parses a fully-populated service result', () => {
+    expect(() => IngestFactResponseSchema.parse(fullResponse)).not.toThrow();
+  });
+
+  it('a REJECTED outcome carries a null factId', () => {
+    const rejected: IngestResult = { factId: null, outcome: 'REJECTED', reason: 'lower trust' };
+    expect(() => IngestFactResponseSchema.parse(rejected)).not.toThrow();
+  });
+
+  it('pins every request/response key on both sides', () => {
+    expectKeys(IngestFactRequestSchema.shape, fullRequest);
+    expectKeys(IngestFactResponseSchema.shape, fullResponse);
+    expectKeys(EntityRefSchema.shape, fullEntityRef);
+    expectKeys(FactSourceSchema.shape, fullSource);
+    expectKeys(SourceEvidenceSchema.shape, fullEvidence);
+  });
+
+  it('rejects an unknown request key (the pipe forbids non-whitelisted)', () => {
+    expect(() => IngestFactRequestSchema.parse({ ...fullRequest, nope: 1 })).toThrow();
+  });
+
+  it('lets the opaque @IsObject() fields carry keys the pipe never validates', () => {
+    // entityRef / source are shape-checked by FactIngestService, not by
+    // class-validator — an extra key inside them is NOT a 400.
+    expect(() =>
+      IngestFactRequestSchema.parse({
+        ...fullRequest,
+        source: { ...fullSource, futureField: 'x' },
+      }),
+    ).not.toThrow();
+  });
+});

--- a/test/contracts-multi-hop.unit-spec.ts
+++ b/test/contracts-multi-hop.unit-spec.ts
@@ -1,0 +1,125 @@
+/**
+ * Wire-contract drift guard for POST /v1/search/multi-hop.
+ *
+ * Fully-populated samples are typed against the REQUEST DTO and the
+ * SERVICE result types (compile-time parity), then parsed against the
+ * zod wire contracts (runtime parity), then pinned key-for-key.
+ */
+import {
+  HopOutcomeSchema,
+  HopPlanSchema,
+  MultiHopRequestSchema,
+  MultiHopResponseSchema,
+} from '../src/contracts/search/multi-hop.schema';
+import type { MultiHopDto } from '../src/multi-hop/dto/multi-hop.dto';
+import type { HopOutcome, MultiHopResult } from '../src/multi-hop/multi-hop.types';
+import type { HopPlan } from '../src/multi-hop/multi-hop-planner.service';
+import type { SearchHit } from '../src/search/search.types';
+
+const expectKeys = (shape: Record<string, unknown>, sample: Record<string, unknown>) =>
+  expect(Object.keys(shape).sort()).toEqual(Object.keys(sample).sort());
+
+const hit: SearchHit = {
+  entityId: 'knowledge_entity:cuid_abc',
+  entityType: 'person',
+  canonicalName: 'Customer 42',
+  externalRefs: {},
+  facts: [],
+  score: 0.7,
+};
+
+const fullHopPlan: Required<HopPlan> = {
+  subQuery: 'tenants who complained in April',
+  predicates: ['complained_about'],
+  combination: 'seed',
+  asOf: '2026-04-30T00:00:00.000Z',
+  rationale: 'anchor the chain on April complaints',
+};
+
+const fullHopOutcome: Required<HopOutcome> = {
+  hop: fullHopPlan,
+  hopEntityIds: ['knowledge_entity:cuid_abc'],
+  runningEntityIds: ['knowledge_entity:cuid_abc'],
+  hits: [hit],
+  supportingFactIds: ['knowledge_fact:abc'],
+};
+
+const fullRequest: Required<MultiHopDto> = {
+  query: 'tenants who complained in April AND upgraded after',
+  limit: 5,
+  entityTypes: ['person'],
+  predicates: ['complained_about'],
+  entityIds: [],
+  asOf: '2026-09-01T00:00:00.000Z',
+  userId: 'user_42',
+  minConfidence: 0.2,
+  includeContested: false,
+  includeRetracted: false,
+  includeStale: false,
+  searchMode: 'hybrid',
+  confidenceFloor: 0.5,
+  requireProvenance: false,
+  tokenBudget: 2_000,
+  outputShape: 'full',
+  queryLang: 'en',
+  disableLangFilter: false,
+  maxHops: 3,
+  synthesize: true,
+  synthesisGuardrails: 'lenient',
+  synthesisModel: 'gpt-4o-mini',
+};
+
+const fullResponse: Required<MultiHopResult> = {
+  isMultiHop: true,
+  hops: [fullHopOutcome],
+  finalEntityIds: ['knowledge_entity:cuid_abc'],
+  finalHits: [hit],
+  supportingFactIds: ['knowledge_fact:abc'],
+  synthesis: {
+    answer: 'Customer 42.',
+    reason: 'verifier_partial',
+    citations: [
+      {
+        factId: 'knowledge_fact:abc',
+        entityId: 'knowledge_entity:cuid_abc',
+        canonicalName: 'Customer 42',
+        predicate: 'complained_about',
+        object: 'late maintenance',
+      },
+    ],
+    tokenUsage: { promptTokens: 900, completionTokens: 60 },
+  },
+};
+
+describe('multi-hop wire contracts', () => {
+  it('MultiHopRequestSchema parses a fully-populated DTO', () => {
+    expect(() => MultiHopRequestSchema.parse(fullRequest)).not.toThrow();
+  });
+
+  it('MultiHopResponseSchema parses a fully-populated service result', () => {
+    expect(() => MultiHopResponseSchema.parse(fullResponse)).not.toThrow();
+  });
+
+  it('a chain run without synthesize omits the synthesis arm', () => {
+    const plain: MultiHopResult = {
+      isMultiHop: false,
+      hops: [],
+      finalEntityIds: [],
+      finalHits: [],
+      supportingFactIds: [],
+    };
+    expect(() => MultiHopResponseSchema.parse(plain)).not.toThrow();
+  });
+
+  it('pins every request/response key on both sides', () => {
+    expectKeys(MultiHopRequestSchema.shape, fullRequest);
+    expectKeys(MultiHopResponseSchema.shape, fullResponse);
+    expectKeys(HopPlanSchema.shape, fullHopPlan);
+    expectKeys(HopOutcomeSchema.shape, fullHopOutcome);
+  });
+
+  it('inherits the search request fence and enforces the hop budget', () => {
+    expect(() => MultiHopRequestSchema.parse({ ...fullRequest, nope: 1 })).toThrow();
+    expect(() => MultiHopRequestSchema.parse({ query: 'x', maxHops: 6 })).toThrow();
+  });
+});

--- a/test/contracts-search.unit-spec.ts
+++ b/test/contracts-search.unit-spec.ts
@@ -1,0 +1,95 @@
+/**
+ * Wire-contract drift guard for POST /v1/search.
+ *
+ * Fully-populated samples are typed against the REQUEST DTO and the
+ * SERVICE result types (compile-time parity), then parsed against the
+ * zod wire contracts (runtime parity), then pinned key-for-key.
+ */
+import {
+  SearchFactSchema,
+  SearchHitSchema,
+  SearchRequestSchema,
+  SearchResponseSchema,
+} from '../src/contracts/search/search.schema';
+import type { SearchDto } from '../src/search/dto/search.dto';
+import type { SearchHit } from '../src/search/search.types';
+import type { ScoreBreakdown } from '../src/search/internals/types';
+
+const expectKeys = (shape: Record<string, unknown>, sample: Record<string, unknown>) =>
+  expect(Object.keys(shape).sort()).toEqual(Object.keys(sample).sort());
+
+/** See test/contracts-ingest.unit-spec.ts — explain-mode payloads are open objects. */
+const debugPayload = <T>(): T => ({}) as T;
+
+const fullSearchRequest: Required<SearchDto> = {
+  query: 'maintenance issues',
+  limit: 5,
+  entityTypes: ['person'],
+  predicates: ['complained_about'],
+  entityIds: ['knowledge_entity:cuid_abc'],
+  asOf: '2026-09-01T00:00:00.000Z',
+  userId: 'user_42',
+  minConfidence: 0.2,
+  includeContested: true,
+  includeRetracted: false,
+  includeStale: false,
+  searchMode: 'hybrid',
+  confidenceFloor: 0.5,
+  requireProvenance: true,
+  tokenBudget: 2_000,
+  outputShape: 'full',
+  queryLang: 'en',
+  disableLangFilter: false,
+};
+
+const fullFact: Required<SearchHit['facts'][number]> = {
+  factId: 'knowledge_fact:abc',
+  predicate: 'complained_about',
+  object: 'late maintenance',
+  confidence: 0.85,
+  validFrom: '2026-09-01T10:00:00.000Z',
+  validUntil: '2026-10-01T00:00:00.000Z',
+  status: 'active',
+  sourceKey: 'rent:tenant_bot',
+  mentionedAt: '2026-09-01T09:59:00.000Z',
+  scene: 'a maintenance complaint call',
+  highlight: 'late <em>maintenance</em>',
+  score: 0.71,
+  breakdown: debugPayload<ScoreBreakdown>(),
+};
+
+const fullSearchHit: Required<SearchHit> = {
+  entityId: 'knowledge_entity:cuid_abc',
+  entityType: 'person',
+  canonicalName: 'Customer 42',
+  externalRefs: { rent: 'cust_42' },
+  facts: [fullFact],
+  score: 0.71,
+};
+
+describe('search wire contracts', () => {
+  it('SearchRequestSchema parses a fully-populated DTO', () => {
+    expect(() => SearchRequestSchema.parse(fullSearchRequest)).not.toThrow();
+  });
+
+  it('SearchResponseSchema parses a fully-populated service result', () => {
+    expect(() => SearchResponseSchema.parse({ results: [fullSearchHit] })).not.toThrow();
+  });
+
+  it('pins every request/response key on both sides', () => {
+    expectKeys(SearchRequestSchema.shape, fullSearchRequest);
+    expectKeys(SearchHitSchema.shape, fullSearchHit);
+    expectKeys(SearchFactSchema.shape, fullFact);
+    expect(Object.keys(SearchResponseSchema.shape)).toEqual(['results']);
+  });
+
+  it('rejects an unknown request key (the pipe forbids non-whitelisted)', () => {
+    expect(() => SearchRequestSchema.parse({ ...fullSearchRequest, nope: 1 })).toThrow();
+  });
+
+  it('enforces the DTO bounds the pipe enforces', () => {
+    expect(() => SearchRequestSchema.parse({ query: 'x', limit: 101 })).toThrow();
+    expect(() => SearchRequestSchema.parse({ query: 'x', confidenceFloor: 1.5 })).toThrow();
+    expect(() => SearchRequestSchema.parse({ query: 'x', searchMode: 'magic' })).toThrow();
+  });
+});

--- a/test/contracts-synthesize.unit-spec.ts
+++ b/test/contracts-synthesize.unit-spec.ts
@@ -1,0 +1,133 @@
+/**
+ * Wire-contract drift guard for POST /v1/synthesize.
+ *
+ * Fully-populated samples are typed against the REQUEST DTO and the
+ * SERVICE result types (compile-time parity), then parsed against the
+ * zod wire contracts (runtime parity), then pinned key-for-key.
+ */
+import {
+  CitationSchema,
+  EvidenceCitationSchema,
+  SynthesizeRequestSchema,
+  SynthesizeResponseSchema,
+  TokenUsageSchema,
+} from '../src/contracts/synthesize/synthesize.schema';
+import type { SynthesizeDto } from '../src/synthesize/dto/synthesize.dto';
+import type {
+  EvidenceCitation,
+  SynthesizeResult,
+  TokenUsage,
+} from '../src/synthesize/synthesize.types';
+import type { Citation } from '../src/synthesize/fact-index';
+import type { DecisionLogEntry } from '../src/synthesize/decision-log';
+import type { SearchHit } from '../src/search/search.types';
+
+const expectKeys = (shape: Record<string, unknown>, sample: Record<string, unknown>) =>
+  expect(Object.keys(shape).sort()).toEqual(Object.keys(sample).sort());
+
+/** See test/contracts-ingest.unit-spec.ts — explain-mode payloads are open objects. */
+const debugPayload = <T>(): T => ({}) as T;
+
+const hit: SearchHit = {
+  entityId: 'knowledge_entity:cuid_abc',
+  entityType: 'person',
+  canonicalName: 'Customer 42',
+  externalRefs: {},
+  facts: [],
+  score: 0.7,
+};
+
+const fullCitation: Required<Citation> = {
+  factId: 'knowledge_fact:abc',
+  entityId: 'knowledge_entity:cuid_abc',
+  canonicalName: 'Customer 42',
+  predicate: 'complained_about',
+  object: 'late maintenance',
+  sourceKey: 'rent:tenant_bot',
+};
+
+const fullUsage: Required<TokenUsage> = { promptTokens: 900, completionTokens: 60 };
+
+const fullEvidenceCitation: Required<EvidenceCitation> = {
+  episodeId: 'episode:e1',
+  conversationId: 'conv_1',
+  occurredAt: '2026-09-01T10:00:00.000Z',
+  span: { start: 2, end: 22, exact: 'moved to Lisbon last' },
+  fragmentId: 'evidence_fragment:f1',
+  assetId: 'evidence_asset:a1',
+  capability: 'visual',
+  excerpt: 'a photo of the leaking ceiling',
+  beliefId: 'semantic_belief:b1',
+  sceneId: 'memory_episode:s1',
+};
+
+const fullRequest: Required<SynthesizeDto> = {
+  query: 'what did customer 42 complain about?',
+  limit: 5,
+  entityTypes: ['person'],
+  predicates: ['complained_about'],
+  entityIds: ['knowledge_entity:cuid_abc'],
+  asOf: '2026-09-01T00:00:00.000Z',
+  userId: 'user_42',
+  minConfidence: 0.2,
+  includeContested: false,
+  includeRetracted: false,
+  includeStale: false,
+  searchMode: 'hybrid',
+  confidenceFloor: 0.5,
+  requireProvenance: false,
+  tokenBudget: 2_000,
+  outputShape: 'full',
+  queryLang: 'en',
+  disableLangFilter: false,
+  synthesisModel: 'gpt-4o-mini',
+  synthesisGuardrails: 'strict',
+  explain: true,
+  answerLang: 'en',
+};
+
+const fullResponse: Required<SynthesizeResult> = {
+  answer: 'Late maintenance.',
+  reason: 'verifier_partial',
+  citations: [fullCitation],
+  results: [hit],
+  evidenceCitations: [fullEvidenceCitation],
+  decisionLog: [debugPayload<DecisionLogEntry>()],
+  tokenUsage: fullUsage,
+  cached: false,
+};
+
+describe('synthesize wire contracts', () => {
+  it('SynthesizeRequestSchema parses a fully-populated DTO', () => {
+    expect(() => SynthesizeRequestSchema.parse(fullRequest)).not.toThrow();
+  });
+
+  it('SynthesizeResponseSchema parses a fully-populated service result', () => {
+    expect(() => SynthesizeResponseSchema.parse(fullResponse)).not.toThrow();
+  });
+
+  it('an abstention carries a null answer plus a reason', () => {
+    const abstained: SynthesizeResult = {
+      answer: null,
+      reason: 'low_coverage',
+      citations: [],
+      results: [],
+    };
+    expect(() => SynthesizeResponseSchema.parse(abstained)).not.toThrow();
+  });
+
+  it('pins every request/response key on both sides', () => {
+    expectKeys(SynthesizeRequestSchema.shape, fullRequest);
+    expectKeys(SynthesizeResponseSchema.shape, fullResponse);
+    expectKeys(CitationSchema.shape, fullCitation);
+    expectKeys(EvidenceCitationSchema.shape, fullEvidenceCitation);
+    expectKeys(TokenUsageSchema.shape, fullUsage);
+  });
+
+  it('inherits the search request fence (unknown key rejected, bounds enforced)', () => {
+    expect(() => SynthesizeRequestSchema.parse({ ...fullRequest, nope: 1 })).toThrow();
+    expect(() =>
+      SynthesizeRequestSchema.parse({ query: 'x', synthesisGuardrails: 'maybe' }),
+    ).toThrow();
+  });
+});

--- a/test/openapi-doc.unit-spec.ts
+++ b/test/openapi-doc.unit-spec.ts
@@ -18,6 +18,18 @@ const committed = JSON.parse(
 
 /** Every platform path+method the spec promises to document. */
 const PLATFORM_OPERATIONS: Array<[string, string]> = [
+  // The memory core — the README quick start's two calls plus the two
+  // reasoning surfaces on the same retrieval stack. No feature flag.
+  ['/v1/ingest/fact', 'post'],
+  ['/v1/search', 'post'],
+  ['/v1/search/multi-hop', 'post'],
+  ['/v1/synthesize', 'post'],
+  // Entity READ surface (the GDPR cascade on the same controller is an
+  // operator action and stays on the docs/api.md admin index).
+  ['/v1/entities/autocomplete', 'get'],
+  ['/v1/entities/{id}', 'get'],
+  ['/v1/entities/{id}/timeline', 'get'],
+  ['/v1/entities/{id}/connections', 'get'],
   ['/v1/registry/packs', 'get'],
   ['/v1/registry/packs/{packId}', 'get'],
   ['/v1/registry/packs/{packId}/{version}', 'get'],
@@ -38,6 +50,9 @@ const PLATFORM_OPERATIONS: Array<[string, string]> = [
   ['/v1/admin/packs/{packId}/eval', 'post'],
   ['/v1/facts/{id}', 'get'],
   ['/v1/facts/{id}/provenance', 'get'],
+  // Retraction is deliberately NOT behind FACTS_API_ENABLED — a tenant
+  // must always be able to remove a fact (facts.controller.ts).
+  ['/v1/facts/{id}/retract', 'post'],
   ['/v1/beliefs', 'get'],
   ['/v1/beliefs/{id}', 'get'],
   ['/v1/users/{userId}/profile', 'get'],


### PR DESCRIPTION
## The gap

`docs/openapi.json` declared **46 paths** while the service serves **192 route handlers across 59 controllers** (verified on `main` at `4fdf284`). Most of that gap is deliberate — the document scopes itself to the platform surface and excludes admin/ops — but the exclusion list had become indefensible in one specific way: `POST /v1/ingest/fact` and `POST /v1/search` are the **only two endpoints in the README's quick start** (`README.md:241`, `README.md:253`), and neither appeared in the machine-readable contract. The product's headline write and headline read were undocumented.

## What this publishes

Nine paths, all non-ops. **46 → 55 paths**, 92 → 128 component schemas.

| Path | Method | Scope | Notes |
| --- | --- | --- | --- |
| `/v1/ingest/fact` | POST | `brain:write` | The headline write — response reports the resolver's *decision*, not an ack |
| `/v1/search` | POST | `brain:read` | The headline read — hybrid retrieval, `expensive` throttle bucket |
| `/v1/search/multi-hop` | POST | `brain:read` | Planner-decomposed chain + evidence chain |
| `/v1/synthesize` | POST | `brain:read` | Corrective RAG with reasoned abstention |
| `/v1/facts/{id}/retract` | POST | `brain:write` | The `/v1/facts` write surface |
| `/v1/entities/autocomplete` | GET | `brain:read` | Entity read surface |
| `/v1/entities/{id}` | GET | `brain:read` | Entity read surface |
| `/v1/entities/{id}/timeline` | GET | `brain:read` | Entity read surface |
| `/v1/entities/{id}/connections` | GET | `brain:read` | Entity read surface |

## Where the schemas come from

**None of these nine routes had a zod wire contract** — they validate with class-validator DTOs and return plain TS service types. Rather than hand-write JSON Schema that can drift from the code, this adds the missing contracts under `src/contracts/` (where every other published path's schemas already live) and pins each one to the runtime type it mirrors using the repo's existing parity idiom:

- `src/contracts/ingest/ingest.schema.ts` ↔ `IngestFactDto` / `IngestResult`
- `src/contracts/search/search.schema.ts` ↔ `SearchDto` / `SearchHit`
- `src/contracts/search/multi-hop.schema.ts` ↔ `MultiHopDto` / `MultiHopResult`
- `src/contracts/synthesize/synthesize.schema.ts` ↔ `SynthesizeDto` / `SynthesizeResult`
- `src/contracts/entities/entities.schema.ts` ↔ `EntityProfile` / `TimelineEvent` / `ConnectionEdge` / `AutocompleteSuggestion`
- `src/contracts/facts/facts.schema.ts` (extended) ↔ `RetractFactDto` / `RetractResult`

Each gets a `test/contracts-*.unit-spec.ts` guard in the same shape as the existing `test/contracts-facts.unit-spec.ts`: a fully-populated sample typed as `Required<TheRuntimeType>` (compile-time parity), parsed by the zod schema (runtime parity), then pinned key-for-key (`Object.keys(schema.shape)` vs `Object.keys(sample)`). **A field added on one side without the other now fails the unit suite** — the same drift gate the rest of the document already relies on.

Two fidelity details the schemas encode because the runtime does:

- **Request objects are strict** (`additionalProperties: false`). The global `ValidationPipe` runs `forbidNonWhitelisted: true` (`src/main.ts`), so a stray body key is a 400, not a silent strip.
- **The opaque `@IsObject()` fields are loose** (`entityRef`, `source`, `metadata`, `retractedBy`). class-validator never walks into them — their inner shapes are checked service-side — so an extra key inside them is *not* a 400, and the published schema says exactly that.

### The one place a shape is deliberately not pinned

Three `explain`-mode payloads are published as **open objects**: a search hit's `breakdown` (`ScoreBreakdown`), a synthesis `decisionLog` entry, and an ingest `conflictExplanation`. These mirror scorer/resolver internals that move with every retrieval lever; pinning them field-by-field would publish a promise the engine never made. The rule is stated in the script's docblock and in each schema, so it reads as a decision rather than an omission.

## Exclusions kept deliberate — and written down

The script's header comment previously described a scope the document had outgrown. It now states the **current selection rule** in full: what is published (memory core, registry + marketplace + tenant pack admin, document pipeline + indexer protocol, raw-substrate driver, evidence substrate, source reputation) and what is excluded and why:

- **Operator/ops surfaces** — jobs, leases, DLQ, policy, predicates, stats, traces, calibration, migrations, scheduler, maintenance, and everything behind `brain:platform_admin`. Indexed in `docs/api.md`; they change with the operator playbook, not with an integration.
- **`POST /v1/entities/{id}/forget`** — on an otherwise-published controller, but it is the hard GDPR cascade (`brain:admin`), an operator action rather than part of the entity read surface. Left out on the ops rule, not by accident.
- **The admin BFF**, its dynamic UI paths, internal poller/changefeed surfaces, health/metrics.
- **The MCP transport, `ALL /mcp/{companyId}`** — explicitly called out in the docblock so the next reader does not "fix" it. It is JSON-RPC 2.0 over MCP Streamable HTTP: one URL carrying `initialize` / `tools/list` / `tools/call` messages whose shapes live in the MCP tool registrations (`src/mcp/*-tools.ts`), not in an HTTP method+path matrix. An OpenAPI `paths` block can only lie about it; clients discover the surface through `tools/list`.

`docs/api.md`'s lead paragraph was describing the old, narrower scope and is updated to match.

## Findings

Contract-vs-runtime disagreements found while transcribing — **reported, not papered over**. None is fixed here (this PR is contract publication only), and none blocks the published schemas, which describe the runtime as it actually behaves:

1. **`RetractFactDto.retractedBy` is unvalidated.** It carries `@IsObject()` with no `@ValidateNested()` / `@Type()`, so the documented inner shape `{ userId?: string; source: 'human' | 'system' }` is *never enforced* — `{}` and `{ source: 'banana' }` both pass the pipe. The published schema is a loose object with the documented fields, matching what actually gets through. Same class of gap as `IngestFactDto.entityRef` / `source`, except those two *are* shape-checked downstream in `FactIngestService`; `retractedBy` is not checked anywhere.
2. **`SynthesizeDto.explain` coerces truthily.** It carries `@Type(() => Boolean)`, and with the global `transform: true` that runs before `@IsBoolean()` — so the string `"false"` becomes `true`. `IngestFactDto.explain` has the same decorator; `MultiHopDto.synthesize` deliberately does not, so it requires a real JSON boolean. Two sibling boolean flags on the same request family behave differently. The schemas document all three as `boolean` (the JSON contract), and the coercion is a DTO-level inconsistency worth a follow-up.
3. **`SynthesizeDto.answerLang` and `SearchDto.queryLang` are bare `@IsString()`** despite being documented as ISO 639-1 hints — any string passes. Published as `string`, not as an enum, because that is the truth.
4. **`POST /v1/search` returns `Promise<{ results: SearchHit[] }>` with no named envelope type** — the response type is anonymous at the service boundary. The new `SearchResponseSchema` gives it a name in the contract; the service signature is untouched.

## Left out of this PR, on purpose

- `POST /v1/ingest/mention` and `POST /v1/ingest/link` — genuine platform writes on the same controller as the published `/v1/ingest/fact`, and a real remaining gap, but outside this PR's stated scope. `mention` in particular runs the LLM extractor and its result shape needs its own contract pass. Flagging rather than silently skipping.
- `POST /v1/entities/{id}/forget` — excluded on the ops rule (see above).

## Gates

Each run without piping to `tail`/`head`, exit code captured directly:

| Gate | Exit |
| --- | --- |
| `pnpm typecheck` | `0` |
| `pnpm lint:ci` | `0` |
| `pnpm format:check` | `0` |
| unit suite (385 suites, 4588 tests) | `0` |

`pnpm openapi:build` regenerated **both** copies (`docs/openapi.json` and `brain-landing/public/openapi.json`) in one run — the byte-identity assertion in `test/openapi-doc.unit-spec.ts` passes, which is what bit the release branch yesterday.

No behavior change: no route added, no DTO touched, no controller touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB
