### PR TITLE
feat(indexers): operator view of installed indexers and run health

### DIFF
--- a/brain-landing/public/openapi.json
+++ b/brain-landing/public/openapi.json
@@ -2039,6 +2039,400 @@
         ],
         "type": "object"
       },
+      "IndexerCandidateTotals": {
+        "additionalProperties": false,
+        "properties": {
+          "committed": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "duplicate": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "expired": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "merged": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "pending": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "rejected": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "submitted": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "submitted",
+          "pending",
+          "committed",
+          "merged",
+          "duplicate",
+          "rejected",
+          "expired"
+        ],
+        "type": "object"
+      },
+      "IndexerExternalHealth": {
+        "additionalProperties": false,
+        "properties": {
+          "lastClaimAt": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "oldestPendingAt": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "pendingWork": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "polledRecently": {
+            "type": "boolean"
+          },
+          "polledWithinHours": {
+            "exclusiveMinimum": 0,
+            "maximum": 9007199254740991,
+            "type": "integer"
+          },
+          "publisher": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "publisher",
+          "pendingWork",
+          "oldestPendingAt",
+          "lastClaimAt",
+          "polledRecently",
+          "polledWithinHours"
+        ],
+        "type": "object"
+      },
+      "IndexerOverview": {
+        "additionalProperties": false,
+        "properties": {
+          "candidates": {
+            "$ref": "#/components/schemas/IndexerCandidateTotals"
+          },
+          "description": {
+            "type": "string"
+          },
+          "external": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/IndexerExternalHealth"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "installedAt": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "lastRun": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/IndexerRunSummary"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "mode": {
+            "enum": [
+              "virtual",
+              "dedicated",
+              "external"
+            ],
+            "type": "string"
+          },
+          "packId": {
+            "type": "string"
+          },
+          "packVersion": {
+            "type": "string"
+          },
+          "runs": {
+            "$ref": "#/components/schemas/IndexerRunTotals"
+          },
+          "source": {
+            "enum": [
+              "builtin",
+              "installed"
+            ],
+            "type": "string"
+          },
+          "truncated": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "packId",
+          "packVersion",
+          "mode",
+          "source",
+          "description",
+          "installedAt",
+          "lastRun",
+          "runs",
+          "candidates",
+          "external",
+          "truncated"
+        ],
+        "type": "object"
+      },
+      "IndexerOverviewListResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "indexers": {
+            "items": {
+              "$ref": "#/components/schemas/IndexerOverview"
+            },
+            "type": "array"
+          },
+          "tenant": {
+            "type": "string"
+          },
+          "window": {
+            "$ref": "#/components/schemas/IndexerWindow"
+          }
+        },
+        "required": [
+          "tenant",
+          "window",
+          "indexers"
+        ],
+        "type": "object"
+      },
+      "IndexerRunListResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "packId": {
+            "type": "string"
+          },
+          "runs": {
+            "items": {
+              "$ref": "#/components/schemas/IndexerRunSummary"
+            },
+            "type": "array"
+          },
+          "tenant": {
+            "type": "string"
+          },
+          "truncated": {
+            "type": "boolean"
+          },
+          "window": {
+            "$ref": "#/components/schemas/IndexerWindow"
+          }
+        },
+        "required": [
+          "tenant",
+          "packId",
+          "window",
+          "runs",
+          "truncated"
+        ],
+        "type": "object"
+      },
+      "IndexerRunStats": {
+        "additionalProperties": false,
+        "properties": {
+          "chunks": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "durationMs": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "entities": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "facts": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "relations": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "chunks",
+          "entities",
+          "facts",
+          "relations",
+          "durationMs"
+        ],
+        "type": "object"
+      },
+      "IndexerRunSummary": {
+        "additionalProperties": false,
+        "properties": {
+          "candidates": {
+            "$ref": "#/components/schemas/IndexerCandidateTotals"
+          },
+          "documentId": {
+            "type": "string"
+          },
+          "error": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "external": {
+            "type": "boolean"
+          },
+          "finishedAt": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "packVersion": {
+            "type": "string"
+          },
+          "runId": {
+            "type": "string"
+          },
+          "startedAt": {
+            "type": "string"
+          },
+          "stats": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/IndexerRunStats"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "status": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "runId",
+          "documentId",
+          "packVersion",
+          "status",
+          "external",
+          "startedAt",
+          "finishedAt",
+          "stats",
+          "error",
+          "candidates"
+        ],
+        "type": "object"
+      },
+      "IndexerRunTotals": {
+        "additionalProperties": false,
+        "properties": {
+          "failed": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "pending": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "running": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "skipped": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "succeeded": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "total": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "total",
+          "pending",
+          "running",
+          "succeeded",
+          "failed",
+          "skipped"
+        ],
+        "type": "object"
+      },
+      "IndexerWindow": {
+        "additionalProperties": false,
+        "properties": {
+          "days": {
+            "exclusiveMinimum": 0,
+            "maximum": 9007199254740991,
+            "type": "integer"
+          },
+          "runCap": {
+            "exclusiveMinimum": 0,
+            "maximum": 9007199254740991,
+            "type": "integer"
+          },
+          "since": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "since",
+          "days",
+          "runCap"
+        ],
+        "type": "object"
+      },
       "IndexerWorkItem": {
         "additionalProperties": false,
         "properties": {
@@ -4998,6 +5392,135 @@
   },
   "openapi": "3.1.0",
   "paths": {
+    "/v1/admin/indexers": {
+      "get": {
+        "description": "One row per pack that declared an `indexer` descriptor (a pack without one rides the union pass and has no run ledger of its own, so it is absent): execution mode, pack id + installed version, the last run, and run/candidate tallies over a bounded recent window. For `external` packs it also reports publisher liveness — unclaimed backlog and the newest claim, the ledger-derived proxy for \"is the publisher still polling\". Read-only. Answers `404` until `INDEXER_OPERATOR_VIEW_ENABLED=1`. Source: src/documents/indexer-admin.controller.ts.\n\nRequired scope: `brain:admin`.",
+        "operationId": "listIndexerOperatorView",
+        "parameters": [
+          {
+            "description": "Target tenant (platform operators only).",
+            "in": "query",
+            "name": "tenant",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Window width in days (default 7, max 90).",
+            "in": "query",
+            "name": "days",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Runs read per indexer (default 50, max 200).",
+            "in": "query",
+            "name": "runCap",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IndexerOverviewListResponse"
+                }
+              }
+            },
+            "description": "Installed indexers and run health."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "summary": "List the tenant's installed indexers and their run health",
+        "tags": [
+          "Indexer operations"
+        ]
+      }
+    },
+    "/v1/admin/indexers/{packId}/runs": {
+      "get": {
+        "description": "The `indexer_run` ledger rows of a single declared indexer, newest first, each with its staged-candidate tallies. A pack that is not a declared indexer of this tenant answers 404. Read-only. Answers `404` until `INDEXER_OPERATOR_VIEW_ENABLED=1`. Source: src/documents/indexer-admin.controller.ts.\n\nRequired scope: `brain:admin`.",
+        "operationId": "listIndexerRuns",
+        "parameters": [
+          {
+            "description": "The indexer (= pack) id.",
+            "in": "path",
+            "name": "packId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Target tenant (platform operators only).",
+            "in": "query",
+            "name": "tenant",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Window width in days (default 7, max 90).",
+            "in": "query",
+            "name": "days",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Max runs to return (default 50, max 200).",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IndexerRunListResponse"
+                }
+              }
+            },
+            "description": "Recent runs."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "summary": "Recent runs of one indexer",
+        "tags": [
+          "Indexer operations"
+        ]
+      }
+    },
     "/v1/admin/packs": {
       "get": {
         "description": "Builtin packs are globally available and cannot be installed or uninstalled here. Source: src/admin/admin-packs.controller.ts.\n\nRequired scope: `brain:admin`.",
@@ -8199,6 +8722,10 @@
     {
       "description": "The external-indexer protocol (scope `indexer:write`): poll → claim → read content → submit candidates / fail. See docs/indexer-protocol.md.",
       "name": "Indexer work"
+    },
+    {
+      "description": "Read-only operator view (scope `brain:admin`) over the tenant’s installed indexers and their run health. Dark behind INDEXER_OPERATOR_VIEW_ENABLED (default off).",
+      "name": "Indexer operations"
     },
     {
       "description": "Read-only trust inputs (scope `brain:read`): declared source identity ⋈ learned reputation. Public projection — operator annotations (owner/note) stay on the admin surface.",

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -2039,6 +2039,400 @@
         ],
         "type": "object"
       },
+      "IndexerCandidateTotals": {
+        "additionalProperties": false,
+        "properties": {
+          "committed": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "duplicate": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "expired": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "merged": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "pending": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "rejected": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "submitted": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "submitted",
+          "pending",
+          "committed",
+          "merged",
+          "duplicate",
+          "rejected",
+          "expired"
+        ],
+        "type": "object"
+      },
+      "IndexerExternalHealth": {
+        "additionalProperties": false,
+        "properties": {
+          "lastClaimAt": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "oldestPendingAt": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "pendingWork": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "polledRecently": {
+            "type": "boolean"
+          },
+          "polledWithinHours": {
+            "exclusiveMinimum": 0,
+            "maximum": 9007199254740991,
+            "type": "integer"
+          },
+          "publisher": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "publisher",
+          "pendingWork",
+          "oldestPendingAt",
+          "lastClaimAt",
+          "polledRecently",
+          "polledWithinHours"
+        ],
+        "type": "object"
+      },
+      "IndexerOverview": {
+        "additionalProperties": false,
+        "properties": {
+          "candidates": {
+            "$ref": "#/components/schemas/IndexerCandidateTotals"
+          },
+          "description": {
+            "type": "string"
+          },
+          "external": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/IndexerExternalHealth"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "installedAt": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "lastRun": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/IndexerRunSummary"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "mode": {
+            "enum": [
+              "virtual",
+              "dedicated",
+              "external"
+            ],
+            "type": "string"
+          },
+          "packId": {
+            "type": "string"
+          },
+          "packVersion": {
+            "type": "string"
+          },
+          "runs": {
+            "$ref": "#/components/schemas/IndexerRunTotals"
+          },
+          "source": {
+            "enum": [
+              "builtin",
+              "installed"
+            ],
+            "type": "string"
+          },
+          "truncated": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "packId",
+          "packVersion",
+          "mode",
+          "source",
+          "description",
+          "installedAt",
+          "lastRun",
+          "runs",
+          "candidates",
+          "external",
+          "truncated"
+        ],
+        "type": "object"
+      },
+      "IndexerOverviewListResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "indexers": {
+            "items": {
+              "$ref": "#/components/schemas/IndexerOverview"
+            },
+            "type": "array"
+          },
+          "tenant": {
+            "type": "string"
+          },
+          "window": {
+            "$ref": "#/components/schemas/IndexerWindow"
+          }
+        },
+        "required": [
+          "tenant",
+          "window",
+          "indexers"
+        ],
+        "type": "object"
+      },
+      "IndexerRunListResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "packId": {
+            "type": "string"
+          },
+          "runs": {
+            "items": {
+              "$ref": "#/components/schemas/IndexerRunSummary"
+            },
+            "type": "array"
+          },
+          "tenant": {
+            "type": "string"
+          },
+          "truncated": {
+            "type": "boolean"
+          },
+          "window": {
+            "$ref": "#/components/schemas/IndexerWindow"
+          }
+        },
+        "required": [
+          "tenant",
+          "packId",
+          "window",
+          "runs",
+          "truncated"
+        ],
+        "type": "object"
+      },
+      "IndexerRunStats": {
+        "additionalProperties": false,
+        "properties": {
+          "chunks": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "durationMs": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "entities": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "facts": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "relations": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "chunks",
+          "entities",
+          "facts",
+          "relations",
+          "durationMs"
+        ],
+        "type": "object"
+      },
+      "IndexerRunSummary": {
+        "additionalProperties": false,
+        "properties": {
+          "candidates": {
+            "$ref": "#/components/schemas/IndexerCandidateTotals"
+          },
+          "documentId": {
+            "type": "string"
+          },
+          "error": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "external": {
+            "type": "boolean"
+          },
+          "finishedAt": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "packVersion": {
+            "type": "string"
+          },
+          "runId": {
+            "type": "string"
+          },
+          "startedAt": {
+            "type": "string"
+          },
+          "stats": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/IndexerRunStats"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "status": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "runId",
+          "documentId",
+          "packVersion",
+          "status",
+          "external",
+          "startedAt",
+          "finishedAt",
+          "stats",
+          "error",
+          "candidates"
+        ],
+        "type": "object"
+      },
+      "IndexerRunTotals": {
+        "additionalProperties": false,
+        "properties": {
+          "failed": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "pending": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "running": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "skipped": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "succeeded": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          },
+          "total": {
+            "maximum": 9007199254740991,
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "total",
+          "pending",
+          "running",
+          "succeeded",
+          "failed",
+          "skipped"
+        ],
+        "type": "object"
+      },
+      "IndexerWindow": {
+        "additionalProperties": false,
+        "properties": {
+          "days": {
+            "exclusiveMinimum": 0,
+            "maximum": 9007199254740991,
+            "type": "integer"
+          },
+          "runCap": {
+            "exclusiveMinimum": 0,
+            "maximum": 9007199254740991,
+            "type": "integer"
+          },
+          "since": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "since",
+          "days",
+          "runCap"
+        ],
+        "type": "object"
+      },
       "IndexerWorkItem": {
         "additionalProperties": false,
         "properties": {
@@ -4998,6 +5392,135 @@
   },
   "openapi": "3.1.0",
   "paths": {
+    "/v1/admin/indexers": {
+      "get": {
+        "description": "One row per pack that declared an `indexer` descriptor (a pack without one rides the union pass and has no run ledger of its own, so it is absent): execution mode, pack id + installed version, the last run, and run/candidate tallies over a bounded recent window. For `external` packs it also reports publisher liveness — unclaimed backlog and the newest claim, the ledger-derived proxy for \"is the publisher still polling\". Read-only. Answers `404` until `INDEXER_OPERATOR_VIEW_ENABLED=1`. Source: src/documents/indexer-admin.controller.ts.\n\nRequired scope: `brain:admin`.",
+        "operationId": "listIndexerOperatorView",
+        "parameters": [
+          {
+            "description": "Target tenant (platform operators only).",
+            "in": "query",
+            "name": "tenant",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Window width in days (default 7, max 90).",
+            "in": "query",
+            "name": "days",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Runs read per indexer (default 50, max 200).",
+            "in": "query",
+            "name": "runCap",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IndexerOverviewListResponse"
+                }
+              }
+            },
+            "description": "Installed indexers and run health."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "summary": "List the tenant's installed indexers and their run health",
+        "tags": [
+          "Indexer operations"
+        ]
+      }
+    },
+    "/v1/admin/indexers/{packId}/runs": {
+      "get": {
+        "description": "The `indexer_run` ledger rows of a single declared indexer, newest first, each with its staged-candidate tallies. A pack that is not a declared indexer of this tenant answers 404. Read-only. Answers `404` until `INDEXER_OPERATOR_VIEW_ENABLED=1`. Source: src/documents/indexer-admin.controller.ts.\n\nRequired scope: `brain:admin`.",
+        "operationId": "listIndexerRuns",
+        "parameters": [
+          {
+            "description": "The indexer (= pack) id.",
+            "in": "path",
+            "name": "packId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Target tenant (platform operators only).",
+            "in": "query",
+            "name": "tenant",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Window width in days (default 7, max 90).",
+            "in": "query",
+            "name": "days",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Max runs to return (default 50, max 200).",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IndexerRunListResponse"
+                }
+              }
+            },
+            "description": "Recent runs."
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          },
+          "404": {
+            "$ref": "#/components/responses/NotFound"
+          }
+        },
+        "summary": "Recent runs of one indexer",
+        "tags": [
+          "Indexer operations"
+        ]
+      }
+    },
     "/v1/admin/packs": {
       "get": {
         "description": "Builtin packs are globally available and cannot be installed or uninstalled here. Source: src/admin/admin-packs.controller.ts.\n\nRequired scope: `brain:admin`.",
@@ -8199,6 +8722,10 @@
     {
       "description": "The external-indexer protocol (scope `indexer:write`): poll → claim → read content → submit candidates / fail. See docs/indexer-protocol.md.",
       "name": "Indexer work"
+    },
+    {
+      "description": "Read-only operator view (scope `brain:admin`) over the tenant’s installed indexers and their run health. Dark behind INDEXER_OPERATOR_VIEW_ENABLED (default off).",
+      "name": "Indexer operations"
     },
     {
       "description": "Read-only trust inputs (scope `brain:read`): declared source identity ⋈ learned reputation. Public projection — operator annotations (owner/note) stay on the admin surface.",

--- a/scripts/build-openapi.ts
+++ b/scripts/build-openapi.ts
@@ -121,6 +121,17 @@ import {
   WorkContentResponseSchema,
 } from '../src/contracts/indexer/indexer-work.schema';
 import {
+  IndexerCandidateTotalsSchema,
+  IndexerExternalHealthSchema,
+  IndexerOverviewListResponseSchema,
+  IndexerOverviewSchema,
+  IndexerRunListResponseSchema,
+  IndexerRunStatsSchema,
+  IndexerRunSummarySchema,
+  IndexerRunTotalsSchema,
+  IndexerWindowSchema,
+} from '../src/contracts/indexer/indexer-operator.schema';
+import {
   CandidateSchema,
   CommitCountsSchema,
   DocumentCandidatesResponseSchema,
@@ -309,6 +320,16 @@ const ZOD_COMPONENTS: Record<string, z.ZodType> = {
   IndexerWorkListResponse: IndexerWorkListResponseSchema,
   WorkContentChunk: WorkContentChunkSchema,
   WorkContentResponse: WorkContentResponseSchema,
+  // --- indexer operator view (src/contracts/indexer/indexer-operator.schema.ts)
+  IndexerCandidateTotals: IndexerCandidateTotalsSchema,
+  IndexerExternalHealth: IndexerExternalHealthSchema,
+  IndexerOverview: IndexerOverviewSchema,
+  IndexerOverviewListResponse: IndexerOverviewListResponseSchema,
+  IndexerRunListResponse: IndexerRunListResponseSchema,
+  IndexerRunStats: IndexerRunStatsSchema,
+  IndexerRunSummary: IndexerRunSummarySchema,
+  IndexerRunTotals: IndexerRunTotalsSchema,
+  IndexerWindow: IndexerWindowSchema,
   // --- raw-substrate driver (src/contracts/episodes/driver.schema.ts)
   EpisodeWire: EpisodeWireSchema,
   EpisodesListResponse: EpisodesListResponseSchema,
@@ -1966,6 +1987,72 @@ function indexerWorkPaths(): Json {
   };
 }
 
+/** Dark-launch note for the read-only indexer operator view. */
+const INDEXER_OPERATOR_NOTE = 'Read-only. Answers `404` until `INDEXER_OPERATOR_VIEW_ENABLED=1`.';
+
+function indexerOperatorPaths(): Json {
+  return {
+    '/v1/admin/indexers': {
+      get: operation({
+        operationId: 'listIndexerOperatorView',
+        tag: 'Indexer operations',
+        summary: "List the tenant's installed indexers and their run health",
+        description:
+          'One row per pack that declared an `indexer` descriptor (a pack ' +
+          'without one rides the union pass and has no run ledger of its ' +
+          'own, so it is absent): execution mode, pack id + installed ' +
+          'version, the last run, and run/candidate tallies over a ' +
+          'bounded recent window. For `external` packs it also reports ' +
+          'publisher liveness — unclaimed backlog and the newest claim, ' +
+          'the ledger-derived proxy for "is the publisher still polling". ' +
+          `${INDEXER_OPERATOR_NOTE} ` +
+          'Source: src/documents/indexer-admin.controller.ts.',
+        scope: 'brain:admin',
+        parameters: [
+          queryParam('tenant', 'Target tenant (platform operators only).'),
+          queryParam('days', 'Window width in days (default 7, max 90).', { type: 'integer' }),
+          queryParam('runCap', 'Runs read per indexer (default 50, max 200).', {
+            type: 'integer',
+          }),
+        ],
+        responses: {
+          '200': jsonResponse(
+            'Installed indexers and run health.',
+            ref('IndexerOverviewListResponse'),
+          ),
+          ...AUTH_ERRORS,
+          '404': errorRef('NotFound'),
+        },
+      }),
+    },
+    '/v1/admin/indexers/{packId}/runs': {
+      get: operation({
+        operationId: 'listIndexerRuns',
+        tag: 'Indexer operations',
+        summary: 'Recent runs of one indexer',
+        description:
+          'The `indexer_run` ledger rows of a single declared indexer, ' +
+          'newest first, each with its staged-candidate tallies. A pack ' +
+          'that is not a declared indexer of this tenant answers 404. ' +
+          `${INDEXER_OPERATOR_NOTE} ` +
+          'Source: src/documents/indexer-admin.controller.ts.',
+        scope: 'brain:admin',
+        parameters: [
+          pathParam('packId', 'The indexer (= pack) id.'),
+          queryParam('tenant', 'Target tenant (platform operators only).'),
+          queryParam('days', 'Window width in days (default 7, max 90).', { type: 'integer' }),
+          queryParam('limit', 'Max runs to return (default 50, max 200).', { type: 'integer' }),
+        ],
+        responses: {
+          '200': jsonResponse('Recent runs.', ref('IndexerRunListResponse')),
+          ...AUTH_ERRORS,
+          '404': errorRef('NotFound'),
+        },
+      }),
+    },
+  };
+}
+
 /* ------------------------------------------------------------------ *
  * Document assembly.
  * ------------------------------------------------------------------ */
@@ -2291,6 +2378,13 @@ export function buildOpenApiDocument(): Json {
           'See docs/indexer-protocol.md.',
       },
       {
+        name: 'Indexer operations',
+        description:
+          'Read-only operator view (scope `brain:admin`) over the ' +
+          'tenant’s installed indexers and their run health. Dark behind ' +
+          'INDEXER_OPERATOR_VIEW_ENABLED (default off).',
+      },
+      {
         name: 'Sources',
         description:
           'Read-only trust inputs (scope `brain:read`): declared source ' +
@@ -2369,6 +2463,7 @@ export function buildOpenApiDocument(): Json {
       ...packsAdminPaths(),
       ...documentsPaths(),
       ...indexerWorkPaths(),
+      ...indexerOperatorPaths(),
       ...sourcesPaths(),
       ...driverPaths(),
       ...memoryReadPaths(),

--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -1615,6 +1615,15 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
       'Dedicated per-pack indexer runs + relevance router + async fan-out + external work items. Off = only the generalist union pass runs.',
   },
   {
+    key: 'INDEXER_OPERATOR_VIEW_ENABLED',
+    category: 'pipeline',
+    defaultValue: '0',
+    runtimeMutable: true,
+    isBooleanFlag: true,
+    description:
+      'Read-only operator view over the tenant’s installed indexers and their run health (GET /v1/admin/indexers + /v1/admin/indexers/{packId}/runs, scope brain:admin): mode, pack version, last run, window-bounded run/candidate tallies, and — for external packs — publisher poll liveness derived from the claim ledger. Off = both routes 404. No mutation verbs; nothing about extraction changes either way.',
+  },
+  {
     key: 'PACK_SEED_INGEST_ENABLED',
     category: 'pipeline',
     defaultValue: '1',

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -1061,6 +1061,9 @@ const KNOWN_BOOLEAN_FLAGS = [
   // dropped. Off (default) → composed rows byte-identical.
   'PRIVACY_COMPOSER_USER_SCOPE',
   'INDEXER_WEBHOOK_PUSH_ENABLED',
+  // Read-only operator view over installed indexers and their run health
+  // (GET /v1/admin/indexers). Off (default) → both routes 404.
+  'INDEXER_OPERATOR_VIEW_ENABLED',
   'REINDEX_ON_PACK_INSTALL',
   'DOCUMENT_ALLOW_UNGROUNDED_EXTERNAL',
   // Default-ON: read as `PACK_SEED_INGEST_ENABLED ?? '1'` before

--- a/src/contracts/indexer/indexer-operator.schema.ts
+++ b/src/contracts/indexer/indexer-operator.schema.ts
@@ -1,0 +1,148 @@
+import { z } from 'zod';
+
+/**
+ * Wire contracts for the OPERATOR view over a tenant's indexers
+ * (`/v1/admin/indexers`, scope `brain:admin`, flag
+ * INDEXER_OPERATOR_VIEW_ENABLED).
+ *
+ * An indexer's identity IS its pack (`indexerId === packId`; the
+ * descriptor lives inside the signed pack manifest), and the run ledger
+ * `indexer_run` is keyed by (docId, packId, packVersion). Until now the
+ * only HTTP surface over that ledger was GET /v1/indexer/work — the
+ * external poller's own work queue, not an operator's view. This is the
+ * read-only view: which indexers a tenant has, and how their runs are
+ * doing over a bounded recent window.
+ *
+ * Read-only by construction: no verb here mutates a run, a candidate, or
+ * a pack installation.
+ */
+
+/** Indexer execution modes (mirrors IndexerDescriptor.mode). */
+export const IndexerModeSchema = z.enum(['virtual', 'dedicated', 'external']);
+
+/** Where the pack came from: shipped with the service, or installed. */
+export const IndexerSourceSchema = z.enum(['builtin', 'installed']);
+
+/** The bounded window every aggregate on this surface is computed over. */
+export const IndexerWindowSchema = z.object({
+  /** Inclusive lower bound (ISO-8601) on `indexer_run.createdAt`. */
+  since: z.string(),
+  /** Window width in days (clamped server-side). */
+  days: z.number().int().positive(),
+  /** Per-indexer cap on runs read; true when the cap was hit. */
+  runCap: z.number().int().positive(),
+});
+
+/** Run-status tallies over the window (statuses of migration 0049). */
+export const IndexerRunTotalsSchema = z.object({
+  total: z.number().int().nonnegative(),
+  pending: z.number().int().nonnegative(),
+  running: z.number().int().nonnegative(),
+  succeeded: z.number().int().nonnegative(),
+  failed: z.number().int().nonnegative(),
+  skipped: z.number().int().nonnegative(),
+});
+
+/** Candidate-status tallies over the same window's runs (migration 0049). */
+export const IndexerCandidateTotalsSchema = z.object({
+  /** Every candidate staged by the window's runs ("submitted"). */
+  submitted: z.number().int().nonnegative(),
+  pending: z.number().int().nonnegative(),
+  committed: z.number().int().nonnegative(),
+  merged: z.number().int().nonnegative(),
+  duplicate: z.number().int().nonnegative(),
+  rejected: z.number().int().nonnegative(),
+  expired: z.number().int().nonnegative(),
+});
+
+/** Per-run extraction stats as finalizeRun recorded them. */
+export const IndexerRunStatsSchema = z.object({
+  chunks: z.number().int().nonnegative(),
+  entities: z.number().int().nonnegative(),
+  facts: z.number().int().nonnegative(),
+  relations: z.number().int().nonnegative(),
+  durationMs: z.number().int().nonnegative(),
+});
+
+/** One `indexer_run` row as an operator reads it. */
+export const IndexerRunSummarySchema = z.object({
+  runId: z.string(),
+  documentId: z.string(),
+  packVersion: z.string(),
+  status: z.string(),
+  /** true = an external work item (pull API), not an in-process run. */
+  external: z.boolean(),
+  /** `createdAt` — also the claim-lease clock for external runs. */
+  startedAt: z.string(),
+  finishedAt: z.string().nullable(),
+  stats: IndexerRunStatsSchema.nullable(),
+  /** Failure message as the ledger recorded it (capped server-side). */
+  error: z.string().nullable(),
+  candidates: IndexerCandidateTotalsSchema,
+});
+
+/**
+ * External-publisher liveness, derived from the ledger — there is no
+ * separate poll journal, so `lastClaimAt` (the newest claim over the
+ * window) is the honest proxy for "the publisher is polling".
+ */
+export const IndexerExternalHealthSchema = z.object({
+  /** Trust-store key declared by the manifest, when it declares one. */
+  publisher: z.string().nullable(),
+  /** Work items still waiting to be claimed (window-bounded). */
+  pendingWork: z.number().int().nonnegative(),
+  /** Oldest unclaimed work item in the window, if any. */
+  oldestPendingAt: z.string().nullable(),
+  /** Newest claim seen in the window — the poll proxy. */
+  lastClaimAt: z.string().nullable(),
+  /** lastClaimAt within `polledWithinHours`. */
+  polledRecently: z.boolean(),
+  polledWithinHours: z.number().int().positive(),
+});
+
+/** One indexer (= one pack carrying an `indexer` descriptor). */
+export const IndexerOverviewSchema = z.object({
+  /** Pack id — the indexer's identity. */
+  packId: z.string(),
+  /** Version the tenant currently runs (installed row, or builtin). */
+  packVersion: z.string(),
+  mode: IndexerModeSchema,
+  source: IndexerSourceSchema,
+  description: z.string(),
+  /** Install timestamp for `installed` packs; null for builtins. */
+  installedAt: z.string().nullable(),
+  /** Most recent run in the window, or null when the indexer is idle. */
+  lastRun: IndexerRunSummarySchema.nullable(),
+  runs: IndexerRunTotalsSchema,
+  candidates: IndexerCandidateTotalsSchema,
+  /** Present only for `external` mode; null otherwise. */
+  external: IndexerExternalHealthSchema.nullable(),
+  /** true = the per-indexer run cap was hit, so tallies are partial. */
+  truncated: z.boolean(),
+});
+
+export const IndexerOverviewListResponseSchema = z.object({
+  tenant: z.string(),
+  window: IndexerWindowSchema,
+  indexers: z.array(IndexerOverviewSchema),
+});
+
+export const IndexerRunListResponseSchema = z.object({
+  tenant: z.string(),
+  packId: z.string(),
+  window: IndexerWindowSchema,
+  runs: z.array(IndexerRunSummarySchema),
+  truncated: z.boolean(),
+});
+
+export type IndexerMode = z.infer<typeof IndexerModeSchema>;
+export type IndexerSource = z.infer<typeof IndexerSourceSchema>;
+export type IndexerWindow = z.infer<typeof IndexerWindowSchema>;
+export type IndexerRunTotals = z.infer<typeof IndexerRunTotalsSchema>;
+export type IndexerCandidateTotals = z.infer<typeof IndexerCandidateTotalsSchema>;
+export type IndexerRunStats = z.infer<typeof IndexerRunStatsSchema>;
+export type IndexerRunSummary = z.infer<typeof IndexerRunSummarySchema>;
+export type IndexerExternalHealth = z.infer<typeof IndexerExternalHealthSchema>;
+export type IndexerOverview = z.infer<typeof IndexerOverviewSchema>;
+export type IndexerOverviewListResponse = z.infer<typeof IndexerOverviewListResponseSchema>;
+export type IndexerRunListResponse = z.infer<typeof IndexerRunListResponseSchema>;

--- a/src/db/migrations/0131_indexer_run_pack_idx.surql
+++ b/src/db/migrations/0131_indexer_run_pack_idx.surql
@@ -1,0 +1,26 @@
+-- 0131: indexer_run_pack_idx — the index behind the operator view over
+-- installed indexers (GET /v1/admin/indexers, INDEXER_OPERATOR_VIEW_ENABLED).
+--
+-- WHY. An indexer's identity IS its pack, and the run ledger has been
+-- keyed by (docId, packId, packVersion) since 0049 — but every index over
+-- indexer_run so far served a WRITER's access path: the identity UNIQUE
+-- (idempotency), `status` (the stale reaper), and (external, status)
+-- (work discovery). Nothing indexed a READ by pack, because until now
+-- nothing read the ledger BY pack: /v1/indexer/work asks "what work is
+-- pending", never "how is pack X doing". The operator view asks exactly
+-- the latter, per installed indexer, so without this index each row of
+-- the response costs a full table scan of the tenant's run ledger.
+--
+-- WHAT. A single-field index on packId. Deliberately NOT a compound
+-- (packId, createdAt): the recency bound rides in the WHERE and the
+-- result set is LIMITed per pack, so the leading equality is what
+-- matters — and a compound index would put `createdAt` (a field the
+-- stale-reaper's UPDATE ... WHERE does reference) into an index, which
+-- is precisely the SurrealDB 3.2.4 planner shape we keep away from
+-- mutating statements. `packId` appears in no DELETE/UPDATE ... WHERE
+-- anywhere in the service, so this index can only ever serve reads.
+--
+-- Non-unique by construction: one pack has many runs (one per document ×
+-- pack version).
+
+DEFINE INDEX IF NOT EXISTS indexer_run_pack_idx ON indexer_run FIELDS packId;

--- a/src/documents/documents-gate.ts
+++ b/src/documents/documents-gate.ts
@@ -14,6 +14,19 @@ export function assertDocumentIngestEnabled(): void {
   }
 }
 
+/**
+ * The read-only operator view over installed indexers and their run
+ * health (GET /v1/admin/indexers, INDEXER_OPERATOR_VIEW_ENABLED).
+ * Deliberately its OWN flag rather than riding DOCUMENT_INGEST_ENABLED:
+ * this is a new read surface over an existing ledger, and a tenant should
+ * be able to open it (or not) independently of the write pipeline.
+ * Read at call time so a flip is runtime-mutable. Default off ⇒ the
+ * routes 404, exactly as if they did not exist.
+ */
+export function indexerOperatorViewEnabled(): boolean {
+  return envFlagEnabled(process.env.INDEXER_OPERATOR_VIEW_ENABLED);
+}
+
 export function docMaxChars(): number {
   const v = process.env.DOC_MAX_CHARS;
   const n = v ? parseInt(v, 10) : NaN;

--- a/src/documents/documents.module.ts
+++ b/src/documents/documents.module.ts
@@ -10,6 +10,8 @@ import { ExternalCandidatesController } from './external-candidates.controller';
 import { ExternalCandidatesService } from './external-candidates.service';
 import { IndexerWorkController } from './indexer-work.controller';
 import { IndexerWorkService } from './indexer-work.service';
+import { IndexerAdminController } from './indexer-admin.controller';
+import { IndexerOperatorService } from './indexer-operator.service';
 import { IndexerWebhookService } from './indexer-webhook.service';
 import { DocumentStoreService } from './document-store.service';
 import { CandidateStoreService } from './candidate-store.service';
@@ -50,6 +52,7 @@ import { OutcomesModule } from '../outcomes/outcomes.module';
     DocumentsIngestController,
     ExternalCandidatesController,
     IndexerWorkController,
+    IndexerAdminController,
   ],
   providers: [
     DocumentStoreService,
@@ -66,6 +69,7 @@ import { OutcomesModule } from '../outcomes/outcomes.module';
     MentionViaDocumentService,
     ExternalCandidatesService,
     IndexerWorkService,
+    IndexerOperatorService,
     IndexerWebhookService,
     SceneCandidateWriterService,
   ],

--- a/src/documents/indexer-admin.controller.ts
+++ b/src/documents/indexer-admin.controller.ts
@@ -1,0 +1,99 @@
+import { Controller, Get, NotFoundException, Param, Query, Req, UseGuards } from '@nestjs/common';
+import { ApiKeyGuard, RequireScopes } from '../auth/api-key.guard';
+import type { AuthenticatedRequest } from '../auth/api-key.types';
+import { ApiKeyService } from '../auth/api-key.service';
+import { resolvePlatformTenant } from '../auth/tenant-scope';
+import type {
+  IndexerOverviewListResponse,
+  IndexerRunListResponse,
+} from '../contracts/indexer/indexer-operator.schema';
+import { IndexerOperatorService } from './indexer-operator.service';
+import { indexerOperatorViewEnabled } from './documents-gate';
+
+/**
+ * The operator view over a tenant's indexers — the gap this closes: an
+ * indexer's identity IS its pack, and `indexer_run` has recorded run
+ * health since migration 0049, but the only HTTP surface over that
+ * ledger was GET /v1/indexer/work — the EXTERNAL poller's own work
+ * queue, not an operator's view. Nothing listed a tenant's installed
+ * indexers or told an operator whether they were running, failing, or
+ * (for external packs) being polled at all.
+ *
+ *  - GET /v1/admin/indexers            — one row per declared indexer:
+ *    mode, pack id + installed version, last run, and window-bounded
+ *    run/candidate tallies (plus publisher liveness for external mode).
+ *  - GET /v1/admin/indexers/:packId/runs — recent runs of one indexer.
+ *
+ * READ-ONLY: no mutation verb lives here. Retrying, releasing, or
+ * re-indexing stays with the surfaces that already own those decisions.
+ *
+ * Dark behind INDEXER_OPERATOR_VIEW_ENABLED (default off ⇒ 404 — the
+ * route does not exist for a tenant that has not opted in), read at call
+ * time so a flip is runtime-mutable. Scope `brain:admin` like every
+ * sibling under /v1/admin; the tenant seam is resolvePlatformTenant, so
+ * a plain admin can only ever read its OWN tenant's ledger.
+ */
+@Controller('v1/admin/indexers')
+@UseGuards(ApiKeyGuard)
+export class IndexerAdminController {
+  constructor(
+    private readonly operator: IndexerOperatorService,
+    private readonly apiKeys: ApiKeyService,
+  ) {}
+
+  @Get()
+  @RequireScopes('brain:admin')
+  async list(
+    @Req() req: AuthenticatedRequest,
+    @Query() q: IndexerViewQuery = {},
+  ): Promise<IndexerOverviewListResponse> {
+    if (!indexerOperatorViewEnabled()) throw new NotFoundException();
+    return this.operator.listIndexers({
+      companyId: this.resolveTenant(req, q.tenant),
+      days: parseCount(q.days),
+      runCap: parseCount(q.runCap),
+    });
+  }
+
+  @Get(':packId/runs')
+  @RequireScopes('brain:admin')
+  async runs(
+    @Req() req: AuthenticatedRequest,
+    @Param('packId') packId: string,
+    @Query() q: IndexerViewQuery = {},
+  ): Promise<IndexerRunListResponse> {
+    if (!indexerOperatorViewEnabled()) throw new NotFoundException();
+    return this.operator.listRuns({
+      companyId: this.resolveTenant(req, q.tenant),
+      packId,
+      days: parseCount(q.days),
+      limit: parseCount(q.limit),
+    });
+  }
+
+  /** ONE tenant-resolution seam for both reads (the R3 admin idiom). */
+  private resolveTenant(req: AuthenticatedRequest, requested: string | undefined): string {
+    return resolvePlatformTenant(req, requested, {
+      knownTenants: () => this.apiKeys.knownCompanyIds(),
+    });
+  }
+}
+
+/** Query string of both reads — every field optional, every value clamped. */
+interface IndexerViewQuery {
+  /** Target tenant; only a platform operator may name a foreign one. */
+  tenant?: string;
+  /** Window width in days (default 7, max 90). */
+  days?: string;
+  /** Runs read per indexer on the list route (default 50, max 200). */
+  runCap?: string;
+  /** Runs returned by the detail route (default 50, max 200). */
+  limit?: string;
+}
+
+/** Query ints are advisory — the service clamps; garbage reads as absent. */
+function parseCount(v: string | undefined): number | undefined {
+  if (v === undefined) return undefined;
+  const n = parseInt(v, 10);
+  return Number.isFinite(n) ? n : undefined;
+}

--- a/src/documents/indexer-operator.service.ts
+++ b/src/documents/indexer-operator.service.ts
@@ -1,0 +1,387 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { SurrealService, queryRows } from '../db/surreal.service';
+import { IndexerRouterService } from '../indexers/indexer-router.service';
+import type { IndexerBinding } from '../indexers/routing';
+import type {
+  IndexerCandidateTotals,
+  IndexerExternalHealth,
+  IndexerOverview,
+  IndexerOverviewListResponse,
+  IndexerRunListResponse,
+  IndexerRunStats,
+  IndexerRunSummary,
+  IndexerRunTotals,
+  IndexerWindow,
+} from '../contracts/indexer/indexer-operator.schema';
+
+/** Window defaults/caps — every aggregate on this surface is bounded. */
+const DEFAULT_WINDOW_DAYS = 7;
+const MAX_WINDOW_DAYS = 90;
+/** Runs read per indexer for the list view (the aggregate's row budget). */
+const DEFAULT_LIST_RUN_CAP = 50;
+const MAX_LIST_RUN_CAP = 200;
+/** Runs returned by the per-pack detail route. */
+const DEFAULT_DETAIL_LIMIT = 50;
+const MAX_DETAIL_LIMIT = 200;
+/** Upper bound on indexers enumerated in one response. */
+const MAX_INDEXERS = 50;
+/** Run ids per candidate-tally query — keeps the IN-list bounded. */
+const CANDIDATE_ID_BATCH = 500;
+/** An external publisher counts as "polling" if it claimed within this. */
+const POLLED_WITHIN_HOURS = 24;
+/** Ledger error messages are operator-facing text, not a payload dump. */
+const ERROR_MAX_CHARS = 500;
+
+const DAY_MS = 86_400_000;
+
+/** Raw `indexer_run` projection this surface reads. */
+interface OperatorRunRow {
+  id: unknown;
+  docId?: unknown;
+  packId?: unknown;
+  packVersion?: unknown;
+  status?: unknown;
+  external?: unknown;
+  createdAt?: unknown;
+  finishedAt?: unknown;
+  claimedAt?: unknown;
+  stats?: unknown;
+  error?: unknown;
+}
+
+/** GROUP BY runId, status tally over `candidate`. */
+interface CandidateTallyRow {
+  runId?: unknown;
+  status?: unknown;
+  n?: unknown;
+}
+
+/**
+ * The OPERATOR view over a tenant's indexers — the read-only counterpart
+ * to GET /v1/indexer/work (which is the external poller's OWN queue, not
+ * an operator's view).
+ *
+ * An indexer's identity IS its pack: the `indexer` descriptor lives
+ * inside the pack manifest, and `indexer_run` rows are keyed by
+ * (docId, packId, packVersion). So "list the tenant's indexers" is
+ * "list the tenant's packs that DECLARED an indexer descriptor" — the
+ * router already resolves exactly that set (builtin + active installed),
+ * and reusing it keeps ONE definition of "installed for this tenant".
+ * A pack with no descriptor is absent: its facts ride the union pass and
+ * it has no run ledger of its own.
+ *
+ * Fences:
+ *  - every query runs inside `withCompany`, so a tenant's aggregate is
+ *    computed from that tenant's rows only — there is no cross-tenant
+ *    read path here, sanctioned or otherwise;
+ *  - the pack set is the tenant's own bindings, so a foreign pack id on
+ *    the detail route is a 404, not a probe of another tenant's ledger;
+ *  - every read is window-bounded AND row-capped (`truncated` says when
+ *    a cap bit), and hits `indexer_run_pack_idx` / `candidate_run_idx`.
+ *
+ * Read-only: nothing here writes, and no statement is a DELETE/UPDATE …
+ * WHERE over an indexed field (the 3.2.4 planner hazard).
+ */
+@Injectable()
+export class IndexerOperatorService {
+  constructor(
+    private readonly surreal: SurrealService,
+    private readonly router: IndexerRouterService,
+  ) {}
+
+  /** Every declared indexer of a tenant plus its run health. */
+  async listIndexers(p: {
+    companyId: string;
+    days?: number | undefined;
+    runCap?: number | undefined;
+  }): Promise<IndexerOverviewListResponse> {
+    const window = makeWindow(p.days, clamp(p.runCap, DEFAULT_LIST_RUN_CAP, MAX_LIST_RUN_CAP));
+    const bindings = await this.declaredIndexers(p.companyId);
+    const byPack = await this.runsByPack(
+      p.companyId,
+      bindings.map((b) => b.indexerId),
+      window,
+    );
+    const tallies = await this.candidateTallies(
+      p.companyId,
+      [...byPack.values()].flatMap((rows) => rows.map((r) => r.id)),
+    );
+    const ctx = { tallies, runCap: window.runCap };
+    const indexers = bindings.map((b) => overviewOf(b, byPack.get(b.indexerId) ?? [], ctx));
+    return { tenant: p.companyId, window, indexers };
+  }
+
+  /** Recent runs of ONE declared indexer, newest first. */
+  async listRuns(p: {
+    companyId: string;
+    packId: string;
+    days?: number | undefined;
+    limit?: number | undefined;
+  }): Promise<IndexerRunListResponse> {
+    const window = makeWindow(p.days, clamp(p.limit, DEFAULT_DETAIL_LIMIT, MAX_DETAIL_LIMIT));
+    const bindings = await this.declaredIndexers(p.companyId);
+    if (!bindings.some((b) => b.indexerId === p.packId)) {
+      throw new NotFoundException(`indexer "${p.packId}" is not installed for this tenant`);
+    }
+    const rows = (await this.runsByPack(p.companyId, [p.packId], window)).get(p.packId) ?? [];
+    const tallies = await this.candidateTallies(
+      p.companyId,
+      rows.map((r) => r.id),
+    );
+    return {
+      tenant: p.companyId,
+      packId: p.packId,
+      window,
+      runs: rows.map((r) => runSummaryOf(r, tallies)),
+      truncated: rows.length >= window.runCap,
+    };
+  }
+
+  /**
+   * The tenant's packs that DECLARED an `indexer` descriptor, capped and
+   * ordered so the response is stable across calls.
+   */
+  private async declaredIndexers(companyId: string): Promise<IndexerBinding[]> {
+    const bindings = await this.router.bindingsFor(companyId);
+    return bindings
+      .filter((b) => b.declared === true)
+      .sort((a, b) => a.indexerId.localeCompare(b.indexerId))
+      .slice(0, MAX_INDEXERS);
+  }
+
+  /**
+   * Recent runs per pack. Deliberately ONE capped query per pack rather
+   * than a single `packId INSIDE […]` scan: a shared cap lets one busy
+   * indexer crowd every other one out of the window and silently skew
+   * their aggregates.
+   */
+  private async runsByPack(
+    companyId: string,
+    packIds: string[],
+    window: IndexerWindow,
+  ): Promise<Map<string, OperatorRunRow[]>> {
+    const out = new Map<string, OperatorRunRow[]>();
+    if (packIds.length === 0) return out;
+    await this.surreal.withCompany(companyId, async (db) => {
+      for (const packId of packIds) {
+        const rows = await queryRows<OperatorRunRow>(
+          db,
+          `SELECT id, docId, packId, packVersion, status, external,
+                  createdAt, finishedAt, claimedAt, stats, error
+             FROM indexer_run
+             WHERE packId = $pack
+               AND createdAt >= time::now() - duration::from_millis($windowMs)
+             ORDER BY createdAt DESC
+             LIMIT ${window.runCap}`,
+          { pack: packId, windowMs: window.days * DAY_MS },
+        );
+        out.set(packId, rows);
+      }
+    });
+    return out;
+  }
+
+  /** runId → candidate status tallies, over a bounded id set. */
+  private async candidateTallies(
+    companyId: string,
+    runIds: unknown[],
+  ): Promise<Map<string, IndexerCandidateTotals>> {
+    const out = new Map<string, IndexerCandidateTotals>();
+    if (runIds.length === 0) return out;
+    await this.surreal.withCompany(companyId, async (db) => {
+      for (let i = 0; i < runIds.length; i += CANDIDATE_ID_BATCH) {
+        const batch = runIds.slice(i, i + CANDIDATE_ID_BATCH);
+        const rows = await queryRows<CandidateTallyRow>(
+          db,
+          `SELECT runId, status, count() AS n FROM candidate
+             WHERE runId INSIDE $ids
+             GROUP BY runId, status`,
+          { ids: batch },
+        );
+        for (const r of rows) {
+          const key = String(r.runId ?? '');
+          if (key === '') continue;
+          const totals = out.get(key) ?? emptyCandidateTotals();
+          addCandidateStatus(totals, String(r.status ?? ''), toCount(r.n));
+          out.set(key, totals);
+        }
+      }
+    });
+    return out;
+  }
+}
+
+/** Everything an overview row needs beyond its binding and its runs. */
+interface OverviewContext {
+  tallies: Map<string, IndexerCandidateTotals>;
+  runCap: number;
+}
+
+function overviewOf(
+  b: IndexerBinding,
+  rows: OperatorRunRow[],
+  ctx: OverviewContext,
+): IndexerOverview {
+  const { tallies } = ctx;
+  const runs = emptyRunTotals();
+  const candidates = emptyCandidateTotals();
+  for (const r of rows) {
+    addRunStatus(runs, String(r.status ?? ''));
+    mergeCandidateTotals(candidates, tallies.get(String(r.id)) ?? emptyCandidateTotals());
+  }
+  const first = rows[0];
+  return {
+    packId: b.indexerId,
+    packVersion: b.packVersion,
+    mode: b.mode,
+    source: b.source ?? 'builtin',
+    description: b.description,
+    installedAt: b.installedAt ? b.installedAt.toISOString() : null,
+    lastRun: first ? runSummaryOf(first, tallies) : null,
+    runs,
+    candidates,
+    external: b.mode === 'external' ? externalHealthOf(b, rows) : null,
+    truncated: rows.length >= ctx.runCap,
+  };
+}
+
+/**
+ * External-publisher liveness from the ledger alone. There is no poll
+ * journal, so the newest `claimedAt` in the window is the honest proxy
+ * for "the publisher is alive"; a growing unclaimed backlog with a stale
+ * (or absent) claim is what "the publisher stopped polling" looks like.
+ */
+function externalHealthOf(b: IndexerBinding, rows: OperatorRunRow[]): IndexerExternalHealth {
+  let lastClaimMs: number | null = null;
+  let pendingWork = 0;
+  let oldestPendingMs: number | null = null;
+  for (const r of rows) {
+    if (r.external !== true) continue;
+    const claimed = toMillis(r.claimedAt);
+    if (claimed !== null && (lastClaimMs === null || claimed > lastClaimMs)) lastClaimMs = claimed;
+    if (String(r.status ?? '') !== 'pending') continue;
+    pendingWork += 1;
+    const created = toMillis(r.createdAt);
+    if (created !== null && (oldestPendingMs === null || created < oldestPendingMs)) {
+      oldestPendingMs = created;
+    }
+  }
+  const publisher = b.external?.publisher;
+  return {
+    publisher: publisher !== undefined && publisher !== '' ? publisher : null,
+    pendingWork,
+    oldestPendingAt: oldestPendingMs === null ? null : new Date(oldestPendingMs).toISOString(),
+    lastClaimAt: lastClaimMs === null ? null : new Date(lastClaimMs).toISOString(),
+    polledRecently:
+      lastClaimMs !== null && Date.now() - lastClaimMs <= POLLED_WITHIN_HOURS * 3_600_000,
+    polledWithinHours: POLLED_WITHIN_HOURS,
+  };
+}
+
+function runSummaryOf(
+  r: OperatorRunRow,
+  tallies: Map<string, IndexerCandidateTotals>,
+): IndexerRunSummary {
+  const startedMs = toMillis(r.createdAt);
+  const finishedMs = toMillis(r.finishedAt);
+  return {
+    runId: String(r.id),
+    documentId: String(r.docId ?? ''),
+    packVersion: String(r.packVersion ?? ''),
+    status: String(r.status ?? ''),
+    external: r.external === true,
+    startedAt: startedMs === null ? '' : new Date(startedMs).toISOString(),
+    finishedAt: finishedMs === null ? null : new Date(finishedMs).toISOString(),
+    stats: statsOf(r.stats),
+    error: errorOf(r.error),
+    candidates: tallies.get(String(r.id)) ?? emptyCandidateTotals(),
+  };
+}
+
+/** `stats` is a FLEXIBLE object — TS owns the shape, so read defensively. */
+function statsOf(v: unknown): IndexerRunStats | null {
+  if (!v || typeof v !== 'object') return null;
+  const o = v as Record<string, unknown>;
+  return {
+    chunks: toCount(o.chunks),
+    entities: toCount(o.entities),
+    facts: toCount(o.facts),
+    relations: toCount(o.relations),
+    durationMs: toCount(o.durationMs),
+  };
+}
+
+function errorOf(v: unknown): string | null {
+  if (!v || typeof v !== 'object') return null;
+  const msg = (v as Record<string, unknown>).message;
+  if (msg === undefined || msg === null) return null;
+  const text = String(msg).slice(0, ERROR_MAX_CHARS);
+  return text === '' ? null : text;
+}
+
+function emptyRunTotals(): IndexerRunTotals {
+  return { total: 0, pending: 0, running: 0, succeeded: 0, failed: 0, skipped: 0 };
+}
+
+function addRunStatus(t: IndexerRunTotals, status: string): void {
+  t.total += 1;
+  if (status === 'pending') t.pending += 1;
+  else if (status === 'running') t.running += 1;
+  else if (status === 'succeeded') t.succeeded += 1;
+  else if (status === 'failed') t.failed += 1;
+  else if (status === 'skipped') t.skipped += 1;
+}
+
+function emptyCandidateTotals(): IndexerCandidateTotals {
+  return {
+    submitted: 0,
+    pending: 0,
+    committed: 0,
+    merged: 0,
+    duplicate: 0,
+    rejected: 0,
+    expired: 0,
+  };
+}
+
+function addCandidateStatus(t: IndexerCandidateTotals, status: string, n: number): void {
+  t.submitted += n;
+  if (status === 'pending') t.pending += n;
+  else if (status === 'committed') t.committed += n;
+  else if (status === 'merged') t.merged += n;
+  else if (status === 'duplicate') t.duplicate += n;
+  else if (status === 'rejected') t.rejected += n;
+  else if (status === 'expired') t.expired += n;
+}
+
+function mergeCandidateTotals(into: IndexerCandidateTotals, from: IndexerCandidateTotals): void {
+  into.submitted += from.submitted;
+  into.pending += from.pending;
+  into.committed += from.committed;
+  into.merged += from.merged;
+  into.duplicate += from.duplicate;
+  into.rejected += from.rejected;
+  into.expired += from.expired;
+}
+
+/** The one place the window/cap bounds are decided. */
+export function makeWindow(days: number | undefined, runCap: number): IndexerWindow {
+  const d = clamp(days, DEFAULT_WINDOW_DAYS, MAX_WINDOW_DAYS);
+  return { since: new Date(Date.now() - d * DAY_MS).toISOString(), days: d, runCap };
+}
+
+function clamp(v: number | undefined, fallback: number, max: number): number {
+  if (v === undefined || !Number.isFinite(v) || v <= 0) return fallback;
+  return Math.min(Math.floor(v), max);
+}
+
+function toCount(v: unknown): number {
+  const n = Number(v);
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : 0;
+}
+
+function toMillis(v: unknown): number | null {
+  if (v === undefined || v === null) return null;
+  const ms = new Date(String(v)).getTime();
+  return Number.isNaN(ms) ? null : ms;
+}

--- a/src/indexers/indexer-router.service.ts
+++ b/src/indexers/indexer-router.service.ts
@@ -39,20 +39,30 @@ export class IndexerRouterService {
 
   /** All indexer bindings for a tenant: builtin + active installed packs. */
   async bindingsFor(companyId: string): Promise<IndexerBinding[]> {
-    const manifests = [...BUILTIN_PACKS, ...(await this.installedManifests(companyId))];
+    const installed = await this.installedPacks(companyId);
+    const entries: InstalledPack[] = [
+      ...BUILTIN_PACKS.map((m) => ({ manifest: m, source: 'builtin' as const })),
+      ...installed,
+    ];
     const seen = new Set<string>();
     const bindings: IndexerBinding[] = [];
-    for (const m of manifests) {
+    for (const e of entries) {
+      const m = e.manifest;
       if (seen.has(m.id)) continue;
       seen.add(m.id);
       bindings.push({
         indexerId: m.id,
-        packVersion: m.version,
+        // An installed row's own `version` column is the tenant's
+        // effective version; the embedded manifest is its mirror.
+        packVersion: e.version ?? m.version,
         mode: m.indexer?.mode ?? 'virtual',
         description: m.description,
         relevance: m.indexer?.relevance,
         dedicated: m.indexer?.dedicated,
         external: m.indexer?.external,
+        source: e.source,
+        installedAt: e.installedAt,
+        declared: m.indexer !== undefined,
       });
     }
     return bindings;
@@ -122,14 +132,22 @@ export class IndexerRouterService {
     return matched.sort((a, b) => b.sim - a.sim).map((m) => m.binding);
   }
 
-  private async installedManifests(companyId: string): Promise<DomainPackManifest[]> {
+  private async installedPacks(companyId: string): Promise<InstalledPack[]> {
     try {
       return await this.surreal.withCompany(companyId, async (db) => {
-        const rows = await queryRows<{ manifest: DomainPackManifest }>(
-          db,
-          `SELECT manifest FROM domain_pack WHERE status = 'active'`,
-        );
-        return rows.map((r) => r.manifest).filter(Boolean);
+        const rows = await queryRows<{
+          manifest: DomainPackManifest;
+          version?: unknown;
+          installedAt?: unknown;
+        }>(db, `SELECT manifest, version, installedAt FROM domain_pack WHERE status = 'active'`);
+        return rows
+          .filter((r) => Boolean(r.manifest))
+          .map((r) => ({
+            manifest: r.manifest,
+            source: 'installed' as const,
+            version: r.version === undefined || r.version === null ? undefined : String(r.version),
+            installedAt: toDate(r.installedAt),
+          }));
       });
     } catch (e) {
       this.logger.warn(
@@ -138,6 +156,20 @@ export class IndexerRouterService {
       return [];
     }
   }
+}
+
+/** A manifest plus where it came from (builtin bundle vs domain_pack row). */
+interface InstalledPack {
+  manifest: DomainPackManifest;
+  source: 'builtin' | 'installed';
+  version?: string | undefined;
+  installedAt?: Date | undefined;
+}
+
+function toDate(v: unknown): Date | undefined {
+  if (v === undefined || v === null) return undefined;
+  const d = new Date(String(v));
+  return Number.isNaN(d.getTime()) ? undefined : d;
 }
 
 /** Upper bound on dedicated indexers per document — the LLM-call fan-out is

--- a/src/indexers/routing.ts
+++ b/src/indexers/routing.ts
@@ -17,6 +17,19 @@ export interface IndexerBinding {
   relevance?: IndexerRelevance | undefined;
   dedicated?: IndexerDescriptor['dedicated'] | undefined;
   external?: IndexerDescriptor['external'] | undefined;
+  /**
+   * Provenance of the binding — inert for routing (the layers below never
+   * read these), carried for the operator view (`/v1/admin/indexers`),
+   * which must distinguish "ships with the service" from "this tenant
+   * installed it" and must list ONLY packs that actually declared an
+   * `indexer` descriptor (an absent descriptor reads as 'virtual', which
+   * is a routing default, not an operator's statement of intent).
+   */
+  source?: 'builtin' | 'installed' | undefined;
+  /** Install timestamp of the domain_pack row; absent for builtins. */
+  installedAt?: Date | undefined;
+  /** true = the manifest carried an explicit `indexer` descriptor. */
+  declared?: boolean | undefined;
 }
 
 export interface RoutingInput {

--- a/test/indexer-operator-view.e2e-spec.ts
+++ b/test/indexer-operator-view.e2e-spec.ts
@@ -1,0 +1,197 @@
+/**
+ * E2E for the read-only operator view over installed indexers
+ * (GET /v1/admin/indexers, INDEXER_OPERATOR_VIEW_ENABLED) — end to end on
+ * a real DB, mirroring the sibling indexer/document suites.
+ *
+ * Proves the gap it closes: ingest routes a document to the builtin
+ * external pack (code_memory), the run ledger records it, and an OPERATOR
+ * — not the poller — can see which indexers the tenant has, what their
+ * last run did, and whether the external publisher is polling. Also pins
+ * the fences: 404 while the flag is off, a pack with no `indexer`
+ * descriptor absent from the list, and an unknown pack 404 on the detail
+ * route.
+ */
+import { AppFixture, createApp } from './app-fixture';
+
+const PLAIN_MANIFEST = {
+  id: 'medical',
+  version: '1.0.0',
+  // No `indexer` descriptor: this pack rides the union pass and has no
+  // run ledger of its own, so the operator view must NOT list it.
+  description: 'Medical domain ontology (test pack, no indexer descriptor).',
+  predicates: [
+    {
+      localId: 'diagnosis',
+      displayLabel: 'diagnosis',
+      description: 'TYPE subject is a patient; value is a diagnosis',
+      datatype: 'string',
+      semantics: 'append_only',
+      decayHalfLifeDays: null,
+      piiClass: 'sensitive',
+      status: 'active',
+    },
+  ],
+};
+
+interface Overview {
+  packId: string;
+  packVersion: string;
+  mode: string;
+  source: string;
+  lastRun: { runId: string; status: string; documentId: string } | null;
+  runs: { total: number; pending: number; succeeded: number; failed: number };
+  candidates: { submitted: number; committed: number; rejected: number };
+  external: {
+    publisher: string | null;
+    pendingWork: number;
+    oldestPendingAt: string | null;
+    lastClaimAt: string | null;
+    polledRecently: boolean;
+  } | null;
+  truncated: boolean;
+}
+
+describe('indexer operator view (e2e)', () => {
+  let f: AppFixture;
+  const auth = () => ({ Authorization: `Bearer ${f.apiKey}` });
+
+  const DOC_TEXT =
+    'Decision log for src/router.ts: the relevance router gates dedicated ' +
+    'indexer runs so pack fan-out cannot blow the LLM budget.';
+
+  beforeAll(async () => {
+    f = await createApp({
+      companyId: 'co_indexer_operator_e2e',
+      scopes: ['brain:read', 'brain:write', 'brain:admin', 'brain:read_pii', 'indexer:write'],
+    });
+    process.env.DOCUMENT_INGEST_ENABLED = '1';
+    // External work items are produced by the multi-indexer router.
+    process.env.DOCUMENT_MULTI_INDEXER_ENABLED = '1';
+  });
+
+  afterAll(async () => {
+    delete process.env.DOCUMENT_INGEST_ENABLED;
+    delete process.env.DOCUMENT_MULTI_INDEXER_ENABLED;
+    delete process.env.INDEXER_OPERATOR_VIEW_ENABLED;
+    if (f) await f.close();
+  });
+
+  async function view(query = ''): Promise<Overview[]> {
+    const r = await f.http.get(`/v1/admin/indexers${query}`).set(auth());
+    expect(r.status).toBe(200);
+    return r.body.indexers as Overview[];
+  }
+
+  it('404s both routes while the flag is off', async () => {
+    delete process.env.INDEXER_OPERATOR_VIEW_ENABLED;
+    expect((await f.http.get('/v1/admin/indexers').set(auth())).status).toBe(404);
+    expect((await f.http.get('/v1/admin/indexers/code_memory/runs').set(auth())).status).toBe(404);
+  });
+
+  it('lists the tenant’s declared indexers once the flag is on', async () => {
+    process.env.INDEXER_OPERATOR_VIEW_ENABLED = '1';
+    const r = await f.http.get('/v1/admin/indexers').set(auth());
+    expect(r.status).toBe(200);
+    expect(r.body.tenant).toBe('co_indexer_operator_e2e');
+    expect(r.body.window).toMatchObject({ days: 7, runCap: 50 });
+    expect(typeof r.body.window.since).toBe('string');
+
+    const code = (r.body.indexers as Overview[]).find((i) => i.packId === 'code_memory');
+    expect(code).toBeDefined();
+    expect(code?.mode).toBe('external');
+    expect(code?.source).toBe('builtin');
+    expect(code?.packVersion.length).toBeGreaterThan(0);
+    // An idle indexer is still listed — with an empty ledger, not absent.
+    expect(code?.external).not.toBeNull();
+    expect(code?.truncated).toBe(false);
+  });
+
+  it('omits an installed pack that declares no indexer descriptor', async () => {
+    process.env.INDEXER_OPERATOR_VIEW_ENABLED = '1';
+    const install = await f.http
+      .post('/v1/admin/packs')
+      .set(auth())
+      .send({ manifest: PLAIN_MANIFEST });
+    expect([200, 201]).toContain(install.status);
+
+    const packs = await view();
+    expect(packs.map((i) => i.packId)).toContain('code_memory');
+    expect(packs.map((i) => i.packId)).not.toContain('medical');
+  });
+
+  it('surfaces the run ledger and publisher liveness for an external pack', async () => {
+    process.env.INDEXER_OPERATOR_VIEW_ENABLED = '1';
+    f.extractor.setScript({ entities: [], facts: [], edges: [] });
+    const ingest = await f.http
+      .post('/v1/ingest/document')
+      .set(auth())
+      .send({
+        kind: 'markdown',
+        text: DOC_TEXT,
+        occurredAt: '2026-07-01T10:00:00.000Z',
+        contextRef: { vertical: 'operator_e2e' },
+        indexers: ['code_memory'],
+      });
+    expect(ingest.status).toBe(201);
+    const documentId = ingest.body.documentId as string;
+
+    const before = (await view()).find((i) => i.packId === 'code_memory');
+    expect(before?.runs.total).toBeGreaterThanOrEqual(1);
+    expect(before?.runs.pending).toBeGreaterThanOrEqual(1);
+    expect(before?.lastRun).not.toBeNull();
+    expect(before?.lastRun?.documentId).toBe(documentId);
+    expect(before?.lastRun?.status).toBe('pending');
+    // Unclaimed work with no claim ever seen = the publisher is not polling.
+    expect(before?.external?.pendingWork).toBeGreaterThanOrEqual(1);
+    expect(before?.external?.oldestPendingAt).not.toBeNull();
+    expect(before?.external?.lastClaimAt).toBeNull();
+    expect(before?.external?.polledRecently).toBe(false);
+
+    // The publisher polls and claims — the operator view must notice.
+    const work = await f.http.get('/v1/indexer/work?packId=code_memory').set(auth());
+    expect(work.status).toBe(200);
+    const item = (work.body.work as Array<{ runId: string; documentId: string }>).find(
+      (w) => w.documentId === documentId,
+    );
+    expect(item).toBeDefined();
+    const claim = await f.http
+      .post(`/v1/indexer/work/${encodeURIComponent(item!.runId)}/claim`)
+      .set(auth());
+    expect(claim.status).toBe(201);
+
+    const after = (await view()).find((i) => i.packId === 'code_memory');
+    expect(after?.external?.lastClaimAt).not.toBeNull();
+    expect(after?.external?.polledRecently).toBe(true);
+    expect(after?.runs.total).toBeGreaterThanOrEqual(1);
+    expect(after?.lastRun?.status).toBe('running');
+  });
+
+  it('lists recent runs of one indexer and clamps the window', async () => {
+    process.env.INDEXER_OPERATOR_VIEW_ENABLED = '1';
+    const r = await f.http
+      .get('/v1/admin/indexers/code_memory/runs?days=9999&limit=9999')
+      .set(auth());
+    expect(r.status).toBe(200);
+    expect(r.body.packId).toBe('code_memory');
+    expect(r.body.window).toMatchObject({ days: 90, runCap: 200 });
+    expect(Array.isArray(r.body.runs)).toBe(true);
+    expect(r.body.runs.length).toBeGreaterThanOrEqual(1);
+    expect(r.body.truncated).toBe(false);
+    const run = r.body.runs[0] as { runId: string; packVersion: string; candidates: unknown };
+    expect(typeof run.runId).toBe('string');
+    expect(typeof run.packVersion).toBe('string');
+    expect(run.candidates).toMatchObject({ submitted: expect.any(Number) });
+  });
+
+  it('404s the detail route for a pack that is not a declared indexer', async () => {
+    process.env.INDEXER_OPERATOR_VIEW_ENABLED = '1';
+    expect((await f.http.get('/v1/admin/indexers/medical/runs').set(auth())).status).toBe(404);
+    expect((await f.http.get('/v1/admin/indexers/nope/runs').set(auth())).status).toBe(404);
+  });
+
+  it('denies a plain admin asking for another tenant', async () => {
+    process.env.INDEXER_OPERATOR_VIEW_ENABLED = '1';
+    const r = await f.http.get('/v1/admin/indexers?tenant=co_someone_else').set(auth());
+    expect(r.status).toBe(403);
+  });
+});

--- a/test/indexer-operator-view.unit-spec.ts
+++ b/test/indexer-operator-view.unit-spec.ts
@@ -1,0 +1,412 @@
+/**
+ * The read-only operator view over installed indexers
+ * (GET /v1/admin/indexers, INDEXER_OPERATOR_VIEW_ENABLED).
+ *
+ * Covers: the wire contracts, the "declared descriptor or absent" rule,
+ * aggregates computed from fixture ledger rows, the window/row caps, the
+ * tenant fence (both the controller's resolvePlatformTenant seam and the
+ * service's withCompany seam), and flag-off 404.
+ */
+import { ForbiddenException, NotFoundException } from '@nestjs/common';
+import { IndexerOperatorService } from '../src/documents/indexer-operator.service';
+import { IndexerAdminController } from '../src/documents/indexer-admin.controller';
+import type { IndexerRouterService } from '../src/indexers/indexer-router.service';
+import type { IndexerBinding } from '../src/indexers/routing';
+import type { SurrealService } from '../src/db/surreal.service';
+import type { ApiKeyService } from '../src/auth/api-key.service';
+import type { AuthenticatedRequest } from '../src/auth/api-key.types';
+import {
+  IndexerOverviewListResponseSchema,
+  IndexerRunListResponseSchema,
+} from '../src/contracts/indexer/indexer-operator.schema';
+
+const FLAG = 'INDEXER_OPERATOR_VIEW_ENABLED';
+const HOUR = 3_600_000;
+
+function binding(over: Partial<IndexerBinding> & { indexerId: string }): IndexerBinding {
+  return {
+    packVersion: '1.0.0',
+    mode: 'dedicated',
+    description: 'a pack',
+    source: 'installed',
+    declared: true,
+    ...over,
+  };
+}
+
+/** Two dedicated packs, one external pack, one pack with NO descriptor. */
+const BINDINGS: IndexerBinding[] = [
+  binding({ indexerId: 'legal', installedAt: new Date('2026-01-02T03:04:05.000Z') }),
+  binding({
+    indexerId: 'remote',
+    mode: 'external',
+    external: { publisher: 'acme' },
+    source: 'builtin',
+  }),
+  binding({ indexerId: 'core', source: 'builtin', declared: false }),
+];
+
+interface FakeDb {
+  query: (sql: string, vars?: Record<string, unknown>) => Promise<unknown[]>;
+}
+
+interface Recorded {
+  tenants: string[];
+  sql: string[];
+}
+
+/** Fixture ledger: run rows per pack + candidate tallies per run id. */
+function makeService(p: {
+  runs?: Record<string, Array<Record<string, unknown>>>;
+  candidates?: Array<{ runId: string; status: string; n: number }>;
+  bindings?: IndexerBinding[];
+}): { svc: IndexerOperatorService; rec: Recorded } {
+  const rec: Recorded = { tenants: [], sql: [] };
+  const db: FakeDb = {
+    query: async (sql, vars) => {
+      rec.sql.push(sql);
+      if (sql.includes('FROM indexer_run')) {
+        return [p.runs?.[String(vars?.pack)] ?? []];
+      }
+      const ids = new Set((vars?.ids as unknown[] | undefined)?.map(String) ?? []);
+      return [(p.candidates ?? []).filter((c) => ids.has(c.runId))];
+    },
+  };
+  const surreal = {
+    withCompany: async <T>(companyId: string, fn: (db: FakeDb) => Promise<T>): Promise<T> => {
+      rec.tenants.push(companyId);
+      return fn(db);
+    },
+  } as unknown as SurrealService;
+  const router = {
+    bindingsFor: () => Promise.resolve(p.bindings ?? BINDINGS),
+  } as unknown as IndexerRouterService;
+  return { svc: new IndexerOperatorService(surreal, router), rec };
+}
+
+function makeController(svc: IndexerOperatorService): IndexerAdminController {
+  const apiKeys = { knownCompanyIds: () => ['co_test', 'co_other'] } as unknown as ApiKeyService;
+  return new IndexerAdminController(svc, apiKeys);
+}
+
+function req(scopes: string[] = ['brain:admin']): AuthenticatedRequest {
+  return { brainAuth: { companyId: 'co_test', scopes } } as unknown as AuthenticatedRequest;
+}
+
+describe('IndexerOperatorService.listIndexers()', () => {
+  it('matches IndexerOverviewListResponseSchema', async () => {
+    const { svc } = makeService({
+      runs: {
+        legal: [
+          {
+            id: 'indexer_run:r1',
+            docId: 'source_document:d1',
+            packId: 'legal',
+            packVersion: '1.0.0',
+            status: 'succeeded',
+            external: false,
+            createdAt: '2026-09-01T00:00:00.000Z',
+            finishedAt: '2026-09-01T00:00:09.000Z',
+            stats: { chunks: 2, entities: 5, facts: 7, relations: 1, durationMs: 9000 },
+          },
+        ],
+      },
+      candidates: [{ runId: 'indexer_run:r1', status: 'committed', n: 7 }],
+    });
+    const parsed = IndexerOverviewListResponseSchema.safeParse(
+      await svc.listIndexers({ companyId: 'co_test' }),
+    );
+    if (!parsed.success) {
+      throw new Error(`operator view drifted: ${JSON.stringify(parsed.error.issues, null, 2)}`);
+    }
+  });
+
+  it('omits a pack that declared no indexer descriptor', async () => {
+    const { svc } = makeService({});
+    const out = await svc.listIndexers({ companyId: 'co_test' });
+    expect(out.indexers.map((i) => i.packId)).toEqual(['legal', 'remote']);
+  });
+
+  it('computes run and candidate aggregates from the ledger rows', async () => {
+    const { svc } = makeService({
+      runs: {
+        legal: [
+          {
+            id: 'indexer_run:r2',
+            docId: 'source_document:d2',
+            packId: 'legal',
+            packVersion: '1.0.0',
+            status: 'failed',
+            createdAt: '2026-09-02T00:00:00.000Z',
+            finishedAt: '2026-09-02T00:00:01.000Z',
+            error: { message: 'boom' },
+          },
+          {
+            id: 'indexer_run:r1',
+            docId: 'source_document:d1',
+            packId: 'legal',
+            packVersion: '1.0.0',
+            status: 'succeeded',
+            createdAt: '2026-09-01T00:00:00.000Z',
+          },
+          {
+            id: 'indexer_run:r0',
+            docId: 'source_document:d0',
+            packId: 'legal',
+            packVersion: '0.9.0',
+            status: 'skipped',
+            createdAt: '2026-08-31T00:00:00.000Z',
+          },
+        ],
+      },
+      candidates: [
+        { runId: 'indexer_run:r1', status: 'committed', n: 4 },
+        { runId: 'indexer_run:r1', status: 'rejected', n: 1 },
+        { runId: 'indexer_run:r2', status: 'pending', n: 2 },
+        // Belongs to another indexer's run — must not land in these tallies.
+        { runId: 'indexer_run:zz', status: 'committed', n: 99 },
+      ],
+    });
+    const out = await svc.listIndexers({ companyId: 'co_test' });
+    const legal = out.indexers.find((i) => i.packId === 'legal');
+    expect(legal?.runs).toEqual({
+      total: 3,
+      pending: 0,
+      running: 0,
+      succeeded: 1,
+      failed: 1,
+      skipped: 1,
+    });
+    expect(legal?.candidates).toEqual({
+      submitted: 7,
+      pending: 2,
+      committed: 4,
+      merged: 0,
+      duplicate: 0,
+      rejected: 1,
+      expired: 0,
+    });
+    // Newest first — the ledger query orders DESC, the view keeps it.
+    expect(legal?.lastRun?.runId).toBe('indexer_run:r2');
+    expect(legal?.lastRun?.error).toBe('boom');
+    expect(legal?.lastRun?.candidates.pending).toBe(2);
+    expect(legal?.installedAt).toBe('2026-01-02T03:04:05.000Z');
+    expect(legal?.source).toBe('installed');
+    // A non-external indexer carries no publisher health.
+    expect(legal?.external).toBeNull();
+  });
+
+  it('reports external publisher liveness from the claim ledger', async () => {
+    const now = Date.now();
+    const { svc } = makeService({
+      runs: {
+        remote: [
+          {
+            id: 'indexer_run:x2',
+            docId: 'source_document:d9',
+            packId: 'remote',
+            packVersion: '1.0.0',
+            status: 'pending',
+            external: true,
+            createdAt: new Date(now - 2 * HOUR).toISOString(),
+          },
+          {
+            id: 'indexer_run:x1',
+            docId: 'source_document:d8',
+            packId: 'remote',
+            packVersion: '1.0.0',
+            status: 'pending',
+            external: true,
+            createdAt: new Date(now - 30 * HOUR).toISOString(),
+          },
+          {
+            id: 'indexer_run:x0',
+            docId: 'source_document:d7',
+            packId: 'remote',
+            packVersion: '1.0.0',
+            status: 'succeeded',
+            external: true,
+            createdAt: new Date(now - 40 * HOUR).toISOString(),
+            claimedAt: new Date(now - 3 * HOUR).toISOString(),
+          },
+        ],
+      },
+    });
+    const out = await svc.listIndexers({ companyId: 'co_test' });
+    const remote = out.indexers.find((i) => i.packId === 'remote');
+    expect(remote?.external?.publisher).toBe('acme');
+    expect(remote?.external?.pendingWork).toBe(2);
+    expect(remote?.external?.oldestPendingAt).toBe(new Date(now - 30 * HOUR).toISOString());
+    expect(remote?.external?.lastClaimAt).toBe(new Date(now - 3 * HOUR).toISOString());
+    expect(remote?.external?.polledRecently).toBe(true);
+  });
+
+  it('reads a publisher that never claimed as not polling', async () => {
+    const { svc } = makeService({
+      runs: {
+        remote: [
+          {
+            id: 'indexer_run:x1',
+            docId: 'source_document:d8',
+            packId: 'remote',
+            packVersion: '1.0.0',
+            status: 'pending',
+            external: true,
+            createdAt: new Date(Date.now() - 5 * HOUR).toISOString(),
+          },
+        ],
+      },
+    });
+    const out = await svc.listIndexers({ companyId: 'co_test' });
+    const remote = out.indexers.find((i) => i.packId === 'remote');
+    expect(remote?.external?.lastClaimAt).toBeNull();
+    expect(remote?.external?.polledRecently).toBe(false);
+  });
+
+  it('clamps the window and the per-indexer row cap', async () => {
+    const { svc, rec } = makeService({});
+    const wide = await svc.listIndexers({ companyId: 'co_test', days: 9999, runCap: 9999 });
+    expect(wide.window.days).toBe(90);
+    expect(wide.window.runCap).toBe(200);
+    expect(rec.sql.some((s) => s.includes('LIMIT 200'))).toBe(true);
+
+    const dflt = await svc.listIndexers({ companyId: 'co_test' });
+    expect(dflt.window.days).toBe(7);
+    expect(dflt.window.runCap).toBe(50);
+
+    const junk = await svc.listIndexers({ companyId: 'co_test', days: -3, runCap: 0 });
+    expect(junk.window.days).toBe(7);
+    expect(junk.window.runCap).toBe(50);
+  });
+
+  it('flags a truncated indexer when the row cap bites', async () => {
+    const rows = Array.from({ length: 3 }, (_, i) => ({
+      id: `indexer_run:r${i}`,
+      docId: 'source_document:d1',
+      packId: 'legal',
+      packVersion: '1.0.0',
+      status: 'succeeded',
+      createdAt: '2026-09-01T00:00:00.000Z',
+    }));
+    const { svc } = makeService({ runs: { legal: rows } });
+    const out = await svc.listIndexers({ companyId: 'co_test', runCap: 3 });
+    expect(out.indexers.find((i) => i.packId === 'legal')?.truncated).toBe(true);
+    expect(out.indexers.find((i) => i.packId === 'remote')?.truncated).toBe(false);
+  });
+
+  it('reads only the requested tenant (no cross-tenant fan-out)', async () => {
+    const { svc, rec } = makeService({
+      runs: {
+        legal: [
+          {
+            id: 'indexer_run:r1',
+            docId: 'source_document:d1',
+            packId: 'legal',
+            packVersion: '1.0.0',
+            status: 'succeeded',
+            createdAt: '2026-09-01T00:00:00.000Z',
+          },
+        ],
+      },
+      candidates: [{ runId: 'indexer_run:r1', status: 'committed', n: 1 }],
+    });
+    await svc.listIndexers({ companyId: 'co_test' });
+    expect(new Set(rec.tenants)).toEqual(new Set(['co_test']));
+  });
+});
+
+describe('IndexerOperatorService.listRuns()', () => {
+  it('matches IndexerRunListResponseSchema', async () => {
+    const { svc } = makeService({
+      runs: {
+        legal: [
+          {
+            id: 'indexer_run:r1',
+            docId: 'source_document:d1',
+            packId: 'legal',
+            packVersion: '1.0.0',
+            status: 'succeeded',
+            createdAt: '2026-09-01T00:00:00.000Z',
+            finishedAt: '2026-09-01T00:00:09.000Z',
+            stats: { chunks: 2, entities: 5, facts: 7, relations: 1, durationMs: 9000 },
+          },
+        ],
+      },
+      candidates: [{ runId: 'indexer_run:r1', status: 'merged', n: 3 }],
+    });
+    const out = await svc.listRuns({ companyId: 'co_test', packId: 'legal' });
+    const parsed = IndexerRunListResponseSchema.safeParse(out);
+    if (!parsed.success) {
+      throw new Error(`run list drifted: ${JSON.stringify(parsed.error.issues, null, 2)}`);
+    }
+    expect(out.runs[0]?.candidates.merged).toBe(3);
+    expect(out.runs[0]?.stats?.facts).toBe(7);
+  });
+
+  it('404s for a pack that is not a declared indexer of this tenant', async () => {
+    const { svc } = makeService({});
+    await expect(svc.listRuns({ companyId: 'co_test', packId: 'core' })).rejects.toBeInstanceOf(
+      NotFoundException,
+    );
+    await expect(svc.listRuns({ companyId: 'co_test', packId: 'nope' })).rejects.toBeInstanceOf(
+      NotFoundException,
+    );
+  });
+
+  it('clamps the detail limit', async () => {
+    const { svc, rec } = makeService({});
+    const out = await svc.listRuns({ companyId: 'co_test', packId: 'legal', limit: 9999 });
+    expect(out.window.runCap).toBe(200);
+    expect(rec.sql.some((s) => s.includes('LIMIT 200'))).toBe(true);
+  });
+});
+
+describe('IndexerAdminController — gate and tenant fence', () => {
+  const original = process.env[FLAG];
+  afterEach(() => {
+    if (original === undefined) delete process.env[FLAG];
+    else process.env[FLAG] = original;
+  });
+
+  it('404s both routes while the flag is off', async () => {
+    delete process.env[FLAG];
+    const { svc } = makeService({});
+    const c = makeController(svc);
+    await expect(c.list(req())).rejects.toBeInstanceOf(NotFoundException);
+    await expect(c.runs(req(), 'legal')).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('serves both routes once the flag is on', async () => {
+    process.env[FLAG] = '1';
+    const { svc } = makeService({});
+    const c = makeController(svc);
+    await expect(c.list(req())).resolves.toMatchObject({ tenant: 'co_test' });
+    await expect(c.runs(req(), 'legal')).resolves.toMatchObject({ packId: 'legal' });
+  });
+
+  it('denies a plain admin asking for another tenant', async () => {
+    process.env[FLAG] = '1';
+    const { svc, rec } = makeService({});
+    const c = makeController(svc);
+    await expect(c.list(req(), { tenant: 'co_other' })).rejects.toBeInstanceOf(ForbiddenException);
+    await expect(c.runs(req(), 'legal', { tenant: 'co_other' })).rejects.toBeInstanceOf(
+      ForbiddenException,
+    );
+    expect(rec.tenants).toEqual([]);
+  });
+
+  it('passes the caller’s own tenant through unchanged', async () => {
+    process.env[FLAG] = '1';
+    const { svc } = makeService({});
+    const out = await makeController(svc).list(req(), { tenant: 'co_test' });
+    expect(out.tenant).toBe('co_test');
+  });
+
+  it('ignores unparsable query numbers instead of failing', async () => {
+    process.env[FLAG] = '1';
+    const { svc } = makeService({});
+    const out = await makeController(svc).list(req(), { days: 'abc', runCap: 'xyz' });
+    expect(out.window.days).toBe(7);
+    expect(out.window.runCap).toBe(50);
+  });
+});

--- a/test/openapi-doc.unit-spec.ts
+++ b/test/openapi-doc.unit-spec.ts
@@ -68,6 +68,9 @@ const PLATFORM_OPERATIONS: Array<[string, string]> = [
   ['/v1/indexer/work/{runId}/heartbeat', 'post'],
   ['/v1/indexer/work/{runId}/content', 'get'],
   ['/v1/indexer/work/{runId}/fail', 'post'],
+  // Read-only operator view — 404 until INDEXER_OPERATOR_VIEW_ENABLED=1.
+  ['/v1/admin/indexers', 'get'],
+  ['/v1/admin/indexers/{packId}/runs', 'get'],
   ['/v1/sources', 'get'],
   ['/v1/sources/{sourceKey}', 'get'],
   // raw-substrate driver v1 (episodes read + subscriptions + projections)


### PR DESCRIPTION
## The gap

An indexer's identity **is** its pack: the `indexer` descriptor lives inside the signed pack manifest (`src/ai/domain-packs/manifest.ts`), and `indexer_run` rows have been keyed by `packId` + `packVersion` since migration `0049`. The router builds one binding per installed pack.

But nothing tenant- or operator-facing ever listed those indexers or their run health. The only HTTP surface over the ledger was `GET /v1/indexer/work` — the **external poller's own work queue**, not an operator's view. An operator could not answer "which indexers does this tenant have", "did the last run fail", or "has the external publisher polled at all".

## What this adds

Two read-only routes, dark behind `INDEXER_OPERATOR_VIEW_ENABLED` (default off ⇒ `404`):

**`GET /v1/admin/indexers`** — one row per pack that *declared* an indexer descriptor. A pack without one rides the union extraction pass and has no run ledger of its own, so it is absent from the list. Each row carries:

- execution mode (`virtual` / `dedicated` / `external`), pack id, the version the tenant actually runs, and `installedAt` (`builtin` vs `installed`);
- `lastRun` — run id, document, status, started/finished, extraction stats, the failure message when there is one, and that run's candidate tallies;
- `runs` — window tallies by status (`pending` / `running` / `succeeded` / `failed` / `skipped`);
- `candidates` — window tallies by status (`submitted` / `pending` / `committed` / `merged` / `duplicate` / `rejected` / `expired`);
- `external` (external mode only) — declared publisher, unclaimed backlog, oldest waiting item, newest claim, and `polledRecently`. There is no separate poll journal, so the newest `claimedAt` is the honest proxy for "the publisher is alive"; a growing backlog with a stale or absent claim is what "the publisher stopped polling" looks like;
- `truncated` — true when the per-indexer row cap bit, so partial tallies never read as complete ones.

**`GET /v1/admin/indexers/{packId}/runs`** — recent runs of one indexer, newest first, each with its staged-candidate tallies.

**Read-only.** No mutation verb ships here — retrying, releasing and re-indexing stay with the surfaces that already own those decisions.

## Fences

- `brain:admin` like every sibling under `/v1/admin`; the tenant seam is `resolvePlatformTenant`, so a plain admin can only ever read its **own** tenant (a foreign `tenant` is a `403`), and every query runs inside `withCompany`.
- The pack set is the tenant's own bindings, so an unknown or non-indexer pack id is a `404` rather than a probe of another tenant's ledger.
- Every read is window-bounded (7 days default, 90 max) **and** row-capped per indexer (50 default, 200 max). The run query is one capped statement **per pack** rather than a shared cap — a busy indexer must not crowd the others out of their own aggregate.

## Migration 0131

`indexer_run_pack_idx` on `packId`. Every existing index over `indexer_run` served a *writer's* access path — the identity UNIQUE, `status` (stale reaper), `(external, status)` (work discovery) — because nothing had ever read the ledger *by pack*. Deliberately single-field: `packId` appears in no `DELETE`/`UPDATE … WHERE` anywhere in the service, so this index can only serve reads and stays clear of the SurrealDB 3.2.4 planner shape we keep away from mutating statements.

## Notes

- `IndexerBinding` gains three inert fields (`source`, `installedAt`, `declared`) so "installed for this tenant" keeps exactly **one** definition — the router's — instead of the operator view growing a second one. Routing itself never reads them.
- Own flag rather than riding `DOCUMENT_INGEST_ENABLED`: this is a new read surface over an existing ledger, and a tenant should be able to open it independently of the write pipeline. Config-catalog entry + `KNOWN_BOOLEAN_FLAGS` registration included.
- Contracts are zod (`src/contracts/indexer/indexer-operator.schema.ts`), published to both OpenAPI copies via `pnpm openapi:build`. The edit to `scripts/build-openapi.ts` is purely additive (one import block, one `ZOD_COMPONENTS` block, one `indexerOperatorPaths()`, one tag) to stay trivially mergeable with the concurrent core-paths work.

## Tests

- `test/indexer-operator-view.unit-spec.ts` — wire contracts, the declared-descriptor rule, aggregates computed from fixture ledger rows, cross-run tally isolation, window/row clamps, the truncation flag, the `withCompany` tenant fence, `resolvePlatformTenant` denial, and flag-off `404`.
- `test/indexer-operator-view.e2e-spec.ts` — mirrors the sibling indexer/document suites on a real DB: flag-off `404`, an installed pack without a descriptor stays absent, ingest routes a document to the builtin external pack and the operator sees the pending run plus a publisher that has not polled, then sees the claim land as `lastClaimAt` / `polledRecently`.

## Gates (local, exit codes captured, no pipes)

| gate | result |
| --- | --- |
| `pnpm typecheck` | 0 |
| `pnpm lint:ci` | 0 |
| `pnpm format:check` | 0 |
| unit suite | 0 — 381 suites, 4570 tests |
| `pnpm openapi:build` + `openapi-doc.unit-spec` | 0 — 48 paths, 102 schemas, both copies byte-identical |
| e2e (new spec) | 0 — 7/7 |
| e2e (siblings: indexer-work, documents-pipeline, external-candidates, domain-pack-install) | 0 — 42/42 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB
