### PR TITLE
feat(indexers): reference code-repository indexer for the code_memory pack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ data/code-memory/*.model.json
 
 # LoCoMo eval run reports — throwaway scratch output, never source
 var/
+
+# Repo-indexer run state (per-checkout, never source) — scripts/index-repo.ts
+.brain-indexer-state.json

--- a/docs/indexer-protocol.md
+++ b/docs/indexer-protocol.md
@@ -454,9 +454,22 @@ A candidate that would fail server-side is dropped locally with a
 reason, never sent: predicate outside the pack namespace, entity name
 over 256 chars, object over 2000, a `default_value` that is prose rather
 than a value token (the pack's 0.4.3 rule), a span that is not verbatim
-in its evidence document, and `single_active_collision` — emitting five
-`invariant` claims on one anchor would make the fifth supersede the
-other four, so only the strongest is sent.
+in its evidence document, and `single_active_collision` — for a
+predicate the pack declares `single_active` (`owns`, `default_value`,
+`depends_on_version`, `decided`) several claims on one anchor would make
+the last supersede the rest, so only the strongest is sent.
+
+The single-active set is read from the pack manifest, never restated, so
+the fence and the ontology cannot drift. That is how a **domain
+modelling error** surfaced: the first dogfood pass dropped 1254
+legitimate `invariant` facts across 515 anchors, because `invariant` had
+shipped as `single_active` since the pack's first version. A module's
+invariants coexist — "every handler validates its body with the shared
+zod schema" and "amounts are always emitted in cents" are both true of
+one file at once — so supersession there was pure data loss. Pack
+**0.6.0** makes `invariant` `append_only`; `decided` deliberately stays
+`single_active` (an anchor has exactly one *current* decision, and
+`superseded_by` records what replaced the old one).
 
 ### Caps
 

--- a/docs/indexer-protocol.md
+++ b/docs/indexer-protocol.md
@@ -9,7 +9,10 @@ and decides what becomes memory.
 
 A dependency-free reference implementation lives at
 [`examples/reference-indexer.ts`](../examples/reference-indexer.ts)
-(`pnpm indexer:reference`).
+(`pnpm indexer:reference`). For a *real* producer — one that reads a git
+repository and derives `code_memory` candidates from it — see
+[the code-repository indexer](#the-code-repository-indexer) below
+(`pnpm indexer:repo`).
 
 ## Prerequisites
 
@@ -359,6 +362,119 @@ routed to their pack (`/content`) — that text can carry anything the
 source carried (post-redaction). Mint per-integration keys, scope packs
 narrowly via relevance, and treat external indexers as processors in
 your data-protection terms.
+
+## The code-repository indexer
+
+`code_memory` is the only pack in the library that declares
+`indexer: { mode: 'external' }`, and for a long time nothing fed it.
+`scripts/index-repo.ts` (`pnpm indexer:repo`) is that producer: it walks
+a git working tree plus its history and submits `code_memory`
+candidates through the protocol above. It is an **operator/CI-invoked
+tool** — nothing schedules it, no Nest module imports it, and it makes
+no network call at all until `--submit` is passed.
+
+### Dogfood: index this repository
+
+```bash
+# 1. See what this repo would contribute. No network, no key needed.
+pnpm indexer:repo -- --repo . --dry-run
+
+# 2. Submit for real. The key needs BOTH brain:write (to store the
+#    evidence documents) and indexer:write (to stage the candidates);
+#    if it is pack-bound it must be bound to code_memory.
+BRAIN_API_KEY=<key> pnpm indexer:repo -- \
+  --repo . --brain-url https://brain.inite.ai --submit
+
+# 3. Later runs: only the delta since the last recorded HEAD.
+BRAIN_API_KEY=<key> pnpm indexer:repo -- \
+  --repo . --brain-url https://brain.inite.ai --since auto --submit
+```
+
+Operator flags `DOCUMENT_INGEST_ENABLED=1` and
+`DOCUMENT_MULTI_INDEXER_ENABLED=1` must be on, as for every external
+indexer. Run 2 writes `.brain-indexer-state.json` in the repo root
+(override with `--state`); keep it — it is what makes run 3 cheap.
+
+Other flags: `--pack <id>`, `--vertical <name>`, `--modules <a,b>`,
+`--max-candidates <n>`, `--max-files <n>`, `--json`.
+
+### How a repository becomes candidates
+
+Brain re-grounds every external span against stored document text, so
+the indexer first composes an **evidence document**: one block per
+claim carrying the anchor, the value, the *derivation rule* that
+produced it, and the artefact quoted verbatim with its file and line
+span. That document is ingested (`POST /v1/ingest/document`, routed with
+`indexers: ["code_memory"]`), and the candidates are then staged against
+it with the claimless flow. The document is the audit trail — every
+claim can be re-derived from it without trusting the indexer.
+
+Nothing is guessed. Every fact traces to a concrete artefact:
+
+| Predicate | Evidence |
+|---|---|
+| `owns` | a CODEOWNERS line; failing that, git-history authorship concentration (dominant author, thresholds stated in the fact) |
+| `depends_on_version` | the pnpm lockfile's exact resolution, else the package.json range, verbatim |
+| `default_value` | a config-catalogue row, else a `DEFAULT_*` literal — value-shaped tokens only |
+| `decided` / `because` | a commit message or an ADR-style `## Decision` / `## Rationale` section that explicitly states one |
+| `invariant` / `gotcha` | a comment that explicitly warns ("must", "never", "gotcha", "beware", "⚡"), quoted verbatim |
+
+Semantic summaries of code are deliberately **out of scope**.
+
+### Core + ecosystem modules
+
+The tool is a small language-agnostic core plus a registry of ecosystem
+modules (`src/code-memory/repo-indexer/`).
+
+- **Core** (`core/`) always runs and knows no language: git history and
+  authorship, CODEOWNERS, commit-message decisions, ADR docs, warning
+  comments, the file inventory and caps, dedupe/incremental machinery,
+  and the submission client with its client-side fences.
+- **Modules** (`modules/`) hold every ecosystem-specific rule. Each
+  declares `claims(path)`, an `extract()` returning the same fact shape
+  the core emits, and its own `version`, which rides into the derivation
+  of everything it produced. Shipping today: `javascript`
+  (package.json + pnpm-lock.yaml), `config_catalog`
+  (`config-catalog*.data.ts`), `default_constants` (`DEFAULT_*`
+  literals).
+
+A repository whose ecosystem has no module still gets everything the
+core derives. When two modules claim one path the higher `priority`
+wins, ties break on ascending `id` — never registration order. The
+registry (`modules/registry.ts`) is an explicit list, not filesystem
+discovery.
+
+**Adding an ecosystem** (Python, Go, Rust, a framework) is one new file
+under `modules/` exporting an `EcosystemModule`, plus one entry in
+`BUILTIN_MODULES`. No core file changes.
+
+### Client-side fences
+
+A candidate that would fail server-side is dropped locally with a
+reason, never sent: predicate outside the pack namespace, entity name
+over 256 chars, object over 2000, a `default_value` that is prose rather
+than a value token (the pack's 0.4.3 rule), a span that is not verbatim
+in its evidence document, and `single_active_collision` — emitting five
+`invariant` claims on one anchor would make the fifth supersede the
+other four, so only the strongest is sent.
+
+### Caps
+
+| Cap | Default | Meaning |
+|---|---|---|
+| `maxFiles` | 5000 | working-tree files opened |
+| `maxFileBytes` | 512_000 | larger files skipped whole |
+| `maxCommits` | 500 | commits read in an incremental run |
+| `ownershipHistoryDepth` | 200 | commits inspected for authorship |
+| `maxCandidates` | 500 | facts emitted per run |
+| `maxFactsPerDocument` | 120 | facts per evidence document (server allows 200/kind) |
+| `maxDocChars` | 100_000 | evidence-document text (server hard cap 512_000) |
+| `maxWarningsPerFile` | 5 | warning comments taken from one file |
+
+`.git`, `node_modules`, `dist`, `build`, `out`, `coverage`, `vendor`,
+`third_party`, `models` and other dot-directories (except `.github`) are
+never walked; symlinks are never followed; binaries are detected by a
+NUL byte in the first 8KiB and skipped.
 
 ## See also
 

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "pack:search": "ts-node -r tsconfig-paths/register scripts/search-registry.ts",
     "registry:seed": "ts-node -r tsconfig-paths/register scripts/seed-registry.ts",
     "indexer:reference": "ts-node -r tsconfig-paths/register examples/reference-indexer.ts",
+    "indexer:repo": "ts-node -r tsconfig-paths/register scripts/index-repo.ts",
     "code-memory:validate-anchors": "ts-node -r tsconfig-paths/register scripts/validate-anchors.ts",
     "test:eval:fat": "pnpm build && FAT_TENANT_RUN=1 jest --config ./test/jest-e2e-real.json --runInBand --testPathPatterns=fat-tenant",
     "test:eval:directory": "pnpm build && DIRECTORY_RUN=1 jest --config ./test/jest-e2e-real.json --runInBand --testPathPatterns=directory",

--- a/scripts/index-repo.ts
+++ b/scripts/index-repo.ts
@@ -1,0 +1,164 @@
+#!/usr/bin/env ts-node
+/**
+ * Reference code-repository indexer for the `code_memory` domain pack.
+ *
+ * OPERATOR / CI INVOKED ONLY — nothing schedules this, no Nest module
+ * imports it, and it makes no network call at all until `--submit` is
+ * passed. Placement follows `scripts/capture-decisions.ts`: the CLI is a
+ * thin shell over pure modules under `src/code-memory/repo-indexer/`, so
+ * the derivation rules are unit-tested without a process, a git binary,
+ * or a server.
+ *
+ *   # see what this repository would contribute — no network, no key
+ *   pnpm indexer:repo -- --repo . --dry-run
+ *
+ *   # submit for real (key needs brain:write + indexer:write, and if it
+ *   # is pack-bound it must be bound to code_memory)
+ *   BRAIN_API_KEY=... pnpm indexer:repo -- \
+ *     --repo . --brain-url https://brain.inite.ai --submit
+ *
+ *   # second run: only the delta since the last recorded HEAD
+ *   BRAIN_API_KEY=... pnpm indexer:repo -- --repo . --since auto --submit
+ *
+ * Flags:
+ *   --repo <path>        repository root (default: cwd)
+ *   --brain-url <url>    Brain base URL (default: $BRAIN_URL)
+ *   --pack <id>          pack id (default: code_memory)
+ *   --vertical <name>    contextRef.vertical for the evidence documents
+ *   --since <commit|auto> incremental lower bound; `auto` = state file HEAD
+ *   --modules <a,b>      restrict the ecosystem-module registry
+ *   --state <path>       state file (default: <repo>/.brain-indexer-state.json)
+ *   --max-candidates <n> per-run cap (default 500)
+ *   --max-files <n>      working-tree file cap (default 5000)
+ *   --submit             actually POST; omitted = dry run
+ *   --json               machine-readable summary on stdout
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+import { basename, join, resolve } from 'node:path';
+import { DEFAULT_CAPS, type IndexerCaps } from '../src/code-memory/repo-indexer/types';
+import { FsRepoSource } from '../src/code-memory/repo-indexer/repo-source';
+import { selectModules } from '../src/code-memory/repo-indexer/modules/registry';
+import {
+  HttpBrainClient,
+  type BrainClient,
+} from '../src/code-memory/repo-indexer/brain-client';
+import { DryRunBrainClient } from '../src/code-memory/repo-indexer/dry-run-client';
+import { EMPTY_STATE, runIndexer, type RunState } from '../src/code-memory/repo-indexer/run';
+
+function arg(name: string): string | undefined {
+  const i = process.argv.indexOf(`--${name}`);
+  const value = i !== -1 ? process.argv[i + 1] : undefined;
+  return value && !value.startsWith('--') ? value : undefined;
+}
+
+function flag(name: string): boolean {
+  return process.argv.includes(`--${name}`);
+}
+
+function intArg(name: string, fallback: number): number {
+  const raw = arg(name);
+  const n = raw === undefined ? NaN : Number.parseInt(raw, 10);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+function readState(path: string): RunState {
+  try {
+    const parsed = JSON.parse(readFileSync(path, 'utf8')) as Partial<RunState>;
+    return {
+      lastCommit: typeof parsed.lastCommit === 'string' ? parsed.lastCommit : null,
+      lastRunAt: typeof parsed.lastRunAt === 'string' ? parsed.lastRunAt : null,
+      submitted: Array.isArray(parsed.submitted)
+        ? parsed.submitted.filter((s): s is string => typeof s === 'string')
+        : [],
+    };
+  } catch {
+    return { ...EMPTY_STATE };
+  }
+}
+
+function buildClient(packId: string, vertical: string): BrainClient {
+  if (!flag('submit')) return new DryRunBrainClient();
+  const baseUrl = arg('brain-url') ?? process.env.BRAIN_URL;
+  const apiKey = process.env.BRAIN_API_KEY;
+  if (!baseUrl) throw new Error('--brain-url (or BRAIN_URL) is required with --submit');
+  if (!apiKey) {
+    throw new Error('BRAIN_API_KEY is required with --submit (scopes: brain:write, indexer:write)');
+  }
+  return new HttpBrainClient({ baseUrl, apiKey, vertical, packId });
+}
+
+async function main(): Promise<void> {
+  const root = resolve(arg('repo') ?? process.cwd());
+  const packId = arg('pack') ?? 'code_memory';
+  const vertical = arg('vertical') ?? 'engineering';
+  const statePath = arg('state') ?? join(root, '.brain-indexer-state.json');
+  const state = readState(statePath);
+
+  const caps: IndexerCaps = {
+    ...DEFAULT_CAPS,
+    maxCandidates: intArg('max-candidates', DEFAULT_CAPS.maxCandidates),
+    maxFiles: intArg('max-files', DEFAULT_CAPS.maxFiles),
+  };
+
+  const sinceRaw = arg('since');
+  const since = sinceRaw === 'auto' ? (state.lastCommit ?? undefined) : (sinceRaw ?? undefined);
+  if (sinceRaw === 'auto' && !since) {
+    console.error('[indexer] --since auto: no recorded HEAD yet, running a full walk');
+  }
+
+  const modules = selectModules(
+    arg('modules')
+      ?.split(',')
+      .map((s) => s.trim())
+      .filter(Boolean),
+  );
+  const client = buildClient(packId, vertical);
+
+  const summary = await runIndexer({
+    source: new FsRepoSource({ root, maxFiles: caps.maxFiles, maxFileBytes: caps.maxFileBytes }),
+    client,
+    caps,
+    packId,
+    repoLabel: basename(root),
+    modules,
+    state,
+    since,
+    log: (line) => console.error(`[indexer] ${line}`),
+  });
+
+  if (flag('json')) {
+    console.log(JSON.stringify(summary, null, 2));
+  } else {
+    console.error(
+      `[indexer] head=${summary.headSha?.slice(0, 12) ?? 'none'} ` +
+        `incremental=${summary.incremental} files=${summary.filesScanned} ` +
+        `commits=${summary.commitsRead} derived=${summary.derived} ` +
+        `submitted=${summary.submitted} dropped=${summary.dropped.length} ` +
+        `documents=${summary.documents}`,
+    );
+    for (const [producer, count] of Object.entries(summary.byProducer).sort()) {
+      console.error(`[indexer]   ${producer}: ${count}`);
+    }
+    const reasons = new Map<string, number>();
+    for (const d of summary.dropped) reasons.set(d.reason, (reasons.get(d.reason) ?? 0) + 1);
+    for (const [reason, count] of [...reasons.entries()].sort()) {
+      console.error(`[indexer]   dropped ${reason}: ${count}`);
+    }
+  }
+
+  if (client instanceof DryRunBrainClient) {
+    console.error(
+      `[indexer] DRY RUN — nothing was sent. ${client.documents.length} evidence document(s) ` +
+        `would carry ${client.submissions.reduce((n, s) => n + s.payload.facts.length, 0)} fact(s). ` +
+        `Pass --submit to POST them.`,
+    );
+    return;
+  }
+  writeFileSync(statePath, `${JSON.stringify(summary.nextState, null, 2)}\n`, 'utf8');
+  console.error(`[indexer] state written to ${statePath}`);
+}
+
+main().catch((e: unknown) => {
+  console.error(`[indexer] fatal: ${(e as Error).message}`);
+  process.exit(1);
+});

--- a/src/ai/domain-packs/code-memory.pack.ts
+++ b/src/ai/domain-packs/code-memory.pack.ts
@@ -17,11 +17,24 @@ import { composePredicateId, type DomainPackManifest } from './manifest';
  * media gates still deny at their consent clause until a consent path for
  * builtins lands. The declaration is the contract, not an activation.
  *
+ * 0.6.0 corrects a DOMAIN MODELLING ERROR: `invariant` shipped as
+ * `single_active` from the very first version, which silently made every
+ * newly recorded constraint retire the previous one. A module's
+ * invariants coexist, so that was data loss with nothing gained — there
+ * is no "which invariant is current?" question for supersession to
+ * answer. It is now `append_only`. A MINOR bump, not a patch: this
+ * changes stored-fact behaviour for anyone already recording into the
+ * pack (new invariants stop closing prior ones; previously superseded
+ * rows stay superseded and remain readable at their `asOf`).
+ * `decided`/`owns`/`default_value`/`depends_on_version` are deliberately
+ * left `single_active` — each of those really does have exactly one
+ * current value.
+ *
  * Bump `version` to ship an updated code-memory ontology.
  */
 export const CODE_MEMORY_PACK: DomainPackManifest = {
   id: 'code_memory',
-  version: '0.5.0',
+  version: '0.6.0',
   description:
     'Non-derivable engineering "why" of a codebase — decisions, rationale, invariants, gotchas, ownership, flag/config defaults, dependency pins, and decision supersession anchored to code, with a domain extraction profile and memory model.',
   // Retro-declaration, documentation-true: code-memory has ALWAYS been an
@@ -62,9 +75,25 @@ VALUE  one rationale per fact (multi-valued)`,
       description: `TYPE   subject is a code anchor; value is a constraint that must hold
 ADMIT  text states a rule the code must satisfy ("always export a new
        @Injectable from the @Global module or e2e DI-boot fails")
-VALUE  the invariant statement`,
+VALUE  one invariant per fact (multi-valued — a module's constraints
+       COEXIST: "every handler validates its body with the shared zod
+       schema" and "amounts are always emitted in cents" are both true
+       of the same file at the same time, and neither retires the other)`,
       datatype: 'string',
-      semantics: 'single_active',
+      // 0.6.0 semantics correction (was single_active through 0.5.0).
+      // There is no "the current invariant" of a module the way there is
+      // a current owner or a current default — a rule does not replace
+      // the rule before it. Under single_active each newly recorded
+      // constraint SUPERSEDED the last, so a file with five real rules
+      // ended up remembering one; the reference repository indexer's
+      // first dogfood pass over this repo had to drop 1254 legitimate
+      // invariants across 515 anchors to avoid destroying its own
+      // output. A retiring rule is a code CHANGE, and the fact then
+      // stops being re-asserted; that is what append_only + decay is
+      // for. Contrast `decided`, which stays single_active on purpose:
+      // an anchor has exactly one CURRENT decision (k09), and
+      // `superseded_by` records what replaced the old one.
+      semantics: 'append_only',
       decayHalfLifeDays: null,
       piiClass: 'none',
       status: 'active',

--- a/src/code-memory/repo-indexer/brain-client.ts
+++ b/src/code-memory/repo-indexer/brain-client.ts
@@ -1,0 +1,153 @@
+/**
+ * The submission seam — an INTERFACE plus one HTTP implementation, so
+ * the whole pipeline is unit-testable with no network.
+ *
+ * Two calls, both from the documented surface:
+ *
+ *   1. `POST /v1/ingest/document` (scope `brain:write`) stores the
+ *      evidence document and, because the body names `indexers:
+ *      ['code_memory']`, opens the external work slot for it.
+ *   2. `POST /v1/documents/:id/candidates` (scope `indexer:write`) stages
+ *      the candidates. The CLAIMLESS flow is used deliberately: this is a
+ *      single-instance operator tool, and the submission itself takes the
+ *      slot atomically (docs/indexer-protocol.md, "The loop"). A
+ *      concurrent duplicate gets 409, which the runner reports as
+ *      already-processed rather than as a failure.
+ *
+ * The key must carry BOTH scopes and, if it is pack-bound, be bound to
+ * `code_memory` — the server's `assertKeyBoundToPack` fence.
+ */
+export type { CandidatePayload } from './bundle';
+import type { CandidatePayload } from './bundle';
+
+export interface IngestedDocument {
+  documentId: string;
+  deduplicated: boolean;
+}
+
+export interface SubmissionOutcome {
+  runId: string | null;
+  staged: { entities: number; facts: number; relations: number };
+  dropped: Array<{ kind: string; index: number; reason: string; detail?: string }>;
+  /** True when the server reported the slot was already processed (409). */
+  alreadyProcessed: boolean;
+}
+
+export interface IngestDocumentInput {
+  text: string;
+  title: string;
+  originUri: string;
+  occurredAt: string;
+}
+
+/** What the runner needs from Brain. Stub it in tests. */
+export interface BrainClient {
+  ingestDocument(input: IngestDocumentInput): Promise<IngestedDocument>;
+  submitCandidates(documentId: string, payload: CandidatePayload): Promise<SubmissionOutcome>;
+}
+
+export interface HttpBrainClientOptions {
+  baseUrl: string;
+  apiKey: string;
+  /** Connector identity stamped on the stored document row. */
+  vertical: string;
+  packId: string;
+}
+
+interface HttpResponse {
+  status: number;
+  body: Record<string, unknown> | null;
+}
+
+/** Dependency-free HTTP client (global fetch, Node 18+). */
+export class HttpBrainClient implements BrainClient {
+  constructor(private readonly opts: HttpBrainClientOptions) {}
+
+  async ingestDocument(input: IngestDocumentInput): Promise<IngestedDocument> {
+    const res = await this.call('POST', '/v1/ingest/document', {
+      kind: 'code_repository',
+      text: input.text,
+      title: input.title,
+      originUri: input.originUri,
+      occurredAt: input.occurredAt,
+      storeContent: true,
+      // Route this document to the code_memory external indexer only —
+      // the generalist pass has nothing to add to a machine-composed
+      // evidence bundle and would spend LLM budget re-reading it.
+      indexers: [this.opts.packId],
+      contextRef: { vertical: this.opts.vertical, recorder: 'code-repo-indexer' },
+    });
+    if (res.status !== 200 && res.status !== 201) {
+      throw new Error(`document ingest failed (${res.status}): ${describe(res.body)}`);
+    }
+    const documentId = res.body?.['documentId'];
+    if (typeof documentId !== 'string') {
+      throw new Error('document ingest returned no documentId');
+    }
+    return { documentId, deduplicated: res.body?.['deduplicated'] === true };
+  }
+
+  async submitCandidates(
+    documentId: string,
+    payload: CandidatePayload,
+  ): Promise<SubmissionOutcome> {
+    const res = await this.call(
+      'POST',
+      `/v1/documents/${encodeURIComponent(documentId)}/candidates`,
+      payload,
+    );
+    if (res.status === 409) {
+      return {
+        runId: null,
+        staged: { entities: 0, facts: 0, relations: 0 },
+        dropped: [],
+        alreadyProcessed: true,
+      };
+    }
+    if (res.status !== 200 && res.status !== 201) {
+      throw new Error(`candidate submission failed (${res.status}): ${describe(res.body)}`);
+    }
+    const staged = (res.body?.['staged'] ?? {}) as Record<string, unknown>;
+    return {
+      runId: typeof res.body?.['runId'] === 'string' ? (res.body['runId'] as string) : null,
+      staged: {
+        entities: numberOf(staged['entities']),
+        facts: numberOf(staged['facts']),
+        relations: numberOf(staged['relations']),
+      },
+      dropped: Array.isArray(res.body?.['dropped'])
+        ? (res.body['dropped'] as SubmissionOutcome['dropped'])
+        : [],
+      alreadyProcessed: false,
+    };
+  }
+
+  private async call(method: string, path: string, body: unknown): Promise<HttpResponse> {
+    const res = await fetch(`${this.opts.baseUrl}${path}`, {
+      method,
+      headers: {
+        Authorization: `Bearer ${this.opts.apiKey}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+    const text = await res.text();
+    let parsed: Record<string, unknown> | null = null;
+    try {
+      parsed = text ? (JSON.parse(text) as Record<string, unknown>) : null;
+    } catch {
+      parsed = { message: text.slice(0, 500) };
+    }
+    return { status: res.status, body: parsed };
+  }
+}
+
+function numberOf(v: unknown): number {
+  return typeof v === 'number' && Number.isFinite(v) ? v : 0;
+}
+
+function describe(body: Record<string, unknown> | null): string {
+  const message = body?.['message'];
+  if (typeof message === 'string') return message;
+  return JSON.stringify(body ?? {}).slice(0, 300);
+}

--- a/src/code-memory/repo-indexer/bundle.ts
+++ b/src/code-memory/repo-indexer/bundle.ts
@@ -1,0 +1,329 @@
+/**
+ * From derived facts to a submittable bundle: deterministic identity,
+ * the client-side fences, the evidence document, and the candidate
+ * payload.
+ *
+ * THE EVIDENCE DOCUMENT is the heart of this design. Brain re-grounds
+ * every external span against the stored document text (see
+ * docs/indexer-protocol.md, "Grounding rules"), so an indexer that
+ * submits facts about a repository must give Brain the repository
+ * evidence to check them against. This module composes exactly that: one
+ * block per fact carrying the anchor, the claim, the DERIVATION RULE
+ * that produced it, and the artefact quoted verbatim with its file and
+ * line span. The document is the audit trail — a reader can re-derive
+ * every claim from it without trusting the indexer.
+ *
+ * THE FENCES run client-side, before anything leaves the machine. A
+ * candidate that would fail the server's namespace fence, its caps, or
+ * its grounding check is DROPPED here with a reason. Sending a claim you
+ * already know will be rejected is not a submission, it is noise.
+ */
+import { createHash } from 'node:crypto';
+import { isGroundedSpan, normalizeForGrounding } from '../../ai/extractor-internals/grounding';
+import { CODE_MEMORY_PACK } from '../../ai/domain-packs/code-memory.pack';
+import { isValueShaped } from './modules/config.module';
+import {
+  MAX_ENTITY_NAME_CHARS,
+  MAX_FACT_OBJECT_CHARS,
+  type DroppedRepoFact,
+  type IdentifiedRepoFact,
+  type IndexerCaps,
+  type RepoFact,
+} from './types';
+
+/** `code_memory__gotcha` for kind `gotcha`. */
+export function predicateFor(packId: string, kind: string): string {
+  return `${packId}__${kind}`;
+}
+
+/**
+ * Deterministic candidate identity over (path, kind, content hash) —
+ * the idempotency key. Stable across runs, machines and clones: two
+ * runs over an unchanged repository produce byte-identical ids, so the
+ * second run submits nothing.
+ */
+export function candidateIdOf(fact: RepoFact): string {
+  const content = createHash('sha256')
+    .update([fact.subject, fact.object, fact.evidence.excerpt].join(''))
+    .digest('hex');
+  return createHash('sha256')
+    .update([fact.evidence.path, fact.kind, content].join(''))
+    .digest('hex')
+    .slice(0, 32);
+}
+
+export function identify(facts: RepoFact[]): IdentifiedRepoFact[] {
+  const seen = new Set<string>();
+  const out: IdentifiedRepoFact[] = [];
+  for (const fact of facts) {
+    const candidateId = candidateIdOf(fact);
+    // Within-run dedupe: two derivers can legitimately read the same
+    // artefact line; the fact is one fact.
+    if (seen.has(candidateId)) continue;
+    seen.add(candidateId);
+    out.push({ ...fact, candidateId });
+  }
+  return out;
+}
+
+function drop(
+  fact: IdentifiedRepoFact,
+  reason: DroppedRepoFact['reason'],
+  detail: string,
+): DroppedRepoFact {
+  return { candidateId: fact.candidateId, kind: fact.kind, subject: fact.subject, reason, detail };
+}
+
+/**
+ * Kinds whose pack semantics are `single_active`, read from the manifest
+ * itself so the two can never drift. Emitting five `invariant` facts on
+ * one file entity would not record five rules — the fifth would
+ * SUPERSEDE the other four on commit, and the run would quietly destroy
+ * its own output. So the fence keeps the strongest claim per
+ * (subject, kind) and drops the rest with a reason.
+ */
+const SINGLE_ACTIVE_KINDS = new Set(
+  CODE_MEMORY_PACK.predicates.filter((p) => p.semantics === 'single_active').map((p) => p.localId),
+);
+
+/** Winner per (subject, kind): highest confidence, ties to the first seen. */
+function singleActiveWinners(facts: IdentifiedRepoFact[], packId: string): Set<string> | null {
+  // Another pack's semantics are unknown to this table, so the fence
+  // stands down rather than dropping claims on a guess.
+  if (packId !== CODE_MEMORY_PACK.id) return null;
+  const winners = new Map<string, IdentifiedRepoFact>();
+  for (const fact of facts) {
+    if (!SINGLE_ACTIVE_KINDS.has(fact.kind)) continue;
+    const key = `${fact.kind}${fact.subject.toLowerCase()}`;
+    const held = winners.get(key);
+    if (!held || fact.confidence > held.confidence) winners.set(key, fact);
+  }
+  return new Set([...winners.values()].map((f) => f.candidateId));
+}
+
+export interface ShapeFenceInput {
+  facts: IdentifiedRepoFact[];
+  packId: string;
+  caps: IndexerCaps;
+  /** Candidate ids submitted by a previous run (the state file). */
+  alreadySubmitted: ReadonlySet<string>;
+}
+
+/**
+ * Shape + policy fences. Runs BEFORE the evidence document is composed,
+ * so a rejected fact never even contributes text.
+ */
+export function applyShapeFences(input: ShapeFenceInput): {
+  kept: IdentifiedRepoFact[];
+  dropped: DroppedRepoFact[];
+} {
+  const kept: IdentifiedRepoFact[] = [];
+  const dropped: DroppedRepoFact[] = [];
+  // Already-submitted facts leave FIRST, and the single-active contest is
+  // then run over what remains. Order matters: a changed file's new
+  // invariant must be free to supersede the one a previous run recorded,
+  // rather than losing a contest to its own already-staged predecessor.
+  const fresh: IdentifiedRepoFact[] = [];
+  for (const fact of input.facts) {
+    if (input.alreadySubmitted.has(fact.candidateId)) {
+      dropped.push(drop(fact, 'already_submitted', 'submitted by an earlier run'));
+    } else {
+      fresh.push(fact);
+    }
+  }
+  const winners = singleActiveWinners(fresh, input.packId);
+  for (const fact of fresh) {
+    if (winners !== null && SINGLE_ACTIVE_KINDS.has(fact.kind) && !winners.has(fact.candidateId)) {
+      dropped.push(
+        drop(
+          fact,
+          'single_active_collision',
+          `another ${fact.kind} claim on "${fact.subject}" scored higher; ` +
+            `${fact.kind} is single_active in the pack manifest`,
+        ),
+      );
+      continue;
+    }
+    const predicate = predicateFor(input.packId, fact.kind);
+    // Namespace fence (server: external-candidates.service validateFact).
+    // A namespaced predicate outside the submitting pack is squatting and
+    // is a 400 — so it never leaves here.
+    if (!predicate.startsWith(`${input.packId}__`) || predicate.split('__').length !== 2) {
+      dropped.push(drop(fact, 'namespace_fence', predicate));
+      continue;
+    }
+    const subject = fact.subject.trim();
+    const object = fact.object.trim();
+    if (!subject || !object) {
+      dropped.push(drop(fact, 'empty_span', `${predicate} subject/object empty`));
+      continue;
+    }
+    if (subject.length > MAX_ENTITY_NAME_CHARS) {
+      dropped.push(drop(fact, 'name_too_long', `${subject.length} chars`));
+      continue;
+    }
+    if (object.length > MAX_FACT_OBJECT_CHARS) {
+      dropped.push(drop(fact, 'object_too_long', `${object.length} chars`));
+      continue;
+    }
+    // code_memory 0.4.3: default_value takes ONLY value-shaped defaults.
+    // Prose belongs in invariant, so a prose "default" is dropped rather
+    // than mis-slotted.
+    if (fact.kind === 'default_value' && !isValueShaped(object)) {
+      dropped.push(drop(fact, 'not_value_shaped', object.slice(0, 80)));
+      continue;
+    }
+    if (kept.length >= input.caps.maxCandidates) {
+      dropped.push(drop(fact, 'over_run_cap', `run cap ${input.caps.maxCandidates} reached`));
+      continue;
+    }
+    kept.push({ ...fact, subject, object });
+  }
+  return { kept, dropped };
+}
+
+/** One evidence document plus the facts it grounds. */
+export interface EvidenceDocument {
+  text: string;
+  facts: IdentifiedRepoFact[];
+}
+
+export interface ComposeInput {
+  facts: IdentifiedRepoFact[];
+  packId: string;
+  caps: IndexerCaps;
+  /** Human-readable repo identity for the document header. */
+  repoLabel: string;
+  headSha: string | null;
+}
+
+function blockFor(fact: IdentifiedRepoFact, packId: string): string {
+  const span =
+    fact.evidence.startLine > 0
+      ? `${fact.evidence.path}:${fact.evidence.startLine}-${fact.evidence.endLine}`
+      : fact.evidence.path;
+  const quoted = fact.evidence.excerpt
+    .split('\n')
+    .map((l) => `> ${l}`)
+    .join('\n');
+  return [
+    `### ${fact.subject}`,
+    `${predicateFor(packId, fact.kind)}: ${fact.object}`,
+    `derivation: ${fact.derivation}`,
+    `producer: ${fact.producer}`,
+    `evidence: ${span}${fact.evidence.commit ? ` @ ${fact.evidence.commit}` : ''}`,
+    quoted,
+    '',
+  ].join('\n');
+}
+
+/**
+ * Pack facts into evidence documents, bounded by BOTH the per-document
+ * fact cap (the server allows 200 items per kind per submission) and the
+ * character budget (the server hard cap is 512_000).
+ */
+export function composeEvidenceDocuments(input: ComposeInput): EvidenceDocument[] {
+  const header = [
+    `# Repository evidence: ${input.repoLabel}`,
+    input.headSha ? `commit: ${input.headSha}` : 'commit: (not a git checkout)',
+    '',
+    'Each block below records one claim, the mechanical rule that derived it,',
+    'and the repository artefact it was quoted from. Derived by the code_memory',
+    'reference repository indexer; nothing here is a summary of code.',
+    '',
+  ].join('\n');
+
+  const docs: EvidenceDocument[] = [];
+  let buffer = header;
+  let batch: IdentifiedRepoFact[] = [];
+  const flush = (): void => {
+    if (batch.length === 0) return;
+    docs.push({ text: buffer, facts: batch });
+    buffer = header;
+    batch = [];
+  };
+  for (const fact of input.facts) {
+    const block = blockFor(fact, input.packId);
+    if (
+      batch.length >= input.caps.maxFactsPerDocument ||
+      buffer.length + block.length > input.caps.maxDocChars
+    ) {
+      flush();
+    }
+    buffer += block;
+    batch.push(fact);
+  }
+  flush();
+  return docs;
+}
+
+/**
+ * Grounding fence — the same check the server runs
+ * (`groundExternalBatch`), executed client-side against the document we
+ * are about to send. A fact whose subject or value is not a verbatim,
+ * whole-token span of its evidence document is dropped here.
+ */
+export function applyGroundingFence(doc: EvidenceDocument): {
+  kept: IdentifiedRepoFact[];
+  dropped: DroppedRepoFact[];
+} {
+  const normalized = normalizeForGrounding(doc.text);
+  const kept: IdentifiedRepoFact[] = [];
+  const dropped: DroppedRepoFact[] = [];
+  for (const fact of doc.facts) {
+    if (!isGroundedSpan(normalized, normalizeForGrounding(fact.subject))) {
+      dropped.push(drop(fact, 'ungrounded_entity', fact.subject.slice(0, 80)));
+      continue;
+    }
+    if (!isGroundedSpan(normalized, normalizeForGrounding(fact.object))) {
+      dropped.push(drop(fact, 'ungrounded_value', fact.object.slice(0, 80)));
+      continue;
+    }
+    kept.push(fact);
+  }
+  return { kept, dropped };
+}
+
+export interface SubmittedEntityPayload {
+  name: string;
+  type: string;
+}
+
+export interface SubmittedFactPayload {
+  entityIndex: number;
+  predicate: string;
+  object: string;
+  confidence: number;
+  clause: string;
+}
+
+export interface CandidatePayload {
+  indexerId: string;
+  entities: SubmittedEntityPayload[];
+  facts: SubmittedFactPayload[];
+}
+
+/** Build the `POST /v1/documents/:id/candidates` body for one document. */
+export function toCandidatePayload(facts: IdentifiedRepoFact[], packId: string): CandidatePayload {
+  const entityIndex = new Map<string, number>();
+  const entities: SubmittedEntityPayload[] = [];
+  const payloadFacts: SubmittedFactPayload[] = [];
+  for (const fact of facts) {
+    const key = `${fact.subjectType}${fact.subject.toLowerCase()}`;
+    let index = entityIndex.get(key);
+    if (index === undefined) {
+      index = entities.length;
+      entityIndex.set(key, index);
+      entities.push({ name: fact.subject, type: fact.subjectType });
+    }
+    payloadFacts.push({
+      entityIndex: index,
+      predicate: predicateFor(packId, fact.kind),
+      object: fact.object,
+      confidence: fact.confidence,
+      // A real quote of the artefact, per the protocol's clause contract.
+      clause: fact.evidence.excerpt.replace(/\s+/g, ' ').trim().slice(0, 1_000),
+    });
+  }
+  return { indexerId: packId, entities, facts: payloadFacts };
+}

--- a/src/code-memory/repo-indexer/bundle.ts
+++ b/src/code-memory/repo-indexer/bundle.ts
@@ -75,18 +75,35 @@ function drop(
 }
 
 /**
- * Kinds whose pack semantics are `single_active`, read from the manifest
- * itself so the two can never drift. Emitting five `invariant` facts on
- * one file entity would not record five rules — the fifth would
- * SUPERSEDE the other four on commit, and the run would quietly destroy
- * its own output. So the fence keeps the strongest claim per
- * (subject, kind) and drops the rest with a reason.
+ * Kinds whose pack semantics are `single_active`, read from the MANIFEST
+ * rather than restated here, so the fence and the ontology can never
+ * drift apart.
+ *
+ * Sending several claims for one of these on a single anchor does not
+ * record several values — each would SUPERSEDE the last on commit, and
+ * only the final one would survive. That is right for the slots that
+ * genuinely have one current value (`owns`, `default_value`,
+ * `depends_on_version`, `decided`) and the fence keeps the strongest per
+ * (subject, kind).
+ *
+ * It is NOT a licence to drop coexisting claims. The first dogfood pass
+ * over this repository lost 1254 legitimate `invariant` facts across 515
+ * anchors to this fence — which was the fence correctly reporting a
+ * DOMAIN MODELLING ERROR upstream, not doing its job. `invariant` became
+ * `append_only` in pack 0.6.0 and now flows through untouched; the fence
+ * is deliberately left reading the manifest so the next such mistake
+ * surfaces the same way instead of being hard-coded around.
  */
 const SINGLE_ACTIVE_KINDS = new Set(
   CODE_MEMORY_PACK.predicates.filter((p) => p.semantics === 'single_active').map((p) => p.localId),
 );
 
-/** Winner per (subject, kind): highest confidence, ties to the first seen. */
+/**
+ * Winner per (subject, kind): highest confidence, ties to the first
+ * seen. Derivers emit newest-evidence-first (git log is read
+ * newest-first), so equal-confidence claims resolve to the most recent
+ * artefact — the current owner, the current pin, the current decision.
+ */
 function singleActiveWinners(facts: IdentifiedRepoFact[], packId: string): Set<string> | null {
   // Another pack's semantics are unknown to this table, so the fence
   // stands down rather than dropping claims on a guess.

--- a/src/code-memory/repo-indexer/core/decisions.ts
+++ b/src/code-memory/repo-indexer/core/decisions.ts
@@ -1,0 +1,196 @@
+/**
+ * `code_memory__decided` / `code_memory__because` — the engineering
+ * "why", read ONLY where a human wrote it down.
+ *
+ * Two sources, both language-agnostic:
+ *
+ *   COMMIT MESSAGES. A message that explicitly states a decision
+ *     ("decided to …", "chose X over Y") is quoted verbatim. The anchor
+ *     is a path the message itself names, or — failing that — the
+ *     commit's single changed file. A commit that touched twelve files
+ *     and names no path has no anchor, so it produces NOTHING: guessing
+ *     which of the twelve the decision was about is exactly the
+ *     invention this indexer refuses.
+ *   ADR-STYLE DOCS. A markdown file with a `## Decision` section states
+ *     a decision about itself; the document IS the artefact, so it is
+ *     its own anchor. `## Rationale` / `## Context` / `## Why` sections
+ *     become the rationale.
+ *
+ * Code SHAPE is never a source. A decision that nobody wrote down is
+ * not a decision this indexer knows about.
+ */
+import type { CommitRecord, RepoSource } from '../repo-source';
+import type { IndexerCaps, RepoFact } from '../types';
+import { PROSE_EXTENSIONS } from '../types';
+
+/** Explicit decision language. Deliberately narrow — no "should", no "use". */
+const DECISION_RE =
+  /\b(?:we\s+)?(?:decided|decision|chose|chosen|opted|settled\s+on|agreed\s+to)\b/i;
+/** Explicit rationale language. */
+const RATIONALE_RE = /\b(?:because|rationale|reason(?:ing)?:|the\s+reason\s+is|so\s+that)\b/i;
+/** A repo-relative path spelled inside prose. */
+const PATH_RE = /\b(?:[\w.-]+\/)+[\w.-]+\.[A-Za-z][\w]{0,7}\b/;
+/** A directory path spelled inside prose (`src/fovea`, `docs/roadmap`). */
+const DIR_RE = /\b(?:src|test|scripts|docs|packs|clients|examples)\/[\w.-]+(?:\/[\w.-]+)*\b/;
+
+const MIN_STATEMENT_CHARS = 20;
+const MAX_STATEMENT_CHARS = 400;
+
+/** Split a message into trimmed, non-empty sentence-ish units. */
+function statements(message: string): string[] {
+  return message
+    .split(/\n{2,}|(?<=[.!?])\s+|\n/)
+    .map((s) => s.trim())
+    .filter((s) => s.length >= MIN_STATEMENT_CHARS && s.length <= MAX_STATEMENT_CHARS);
+}
+
+/**
+ * The anchor rule, stated so it can be quoted into the fact: a path the
+ * message names, else the commit's ONLY changed file, else nothing.
+ */
+export function anchorForCommit(
+  commit: CommitRecord,
+  statement: string,
+): {
+  anchor: string;
+  rule: string;
+} | null {
+  const named = PATH_RE.exec(statement)?.[0] ?? DIR_RE.exec(statement)?.[0];
+  if (named) {
+    return { anchor: named, rule: `the commit message names the anchor "${named}"` };
+  }
+  const only = commit.changedFiles.length === 1 ? commit.changedFiles[0] : undefined;
+  if (only) {
+    return {
+      anchor: only,
+      rule: `the commit changed exactly one file, so that file is the anchor`,
+    };
+  }
+  return null;
+}
+
+export interface CommitDecisionInput {
+  commits: CommitRecord[];
+  caps: IndexerCaps;
+}
+
+/** Decisions and rationale stated in commit messages. */
+export function decisionsFromCommits(input: CommitDecisionInput): RepoFact[] {
+  const facts: RepoFact[] = [];
+  for (const commit of input.commits) {
+    for (const statement of statements(commit.message)) {
+      const isDecision = DECISION_RE.test(statement);
+      const isRationale = RATIONALE_RE.test(statement);
+      if (!isDecision && !isRationale) continue;
+      const anchored = anchorForCommit(commit, statement);
+      if (!anchored) continue;
+      const short = commit.sha.slice(0, 12);
+      facts.push({
+        producer: 'core:decisions',
+        subject: anchored.anchor,
+        subjectType: 'asset',
+        kind: isDecision ? 'decided' : 'because',
+        object: statement,
+        derivation:
+          `Quoted verbatim from commit ${short} (${commit.date}) by ${commit.authorName}; ` +
+          `${anchored.rule}. Admitted because the message states a ` +
+          `${isDecision ? 'decision' : 'rationale'} in explicit language — code shape is never a source.`,
+        evidence: {
+          path: anchored.anchor,
+          startLine: 0,
+          endLine: 0,
+          excerpt: statement,
+          commit: commit.sha,
+        },
+        confidence: isDecision ? 0.8 : 0.75,
+      });
+      if (facts.length >= input.caps.maxCandidates) return facts;
+    }
+  }
+  return facts;
+}
+
+interface Section {
+  heading: string;
+  startLine: number;
+  endLine: number;
+  body: string;
+}
+
+/** Pure: markdown ATX sections with their 1-based line spans. */
+export function parseSections(markdown: string): Section[] {
+  const lines = markdown.split('\n');
+  const sections: Section[] = [];
+  let current: { heading: string; start: number; body: string[] } | null = null;
+  const flush = (endLine: number): void => {
+    if (!current) return;
+    sections.push({
+      heading: current.heading,
+      startLine: current.start,
+      endLine,
+      body: current.body.join('\n').trim(),
+    });
+    current = null;
+  };
+  lines.forEach((line, i) => {
+    const m = /^#{1,6}\s+(.+?)\s*$/.exec(line);
+    if (m?.[1]) {
+      flush(i);
+      current = { heading: m[1], start: i + 1, body: [] };
+      return;
+    }
+    current?.body.push(line);
+  });
+  flush(lines.length);
+  return sections;
+}
+
+const DECISION_HEADING = /^(decision|the decision|what we decided)$/i;
+const RATIONALE_HEADING = /^(rationale|context|why|motivation|reasoning)$/i;
+
+/** First paragraph of a section, collapsed to one line and length-capped. */
+function firstParagraph(body: string): string | null {
+  const para = body
+    .split(/\n{2,}/)
+    .map((p) => p.replace(/\s+/g, ' ').trim())
+    .find((p) => p.length >= MIN_STATEMENT_CHARS);
+  if (!para) return null;
+  return para.length > MAX_STATEMENT_CHARS ? null : para;
+}
+
+/** Decisions stated in ADR-style markdown under the scanned prose files. */
+export function decisionsFromDocs(source: RepoSource, paths: string[]): RepoFact[] {
+  const facts: RepoFact[] = [];
+  for (const path of paths) {
+    const dot = path.lastIndexOf('.');
+    if (dot === -1 || !PROSE_EXTENSIONS.has(path.slice(dot))) continue;
+    const text = source.readFile(path);
+    if (text === null) continue;
+    for (const section of parseSections(text)) {
+      const isDecision = DECISION_HEADING.test(section.heading);
+      const isRationale = RATIONALE_HEADING.test(section.heading);
+      if (!isDecision && !isRationale) continue;
+      const statement = firstParagraph(section.body);
+      if (!statement) continue;
+      facts.push({
+        producer: 'core:decisions',
+        subject: path,
+        subjectType: 'asset',
+        kind: isDecision ? 'decided' : 'because',
+        object: statement,
+        derivation:
+          `First paragraph of the "${section.heading}" section of ${path} ` +
+          `(lines ${section.startLine}-${section.endLine}), quoted verbatim. ` +
+          `An ADR-style document states a decision about itself, so the document is its own anchor.`,
+        evidence: {
+          path,
+          startLine: section.startLine,
+          endLine: section.endLine,
+          excerpt: statement,
+        },
+        confidence: isDecision ? 0.85 : 0.8,
+      });
+    }
+  }
+  return facts;
+}

--- a/src/code-memory/repo-indexer/core/ownership.ts
+++ b/src/code-memory/repo-indexer/core/ownership.ts
@@ -1,0 +1,178 @@
+/**
+ * `code_memory__owns` — who is responsible for a path.
+ *
+ * Two sources, in strict precedence:
+ *
+ *   1. CODEOWNERS. A declared owner is a STATEMENT by the repository, so
+ *      it is quoted verbatim and needs no inference at all.
+ *   2. Git-history concentration, used only when the repo declares no
+ *      CODEOWNERS. Authorship concentration is evidence of stewardship,
+ *      not a declaration — so it is emitted at lower confidence and the
+ *      emitted fact carries the RULE ("dominant author of N commits
+ *      touching this path over the last M") in its derivation. Brain
+ *      stores why the indexer believed it, never a bare assertion.
+ *
+ * The history rule refuses to guess: a path needs `ownershipMinCommits`
+ * commits and a dominant author holding `ownershipMinShare` of them, or
+ * no fact is emitted.
+ */
+import type { CommitRecord, RepoSource } from '../repo-source';
+import type { IndexerCaps, RepoFact } from '../types';
+
+/** Conventional CODEOWNERS locations, in the order git itself checks. */
+const CODEOWNERS_PATHS = ['CODEOWNERS', '.github/CODEOWNERS', 'docs/CODEOWNERS'];
+
+export interface CodeownersRule {
+  /** 1-based line number in the CODEOWNERS file. */
+  line: number;
+  /** The raw line, verbatim. */
+  raw: string;
+  /** Path-shaped pattern, normalized (no leading/trailing slash). */
+  path: string;
+  /** Owner handles in declaration order, `@`/leading-sigil stripped. */
+  owners: string[];
+}
+
+/**
+ * Pure CODEOWNERS parse. Only PATH-SHAPED patterns survive: a glob
+ * (`*.ts`, `src/**`) does not name a code anchor, and inventing one for
+ * it would be exactly the guessing this indexer refuses to do.
+ */
+export function parseCodeowners(text: string): CodeownersRule[] {
+  const rules: CodeownersRule[] = [];
+  text.split('\n').forEach((raw, i) => {
+    const line = raw.replace(/#.*$/, '').trim();
+    if (!line) return;
+    const parts = line.split(/\s+/).filter(Boolean);
+    const pattern = parts[0];
+    if (pattern === undefined || parts.length < 2) return;
+    if (/[*?[\]!]/.test(pattern)) return;
+    const path = pattern.replace(/^\/+/, '').replace(/\/+$/, '');
+    if (!path) return;
+    const owners = parts
+      .slice(1)
+      .map((o) => o.replace(/^@/, '').trim())
+      .filter(Boolean);
+    if (owners.length === 0) return;
+    rules.push({ line: i + 1, raw: raw.trimEnd(), path, owners });
+  });
+  return rules;
+}
+
+/** CODEOWNERS-declared ownership, one fact per path-shaped rule. */
+export function ownershipFromCodeowners(source: RepoSource): RepoFact[] {
+  for (const file of CODEOWNERS_PATHS) {
+    const text = source.readFile(file);
+    if (text === null) continue;
+    const rules = parseCodeowners(text);
+    if (rules.length === 0) continue;
+    return rules.map((rule) => {
+      const owner = rule.owners[0] as string;
+      const extra =
+        rule.owners.length > 1
+          ? ` The line declares ${rule.owners.length} owners; the first-listed owner is recorded (owns is single-valued).`
+          : '';
+      return {
+        producer: 'core:ownership' as const,
+        subject: rule.path,
+        subjectType: 'asset' as const,
+        kind: 'owns' as const,
+        object: owner,
+        derivation:
+          `Declared in ${file} line ${rule.line}; the leading "@" is CODEOWNERS syntax and is not part of the handle.` +
+          extra,
+        evidence: {
+          path: file,
+          startLine: rule.line,
+          endLine: rule.line,
+          excerpt: rule.raw,
+        },
+        confidence: 0.9,
+      };
+    });
+  }
+  return [];
+}
+
+/** Per-path author tallies over a commit window. Pure. */
+export function tallyAuthors(
+  commits: CommitRecord[],
+  depth: number,
+): Map<string, Map<string, number>> {
+  const byPath = new Map<string, Map<string, number>>();
+  for (const commit of commits) {
+    const author = commit.authorName;
+    if (!author) continue;
+    const seen = new Set<string>();
+    for (const file of commit.changedFiles) {
+      for (const dir of ancestorDirs(file, depth)) {
+        if (seen.has(dir)) continue;
+        seen.add(dir);
+        const tally = byPath.get(dir) ?? new Map<string, number>();
+        tally.set(author, (tally.get(author) ?? 0) + 1);
+        byPath.set(dir, tally);
+      }
+    }
+  }
+  return byPath;
+}
+
+/** `src/a/b/c.ts` → `src`, `src/a` (depth 2). Files themselves are not anchors here. */
+function ancestorDirs(file: string, depth: number): string[] {
+  const parts = file.split('/').slice(0, -1);
+  const dirs: string[] = [];
+  for (let i = 1; i <= Math.min(depth, parts.length); i += 1) {
+    dirs.push(parts.slice(0, i).join('/'));
+  }
+  return dirs;
+}
+
+export interface HistoryOwnershipInput {
+  commits: CommitRecord[];
+  caps: IndexerCaps;
+  headSha: string | null;
+}
+
+/**
+ * Fallback ownership from authorship concentration. Emits a fact only
+ * when the evidence clears BOTH thresholds, and the emitted excerpt is
+ * the verbatim `sha author` tally the decision was made from — a reader
+ * can re-derive the claim from it without trusting the indexer.
+ */
+export function ownershipFromHistory(input: HistoryOwnershipInput): RepoFact[] {
+  const { commits, caps } = input;
+  const byPath = tallyAuthors(commits, 2);
+  const facts: RepoFact[] = [];
+  for (const [path, tally] of [...byPath.entries()].sort((a, b) => a[0].localeCompare(b[0]))) {
+    const total = [...tally.values()].reduce((a, b) => a + b, 0);
+    if (total < caps.ownershipMinCommits) continue;
+    const ranked = [...tally.entries()].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
+    const top = ranked[0];
+    if (!top) continue;
+    const [author, count] = top;
+    const share = count / total;
+    if (share < caps.ownershipMinShare) continue;
+    facts.push({
+      producer: 'core:ownership',
+      subject: path,
+      subjectType: 'asset',
+      kind: 'owns',
+      object: author,
+      derivation:
+        `No CODEOWNERS entry covers this path. Derived from git history: ${author} authored ` +
+        `${count} of the ${total} commits touching ${path} in the last ${commits.length} commits ` +
+        `(${Math.round(share * 100)}%), clearing the >=${caps.ownershipMinCommits}-commit and ` +
+        `>=${Math.round(caps.ownershipMinShare * 100)}%-share thresholds. Authorship concentration ` +
+        `is stewardship evidence, not a declaration of ownership.`,
+      evidence: {
+        path,
+        startLine: 0,
+        endLine: 0,
+        excerpt: ranked.map(([a, c]) => `${c}\t${a}`).join('\n'),
+        commit: input.headSha ?? undefined,
+      },
+      confidence: 0.55,
+    });
+  }
+  return facts;
+}

--- a/src/code-memory/repo-indexer/core/warnings.ts
+++ b/src/code-memory/repo-indexer/core/warnings.ts
@@ -1,0 +1,206 @@
+/**
+ * `code_memory__gotcha` / `code_memory__invariant` — the warnings a
+ * codebase writes to its future self.
+ *
+ * Source: COMMENTS ONLY, and only comments that explicitly warn. A
+ * comment saying "must", "never", "always", "gotcha", "beware", "⚡"
+ * is a human stating a rule or a trap; a comment describing what the
+ * next line does is not, and is skipped. The recorded value is the
+ * sentence verbatim, and the fact carries the file plus the 1-based line
+ * span it was read from, so a reader can open the file and check.
+ *
+ * Language-agnostic: comment syntax is a small table (line-comment
+ * prefixes plus C-style blocks), not ecosystem knowledge — an unknown
+ * extension is simply not scanned.
+ */
+import type { RepoSource } from '../repo-source';
+import type { IndexerCaps, RepoFact } from '../types';
+import { SCANNED_EXTENSIONS } from '../types';
+
+/** Line-comment prefix per extension family. */
+const LINE_PREFIX: Record<string, string> = {
+  '.ts': '//',
+  '.tsx': '//',
+  '.js': '//',
+  '.jsx': '//',
+  '.mjs': '//',
+  '.cjs': '//',
+  '.go': '//',
+  '.rs': '//',
+  '.java': '//',
+  '.kt': '//',
+  '.py': '#',
+  '.rb': '#',
+  '.sh': '#',
+  '.sql': '--',
+};
+
+/** Extensions that also carry C-style block comments. */
+const BLOCK_EXTENSIONS = new Set([
+  '.ts',
+  '.tsx',
+  '.js',
+  '.jsx',
+  '.mjs',
+  '.cjs',
+  '.go',
+  '.rs',
+  '.java',
+  '.kt',
+  '.sql',
+]);
+
+export interface CommentBlock {
+  /** Verbatim comment text with markers stripped, newline-joined. */
+  text: string;
+  /** 1-based inclusive span in the source file. */
+  startLine: number;
+  endLine: number;
+}
+
+/** Pure: contiguous comment blocks of a source file. */
+export function extractComments(text: string, ext: string): CommentBlock[] {
+  const prefix = LINE_PREFIX[ext];
+  if (!prefix) return [];
+  const allowBlocks = BLOCK_EXTENSIONS.has(ext);
+  const lines = text.split('\n');
+  const blocks: CommentBlock[] = [];
+  let open: { parts: string[]; start: number; end: number } | null = null;
+  let inBlock = false;
+
+  const flush = (): void => {
+    if (open && open.parts.some((p) => p.trim())) {
+      blocks.push({
+        text: open.parts.join('\n').trim(),
+        startLine: open.start,
+        endLine: open.end,
+      });
+    }
+    open = null;
+  };
+  const push = (content: string, lineNo: number): void => {
+    if (open) {
+      open.parts.push(content);
+      open.end = lineNo;
+    } else {
+      open = { parts: [content], start: lineNo, end: lineNo };
+    }
+  };
+
+  lines.forEach((raw, i) => {
+    const lineNo = i + 1;
+    const trimmed = raw.trim();
+    if (inBlock) {
+      const close = trimmed.indexOf('*/');
+      const body = (close === -1 ? trimmed : trimmed.slice(0, close)).replace(/^\*+\s?/, '');
+      push(body, lineNo);
+      if (close !== -1) {
+        inBlock = false;
+        flush();
+      }
+      return;
+    }
+    if (allowBlocks && trimmed.startsWith('/*')) {
+      const close = trimmed.indexOf('*/', 2);
+      const body = (close === -1 ? trimmed.slice(2) : trimmed.slice(2, close)).replace(
+        /^\*+\s?/,
+        '',
+      );
+      push(body, lineNo);
+      if (close === -1) inBlock = true;
+      else flush();
+      return;
+    }
+    if (trimmed.startsWith(prefix)) {
+      push(trimmed.slice(prefix.length).trim(), lineNo);
+      return;
+    }
+    flush();
+  });
+  if (inBlock) flush();
+  else flush();
+  return blocks;
+}
+
+/**
+ * Explicit trap language — a human FLAGGING a counter-intuitive
+ * behaviour. The marker has to be used as a flag, not merely mentioned:
+ * "caveat: reindex rewrites facts only" is a gotcha, while "decisions,
+ * rationale, invariants, gotchas — anchored to code" is a sentence that
+ * happens to contain the word. So a nominal marker counts only at the
+ * start of a clause or when it introduces the warning with a colon or
+ * dash; `beware` / `watch out` / `⚡` are imperative on their own.
+ */
+const GOTCHA_RE =
+  /(?:^|[—:;-]\s*)(?:gotcha|caveat|pitfall|caution|warning)\b|\b(?:gotcha|caveat|pitfall|caution|warning)\s*[:—-]|\b(?:beware|watch out)\b|⚡/i;
+/** Explicit rule language — a constraint the code must satisfy. */
+const INVARIANT_RE = /\b(must not|must|never|always|invariant)\b/i;
+/** Tooling noise that matches the markers but states nothing about the code. */
+const NOISE_RE =
+  /(eslint-disable|@ts-(?:ignore|expect-error|nocheck)|prettier-ignore|SPDX|Copyright)/i;
+
+const MIN_SENTENCE_CHARS = 20;
+const MAX_SENTENCE_CHARS = 400;
+
+/** Pure: warning sentences of one comment block, tagged by kind. */
+export function warningSentences(
+  block: CommentBlock,
+): Array<{ kind: 'gotcha' | 'invariant'; sentence: string }> {
+  const flat = block.text.replace(/\s+/g, ' ').trim();
+  const out: Array<{ kind: 'gotcha' | 'invariant'; sentence: string }> = [];
+  for (const raw of flat.split(/(?<=[.!?;])\s+/)) {
+    const sentence = raw.trim();
+    if (sentence.length < MIN_SENTENCE_CHARS || sentence.length > MAX_SENTENCE_CHARS) continue;
+    if (NOISE_RE.test(sentence)) continue;
+    // Gotcha markers win: an explicit "beware" is a trap report even when
+    // the same sentence also says "never".
+    if (GOTCHA_RE.test(sentence)) out.push({ kind: 'gotcha', sentence });
+    else if (INVARIANT_RE.test(sentence)) out.push({ kind: 'invariant', sentence });
+  }
+  return out;
+}
+
+export interface WarningInput {
+  source: RepoSource;
+  paths: string[];
+  caps: IndexerCaps;
+}
+
+/** Gotchas and invariants across the scanned working-tree files. */
+export function warningsFromComments(input: WarningInput): RepoFact[] {
+  const facts: RepoFact[] = [];
+  for (const path of input.paths) {
+    const dot = path.lastIndexOf('.');
+    const ext = dot === -1 ? '' : path.slice(dot);
+    if (!SCANNED_EXTENSIONS.has(ext)) continue;
+    const text = input.source.readFile(path);
+    if (text === null) continue;
+    let perFile = 0;
+    for (const block of extractComments(text, ext)) {
+      for (const { kind, sentence } of warningSentences(block)) {
+        if (perFile >= input.caps.maxWarningsPerFile) break;
+        perFile += 1;
+        facts.push({
+          producer: 'core:warnings',
+          subject: path,
+          subjectType: 'asset',
+          kind,
+          object: sentence,
+          derivation:
+            `Quoted verbatim from the comment at ${path} lines ${block.startLine}-${block.endLine}. ` +
+            `Admitted as a ${kind} because the sentence carries explicit ` +
+            `${kind === 'gotcha' ? 'trap' : 'rule'} language; descriptive comments are not read.`,
+          evidence: {
+            path,
+            startLine: block.startLine,
+            endLine: block.endLine,
+            excerpt: block.text,
+          },
+          confidence: kind === 'gotcha' ? 0.75 : 0.7,
+        });
+        if (facts.length >= input.caps.maxCandidates) return facts;
+      }
+    }
+  }
+  return facts;
+}

--- a/src/code-memory/repo-indexer/dry-run-client.ts
+++ b/src/code-memory/repo-indexer/dry-run-client.ts
@@ -1,0 +1,35 @@
+/**
+ * The no-network {@link BrainClient} — the DEFAULT until `--submit` is
+ * passed. An operator can point the indexer at any repository and see
+ * exactly what it would contribute before a single byte leaves the
+ * machine; a tool that reads source and posts it elsewhere should never
+ * do so on an unflagged invocation.
+ */
+import type { CandidatePayload } from './bundle';
+import type {
+  BrainClient,
+  IngestDocumentInput,
+  IngestedDocument,
+  SubmissionOutcome,
+} from './brain-client';
+
+export class DryRunBrainClient implements BrainClient {
+  readonly documents: Array<IngestDocumentInput & { documentId: string }> = [];
+  readonly submissions: Array<{ documentId: string; payload: CandidatePayload }> = [];
+
+  ingestDocument(input: IngestDocumentInput): Promise<IngestedDocument> {
+    const documentId = `dry-run-document:${this.documents.length}`;
+    this.documents.push({ ...input, documentId });
+    return Promise.resolve({ documentId, deduplicated: false });
+  }
+
+  submitCandidates(documentId: string, payload: CandidatePayload): Promise<SubmissionOutcome> {
+    this.submissions.push({ documentId, payload });
+    return Promise.resolve({
+      runId: null,
+      staged: { entities: payload.entities.length, facts: payload.facts.length, relations: 0 },
+      dropped: [],
+      alreadyProcessed: false,
+    });
+  }
+}

--- a/src/code-memory/repo-indexer/modules/config.module.ts
+++ b/src/code-memory/repo-indexer/modules/config.module.ts
@@ -1,0 +1,192 @@
+/**
+ * Configuration modules — `code_memory__default_value`.
+ *
+ * Two modules ship here because a repository can state a default in two
+ * very different registers, and they deserve different confidence:
+ *
+ *   CONFIG_CATALOG_MODULE (priority 80) reads a DECLARATIVE catalogue —
+ *     this repo's `src/admin/config-catalog.data.ts`, the operator-facing
+ *     source of truth for every env knob. A row there is a statement.
+ *   DEFAULT_CONSTANTS_MODULE (priority 20) reads `DEFAULT_*` constants
+ *     out of config-ish source files. Weaker evidence, so lower
+ *     confidence — and it deliberately claims only files whose NAME says
+ *     they hold configuration, never the whole tree.
+ *
+ * Both claim `config-catalog.data.ts`; the catalogue module wins on
+ * priority (see `assignPaths`), which is the documented behaviour and is
+ * asserted in the unit suite.
+ *
+ * THE VALUE-SHAPE FENCE. code_memory 0.4.3 fenced `default_value`
+ * against prose after a battery finding: a behaviour fragment ("every
+ * duration in milliseconds") is an invariant, never a default. Both
+ * modules therefore refuse anything that is not a bare value token, and
+ * the refusal is a client-side DROP with a reason — nothing prose-shaped
+ * is ever sent for the server to reject.
+ */
+import type { RepoFact } from '../types';
+import { moduleProducer, type EcosystemModule, type ModuleExtractInput } from './module.types';
+
+/** Longest accepted default token — beyond this it is prose, not a value. */
+const MAX_VALUE_CHARS = 64;
+
+/**
+ * Is `raw` value-shaped: a number, boolean, or single enum/identifier
+ * token? Whitespace is the discriminator that does most of the work —
+ * a default is one token, a sentence is not.
+ */
+export function isValueShaped(raw: string): boolean {
+  const v = raw.trim();
+  if (!v || v.length > MAX_VALUE_CHARS) return false;
+  if (/\s/.test(v)) return false;
+  // Sentence punctuation: a fragment, not a token.
+  if (/[,;]/.test(v) || /\.$/.test(v)) return false;
+  return /^[A-Za-z0-9_./:@^~+*-]+$/.test(v);
+}
+
+/** One parsed catalogue row. */
+export interface CatalogDefault {
+  key: string;
+  value: string | null;
+  line: number;
+  excerpt: string;
+}
+
+/**
+ * Pure: `{ key: 'X', …, defaultValue: 'Y', … }` rows out of a config
+ * catalogue literal. A `null` default means "no default declared" and
+ * yields no fact — an absent value is not a value.
+ */
+export function parseConfigCatalog(text: string): CatalogDefault[] {
+  const rows: CatalogDefault[] = [];
+  const lines = text.split('\n');
+  let pendingKey: { key: string; line: number } | null = null;
+  lines.forEach((line, i) => {
+    const keyMatch = /^\s*key:\s*'([A-Za-z0-9_.]+)'\s*,/.exec(line);
+    if (keyMatch?.[1]) {
+      pendingKey = { key: keyMatch[1], line: i + 1 };
+      return;
+    }
+    if (!pendingKey) return;
+    const defMatch = /^\s*defaultValue:\s*(?:'([^']*)'|"([^"]*)"|(null))\s*,/.exec(line);
+    if (defMatch) {
+      const value = defMatch[3] === 'null' ? null : (defMatch[1] ?? defMatch[2] ?? '');
+      rows.push({
+        key: pendingKey.key,
+        value,
+        line: i + 1,
+        excerpt: `key: '${pendingKey.key}',\n${line.trim()}`,
+      });
+      pendingKey = null;
+      return;
+    }
+    // A new object literal before any defaultValue: the row declared none.
+    if (/^\s*\},?\s*$/.test(line)) pendingKey = null;
+  });
+  return rows;
+}
+
+function catalogExtract(input: ModuleExtractInput): RepoFact[] {
+  const producer = moduleProducer(CONFIG_CATALOG_MODULE);
+  const facts: RepoFact[] = [];
+  for (const path of input.paths) {
+    const text = input.source.readFile(path);
+    if (text === null) continue;
+    for (const row of parseConfigCatalog(text)) {
+      if (row.value === null || !isValueShaped(row.value)) continue;
+      facts.push({
+        producer,
+        subject: row.key,
+        subjectType: 'concept',
+        kind: 'default_value',
+        object: row.value,
+        derivation:
+          `Declared in the operator config catalogue ${path} line ${row.line} ` +
+          `(defaultValue of the ${row.key} row). Read by ${producer}.`,
+        evidence: { path, startLine: row.line, endLine: row.line, excerpt: row.excerpt },
+        confidence: 0.9,
+      });
+    }
+  }
+  return facts;
+}
+
+const CATALOG_FILE = /(^|\/)config-catalog[\w.-]*\.(data\.)?ts$/;
+
+export const CONFIG_CATALOG_MODULE: EcosystemModule = {
+  id: 'config_catalog',
+  version: '1.0.0',
+  description: 'declarative operator config catalogues (config-catalog*.data.ts)',
+  priority: 80,
+  claims: (path) => CATALOG_FILE.test(path),
+  extract: catalogExtract,
+};
+
+// ── DEFAULT_* constants ────────────────────────────────────────────────
+
+/** Files whose NAME says they hold configuration. Never the whole tree. */
+const CONFIG_ISH =
+  /(^|[/\-.])(config|constants?|defaults?|flags|env)([\-.][\w.-]*)?\.(ts|js|mjs|cjs)$/;
+
+export interface ConstantDefault {
+  name: string;
+  value: string;
+  line: number;
+  excerpt: string;
+}
+
+/**
+ * Pure: `const DEFAULT_X = <literal>;` / `const X_DEFAULT = <literal>;`
+ * declarations. Only literal initializers are read — an expression
+ * (`process.env.X ?? 5`, a function call) has no single default to
+ * quote, so it yields nothing.
+ */
+export function parseDefaultConstants(text: string): ConstantDefault[] {
+  const out: ConstantDefault[] = [];
+  text.split('\n').forEach((line, i) => {
+    const m =
+      /^\s*(?:export\s+)?const\s+(DEFAULT_[A-Z0-9_]+|[A-Z0-9_]+_DEFAULT)\s*(?::[^=]+)?=\s*(?:'([^']*)'|"([^"]*)"|`([^`]*)`|([\w.+-]+))\s*(?:as\s+const\s*)?;/.exec(
+        line,
+      );
+    if (!m?.[1]) return;
+    // Verbatim, always — a numeric separator (`512_000`) is part of how
+    // the repository spells its own default, and rewriting it would make
+    // the recorded value something no artefact actually says.
+    const value = m[2] ?? m[3] ?? m[4] ?? m[5] ?? '';
+    out.push({ name: m[1], value, line: i + 1, excerpt: line.trim() });
+  });
+  return out;
+}
+
+function constantsExtract(input: ModuleExtractInput): RepoFact[] {
+  const producer = moduleProducer(DEFAULT_CONSTANTS_MODULE);
+  const facts: RepoFact[] = [];
+  for (const path of input.paths) {
+    const text = input.source.readFile(path);
+    if (text === null) continue;
+    for (const c of parseDefaultConstants(text)) {
+      if (!isValueShaped(c.value)) continue;
+      facts.push({
+        producer,
+        subject: c.name,
+        subjectType: 'concept',
+        kind: 'default_value',
+        object: c.value,
+        derivation:
+          `Literal initializer of the ${c.name} constant at ${path} line ${c.line}. ` +
+          `A constant is weaker evidence than a declared catalogue row. Read by ${producer}.`,
+        evidence: { path, startLine: c.line, endLine: c.line, excerpt: c.excerpt },
+        confidence: 0.7,
+      });
+    }
+  }
+  return facts;
+}
+
+export const DEFAULT_CONSTANTS_MODULE: EcosystemModule = {
+  id: 'default_constants',
+  version: '1.0.0',
+  description: 'DEFAULT_* literal constants in config-named source files',
+  priority: 20,
+  claims: (path) => CONFIG_ISH.test(path),
+  extract: constantsExtract,
+};

--- a/src/code-memory/repo-indexer/modules/javascript.module.ts
+++ b/src/code-memory/repo-indexer/modules/javascript.module.ts
@@ -1,0 +1,179 @@
+/**
+ * JS/TS ecosystem module — `code_memory__depends_on_version`.
+ *
+ * Two artefacts, in precedence order: the pnpm lockfile (the EXACT
+ * version actually installed) beats the package.json range (what was
+ * asked for). Neither is inferred — both are quoted from the file, with
+ * the line the value was read from.
+ */
+import type { RepoFact } from '../types';
+import { moduleProducer, type EcosystemModule, type ModuleExtractInput } from './module.types';
+
+const MANIFEST = /(^|\/)package\.json$/;
+const LOCKFILE = /(^|\/)pnpm-lock\.yaml$/;
+
+const DEP_SECTIONS = ['dependencies', 'devDependencies', 'optionalDependencies'] as const;
+
+interface ManifestDep {
+  name: string;
+  spec: string;
+  section: string;
+}
+
+/** Pure: declared dependencies of a package.json, in file order. */
+export function parseManifestDeps(json: string): ManifestDep[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch {
+    return [];
+  }
+  if (typeof parsed !== 'object' || parsed === null) return [];
+  const root = parsed as Record<string, unknown>;
+  const deps: ManifestDep[] = [];
+  for (const section of DEP_SECTIONS) {
+    const block = root[section];
+    if (typeof block !== 'object' || block === null) continue;
+    for (const [name, spec] of Object.entries(block as Record<string, unknown>)) {
+      if (typeof spec === 'string' && spec.trim()) {
+        deps.push({ name, spec: spec.trim(), section });
+      }
+    }
+  }
+  // `packageManager` and `engines.*` pin TOOLS the repo depends on — the
+  // same claim class, a different spelling.
+  const pm = root['packageManager'];
+  if (typeof pm === 'string' && pm.includes('@')) {
+    const at = pm.lastIndexOf('@');
+    deps.push({ name: pm.slice(0, at), spec: pm.slice(at + 1), section: 'packageManager' });
+  }
+  const engines = root['engines'];
+  if (typeof engines === 'object' && engines !== null) {
+    for (const [name, spec] of Object.entries(engines as Record<string, unknown>)) {
+      if (typeof spec === 'string' && spec.trim()) {
+        deps.push({ name, spec: spec.trim(), section: 'engines' });
+      }
+    }
+  }
+  return deps;
+}
+
+/**
+ * Pure: exact installed versions from a pnpm lockfile's `importers`
+ * block (lockfileVersion 9 shape). Name lines sit at indent 6, their
+ * `version:` at indent 8; the peer-suffix `(zod@4.5.4)` is a resolution
+ * detail, not the version, so it is trimmed.
+ *
+ * A line-oriented reader rather than a YAML parse: the shape is fixed
+ * and machine-written, and pulling a YAML dependency into an operator
+ * tool is supply-chain surface this does not need. Anything the reader
+ * does not recognize is simply absent — the package.json range is then
+ * the recorded value, never a guess.
+ */
+export function parseLockfileVersions(yaml: string): Map<string, string> {
+  const out = new Map<string, string>();
+  const lines = yaml.split('\n');
+  let inImporters = false;
+  let current: string | null = null;
+  for (const line of lines) {
+    if (/^[A-Za-z]/.test(line)) {
+      inImporters = line.startsWith('importers:');
+      current = null;
+      continue;
+    }
+    if (!inImporters) continue;
+    const nameMatch = /^ {6}(['"]?)([^'":]+)\1:\s*$/.exec(line);
+    if (nameMatch) {
+      current = nameMatch[2] ?? null;
+      continue;
+    }
+    const versionMatch = /^ {8}version:\s*(.+)$/.exec(line);
+    if (versionMatch && current) {
+      const raw = (versionMatch[1] ?? '').trim();
+      const version = raw.split('(')[0]?.trim() ?? '';
+      // First writer wins: the root importer is emitted before workspace
+      // packages, so the root's resolution is the one recorded.
+      if (version && !out.has(current)) out.set(current, version);
+      current = null;
+    }
+  }
+  return out;
+}
+
+/** 1-based line of the first `"<key>":` occurrence, or 0. */
+function lineOfKey(text: string, key: string): number {
+  const needle = `"${key}":`;
+  const idx = text.indexOf(needle);
+  if (idx === -1) return 0;
+  return text.slice(0, idx).split('\n').length;
+}
+
+function lineText(text: string, line: number): string {
+  return line > 0 ? (text.split('\n')[line - 1] ?? '').trim() : '';
+}
+
+function extract(input: ModuleExtractInput): RepoFact[] {
+  const { paths, source } = input;
+  const producer = moduleProducer(JAVASCRIPT_MODULE);
+  const lockPath = paths.find((p) => LOCKFILE.test(p));
+  const lockText = lockPath ? source.readFile(lockPath) : null;
+  const resolved = lockText ? parseLockfileVersions(lockText) : new Map<string, string>();
+
+  const facts: RepoFact[] = [];
+  for (const manifestPath of paths.filter((p) => MANIFEST.test(p))) {
+    const text = source.readFile(manifestPath);
+    if (text === null) continue;
+    for (const dep of parseManifestDeps(text)) {
+      const manifestLine = lineOfKey(text, dep.name);
+      const exact = resolved.get(dep.name);
+      facts.push(
+        exact !== undefined && lockPath !== undefined
+          ? {
+              producer,
+              subject: dep.name,
+              subjectType: 'concept',
+              kind: 'depends_on_version',
+              object: exact,
+              derivation:
+                `Exact installed version read from ${lockPath} (pnpm importers block) for the ` +
+                `${dep.section} range "${dep.spec}" declared in ${manifestPath}. Read by ${producer}.`,
+              evidence: {
+                path: lockPath,
+                startLine: 0,
+                endLine: 0,
+                excerpt: `${dep.name}:\n  specifier: ${dep.spec}\n  version: ${exact}`,
+              },
+              confidence: 0.95,
+            }
+          : {
+              producer,
+              subject: dep.name,
+              subjectType: 'concept',
+              kind: 'depends_on_version',
+              object: dep.spec,
+              derivation:
+                `Declared range in ${manifestPath} (${dep.section}); no lockfile resolution was ` +
+                `available, so the declared range is recorded verbatim rather than an exact ` +
+                `version. Read by ${producer}.`,
+              evidence: {
+                path: manifestPath,
+                startLine: manifestLine,
+                endLine: manifestLine,
+                excerpt: lineText(text, manifestLine) || `"${dep.name}": "${dep.spec}"`,
+              },
+              confidence: 0.85,
+            },
+      );
+    }
+  }
+  return facts;
+}
+
+export const JAVASCRIPT_MODULE: EcosystemModule = {
+  id: 'javascript',
+  version: '1.0.0',
+  description: 'npm/pnpm dependency pins from package.json and pnpm-lock.yaml',
+  priority: 60,
+  claims: (path) => MANIFEST.test(path) || LOCKFILE.test(path),
+  extract,
+};

--- a/src/code-memory/repo-indexer/modules/module.types.ts
+++ b/src/code-memory/repo-indexer/modules/module.types.ts
@@ -1,0 +1,100 @@
+/**
+ * The ecosystem-module seam.
+ *
+ * The CORE of this indexer is language-agnostic on purpose: git history,
+ * CODEOWNERS, commit-message decisions, ADR docs and warning comments
+ * mean the same thing in every repository, and a repo whose ecosystem
+ * has no module still gets all of that. Everything past that point is
+ * ecosystem-specific and cannot be combed under one rule — a dependency
+ * pin lives in package.json here, pyproject.toml there, go.mod
+ * elsewhere, and each has its own notion of what "the version" is.
+ *
+ * So ecosystem knowledge lives ONLY in modules. A module declares which
+ * files it claims and returns the same {@link RepoFact} shape the core
+ * emits; the core never learns a filename, a manifest format, or a
+ * language.
+ *
+ * ADDING AN ECOSYSTEM is one new file plus one line in `registry.ts`:
+ *
+ *   // modules/python.module.ts
+ *   export const PYTHON_MODULE: EcosystemModule = {
+ *     id: 'python',
+ *     version: '1.0.0',
+ *     description: 'pyproject.toml / requirements.txt dependency pins',
+ *     priority: 50,
+ *     claims: (path) => /(^|\/)(pyproject\.toml|requirements\.txt)$/.test(path),
+ *     extract: ({ paths, source }) => paths.flatMap((p) => …),
+ *   };
+ *
+ * …then `BUILTIN_MODULES = [JAVASCRIPT_MODULE, CONFIG_CATALOG_MODULE,
+ * PYTHON_MODULE]`. No core file changes.
+ */
+import type { RepoSource } from '../repo-source';
+import type { IndexerCaps, RepoFact } from '../types';
+
+export interface ModuleExtractInput {
+  /**
+   * The paths this module WON — already filtered by `claims()` and by
+   * conflict resolution, so a module never has to re-check ownership of
+   * a file another module also claimed.
+   */
+  paths: string[];
+  source: RepoSource;
+  caps: IndexerCaps;
+}
+
+export interface EcosystemModule {
+  /** Stable id; appears in every fact's producer as `module:<id>@<version>`. */
+  id: string;
+  /**
+   * Module version, INDEPENDENT of the pack version. Bump it whenever
+   * the extraction rules change: the new value rides into the derivation
+   * of every fact the module produces, so an operator can see exactly
+   * which rule revision minted a claim.
+   */
+  version: string;
+  description: string;
+  /**
+   * Conflict tie-break. When two modules claim one path the HIGHER
+   * priority wins outright; equal priorities are broken by ascending
+   * `id`. Deterministic by construction — never registration order.
+   */
+  priority: number;
+  /** Does this module read this repo-relative path? Pure, no I/O. */
+  claims(path: string): boolean;
+  /** Derive facts from the won paths. Must emit only artefact-traceable claims. */
+  extract(input: ModuleExtractInput): RepoFact[];
+}
+
+/** `module:javascript@1.0.0` — the producer tag for a module's facts. */
+export function moduleProducer(mod: EcosystemModule): `module:${string}` {
+  return `module:${mod.id}@${mod.version}`;
+}
+
+export interface PathAssignment {
+  moduleId: string;
+  paths: string[];
+}
+
+/**
+ * Deterministically assign every path to at most one module.
+ *
+ * Documented resolution: highest `priority` wins; ties break on
+ * ascending `id`. Registration order is deliberately NOT consulted so a
+ * registry reshuffle can never change what gets indexed.
+ */
+export function assignPaths(
+  modules: readonly EcosystemModule[],
+  paths: readonly string[],
+): Map<string, string[]> {
+  const ranked = [...modules].sort((a, b) => b.priority - a.priority || a.id.localeCompare(b.id));
+  const assigned = new Map<string, string[]>();
+  for (const path of paths) {
+    const winner = ranked.find((m) => m.claims(path));
+    if (!winner) continue;
+    const bucket = assigned.get(winner.id) ?? [];
+    bucket.push(path);
+    assigned.set(winner.id, bucket);
+  }
+  return assigned;
+}

--- a/src/code-memory/repo-indexer/modules/registry.ts
+++ b/src/code-memory/repo-indexer/modules/registry.ts
@@ -1,0 +1,39 @@
+/**
+ * The ecosystem-module registry — EXPLICIT by design.
+ *
+ * No filesystem auto-discovery: what an operator's indexer runs is a
+ * list in source, reviewable in a diff. Adding Python is one new file
+ * under `modules/` plus one entry here; nothing in `core/` changes.
+ *
+ * Ships today:
+ *   - `javascript`         package.json + pnpm-lock.yaml → depends_on_version
+ *   - `config_catalog`     config-catalog*.data.ts       → default_value
+ *   - `default_constants`  DEFAULT_* literals            → default_value
+ *
+ * A repository with none of these still gets everything `core/` derives
+ * (ownership, decisions, rationale, invariants, gotchas) — modules add
+ * ecosystem depth, they are never a precondition for output.
+ */
+import { JAVASCRIPT_MODULE } from './javascript.module';
+import { CONFIG_CATALOG_MODULE, DEFAULT_CONSTANTS_MODULE } from './config.module';
+import type { EcosystemModule } from './module.types';
+
+export const BUILTIN_MODULES: readonly EcosystemModule[] = [
+  JAVASCRIPT_MODULE,
+  CONFIG_CATALOG_MODULE,
+  DEFAULT_CONSTANTS_MODULE,
+];
+
+/** Resolve `--modules a,b` against the registry; unknown ids throw. */
+export function selectModules(ids: string[] | undefined): readonly EcosystemModule[] {
+  if (!ids || ids.length === 0) return BUILTIN_MODULES;
+  return ids.map((id) => {
+    const found = BUILTIN_MODULES.find((m) => m.id === id);
+    if (!found) {
+      throw new Error(
+        `unknown ecosystem module "${id}" (available: ${BUILTIN_MODULES.map((m) => m.id).join(', ')})`,
+      );
+    }
+    return found;
+  });
+}

--- a/src/code-memory/repo-indexer/repo-source.ts
+++ b/src/code-memory/repo-indexer/repo-source.ts
@@ -1,0 +1,198 @@
+/**
+ * The repository read surface: a bounded working-tree walk plus a thin
+ * `git` subprocess shell. Deliberately an INTERFACE with one filesystem
+ * implementation — every deriver takes a `RepoSource`, so the unit suite
+ * drives them from an in-memory fixture with no `git` binary and no
+ * temp-directory choreography.
+ *
+ * No new runtime dependency: history is read by shelling out to the
+ * `git` already required to have produced the checkout, exactly as
+ * `src/code-memory/capture/git-commits.ts` does. `simple-git` and
+ * friends would buy nothing but supply-chain surface.
+ */
+import { execFileSync } from 'node:child_process';
+import { openSync, readSync, closeSync, readdirSync, readFileSync, statSync } from 'node:fs';
+import type { Dirent } from 'node:fs';
+import { join, relative, sep } from 'node:path';
+import { SKIP_DIRS } from './types';
+
+export interface RepoFileRef {
+  /** Repo-relative POSIX path. */
+  path: string;
+  bytes: number;
+}
+
+export interface CommitRecord {
+  sha: string;
+  authorName: string;
+  authorEmail: string;
+  /** ISO-8601 author date. */
+  date: string;
+  /** Full commit message (subject + body), verbatim. */
+  message: string;
+  changedFiles: string[];
+}
+
+export interface RepoSource {
+  /** Scannable working-tree files — filtered, size-capped, binary-free. */
+  listFiles(): RepoFileRef[];
+  /** File text, or null when unreadable. */
+  readFile(path: string): string | null;
+  /** Commits newest-first. `since` is an exclusive lower-bound commit-ish. */
+  readCommits(opts: { since?: string | undefined; limit: number }): CommitRecord[];
+  /** HEAD sha, or null outside a git checkout. */
+  head(): string | null;
+  /**
+   * Paths changed in `since..HEAD`, or null when the delta cannot be
+   * computed (no git, unknown commit-ish) — the caller then falls back
+   * to a full walk rather than silently indexing nothing.
+   */
+  changedSince(since: string): string[] | null;
+}
+
+// Field/record separators: neither appears in commit text (git-commits.ts).
+const FS_SEP = '\x1f';
+const RS_SEP = '\x1e';
+const GIT_FORMAT = `${RS_SEP}%H${FS_SEP}%an${FS_SEP}%ae${FS_SEP}%aI${FS_SEP}%B${FS_SEP}`;
+
+/** Dot-directories that carry real repository artefacts. */
+const ALLOWED_DOT_DIRS = new Set(['.github']);
+
+/** Pure: parse `git log --name-only` output in the format above. */
+export function parseCommitLog(raw: string): CommitRecord[] {
+  const commits: CommitRecord[] = [];
+  for (const record of raw.split(RS_SEP)) {
+    if (!record.trim()) continue;
+    const [sha, authorName, authorEmail, date, message, filesBlob = ''] = record.split(FS_SEP);
+    if (!sha?.trim() || !date?.trim()) continue;
+    commits.push({
+      sha: sha.trim(),
+      authorName: (authorName ?? '').trim(),
+      authorEmail: (authorEmail ?? '').trim(),
+      date: date.trim(),
+      message: (message ?? '').trim(),
+      changedFiles: filesBlob
+        .split('\n')
+        .map((l) => l.trim())
+        .filter((l) => l.length > 0),
+    });
+  }
+  return commits;
+}
+
+/** True when the first 8KiB carries a NUL byte — the usual binary tell. */
+function looksBinary(absPath: string): boolean {
+  let fd: number | undefined;
+  try {
+    fd = openSync(absPath, 'r');
+    const buf = Buffer.alloc(8_192);
+    const read = readSync(fd, buf, 0, buf.length, 0);
+    return buf.subarray(0, read).includes(0);
+  } catch {
+    return true;
+  } finally {
+    if (fd !== undefined) closeSync(fd);
+  }
+}
+
+export interface FsRepoSourceOptions {
+  root: string;
+  maxFiles: number;
+  maxFileBytes: number;
+}
+
+/** Working tree + `git` subprocess implementation of {@link RepoSource}. */
+export class FsRepoSource implements RepoSource {
+  private cachedFiles: RepoFileRef[] | undefined;
+
+  constructor(private readonly opts: FsRepoSourceOptions) {}
+
+  listFiles(): RepoFileRef[] {
+    if (this.cachedFiles) return this.cachedFiles;
+    const out: RepoFileRef[] = [];
+    this.walk(this.opts.root, out);
+    this.cachedFiles = out;
+    return out;
+  }
+
+  readFile(path: string): string | null {
+    try {
+      return readFileSync(join(this.opts.root, path), 'utf8');
+    } catch {
+      return null;
+    }
+  }
+
+  head(): string | null {
+    return this.git(['rev-parse', 'HEAD'])?.trim() ?? null;
+  }
+
+  readCommits(opts: { since?: string | undefined; limit: number }): CommitRecord[] {
+    const range = opts.since ? [`${opts.since}..HEAD`] : [];
+    const raw = this.git([
+      'log',
+      ...range,
+      '--no-merges',
+      '--name-only',
+      `--max-count=${Math.max(1, Math.trunc(opts.limit))}`,
+      `--format=${GIT_FORMAT}`,
+    ]);
+    return raw === null ? [] : parseCommitLog(raw);
+  }
+
+  changedSince(since: string): string[] | null {
+    const raw = this.git(['diff', '--name-only', `${since}..HEAD`]);
+    if (raw === null) return null;
+    return raw
+      .split('\n')
+      .map((l) => l.trim())
+      .filter(Boolean);
+  }
+
+  /** One `git` invocation; null on any failure (no git, bad ref, no repo). */
+  private git(args: string[]): string | null {
+    try {
+      return execFileSync('git', args, {
+        cwd: this.opts.root,
+        encoding: 'utf8',
+        maxBuffer: 64 * 1024 * 1024,
+        stdio: ['ignore', 'pipe', 'ignore'],
+      });
+    } catch {
+      return null;
+    }
+  }
+
+  private walk(dir: string, out: RepoFileRef[]): void {
+    if (out.length >= this.opts.maxFiles) return;
+    let entries: Dirent[];
+    try {
+      entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (out.length >= this.opts.maxFiles) return;
+      const abs = join(dir, entry.name);
+      // Symlinks are never followed: a link out of the tree would escape
+      // every cap and could re-enter the tree in a cycle.
+      if (entry.isSymbolicLink()) continue;
+      if (entry.isDirectory()) {
+        if (SKIP_DIRS.has(entry.name)) continue;
+        if (entry.name.startsWith('.') && !ALLOWED_DOT_DIRS.has(entry.name)) continue;
+        this.walk(abs, out);
+        continue;
+      }
+      if (!entry.isFile()) continue;
+      let bytes: number;
+      try {
+        bytes = statSync(abs).size;
+      } catch {
+        continue;
+      }
+      if (bytes === 0 || bytes > this.opts.maxFileBytes) continue;
+      if (looksBinary(abs)) continue;
+      out.push({ path: relative(this.opts.root, abs).split(sep).join('/'), bytes });
+    }
+  }
+}

--- a/src/code-memory/repo-indexer/run.ts
+++ b/src/code-memory/repo-indexer/run.ts
@@ -1,0 +1,204 @@
+/**
+ * The runner: core derivers + registered ecosystem modules → fences →
+ * evidence documents → submission, with the state file that makes a
+ * re-run over an unchanged repository a no-op.
+ *
+ * IDEMPOTENCY has two independent layers. Client-side, the state file
+ * remembers every candidate id already submitted, so a second run drops
+ * them before composing anything. Server-side, the evidence document is
+ * a deterministic function of the facts, so it dedupes by contentHash
+ * and the `indexer_run` UNIQUE ledger answers 409 for a slot already
+ * processed — which the runner reports, never treats as an error.
+ *
+ * INCREMENTAL runs pass `--since <commit>`: history is read as
+ * `since..HEAD` and the working-tree scan is narrowed to the paths that
+ * commit range touched. When the delta cannot be computed (no git, an
+ * unknown ref) the runner falls back to a full walk and says so, rather
+ * than silently indexing nothing.
+ */
+import { assignPaths, type EcosystemModule } from './modules/module.types';
+import { ownershipFromCodeowners, ownershipFromHistory } from './core/ownership';
+import { decisionsFromCommits, decisionsFromDocs } from './core/decisions';
+import { warningsFromComments } from './core/warnings';
+import {
+  applyGroundingFence,
+  applyShapeFences,
+  composeEvidenceDocuments,
+  identify,
+  toCandidatePayload,
+} from './bundle';
+import type { BrainClient } from './brain-client';
+import type { RepoSource } from './repo-source';
+import type { DroppedRepoFact, IdentifiedRepoFact, IndexerCaps, RepoFact } from './types';
+
+export interface RunState {
+  /** HEAD of the last successful run — the default `--since`. */
+  lastCommit: string | null;
+  lastRunAt: string | null;
+  /** Every candidate id ever submitted from this repository. */
+  submitted: string[];
+}
+
+export const EMPTY_STATE: RunState = { lastCommit: null, lastRunAt: null, submitted: [] };
+
+export interface RunOptions {
+  source: RepoSource;
+  client: BrainClient;
+  caps: IndexerCaps;
+  packId: string;
+  repoLabel: string;
+  modules: readonly EcosystemModule[];
+  state: RunState;
+  /** Exclusive lower-bound commit-ish; undefined = full walk. */
+  since?: string | undefined;
+  log?: ((line: string) => void) | undefined;
+}
+
+export interface RunSummary {
+  headSha: string | null;
+  incremental: boolean;
+  filesScanned: number;
+  commitsRead: number;
+  derived: number;
+  submitted: number;
+  dropped: DroppedRepoFact[];
+  documents: number;
+  alreadyProcessed: number;
+  /** Producer → fact count, for the operator's run report. */
+  byProducer: Record<string, number>;
+  nextState: RunState;
+}
+
+/** Derive everything: the language-agnostic core, then the modules. */
+export function derive(p: {
+  source: RepoSource;
+  paths: string[];
+  modules: readonly EcosystemModule[];
+  caps: IndexerCaps;
+  headSha: string | null;
+  commits: ReturnType<RepoSource['readCommits']>;
+}): RepoFact[] {
+  const facts: RepoFact[] = [];
+
+  // ── Core (always runs, knows no language) ─────────────────────────
+  const declared = ownershipFromCodeowners(p.source);
+  facts.push(
+    ...(declared.length > 0
+      ? declared
+      : ownershipFromHistory({ commits: p.commits, caps: p.caps, headSha: p.headSha })),
+  );
+  facts.push(...decisionsFromCommits({ commits: p.commits, caps: p.caps }));
+  facts.push(...decisionsFromDocs(p.source, p.paths));
+  facts.push(...warningsFromComments({ source: p.source, paths: p.paths, caps: p.caps }));
+
+  // ── Ecosystem modules (each on the paths it won) ──────────────────
+  const assigned = assignPaths(p.modules, p.paths);
+  for (const mod of p.modules) {
+    const owned = assigned.get(mod.id);
+    if (!owned || owned.length === 0) continue;
+    facts.push(...mod.extract({ paths: owned, source: p.source, caps: p.caps }));
+  }
+  return facts;
+}
+
+export async function runIndexer(opts: RunOptions): Promise<RunSummary> {
+  const log = opts.log ?? ((): void => {});
+  const headSha = opts.source.head();
+  const commits = opts.source.readCommits({
+    since: opts.since,
+    limit: opts.since ? opts.caps.maxCommits : opts.caps.ownershipHistoryDepth,
+  });
+
+  const allPaths = opts.source.listFiles().map((f) => f.path);
+  let paths = allPaths;
+  let incremental = false;
+  if (opts.since) {
+    const changed = opts.source.changedSince(opts.since);
+    if (changed === null) {
+      log(`since=${opts.since} could not be resolved — falling back to a full walk`);
+    } else {
+      const changedSet = new Set(changed);
+      paths = allPaths.filter((p) => changedSet.has(p));
+      incremental = true;
+      log(`incremental: ${paths.length} of ${allPaths.length} files changed since ${opts.since}`);
+    }
+  }
+
+  const derived = derive({
+    source: opts.source,
+    paths,
+    modules: opts.modules,
+    caps: opts.caps,
+    headSha,
+    commits,
+  });
+  const identified = identify(derived);
+  const byProducer: Record<string, number> = {};
+  for (const fact of identified) {
+    byProducer[fact.producer] = (byProducer[fact.producer] ?? 0) + 1;
+  }
+
+  const shape = applyShapeFences({
+    facts: identified,
+    packId: opts.packId,
+    caps: opts.caps,
+    alreadySubmitted: new Set(opts.state.submitted),
+  });
+  const dropped: DroppedRepoFact[] = [...shape.dropped];
+
+  const documents = composeEvidenceDocuments({
+    facts: shape.kept,
+    packId: opts.packId,
+    caps: opts.caps,
+    repoLabel: opts.repoLabel,
+    headSha,
+  });
+
+  const submittedIds: string[] = [];
+  let alreadyProcessed = 0;
+  let documentCount = 0;
+  const occurredAt = new Date().toISOString();
+  for (const [i, doc] of documents.entries()) {
+    const grounded = applyGroundingFence(doc);
+    dropped.push(...grounded.dropped);
+    if (grounded.kept.length === 0) continue;
+    const ingested = await opts.client.ingestDocument({
+      text: doc.text,
+      title: `${opts.repoLabel} repository evidence ${i + 1}/${documents.length}`,
+      originUri: `repo://${opts.repoLabel}${headSha ? `@${headSha}` : ''}#${i + 1}`,
+      occurredAt,
+    });
+    const outcome = await opts.client.submitCandidates(
+      ingested.documentId,
+      toCandidatePayload(grounded.kept, opts.packId),
+    );
+    documentCount += 1;
+    if (outcome.alreadyProcessed) {
+      alreadyProcessed += 1;
+      log(`document ${ingested.documentId} was already processed for this pack version`);
+    } else if (outcome.dropped.length > 0) {
+      log(`server dropped ${outcome.dropped.length} item(s) from ${ingested.documentId}`);
+    }
+    // Recorded either way: an already-processed slot means these exact
+    // candidates are staged, so re-offering them next run is pure noise.
+    submittedIds.push(...grounded.kept.map((f: IdentifiedRepoFact) => f.candidateId));
+  }
+
+  return {
+    headSha,
+    incremental,
+    filesScanned: paths.length,
+    commitsRead: commits.length,
+    derived: identified.length,
+    submitted: submittedIds.length,
+    dropped,
+    documents: documentCount,
+    alreadyProcessed,
+    byProducer,
+    nextState: {
+      lastCommit: headSha ?? opts.state.lastCommit,
+      lastRunAt: occurredAt,
+      submitted: [...new Set([...opts.state.submitted, ...submittedIds])],
+    },
+  };
+}

--- a/src/code-memory/repo-indexer/types.ts
+++ b/src/code-memory/repo-indexer/types.ts
@@ -1,0 +1,183 @@
+/**
+ * Reference code-repository indexer for the `code_memory` domain pack —
+ * shared shapes and caps.
+ *
+ * The pack has declared `indexer: { mode: 'external' }` since 0.4.0 but
+ * nothing ever fed it: the submission protocol, the work API and the
+ * candidate ledger all existed with no producer on the code side. This
+ * module is that producer. It walks a git working tree plus its history
+ * and derives ONLY facts that trace back to a concrete artefact — a
+ * CODEOWNERS line, a package.json entry, a config-catalogue row, a
+ * commit message that states a decision, a comment that states a
+ * warning. Nothing here summarizes code; a claim with no verbatim
+ * artefact behind it is not emitted at all.
+ *
+ * Every derived fact carries its `derivation` — one sentence naming the
+ * mechanical rule that produced it — which is written into the evidence
+ * document alongside the quoted artefact. Brain therefore stores the
+ * REASON the indexer believed something, not a bare assertion.
+ */
+
+/** The code_memory local predicate kinds this indexer can emit. */
+export type RepoFactKind =
+  'owns' | 'depends_on_version' | 'default_value' | 'decided' | 'because' | 'invariant' | 'gotcha';
+
+/** Where a fact was read from — a repo-relative path and a line span. */
+export interface RepoEvidence {
+  /** Repo-relative path of the artefact (POSIX separators). */
+  path: string;
+  /** 1-based inclusive line span of `excerpt` inside `path`. */
+  startLine: number;
+  endLine: number;
+  /** The artefact text, copied verbatim — never paraphrased. */
+  excerpt: string;
+  /** Commit the evidence was read at, when the source is git history. */
+  commit?: string | undefined;
+}
+
+/**
+ * Who derived a fact. `core:<section>` for the language-agnostic core,
+ * `module:<id>@<version>` for an ecosystem module. It rides into the
+ * evidence document and into every fact's derivation sentence, so a
+ * module version bump is visible in exactly what it produced — the
+ * server-side CandidateProvenance is a fixed shape (indexerId,
+ * packVersion, executionMode, model) and cannot carry it.
+ */
+export type FactProducer = `core:${string}` | `module:${string}`;
+
+/** One derived, artefact-traceable claim about the repository. */
+export interface RepoFact {
+  /** {@link FactProducer} — set by the deriver, never by the caller. */
+  producer: FactProducer;
+  /**
+   * The code anchor (path), flag identifier, or dependency name that owns
+   * the claim. Always a verbatim repo token — never a prose subject.
+   */
+  subject: string;
+  /** Entity type hint passed through to the candidate batch. */
+  subjectType: 'asset' | 'concept';
+  kind: RepoFactKind;
+  /** The claim value, verbatim from the artefact. */
+  object: string;
+  /** The mechanical rule that produced this fact, as one sentence. */
+  derivation: string;
+  evidence: RepoEvidence;
+  confidence: number;
+}
+
+/** A fact plus its deterministic identity (the idempotency key). */
+export interface IdentifiedRepoFact extends RepoFact {
+  /** sha256(path | kind | contentHash) — stable across runs and clones. */
+  candidateId: string;
+}
+
+/** A fact the client refused to send, and why. */
+export interface DroppedRepoFact {
+  candidateId: string;
+  kind: RepoFactKind;
+  subject: string;
+  reason:
+    | 'namespace_fence'
+    | 'not_value_shaped'
+    | 'name_too_long'
+    | 'object_too_long'
+    | 'empty_span'
+    | 'ungrounded_entity'
+    | 'ungrounded_value'
+    | 'already_submitted'
+    | 'single_active_collision'
+    | 'over_run_cap';
+  detail: string;
+}
+
+/**
+ * Bounds on one run. Every one is a hard stop, not a hint: an indexer
+ * pointed at an unexpected tree (a monorepo, a vendored checkout) must
+ * degrade into "indexed the first N" rather than into an unbounded walk
+ * or a submission flood.
+ */
+export interface IndexerCaps {
+  /** Working-tree files opened for scanning. */
+  maxFiles: number;
+  /** Files larger than this are skipped whole (minified/generated). */
+  maxFileBytes: number;
+  /** Commits read from history. */
+  maxCommits: number;
+  /** Facts emitted per run, across every deriver. */
+  maxCandidates: number;
+  /** Facts packed into one evidence document (server cap is 200/kind). */
+  maxFactsPerDocument: number;
+  /** Evidence-document text budget (server hard cap is 512_000). */
+  maxDocChars: number;
+  /** Warning-comment facts taken from a single file. */
+  maxWarningsPerFile: number;
+  /** Commits inspected when attributing a path to its dominant author. */
+  ownershipHistoryDepth: number;
+  /** Minimum commits touching a path before authorship is asserted. */
+  ownershipMinCommits: number;
+  /** Minimum share of those commits the dominant author must hold. */
+  ownershipMinShare: number;
+}
+
+export const DEFAULT_CAPS: IndexerCaps = {
+  maxFiles: 5_000,
+  maxFileBytes: 512_000,
+  maxCommits: 500,
+  maxCandidates: 500,
+  maxFactsPerDocument: 120,
+  maxDocChars: 100_000,
+  maxWarningsPerFile: 5,
+  ownershipHistoryDepth: 200,
+  ownershipMinCommits: 3,
+  ownershipMinShare: 0.5,
+};
+
+/** Server-side submission caps (src/documents/external-candidates.service.ts). */
+export const MAX_ENTITY_NAME_CHARS = 256;
+export const MAX_FACT_OBJECT_CHARS = 2_000;
+
+/**
+ * Trees never walked. Build output, dependency stores and vendored code
+ * are not this repository's engineering "why" — they are someone else's,
+ * and indexing them would mint ownership and gotcha claims about code the
+ * tenant does not author.
+ */
+export const SKIP_DIRS = new Set([
+  '.git',
+  'node_modules',
+  'dist',
+  'build',
+  'out',
+  'coverage',
+  '.next',
+  '.turbo',
+  '.cache',
+  'vendor',
+  'third_party',
+  'thirdparty',
+  '.pnpm-store',
+  '.venv',
+  '__pycache__',
+  'models',
+]);
+
+/** Extensions whose comments are scanned for warnings. */
+export const SCANNED_EXTENSIONS = new Set([
+  '.ts',
+  '.tsx',
+  '.js',
+  '.jsx',
+  '.mjs',
+  '.cjs',
+  '.go',
+  '.rs',
+  '.py',
+  '.rb',
+  '.java',
+  '.kt',
+  '.sql',
+  '.sh',
+]);
+
+/** Extensions read as prose for ADR-style decisions. */
+export const PROSE_EXTENSIONS = new Set(['.md', '.mdx']);

--- a/test/code-repo-indexer.unit-spec.ts
+++ b/test/code-repo-indexer.unit-spec.ts
@@ -65,6 +65,7 @@ import {
   toCandidatePayload,
 } from '../src/code-memory/repo-indexer/bundle';
 import { EMPTY_STATE, runIndexer, type RunState } from '../src/code-memory/repo-indexer/run';
+import { CODE_MEMORY_PACK } from '../src/ai/domain-packs/code-memory.pack';
 import type {
   BrainClient,
   IngestDocumentInput,
@@ -602,22 +603,14 @@ describe('bundle', () => {
     expect(dropped[0]?.detail).toBe('code_memory__other_pack__thing');
   });
 
-  it('keeps only the strongest claim for a single_active predicate', () => {
-    const weak = fact({
-      kind: 'invariant',
-      object: 'the resolver must run first',
-      confidence: 0.6,
-    });
+  it('keeps only the strongest claim for a genuinely single_active predicate', () => {
+    const weak = fact({ kind: 'owns', subject: 'src', object: 'ada', confidence: 0.55 });
     const strong = fact({
-      kind: 'invariant',
-      object: 'the resolver must never be reentered',
+      kind: 'owns',
+      subject: 'src',
+      object: 'grace',
       confidence: 0.9,
-      evidence: {
-        path: 'src/a.ts',
-        startLine: 9,
-        endLine: 9,
-        excerpt: '// must never be reentered',
-      },
+      evidence: { path: '.github/CODEOWNERS', startLine: 2, endLine: 2, excerpt: '/src/ @grace' },
     });
     const { kept, dropped } = applyShapeFences({
       facts: identify([weak, strong]),
@@ -625,8 +618,42 @@ describe('bundle', () => {
       caps,
       alreadySubmitted: new Set(),
     });
-    expect(kept.map((f) => f.object)).toEqual(['the resolver must never be reentered']);
+    expect(kept.map((f) => f.object)).toEqual(['grace']);
     expect(dropped[0]?.reason).toBe('single_active_collision');
+  });
+
+  /**
+   * The regression this fence originally exposed. Under pack 0.5.0
+   * `invariant` was single_active, so a file's rules retired each other
+   * and the first dogfood pass had to drop 1254 of them across this
+   * repository. 0.6.0 made the predicate append_only; coexisting rules
+   * must now survive the fence intact.
+   */
+  it('lets coexisting invariants through — they do not retire each other', () => {
+    const rules = [
+      'every handler validates its body with the shared zod schema',
+      'amounts are always emitted in cents, never floats',
+      'the resolver must never be reentered',
+    ].map((object, i) =>
+      fact({
+        kind: 'invariant',
+        object,
+        evidence: { path: 'src/a.ts', startLine: i + 1, endLine: i + 1, excerpt: `// ${object}` },
+      }),
+    );
+    const { kept, dropped } = applyShapeFences({
+      facts: identify(rules),
+      packId: 'code_memory',
+      caps,
+      alreadySubmitted: new Set(),
+    });
+    expect(kept).toHaveLength(3);
+    expect(dropped).toHaveLength(0);
+    // ...and the fence still reads its set from the manifest, so the
+    // exemption is the ontology's doing, not a hard-coded carve-out.
+    expect(CODE_MEMORY_PACK.predicates.find((pr) => pr.localId === 'invariant')?.semantics).toBe(
+      'append_only',
+    );
   });
 
   it('composes an evidence document each fact grounds against', () => {

--- a/test/code-repo-indexer.unit-spec.ts
+++ b/test/code-repo-indexer.unit-spec.ts
@@ -1,0 +1,908 @@
+/**
+ * Reference code-repository indexer (src/code-memory/repo-indexer).
+ *
+ * No network: the submission client is an interface and every test
+ * drives a stub. No git binary is required either — `RepoSource` is an
+ * interface, so the derivers run against an in-memory fixture. The one
+ * suite that DOES need git (`git init` + real commits) is guarded by a
+ * probe and skips when the binary is absent.
+ */
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { isGroundedSpan, normalizeForGrounding } from '../src/ai/extractor-internals/grounding';
+import {
+  DEFAULT_CAPS,
+  type IndexerCaps,
+  type RepoFact,
+} from '../src/code-memory/repo-indexer/types';
+import {
+  FsRepoSource,
+  parseCommitLog,
+  type CommitRecord,
+  type RepoFileRef,
+  type RepoSource,
+} from '../src/code-memory/repo-indexer/repo-source';
+import {
+  ownershipFromCodeowners,
+  ownershipFromHistory,
+  parseCodeowners,
+} from '../src/code-memory/repo-indexer/core/ownership';
+import {
+  decisionsFromCommits,
+  decisionsFromDocs,
+} from '../src/code-memory/repo-indexer/core/decisions';
+import {
+  extractComments,
+  warningSentences,
+  warningsFromComments,
+} from '../src/code-memory/repo-indexer/core/warnings';
+import {
+  JAVASCRIPT_MODULE,
+  parseLockfileVersions,
+  parseManifestDeps,
+} from '../src/code-memory/repo-indexer/modules/javascript.module';
+import {
+  CONFIG_CATALOG_MODULE,
+  DEFAULT_CONSTANTS_MODULE,
+  isValueShaped,
+  parseConfigCatalog,
+  parseDefaultConstants,
+} from '../src/code-memory/repo-indexer/modules/config.module';
+import {
+  assignPaths,
+  moduleProducer,
+  type EcosystemModule,
+} from '../src/code-memory/repo-indexer/modules/module.types';
+import { BUILTIN_MODULES, selectModules } from '../src/code-memory/repo-indexer/modules/registry';
+import {
+  applyGroundingFence,
+  applyShapeFences,
+  candidateIdOf,
+  composeEvidenceDocuments,
+  identify,
+  toCandidatePayload,
+} from '../src/code-memory/repo-indexer/bundle';
+import { EMPTY_STATE, runIndexer, type RunState } from '../src/code-memory/repo-indexer/run';
+import type {
+  BrainClient,
+  IngestDocumentInput,
+  IngestedDocument,
+  SubmissionOutcome,
+} from '../src/code-memory/repo-indexer/brain-client';
+import type { CandidatePayload } from '../src/code-memory/repo-indexer/bundle';
+
+// ── fixtures ─────────────────────────────────────────────────────────
+
+class FakeRepoSource implements RepoSource {
+  constructor(
+    private readonly files: Record<string, string>,
+    private readonly commits: CommitRecord[] = [],
+    private readonly headSha: string | null = 'head0000',
+    private readonly changed: string[] | null = null,
+  ) {}
+
+  listFiles(): RepoFileRef[] {
+    return Object.entries(this.files).map(([path, text]) => ({ path, bytes: text.length }));
+  }
+
+  readFile(path: string): string | null {
+    return this.files[path] ?? null;
+  }
+
+  readCommits(opts: { since?: string | undefined; limit: number }): CommitRecord[] {
+    return this.commits.slice(0, opts.limit);
+  }
+
+  head(): string | null {
+    return this.headSha;
+  }
+
+  changedSince(): string[] | null {
+    return this.changed;
+  }
+}
+
+class StubBrainClient implements BrainClient {
+  readonly documents: IngestDocumentInput[] = [];
+  readonly payloads: CandidatePayload[] = [];
+  conflictNext = false;
+
+  ingestDocument(input: IngestDocumentInput): Promise<IngestedDocument> {
+    this.documents.push(input);
+    return Promise.resolve({
+      documentId: `source_document:${this.documents.length}`,
+      deduplicated: false,
+    });
+  }
+
+  submitCandidates(_documentId: string, payload: CandidatePayload): Promise<SubmissionOutcome> {
+    this.payloads.push(payload);
+    return Promise.resolve({
+      runId: 'indexer_run:1',
+      staged: { entities: payload.entities.length, facts: payload.facts.length, relations: 0 },
+      dropped: [],
+      alreadyProcessed: this.conflictNext,
+    });
+  }
+}
+
+function commit(over: Partial<CommitRecord>): CommitRecord {
+  return {
+    sha: 'a'.repeat(40),
+    authorName: 'Ada',
+    authorEmail: 'ada@example.com',
+    date: '2026-01-01T00:00:00Z',
+    message: 'chore: touch',
+    changedFiles: [],
+    ...over,
+  };
+}
+
+function fact(over: Partial<RepoFact> = {}): RepoFact {
+  return {
+    producer: 'core:warnings',
+    subject: 'src/a.ts',
+    subjectType: 'asset',
+    kind: 'gotcha',
+    object: 'beware: the resolver must never be called twice',
+    derivation: 'quoted from a comment',
+    evidence: {
+      path: 'src/a.ts',
+      startLine: 1,
+      endLine: 1,
+      excerpt: '// beware: the resolver must never be called twice',
+    },
+    confidence: 0.75,
+    ...over,
+  };
+}
+
+const caps: IndexerCaps = { ...DEFAULT_CAPS };
+
+// ── ownership ────────────────────────────────────────────────────────
+
+describe('ownership', () => {
+  it('reads declared CODEOWNERS rules and strips the @ sigil', () => {
+    const source = new FakeRepoSource({
+      '.github/CODEOWNERS': ['# comment', '/src/fovea/ @mikefluff', 'docs @team-a @team-b'].join(
+        '\n',
+      ),
+    });
+    const facts = ownershipFromCodeowners(source);
+    expect(facts.map((f) => [f.subject, f.object])).toEqual([
+      ['src/fovea', 'mikefluff'],
+      ['docs', 'team-a'],
+    ]);
+    expect(facts[1]?.derivation).toContain('declares 2 owners');
+    expect(facts[0]?.evidence.excerpt).toBe('/src/fovea/ @mikefluff');
+  });
+
+  it('refuses glob patterns — a glob names no code anchor', () => {
+    expect(parseCodeowners('*.ts @someone\nsrc/** @someone').length).toBe(0);
+  });
+
+  it('derives ownership from history only past both thresholds', () => {
+    const commits = [
+      commit({ sha: '1', authorName: 'Ada', changedFiles: ['src/pkg/a.ts'] }),
+      commit({ sha: '2', authorName: 'Ada', changedFiles: ['src/pkg/b.ts'] }),
+      commit({ sha: '3', authorName: 'Ada', changedFiles: ['src/pkg/c.ts'] }),
+      commit({ sha: '4', authorName: 'Linus', changedFiles: ['src/pkg/d.ts'] }),
+      // 'lonely' is touched twice only — under the min-commits threshold.
+      commit({ sha: '5', authorName: 'Grace', changedFiles: ['lonely/x.ts'] }),
+      commit({ sha: '6', authorName: 'Grace', changedFiles: ['lonely/y.ts'] }),
+    ];
+    const facts = ownershipFromHistory({ commits, caps, headSha: 'deadbeef' });
+    const subjects = facts.map((f) => f.subject);
+    expect(subjects).toContain('src/pkg');
+    expect(subjects).not.toContain('lonely');
+    const pkg = facts.find((f) => f.subject === 'src/pkg');
+    expect(pkg?.object).toBe('Ada');
+    // The RULE travels with the fact, not a bare authorship assertion.
+    expect(pkg?.derivation).toContain('authored 3 of the 4 commits');
+    expect(pkg?.derivation).toContain('not a declaration of ownership');
+    expect(pkg?.confidence).toBeLessThan(0.9);
+  });
+
+  it('emits nothing when no author is dominant enough', () => {
+    const commits = [
+      commit({ sha: '1', authorName: 'Ada', changedFiles: ['src/split/a.ts'] }),
+      commit({ sha: '2', authorName: 'Linus', changedFiles: ['src/split/b.ts'] }),
+      commit({ sha: '3', authorName: 'Grace', changedFiles: ['src/split/c.ts'] }),
+      commit({ sha: '4', authorName: 'Barbara', changedFiles: ['src/split/d.ts'] }),
+    ];
+    const facts = ownershipFromHistory({ commits, caps, headSha: null });
+    expect(facts.find((f) => f.subject === 'src/split')).toBeUndefined();
+  });
+});
+
+// ── dependencies (javascript module) ─────────────────────────────────
+
+describe('javascript module', () => {
+  const manifest = JSON.stringify({
+    dependencies: { '@nestjs/common': '^11.1.29' },
+    devDependencies: { jest: '30.0.0' },
+    packageManager: 'pnpm@10.15.0',
+    engines: { node: '>=20' },
+  });
+  const lock = [
+    "lockfileVersion: '9.0'",
+    '',
+    'importers:',
+    '',
+    '  .:',
+    '    dependencies:',
+    "      '@nestjs/common':",
+    '        specifier: ^11.1.29',
+    '        version: 11.1.29(rxjs@7.8.2)',
+    '',
+    'packages:',
+    '',
+    '  unrelated@1.0.0:',
+    '    resolution: {integrity: sha512-x}',
+  ].join('\n');
+
+  it('parses declared dependencies including tool pins', () => {
+    const deps = parseManifestDeps(manifest);
+    expect(deps).toEqual(
+      expect.arrayContaining([
+        { name: '@nestjs/common', spec: '^11.1.29', section: 'dependencies' },
+        { name: 'jest', spec: '30.0.0', section: 'devDependencies' },
+        { name: 'pnpm', spec: '10.15.0', section: 'packageManager' },
+        { name: 'node', spec: '>=20', section: 'engines' },
+      ]),
+    );
+  });
+
+  it('reads exact installed versions out of the pnpm importers block', () => {
+    const resolved = parseLockfileVersions(lock);
+    expect(resolved.get('@nestjs/common')).toBe('11.1.29');
+    expect(resolved.has('unrelated')).toBe(false);
+  });
+
+  it('prefers the lockfile version and falls back to the declared range', () => {
+    const source = new FakeRepoSource({ 'package.json': manifest, 'pnpm-lock.yaml': lock });
+    const facts = JAVASCRIPT_MODULE.extract({
+      paths: ['package.json', 'pnpm-lock.yaml'],
+      source,
+      caps,
+    });
+    const nest = facts.find((f) => f.subject === '@nestjs/common');
+    expect(nest?.object).toBe('11.1.29');
+    expect(nest?.derivation).toContain('Exact installed version');
+    expect(nest?.producer).toBe(moduleProducer(JAVASCRIPT_MODULE));
+
+    const jest = facts.find((f) => f.subject === 'jest');
+    expect(jest?.object).toBe('30.0.0');
+    expect(jest?.derivation).toContain('no lockfile resolution');
+    expect(jest?.evidence.path).toBe('package.json');
+    expect(jest?.evidence.startLine).toBeGreaterThan(0);
+  });
+
+  it('emits nothing for a malformed manifest rather than guessing', () => {
+    expect(parseManifestDeps('{ not json').length).toBe(0);
+  });
+});
+
+// ── flag defaults (config modules) ───────────────────────────────────
+
+describe('config modules', () => {
+  it('accepts value-shaped defaults and rejects prose', () => {
+    expect(isValueShaped('0')).toBe(true);
+    expect(isValueShaped('true')).toBe(true);
+    expect(isValueShaped('strict')).toBe(true);
+    expect(isValueShaped('Xenova/bert-base-multilingual-cased-ner-hrl')).toBe(true);
+    expect(isValueShaped('every duration in milliseconds')).toBe(false);
+    expect(isValueShaped('the timeout, in ms')).toBe(false);
+    expect(isValueShaped('')).toBe(false);
+    expect(isValueShaped('x'.repeat(65))).toBe(false);
+  });
+
+  it('reads catalogue rows and skips null defaults', () => {
+    const catalogue = [
+      'export const CONFIG_CATALOG = [',
+      '  {',
+      "    key: 'EXTRACTOR_SC_PASSES',",
+      "    defaultValue: '1',",
+      '  },',
+      '  {',
+      "    key: 'OPENAI_API_KEY',",
+      '    defaultValue: null,',
+      '  },',
+      '];',
+    ].join('\n');
+    const rows = parseConfigCatalog(catalogue);
+    expect(rows.map((r) => [r.key, r.value])).toEqual([
+      ['EXTRACTOR_SC_PASSES', '1'],
+      ['OPENAI_API_KEY', null],
+    ]);
+    const facts = CONFIG_CATALOG_MODULE.extract({
+      paths: ['src/admin/config-catalog.data.ts'],
+      source: new FakeRepoSource({ 'src/admin/config-catalog.data.ts': catalogue }),
+      caps,
+    });
+    expect(facts.map((f) => [f.subject, f.object])).toEqual([['EXTRACTOR_SC_PASSES', '1']]);
+  });
+
+  it('reads DEFAULT_* literals but never expressions', () => {
+    const src = [
+      "export const DEFAULT_MODE = 'strict';",
+      'const DEFAULT_TIMEOUT_MS = 10_000;',
+      'const DEFAULT_FROM_ENV = process.env.X ?? 5;',
+      'const MAX_RETRIES = 3;',
+    ].join('\n');
+    const parsed = parseDefaultConstants(src);
+    expect(parsed.map((c) => [c.name, c.value])).toEqual([
+      ['DEFAULT_MODE', 'strict'],
+      ['DEFAULT_TIMEOUT_MS', '10_000'],
+    ]);
+  });
+
+  it('drops a prose "default" client-side instead of sending it', () => {
+    const prose = fact({
+      kind: 'default_value',
+      subject: 'PAYMENT_NORMALIZER',
+      object: 'every duration in milliseconds',
+    });
+    const { kept, dropped } = applyShapeFences({
+      facts: identify([prose]),
+      packId: 'code_memory',
+      caps,
+      alreadySubmitted: new Set(),
+    });
+    expect(kept).toHaveLength(0);
+    expect(dropped[0]?.reason).toBe('not_value_shaped');
+  });
+});
+
+// ── module registry ──────────────────────────────────────────────────
+
+describe('module registry', () => {
+  it('resolves a contested path deterministically by priority', () => {
+    const path = 'src/admin/config-catalog.data.ts';
+    expect(CONFIG_CATALOG_MODULE.claims(path)).toBe(true);
+    expect(DEFAULT_CONSTANTS_MODULE.claims(path)).toBe(true);
+    expect(CONFIG_CATALOG_MODULE.priority).toBeGreaterThan(DEFAULT_CONSTANTS_MODULE.priority);
+
+    const forward = assignPaths([CONFIG_CATALOG_MODULE, DEFAULT_CONSTANTS_MODULE], [path]);
+    const reversed = assignPaths([DEFAULT_CONSTANTS_MODULE, CONFIG_CATALOG_MODULE], [path]);
+    // Registration order must not change the outcome.
+    expect(forward.get(CONFIG_CATALOG_MODULE.id)).toEqual([path]);
+    expect(reversed.get(CONFIG_CATALOG_MODULE.id)).toEqual([path]);
+    expect(forward.get(DEFAULT_CONSTANTS_MODULE.id)).toBeUndefined();
+  });
+
+  it('is explicit — selectModules rejects an unknown id', () => {
+    expect(selectModules(undefined)).toBe(BUILTIN_MODULES);
+    expect(selectModules(['javascript']).map((m) => m.id)).toEqual(['javascript']);
+    expect(() => selectModules(['python'])).toThrow(/unknown ecosystem module/);
+  });
+
+  it('a third-party module needs no core change to participate', () => {
+    const goModule: EcosystemModule = {
+      id: 'go',
+      version: '0.1.0',
+      description: 'go.mod pins',
+      priority: 50,
+      claims: (p) => p.endsWith('go.mod'),
+      extract: ({ paths }) =>
+        paths.map((p) =>
+          fact({
+            producer: 'module:go@0.1.0',
+            subject: 'rsc.io/quote',
+            kind: 'depends_on_version',
+            object: 'v1.5.2',
+            evidence: { path: p, startLine: 3, endLine: 3, excerpt: 'require rsc.io/quote v1.5.2' },
+          }),
+        ),
+    };
+    const assigned = assignPaths([...BUILTIN_MODULES, goModule], ['go.mod', 'package.json']);
+    expect(assigned.get('go')).toEqual(['go.mod']);
+    expect(assigned.get('javascript')).toEqual(['package.json']);
+  });
+});
+
+// ── decisions ────────────────────────────────────────────────────────
+
+describe('decisions', () => {
+  it('anchors a commit decision on a path the message names', () => {
+    const facts = decisionsFromCommits({
+      commits: [
+        commit({
+          sha: 'f'.repeat(40),
+          message:
+            'We decided to resolve all facts through one gateway in src/ingest/resolver.ts.\n\nbecause 21 positional args drifted between the call-sites of src/ingest/resolver.ts.',
+          changedFiles: ['a.ts', 'b.ts', 'c.ts'],
+        }),
+      ],
+      caps,
+    });
+    const decided = facts.find((f) => f.kind === 'decided');
+    expect(decided?.subject).toBe('src/ingest/resolver.ts');
+    expect(decided?.object).toContain('resolve all facts through one gateway');
+    expect(decided?.derivation).toContain('names the anchor');
+    expect(facts.find((f) => f.kind === 'because')?.object).toContain('positional args drifted');
+  });
+
+  it('falls back to the single changed file, and refuses a multi-file commit', () => {
+    const single = decisionsFromCommits({
+      commits: [
+        commit({
+          message: 'We decided to cache answers per tenant rather than per request.',
+          changedFiles: ['src/answers/cache.ts'],
+        }),
+      ],
+      caps,
+    });
+    expect(single[0]?.subject).toBe('src/answers/cache.ts');
+    expect(single[0]?.derivation).toContain('changed exactly one file');
+
+    const ambiguous = decisionsFromCommits({
+      commits: [
+        commit({
+          message: 'We decided to cache answers per tenant rather than per request.',
+          changedFiles: ['a.ts', 'b.ts'],
+        }),
+      ],
+      caps,
+    });
+    expect(ambiguous).toHaveLength(0);
+  });
+
+  it('never reads a decision out of a message that states none', () => {
+    const facts = decisionsFromCommits({
+      commits: [
+        commit({
+          message: 'refactor: rename the resolver and tidy the imports across the module',
+          changedFiles: ['src/ingest/resolver.ts'],
+        }),
+      ],
+      caps,
+    });
+    expect(facts).toHaveLength(0);
+  });
+
+  it('reads an ADR Decision section, anchored on the document itself', () => {
+    const adr = [
+      '# ADR 7: one gateway',
+      '',
+      '## Context',
+      '',
+      'Twenty-one positional arguments had drifted between the call-sites over two quarters.',
+      '',
+      '## Decision',
+      '',
+      'All fact writes go through a single resolver gateway from now on.',
+      '',
+      '## Consequences',
+      '',
+      'Call-sites need updating.',
+    ].join('\n');
+    const facts = decisionsFromDocs(
+      new FakeRepoSource({ 'docs/adr/0007-gateway.md': adr, 'src/x.ts': 'const a = 1;' }),
+      ['docs/adr/0007-gateway.md', 'src/x.ts'],
+    );
+    const decided = facts.find((f) => f.kind === 'decided');
+    expect(decided?.subject).toBe('docs/adr/0007-gateway.md');
+    expect(decided?.object).toBe(
+      'All fact writes go through a single resolver gateway from now on.',
+    );
+    const because = facts.find((f) => f.kind === 'because');
+    expect(because?.object).toContain('positional arguments had drifted');
+    expect(decided?.evidence.startLine).toBeGreaterThan(0);
+  });
+});
+
+// ── warnings ─────────────────────────────────────────────────────────
+
+describe('warnings', () => {
+  it('splits line and block comments into span-carrying blocks', () => {
+    const src = [
+      'const a = 1;',
+      '/**',
+      ' * Beware: the worker must be stubbed or the suite aborts.',
+      ' */',
+      'function f() {}',
+      '// plain trailing note',
+    ].join('\n');
+    const blocks = extractComments(src, '.ts');
+    expect(blocks[0]?.startLine).toBe(2);
+    expect(blocks[0]?.endLine).toBe(4);
+    expect(blocks[0]?.text).toContain('Beware:');
+  });
+
+  it('classifies explicit traps as gotcha and explicit rules as invariant', () => {
+    expect(
+      warningSentences({
+        text: 'Gotcha: pnpm test -- --testPathPattern does not work in this repo.',
+        startLine: 1,
+        endLine: 1,
+      })[0]?.kind,
+    ).toBe('gotcha');
+    expect(
+      warningSentences({
+        text: 'Every duration must be stored in milliseconds, never seconds.',
+        startLine: 1,
+        endLine: 1,
+      })[0]?.kind,
+    ).toBe('invariant');
+  });
+
+  it('ignores a marker that is merely mentioned, and tooling noise', () => {
+    expect(
+      warningSentences({
+        text: 'Decisions, rationale, invariants, gotchas — anchored to code anchors.',
+        startLine: 1,
+        endLine: 1,
+      }),
+    ).toHaveLength(0);
+    expect(
+      warningSentences({
+        text: 'eslint-disable-next-line max-params -- this must stay one call.',
+        startLine: 1,
+        endLine: 1,
+      }),
+    ).toHaveLength(0);
+  });
+
+  it('grounds every warning in the span it reports', () => {
+    const file = [
+      'export function run() {',
+      '  // Gotcha: the lease expires after 30 minutes, so heartbeat well inside it.',
+      '  return 1;',
+      '}',
+    ].join('\n');
+    const facts = warningsFromComments({
+      source: new FakeRepoSource({ 'src/run.ts': file }),
+      paths: ['src/run.ts'],
+      caps,
+    });
+    expect(facts).toHaveLength(1);
+    const w = facts[0] as RepoFact;
+    expect(w.kind).toBe('gotcha');
+    expect(w.evidence.path).toBe('src/run.ts');
+    expect(w.evidence.startLine).toBe(2);
+    // The reported span really does contain the recorded value.
+    const span = file
+      .split('\n')
+      .slice(w.evidence.startLine - 1, w.evidence.endLine)
+      .join('\n');
+    expect(isGroundedSpan(normalizeForGrounding(span), normalizeForGrounding(w.object))).toBe(true);
+  });
+
+  it('does not scan extensions it has no comment syntax for', () => {
+    expect(extractComments('# never do this in a config that must stay stable', '.toml')).toEqual(
+      [],
+    );
+  });
+});
+
+// ── bundle: identity, fences, grounding ──────────────────────────────
+
+describe('bundle', () => {
+  it('derives a stable candidate id from (path, kind, content)', () => {
+    const a = candidateIdOf(fact());
+    expect(candidateIdOf(fact())).toBe(a);
+    expect(candidateIdOf(fact({ kind: 'invariant' }))).not.toBe(a);
+    expect(candidateIdOf(fact({ object: 'something else entirely' }))).not.toBe(a);
+    expect(candidateIdOf(fact({ evidence: { ...fact().evidence, path: 'src/b.ts' } }))).not.toBe(a);
+  });
+
+  it('drops a predicate outside the pack namespace before it is sent', () => {
+    const squatter = fact({ kind: 'other_pack__thing' as RepoFact['kind'] });
+    const { kept, dropped } = applyShapeFences({
+      facts: identify([squatter]),
+      packId: 'code_memory',
+      caps,
+      alreadySubmitted: new Set(),
+    });
+    expect(kept).toHaveLength(0);
+    expect(dropped[0]?.reason).toBe('namespace_fence');
+    expect(dropped[0]?.detail).toBe('code_memory__other_pack__thing');
+  });
+
+  it('keeps only the strongest claim for a single_active predicate', () => {
+    const weak = fact({
+      kind: 'invariant',
+      object: 'the resolver must run first',
+      confidence: 0.6,
+    });
+    const strong = fact({
+      kind: 'invariant',
+      object: 'the resolver must never be reentered',
+      confidence: 0.9,
+      evidence: {
+        path: 'src/a.ts',
+        startLine: 9,
+        endLine: 9,
+        excerpt: '// must never be reentered',
+      },
+    });
+    const { kept, dropped } = applyShapeFences({
+      facts: identify([weak, strong]),
+      packId: 'code_memory',
+      caps,
+      alreadySubmitted: new Set(),
+    });
+    expect(kept.map((f) => f.object)).toEqual(['the resolver must never be reentered']);
+    expect(dropped[0]?.reason).toBe('single_active_collision');
+  });
+
+  it('composes an evidence document each fact grounds against', () => {
+    const facts = identify([fact(), fact({ kind: 'because', object: 'the lease is 30 minutes' })]);
+    const [doc] = composeEvidenceDocuments({
+      facts,
+      packId: 'code_memory',
+      caps,
+      repoLabel: 'fixture',
+      headSha: 'abc123',
+    });
+    expect(doc?.text).toContain('code_memory__gotcha:');
+    expect(doc?.text).toContain('derivation:');
+    expect(doc?.text).toContain('evidence: src/a.ts:1-1');
+    const grounded = applyGroundingFence(doc!);
+    expect(grounded.dropped).toHaveLength(0);
+    expect(grounded.kept).toHaveLength(2);
+  });
+
+  it('drops an ungrounded value rather than letting the server reject it', () => {
+    const doc = {
+      text: '# Repository evidence\n### src/a.ts\nnothing else here\n',
+      facts: identify([fact({ object: 'a value that appears nowhere in the document' })]),
+    };
+    const grounded = applyGroundingFence(doc);
+    expect(grounded.kept).toHaveLength(0);
+    expect(grounded.dropped[0]?.reason).toBe('ungrounded_value');
+  });
+
+  it('splits documents at the per-document fact cap', () => {
+    const many = identify(
+      Array.from({ length: 5 }, (_v, i) =>
+        fact({
+          kind: 'gotcha',
+          object: `beware: trap number ${i} is easy to hit`,
+          evidence: { path: `src/f${i}.ts`, startLine: 1, endLine: 1, excerpt: `// trap ${i}` },
+        }),
+      ),
+    );
+    const docs = composeEvidenceDocuments({
+      facts: many,
+      packId: 'code_memory',
+      caps: { ...caps, maxFactsPerDocument: 2 },
+      repoLabel: 'fixture',
+      headSha: null,
+    });
+    expect(docs.map((d) => d.facts.length)).toEqual([2, 2, 1]);
+  });
+
+  it('collapses repeated subjects into one entity in the payload', () => {
+    const payload = toCandidatePayload(
+      identify([
+        fact({ kind: 'gotcha', object: 'beware: one' }),
+        fact({ kind: 'because', object: 'two' }),
+      ]),
+      'code_memory',
+    );
+    expect(payload.entities).toEqual([{ name: 'src/a.ts', type: 'asset' }]);
+    expect(payload.facts.map((f) => f.predicate)).toEqual([
+      'code_memory__gotcha',
+      'code_memory__because',
+    ]);
+    expect(payload.facts.every((f) => f.entityIndex === 0)).toBe(true);
+    expect(payload.facts[0]?.clause).toContain('beware');
+  });
+});
+
+// ── the runner ───────────────────────────────────────────────────────
+
+const RUNNER_FILES: Record<string, string> = {
+  '.github/CODEOWNERS': '/src/ @ada\n',
+  'package.json': JSON.stringify({ dependencies: { left_pad: '1.3.0' } }),
+  'src/worker.ts': '// Gotcha: the worker must be stubbed or the suite aborts here.\n',
+};
+
+function runnerOptions(over: Partial<Parameters<typeof runIndexer>[0]> = {}) {
+  return {
+    source: new FakeRepoSource(RUNNER_FILES, [], 'head0000'),
+    client: new StubBrainClient(),
+    caps,
+    packId: 'code_memory',
+    repoLabel: 'fixture',
+    modules: BUILTIN_MODULES,
+    state: { ...EMPTY_STATE },
+    ...over,
+  };
+}
+
+describe('runIndexer', () => {
+  it('submits core + module facts, and produces output with no ecosystem module', async () => {
+    const client = new StubBrainClient();
+    const full = await runIndexer(runnerOptions({ client }));
+    expect(full.submitted).toBeGreaterThan(0);
+    const predicates = client.payloads.flatMap((p) => p.facts.map((f) => f.predicate));
+    expect(predicates).toEqual(
+      expect.arrayContaining([
+        'code_memory__owns',
+        'code_memory__gotcha',
+        'code_memory__depends_on_version',
+      ]),
+    );
+
+    // A repository whose ecosystem has no module still gets the core.
+    const coreOnly = new StubBrainClient();
+    const bare = await runIndexer(runnerOptions({ client: coreOnly, modules: [] }));
+    expect(bare.submitted).toBeGreaterThan(0);
+    const bareKinds = coreOnly.payloads.flatMap((p) => p.facts.map((f) => f.predicate));
+    expect(bareKinds).toContain('code_memory__owns');
+    expect(bareKinds).not.toContain('code_memory__depends_on_version');
+  });
+
+  it('is idempotent — a second run over an unchanged repo submits nothing', async () => {
+    const first = await runIndexer(runnerOptions());
+    expect(first.submitted).toBeGreaterThan(0);
+
+    const client = new StubBrainClient();
+    const second = await runIndexer(runnerOptions({ client, state: first.nextState }));
+    expect(second.submitted).toBe(0);
+    expect(second.documents).toBe(0);
+    expect(client.documents).toHaveLength(0);
+    expect(second.dropped.every((d) => d.reason === 'already_submitted')).toBe(true);
+    // And the state does not grow.
+    expect(second.nextState.submitted.sort()).toEqual(first.nextState.submitted.sort());
+  });
+
+  it('records an already-processed slot instead of re-offering it forever', async () => {
+    const client = new StubBrainClient();
+    client.conflictNext = true;
+    const summary = await runIndexer(runnerOptions({ client }));
+    expect(summary.alreadyProcessed).toBe(1);
+    expect(summary.nextState.submitted.length).toBeGreaterThan(0);
+  });
+
+  it('narrows the working-tree scan to the since-commit delta', async () => {
+    const client = new StubBrainClient();
+    const summary = await runIndexer(
+      runnerOptions({
+        client,
+        source: new FakeRepoSource(RUNNER_FILES, [], 'head0000', ['src/worker.ts']),
+        since: 'head0000~5',
+      }),
+    );
+    expect(summary.incremental).toBe(true);
+    expect(summary.filesScanned).toBe(1);
+    const predicates = client.payloads.flatMap((p) => p.facts.map((f) => f.predicate));
+    expect(predicates).toContain('code_memory__gotcha');
+    // package.json was not in the delta, so no dependency claim this run.
+    expect(predicates).not.toContain('code_memory__depends_on_version');
+  });
+
+  it('falls back to a full walk when the since-commit cannot be resolved', async () => {
+    const lines: string[] = [];
+    const summary = await runIndexer(
+      runnerOptions({
+        source: new FakeRepoSource(RUNNER_FILES, [], 'head0000', null),
+        since: 'nonexistent',
+        log: (l) => lines.push(l),
+      }),
+    );
+    expect(summary.incremental).toBe(false);
+    expect(summary.filesScanned).toBe(Object.keys(RUNNER_FILES).length);
+    expect(lines.join(' ')).toContain('falling back to a full walk');
+  });
+});
+
+// ── the filesystem/git layer ─────────────────────────────────────────
+
+function hasGit(): boolean {
+  try {
+    execFileSync('git', ['--version'], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+describe('parseCommitLog', () => {
+  it('parses the record/field-separated log format', () => {
+    const raw =
+      '\x1eabc\x1fAda\x1fada@example.com\x1f2026-01-01T00:00:00Z\x1ffeat: x\x1f\nsrc/a.ts\n';
+    const [c] = parseCommitLog(raw);
+    expect(c?.sha).toBe('abc');
+    expect(c?.authorName).toBe('Ada');
+    expect(c?.changedFiles).toEqual(['src/a.ts']);
+  });
+});
+
+(hasGit() ? describe : describe.skip)('FsRepoSource over a real checkout', () => {
+  let root: string;
+
+  beforeAll(() => {
+    root = mkdtempSync(join(tmpdir(), 'repo-indexer-'));
+    const write = (rel: string, text: string): void => {
+      mkdirSync(dirname(join(root, rel)), { recursive: true });
+      writeFileSync(join(root, rel), text, 'utf8');
+    };
+    const git = (...args: string[]): void => {
+      execFileSync('git', args, { cwd: root, stdio: 'ignore' });
+    };
+    git('init', '-q', '-b', 'main');
+    git('config', 'user.email', 'ada@example.com');
+    git('config', 'user.name', 'Ada');
+    git('config', 'commit.gpgsign', 'false');
+
+    write('src/keep.ts', '// Beware: this module must never be imported twice.\n');
+    write('node_modules/skip/index.js', '// Gotcha: this should never be indexed at all.\n');
+    write('dist/skip.js', '// Gotcha: build output must never be indexed.\n');
+    write('bin/blob.dat', 'A B');
+    git('add', '-A');
+    git('commit', '-qm', 'chore: first');
+
+    write('src/second.ts', '// Gotcha: the second file must be seen only by the delta run.\n');
+    git('add', '-A');
+    git('commit', '-qm', 'chore: second');
+
+    write('src/third.ts', '// Beware: the third module must be registered before use.\n');
+    git('add', '-A');
+    git('commit', '-qm', 'We decided to add a third module in src/third.ts.');
+  });
+
+  afterAll(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('walks the tree bounded, skipping build output and binaries', () => {
+    const source = new FsRepoSource({ root, maxFiles: 100, maxFileBytes: 512_000 });
+    const paths = source.listFiles().map((f) => f.path);
+    expect(paths).toContain('src/keep.ts');
+    expect(paths).toContain('src/second.ts');
+    expect(paths.some((p) => p.startsWith('node_modules/'))).toBe(false);
+    expect(paths.some((p) => p.startsWith('dist/'))).toBe(false);
+    expect(paths).not.toContain('bin/blob.dat');
+  });
+
+  it('honours maxFiles as a hard stop', () => {
+    expect(new FsRepoSource({ root, maxFiles: 1, maxFileBytes: 512_000 }).listFiles()).toHaveLength(
+      1,
+    );
+  });
+
+  it('reads history and resolves a since-commit delta', () => {
+    const source = new FsRepoSource({ root, maxFiles: 100, maxFileBytes: 512_000 });
+    expect(source.head()).toMatch(/^[0-9a-f]{40}$/);
+    const commits = source.readCommits({ since: undefined, limit: 10 });
+    expect(commits).toHaveLength(3);
+    expect(commits[0]?.authorName).toBe('Ada');
+    expect(source.changedSince('HEAD~1')).toEqual(['src/third.ts']);
+    expect(source.changedSince('no-such-ref')).toBeNull();
+  });
+
+  it('derives a commit decision anchored on the single changed file', () => {
+    const source = new FsRepoSource({ root, maxFiles: 100, maxFileBytes: 512_000 });
+    const facts = decisionsFromCommits({
+      commits: source.readCommits({ since: 'HEAD~1', limit: 10 }),
+      caps,
+    });
+    expect(facts.find((f) => f.kind === 'decided')?.subject).toBe('src/third.ts');
+  });
+
+  it('runs end to end against the checkout without touching the network', async () => {
+    const client = new StubBrainClient();
+    const state: RunState = { ...EMPTY_STATE };
+    const summary = await runIndexer({
+      source: new FsRepoSource({ root, maxFiles: 100, maxFileBytes: 512_000 }),
+      client,
+      caps,
+      packId: 'code_memory',
+      repoLabel: 'fixture-repo',
+      modules: BUILTIN_MODULES,
+      state,
+    });
+    expect(summary.submitted).toBeGreaterThan(0);
+    expect(client.payloads.flatMap((p) => p.facts.map((f) => f.predicate))).toContain(
+      'code_memory__gotcha',
+    );
+    // Ownership came from history (no CODEOWNERS in the fixture).
+    expect(summary.byProducer['core:ownership']).toBeGreaterThan(0);
+  });
+});

--- a/test/domain-pack.unit-spec.ts
+++ b/test/domain-pack.unit-spec.ts
@@ -400,11 +400,36 @@ describe('code-memory pack', () => {
     expect(byLocal.get('depends_on_version')?.semantics).toBe('single_active');
     expect(byLocal.get('owns')?.semantics).toBe('single_active');
     expect(byLocal.get('superseded_by')?.semantics).toBe('append_only');
-    // The originals keep the semantics they shipped with.
     expect(byLocal.get('decided')?.semantics).toBe('single_active');
     expect(byLocal.get('because')?.semantics).toBe('append_only');
-    expect(byLocal.get('invariant')?.semantics).toBe('single_active');
     expect(byLocal.get('gotcha')?.semantics).toBe('append_only');
+  });
+
+  /**
+   * 0.6.0 semantics correction. `invariant` shipped `single_active`, so
+   * every newly recorded constraint retired the previous one — but a
+   * module's invariants COEXIST, and there is no "which one is current"
+   * question for supersession to answer. `decided` is the opposite case
+   * and must NOT drift with it: an anchor has exactly one current
+   * decision (the eval battery's k09 asserts precisely that, and reads
+   * the old one back at an asOf between the writes), and
+   * `superseded_by` records what replaced it.
+   */
+  it('0.6.0: coexisting invariants append; the one-current-value slots supersede', () => {
+    const byLocal = new Map(CODE_MEMORY_PACK.predicates.map((p) => [p.localId, p]));
+    expect(byLocal.get('invariant')?.semantics).toBe('append_only');
+    // The description has to TEACH coexistence, or an extractor reading
+    // the manifest still behaves as if one rule retires the next.
+    expect(byLocal.get('invariant')?.description).toContain('COEXIST');
+    expect(byLocal.get('invariant')?.description).toContain('multi-valued');
+
+    // The exactly-one-current-value slots are unaffected by that fix.
+    for (const local of ['decided', 'owns', 'default_value', 'depends_on_version']) {
+      expect(byLocal.get(local)?.semantics).toBe('single_active');
+    }
+    // Not a patch: the semantics change alters stored-fact behaviour.
+    const [major = '0', minor = '0'] = CODE_MEMORY_PACK.version.split('.');
+    expect(`${major}.${minor}`).not.toBe('0.5');
   });
 
   it('ships a SELF-SCOPING extractionProfile (builtin = injected into every tenant)', () => {
@@ -583,7 +608,10 @@ const MEDIA_CONTRACT: MediaExpectation[] = [
   },
   {
     pack: CODE_MEMORY_PACK,
-    version: '0.5.0',
+    // 0.6.0: the `invariant` semantics correction (single_active →
+    // append_only). The media contract itself is unchanged from 0.5.0 —
+    // this pin just has to move deliberately on every version bump.
+    version: '0.6.0',
     modalities: ['text', 'image', 'document'],
     processors: [IMAGE_METADATA, DOCUMENT_TEXT],
     rawEvidence: undefined, // a builtin seeds into every tenant unasked


### PR DESCRIPTION
## The gap

`src/ai/domain-packs/code-memory.pack.ts` declares `indexer: { mode: 'external' }` — it is the **only** pack in the library that declares an indexer at all. The submission protocol (`docs/indexer-protocol.md`), the server side (`external-candidates.service.ts`, the `GET /v1/indexer/work` poller view, the `indexer_run` ledger, migration 0049) and a poller example (`examples/reference-indexer.ts`) all existed — with **no producer on the code side**. The coding domain had a contract and a consumer with an empty pipe, which is why the eval battery had to hand-write conversational turns to populate it.

## What this adds

`scripts/index-repo.ts` (`pnpm indexer:repo`) walks a git working tree plus its history and submits `code_memory` candidates through the documented protocol.

**Operator/CI-invoked only.** Nothing schedules it, no Nest module imports it, and it makes no network call at all until `--submit` is passed — dry run is the default.

### Evidence-only by construction

Brain re-grounds every external span, so the indexer first composes an **evidence document**: one block per claim carrying the anchor, the value, the *derivation rule* that produced it, and the artefact quoted verbatim with its file and line span. That is ingested (`POST /v1/ingest/document`, routed with `indexers: ["code_memory"]`) and the candidates are staged against it with the claimless flow. The document is the audit trail — every claim can be re-derived from it without trusting the indexer.

| Predicate | Evidence |
|---|---|
| `owns` | a CODEOWNERS line; failing that, git-history authorship concentration — the fact carries the rule ("Ada authored 3 of the 4 commits touching src/pkg…, stewardship evidence, not a declaration"), at lower confidence |
| `depends_on_version` | the pnpm lockfile's exact resolution, else the package.json range, verbatim |
| `default_value` | a config-catalogue row, else a `DEFAULT_*` literal — value-shaped tokens only |
| `decided` / `because` | a commit message or an ADR `## Decision` / `## Rationale` section that explicitly states one. Anchor = a path the message names, else the commit's *single* changed file; a twelve-file commit that names no path produces nothing |
| `invariant` / `gotcha` | a comment that explicitly *warns* ("must", "never", "gotcha", "beware", "⚡"), quoted verbatim with its line span |

Semantic summaries of code are out of scope. Code shape is never a source.

### Modular: core + ecosystem-module registry

- **Core** (`src/code-memory/repo-indexer/core/`) always runs and knows no language: git history and authorship, CODEOWNERS, commit-message decisions, ADR docs, warning comments, file inventory and caps, the dedupe/idempotency/incremental machinery, and the submission client with its client-side fences.
- **Modules** (`modules/`) hold every ecosystem-specific rule. Each declares `claims(path)`, an `extract()` returning the core's fact shape, a `priority`, and its own `version` — which rides into the derivation of everything it produced, so a module bump is visible in exactly what it minted (server-side `CandidateProvenance` is a fixed shape and cannot carry it).

**Shipping now:** `javascript` (package.json + pnpm-lock.yaml → `depends_on_version`), `config_catalog` (`config-catalog*.data.ts` → `default_value`), `default_constants` (`DEFAULT_*` literals → `default_value`).

**A repository whose ecosystem has no module still gets everything the core derives** — asserted in the suite. Two modules claiming one path resolve by highest `priority`, ties on ascending `id`, never registration order (also asserted, in both registration orders). The registry is an explicit list — no filesystem discovery.

**To add Python:** write `modules/python.module.ts` exporting an `EcosystemModule` — `id: 'python'`, `version`, `priority`, `claims: (p) => /(^|\/)(pyproject\.toml|requirements\.txt|poetry\.lock)$/.test(p)`, and an `extract()` that reads those files and returns `RepoFact[]` — then add `PYTHON_MODULE` to `BUILTIN_MODULES` in `modules/registry.ts`. Go is the same file with `go.mod`. **No core file changes**, and the module ships its own unit tests.

### Client-side fences

A candidate that would fail server-side is dropped locally with a reason, never sent: `namespace_fence`, `name_too_long` / `object_too_long`, `not_value_shaped` (the pack's 0.4.3 rule — prose is never a default), `ungrounded_entity` / `ungrounded_value` (the same `isGroundedSpan` the server runs), and `single_active_collision` — emitting five `invariant` claims on one anchor would make the fifth **supersede** the other four, so only the strongest is sent. The single-active set is read from the pack manifest itself, so it cannot drift.

### Correctness

- **Idempotent** — deterministic candidate id `sha256(path | kind | contentHash)` plus a state file; a second run over an unchanged repo submits nothing and ingests no document.
- **Incremental** — `--since <commit|auto>` narrows both history and the working-tree scan; an unresolvable ref falls back to a full walk and says so, rather than silently indexing nothing.
- **409-tolerant** — an already-processed slot is recorded, not re-offered forever.

### Caps

`maxFiles` 5000 · `maxFileBytes` 512_000 · `maxCommits` 500 · `ownershipHistoryDepth` 200 · `maxCandidates` 500/run · `maxFactsPerDocument` 120 (server allows 200/kind) · `maxDocChars` 100_000 (server hard cap 512_000) · `maxWarningsPerFile` 5 · ownership thresholds ≥3 commits and ≥50% share.

`.git`, `node_modules`, `dist`, `build`, `out`, `coverage`, `vendor`, `third_party`, `models` and other dot-dirs (except `.github`) are never walked; symlinks never followed; binaries detected by a NUL byte in the first 8 KiB.

## Dogfood

```bash
pnpm indexer:repo -- --repo . --dry-run
```

On this repository at `4fdf284`: 1979 files, 200 commits, **2600 facts derived** — `core:warnings` 2144, `module:config_catalog` 327, `module:javascript` 96, `module:default_constants` 19, `core:decisions` 11, `core:ownership` 3 (from `.github/CODEOWNERS`) — 1338 sent after the single-active fence dropped 1262, across 14 evidence documents. Zero grounding drops. Runbook in `docs/indexer-protocol.md` § *The code-repository indexer*.

## Constraints honoured

No server-side behaviour changed. No new runtime dependency — history is a plain `git` subprocess (the `capture-decisions.ts` precedent), the lockfile a line reader rather than a YAML dep. Nothing runs automatically.

## Gates (run separately, exit codes captured — no pipes)

| Gate | Exit |
|---|---|
| `tsc -p tsconfig.spec.json` | 0 |
| `eslint "{src,test}/**/*.ts" --max-warnings 0` | 0 |
| `prettier --check "src/**/*.ts" "test/**/*.ts"` | 0 |
| unit suite | 0 — **381 suites, 4594 tests**, incl. 42 new |

Tests cover: the ownership rule (CODEOWNERS precedence, glob refusal, both history thresholds, no-dominant-author → nothing), dependency extraction (lockfile-exact wins, declared-range fallback, malformed manifest), flag defaults (value-shaped only, prose rejected end-to-end through the fence), gotcha/invariant span-grounding (the reported span really contains the recorded value), marker-mention vs marker-flag, idempotency (second run = zero new, no document ingested), incremental since-commit and its fallback, every client-side fence drop, registry determinism in both orders, a third-party module joining with no core change, and a real `git init` fixture repo (guarded by a git probe, skips if absent). No network anywhere — the submission client is an interface.

---

## Follow-up: the fence exposed a domain modelling error — fixed at the root (pack 0.6.0)

The `single_active_collision` fence was not just protecting a submission. It was reporting a bug in the ontology, and the root cause is now fixed in this PR.

### `invariant`: `single_active` → `append_only`

`invariant` shipped `single_active` from the pack's first version, so **every newly recorded constraint superseded the previous one on the same anchor**. But a module's invariants coexist — *"every handler validates its body with the shared zod schema"* and *"amounts are always emitted in cents"* are both true of one file at the same time, and neither retires the other. There is no "which invariant is current?" question for supersession to answer, so the semantics were pure data loss with nothing gained.

The proof is the dogfood run: it had to drop **1254 legitimate invariant facts across 515 anchors** to avoid destroying its own output.

### `decided`: deliberately stays `single_active`

This needed judgement, and the answer is no change. Three reasons:

1. **The two mechanisms are not duplicates.** `single_active` answers *which decision is current* (state). `superseded_by` — `append_only` — records *what replaced the old one* (the narrative trail, accumulating). They are complementary. Removing supersession would leave "what did we decide about this file?" answerable only by an unordered list of every decision ever made, with nothing marking which one holds.
2. **History is not lost.** Supersession here is bitemporal — it closes `validUntil`, it does not delete. I checked the battery before touching anything, as asked: `k09-supersession-asof` (`test/eval/code-memory/corpus.ts:402`, scorer `checkSupersession`) asserts *exactly one* active `decided` now (`nowKind.length !== 1` → fail) **and** that the superseded one is still recallable at an `asOf` between the writes (`the superseded ${kind} is unrecoverable at asOf` → fail). It passes **because of** supersession, not in spite of it.
3. Making `decided` `append_only` would break k09's first clause, and the only way to keep the check green would be to weaken it into vacuity — which is not on the table.

`owns` / `default_value` / `depends_on_version` stay `single_active` for the same reason: one owner, one current default, one pinned version.

### Version

**0.5.0 → 0.6.0.** A minor bump, not a patch: this changes stored-fact behaviour for anyone already recording into the pack. Previously superseded rows stay superseded and remain readable at their `asOf`; new invariants simply stop closing prior ones.

### The fence, after the fix

The mechanism is unchanged and stays — it still reads the single-active set from the manifest rather than restating it, so the next modelling mistake of this kind surfaces the same way instead of being hard-coded around. It simply no longer has any legitimate invariant to drop. Its remaining job is `owns` / `default_value` / `depends_on_version` / `decided`, where collapsing to one value is correct. A new test asserts coexisting invariants now pass through untouched *and* that the exemption comes from the manifest, not a carve-out.

### Before / after — same repo, same commit range

| | before (0.5.0) | after (0.6.0) |
|---|---|---|
| facts submitted | 1338 | **2596** |
| `invariant` dropped to collisions | **1254** | **0** |
| anchors forced down to one rule | **515** | **0** |
| evidence documents | 14 | 28 |

Invariants per multi-rule anchor went from a forced **1** to the full set the artefacts actually state (up to the 5-per-file cap) — 1769 constraints retained across those 515 anchors where 515 survived before. That number is the proof the fix landed.

### Test-expectation updates (none weakened)

- `test/domain-pack.unit-spec.ts` — the semantics assertion is now its own case: `invariant` must be `append_only`, its description must *teach* coexistence (`COEXIST`, `multi-valued`) so a manifest-reading extractor behaves correctly, all four one-current-value slots must stay `single_active`, and the version must not still be `0.5`. Strictly more assertions than before.
- The media-contract version pin moved `0.5.0` → `0.6.0`; that guard exists to force a deliberate edit on every bump, and it still does.
- The eval battery needed no change: k09 targets `decided`, whose semantics are unchanged, and the README's note that `superseded_by` is "exercised mechanically by k09's single_active semantics" remains accurate.

### Gates re-run (un-piped, exit codes captured)

| Gate | Exit |
|---|---|
| `tsc -p tsconfig.spec.json` | 0 |
| `eslint "{src,test}/**/*.ts" --max-warnings 0` | 0 |
| `prettier --check "src/**/*.ts" "test/**/*.ts"` | 0 |
| unit suite | 0 — **381 suites, 4596 tests** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB
