### PR TITLE
feat(indexers): source-version stamps and drift-based staleness for derivable facts

### DIFF
--- a/brain-landing/public/openapi.json
+++ b/brain-landing/public/openapi.json
@@ -4637,6 +4637,38 @@
             },
             "type": "array"
           },
+          "sourceVersion": {
+            "additionalProperties": false,
+            "description": "The revision of the external system of record these claims were read at. Rejected 400 unless PACK_SOURCE_VERSION_STALENESS. Rides into every committed fact's source.sourceVersion, and sweeps the pack's DERIVABLE facts (memoryModel.verificationRules with requires=source_version_match) that were read at an older revision, marking them stale for re-verification.",
+            "properties": {
+              "readAt": {
+                "description": "ISO 8601 datetime the derivation read that revision.",
+                "type": "string"
+              },
+              "ref": {
+                "description": "The line within that system — a branch/ref, a matter id, a study series.",
+                "maxLength": 200,
+                "type": "string"
+              },
+              "system": {
+                "description": "System of record the claims were read from: 'git', 'dms', 'ehr', 'ledger', …",
+                "maxLength": 32,
+                "type": "string"
+              },
+              "version": {
+                "description": "The exact revision read — a commit sha, a document revision id.",
+                "maxLength": 200,
+                "type": "string"
+              }
+            },
+            "required": [
+              "system",
+              "ref",
+              "version",
+              "readAt"
+            ],
+            "type": "object"
+          },
           "stateDeltas": {
             "description": "Lifecycle-transition claims (0110) riding scenes of this submission (sceneIndex). Validated against the pack's memoryModel.stateModels; declared transitions stay advisory (never a gate).",
             "items": {

--- a/docs/indexer-protocol.md
+++ b/docs/indexer-protocol.md
@@ -255,6 +255,61 @@ into shadow `memory_episode` rows under `segmenterVersion`
 counts. Scene payloads are default-deny in the candidates audit view —
 content opens only under `brain:read_pii`.
 
+**Source-version stamps (`sourceVersion`).** When the operator enables
+`PACK_SOURCE_VERSION_STALENESS` (default off — the field is rejected 400
+otherwise), a submission may name the revision of the EXTERNAL system of
+record it read:
+
+```json
+{
+  "sourceVersion": {
+    "system": "git",
+    "ref": "main",
+    "version": "9f2c1ab…",
+    "readAt": "2026-09-08T05:11:00Z"
+  }
+}
+```
+
+Why it exists: some domains have a system of record that is better than
+our copy — exact, versioned, cheap, never wrong about the past. Code has
+git; legal has the DMS revision; medical has the study in PACS. For
+those, memory should MATERIALIZE what is not derivable (a decision, its
+rationale, a gotcha, an invariant) and merely POINT AT what is derivable
+(who owns a file, what a flag defaults to, which version a dependency is
+pinned to). A derivable claim stored as timeless truth is a promise to
+start lying the moment the source moves; bound to a revision it stays
+true forever. All four fields are required (a half-stamp is a 400), and
+the shape is deliberately not git-shaped — a DMS revision id or an EHR
+study id fills the same fields.
+
+The stamp rides candidate provenance into every committed fact's
+`source.sourceVersion`, and the same submission runs a DRIFT SWEEP: the
+pack's derivable facts whose stamp names an older revision of the same
+`system` + `ref` are marked with the existing staleness fields
+(`staleAt` / `staleReason = "source_version_drift"`, migration 0072) as
+candidates for re-verification, and facts back at the current revision
+have that mark cleared. The response then carries a `sourceDrift`
+summary. No git ever runs server-side: the current revision is whatever
+the indexer — the party holding the working tree — reports.
+
+WHICH facts are derivable is the PACK's declaration, never the engine's
+guess. In the manifest `memoryModel`:
+
+```ts
+verificationRules: [
+  { requires: 'source_version_match',
+    appliesTo: ['owns', 'default_value', 'depends_on_version'] },
+]
+```
+
+`appliesTo` names the pack's own predicate localIds and is mandatory for
+this rule. Interpretation predicates (`decided`, `because`, `gotcha`,
+`invariant`) are simply omitted: they are statements about the PAST and
+do not rot when new commits land. A pack that declares no such rule never
+sweeps, and a fact carrying no stamp is untouchable by the sweep by
+construction.
+
 ### 5. Can't process it? Give it back
 
 ```

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -4637,6 +4637,38 @@
             },
             "type": "array"
           },
+          "sourceVersion": {
+            "additionalProperties": false,
+            "description": "The revision of the external system of record these claims were read at. Rejected 400 unless PACK_SOURCE_VERSION_STALENESS. Rides into every committed fact's source.sourceVersion, and sweeps the pack's DERIVABLE facts (memoryModel.verificationRules with requires=source_version_match) that were read at an older revision, marking them stale for re-verification.",
+            "properties": {
+              "readAt": {
+                "description": "ISO 8601 datetime the derivation read that revision.",
+                "type": "string"
+              },
+              "ref": {
+                "description": "The line within that system — a branch/ref, a matter id, a study series.",
+                "maxLength": 200,
+                "type": "string"
+              },
+              "system": {
+                "description": "System of record the claims were read from: 'git', 'dms', 'ehr', 'ledger', …",
+                "maxLength": 32,
+                "type": "string"
+              },
+              "version": {
+                "description": "The exact revision read — a commit sha, a document revision id.",
+                "maxLength": 200,
+                "type": "string"
+              }
+            },
+            "required": [
+              "system",
+              "ref",
+              "version",
+              "readAt"
+            ],
+            "type": "object"
+          },
           "stateDeltas": {
             "description": "Lifecycle-transition claims (0110) riding scenes of this submission (sceneIndex). Validated against the pack's memoryModel.stateModels; declared transitions stay advisory (never a gate).",
             "items": {

--- a/scripts/index-repo.ts
+++ b/scripts/index-repo.ts
@@ -131,6 +131,7 @@ async function main(): Promise<void> {
   } else {
     console.error(
       `[indexer] head=${summary.headSha?.slice(0, 12) ?? 'none'} ` +
+        `ref=${summary.sourceVersion?.ref ?? 'none'} ` +
         `incremental=${summary.incremental} files=${summary.filesScanned} ` +
         `commits=${summary.commitsRead} derived=${summary.derived} ` +
         `submitted=${summary.submitted} dropped=${summary.dropped.length} ` +

--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -782,6 +782,19 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
       'Pack memory projections (migration 0110), TWO producers. DOCUMENT origin: external candidate submissions may carry scenes/stateDeltas validated against the submitting pack’s manifest memoryModel (sceneSchemas / stateModels), staged as candidate kinds scene/state_delta and projected at commit time. CAPTURE origin: a mention turn is matched against the installed packs’ declared sceneSchemas.cues (literal substrings, model-free — no LLM, no embedding) and declared stateModels.states, projected inline at ingest. Both write shadow memory_episode rows under segmenterVersion pack:<packId>+<fp> (registry scenes:<packId>; purge via DELETE /scenes/versions/:v); capture-origin rows also carry a memory_episode_member edge to their L0 turn (the GDPR erasure anchor — the capture producer requires EPISODE_SUBSTRATE_ENABLED and skips a turn it could not capture). Off = submissions carrying either array are rejected 400, no such candidate row is written, no projection runs on either path — byte-identical. The GDPR forget cascades for projected rows run regardless.',
   },
   {
+    key: 'PACK_SOURCE_VERSION_STALENESS',
+    category: 'scenes',
+    // Read at call time (pack-projection-flags.packSourceVersionStaleness-
+    // Enabled) by the external-submission validator and the drift sweep —
+    // never captured in a constructor — so a flip takes effect without
+    // restart.
+    defaultValue: '0',
+    runtimeMutable: true,
+    isBooleanFlag: true,
+    description:
+      'Source-version stamps + drift-based staleness. An external candidate submission may carry sourceVersion = {system, ref, version, readAt} naming the revision of the EXTERNAL system of record it read (git commit, DMS revision, EHR study). The stamp rides candidate provenance into every committed fact’s source.sourceVersion, so a derivable claim reads “at commit abc123, X is Y” instead of the timeless — and eventually false — “X is Y”. The same submission then sweeps: facts of the pack’s DERIVABLE predicate class whose stamp names an older revision of the SAME system+ref are marked with the existing 0072 staleAt/staleReason (reason source_version_drift) as candidates for re-verification, and facts back at the current revision have that mark cleared. Which predicates are derivable is DECLARED by the pack — memoryModel.verificationRules entries with requires=source_version_match and appliesTo=[localIds] — never inferred from predicate names: an interpretation (decided/because/gotcha/invariant) is a statement about the past and never drifts. No git ever runs server-side; the current revision is told to the server by the indexer that holds the working tree. Marking only, the 0072 contract — a drifted fact keeps serving, and the recompose pass is fenced to source.kind=compaction-summary so it never picks these up. Off = a submitted sourceVersion is rejected 400, no candidate payload or fact source gains the key, and no sweep query runs — byte-identical.',
+  },
+  {
     key: 'SCENES_BELIEF_PROMOTION',
     category: 'scenes',
     // Read at call time (scene-flags.sceneBeliefPromotionEnabled) by the

--- a/src/ai/domain-packs/code-memory.pack.ts
+++ b/src/ai/domain-packs/code-memory.pack.ts
@@ -36,11 +36,22 @@ import { composePredicateId, type DomainPackManifest } from './manifest';
  * left `single_active` — each of those really does have exactly one
  * current value.
  *
+ * 0.7.0 declares the DERIVABLE CLASS. Code is the domain where the split
+ * is starkest: git is an external system of record that is better than
+ * our copy — exact, versioned, cheap, and never wrong about the past. So
+ * `owns` / `default_value` / `depends_on_version` are POINTERS at a
+ * state of the repository, only as good as the commit they were read at,
+ * while `decided` / `because` / `invariant` / `gotcha` /
+ * `superseded_by` are MATERIALIZED prose that exists nowhere else and
+ * does not rot when new commits land. The new
+ * `source_version_match` verificationRule names the first group; the
+ * second is simply not listed, and is therefore never swept.
+ *
  * Bump `version` to ship an updated code-memory ontology.
  */
 export const CODE_MEMORY_PACK: DomainPackManifest = {
   id: 'code_memory',
-  version: '0.6.0',
+  version: '0.7.0',
   description:
     'Non-derivable engineering "why" of a codebase — decisions, rationale, invariants, gotchas, ownership, flag/config defaults, dependency pins, and decision supersession anchored to code, with a domain extraction profile and memory model.',
   // Retro-declaration, documentation-true: code-memory has ALWAYS been an
@@ -325,7 +336,28 @@ never split its clauses across facts or predicates.`,
     ],
     // The dogfood north-star claim class: "what is the current default of X"
     // must not serve stale — a default_value claim deserves a recency check.
-    verificationRules: [{ claimPattern: 'default', requires: 'recency_check' }],
+    verificationRules: [
+      { claimPattern: 'default', requires: 'recency_check' },
+      // THE DERIVABLE CLASS. Each of these three POINTS AT a state of the
+      // working tree that git can re-derive exactly at any moment: who
+      // owns a path (CODEOWNERS / authorship concentration), what a flag
+      // or constant defaults to, which version a dependency is pinned to.
+      // Stored as timeless truth they would start lying on the next
+      // merge, so they are bound to the commit they were read at and go
+      // back for re-verification when the source moves on.
+      //
+      // `decided`, `because`, `invariant`, `gotcha` and `superseded_by`
+      // are deliberately ABSENT. They are interpretation — the reason a
+      // choice was made, the constraint someone learned the hard way —
+      // which exists only in prose and is lost without us. A statement
+      // about the past does not become false because the future arrived,
+      // so calendar age and commit drift are both the wrong question for
+      // them.
+      {
+        requires: 'source_version_match',
+        appliesTo: ['owns', 'default_value', 'depends_on_version'],
+      },
+    ],
     retentionHints: [
       { predicateOrScene: 'decided', hint: 'durable' },
       { predicateOrScene: 'invariant', hint: 'durable' },

--- a/src/ai/domain-packs/manifest.ts
+++ b/src/ai/domain-packs/manifest.ts
@@ -358,7 +358,30 @@ export interface PackVerificationRule {
   /** Literal substring (2..128 chars) selecting claims — NOT a pattern;
    *  absent = the rule applies to all of the pack's claims. */
   claimPattern?: string;
-  requires: 'human_confirmation' | 'corroboration' | 'recency_check';
+  /**
+   * `source_version_match` is the DERIVABLE-CLASS declaration: the claim
+   * is re-derivable at any moment from an external system of record
+   * (git, a DMS, an EHR, a ledger), so it is only as good as the version
+   * it was read at — when that version moves on, the claim is a
+   * candidate for re-verification. The other three are about how a claim
+   * EARNS confidence; this one is about when it LOSES currency.
+   */
+  requires: 'human_confirmation' | 'corroboration' | 'recency_check' | 'source_version_match';
+  /**
+   * The pack's OWN predicate localIds this rule covers — the declarative
+   * split between what rots and what does not. `depends_on_version`
+   * describes a state of the source and drifts with it; `decided` /
+   * `because` / `gotcha` describe the PAST and are still exactly as true
+   * after a thousand commits. Listing the first class and omitting the
+   * second is how a domain says so, instead of the engine guessing from
+   * predicate names.
+   *
+   * Absent = the rule is not predicate-scoped (the pre-existing
+   * claimPattern behaviour). A `source_version_match` rule REQUIRES it:
+   * a drift sweep with no declared class would either touch everything
+   * or nothing, and both are wrong.
+   */
+  appliesTo?: string[];
 }
 
 /** ADVISORY retention preference for one of the pack's own predicates

--- a/src/ai/domain-packs/validate-memory-model.ts
+++ b/src/ai/domain-packs/validate-memory-model.ts
@@ -43,7 +43,16 @@ import {
 const SNAKE = /^[a-z][a-z0-9_]*$/;
 /** Fixed zoom targets available to every pack alongside its own scenes. */
 const ZOOM_LITERALS = new Set(['episodes', 'facts', 'scenes']);
-const REQUIRES = new Set(['human_confirmation', 'corroboration', 'recency_check']);
+const REQUIRES = new Set([
+  'human_confirmation',
+  'corroboration',
+  'recency_check',
+  'source_version_match',
+]);
+/** Rules that MUST name the predicate class they cover (see appliesTo). */
+const REQUIRES_APPLIES_TO = new Set(['source_version_match']);
+/** A rule cannot cover more of the pack's predicates than it HAS. */
+const MM_MAX_APPLIES_TO = 32;
 const RETENTION_HINTS = new Set(['ephemeral', 'standard', 'durable']);
 const MEMORY_MODEL_FIELDS = new Set([
   'sceneSchemas',
@@ -201,7 +210,7 @@ export function validateMemoryModel(pack: DomainPackManifest, mm: unknown): void
     predicateLocalIds,
     sceneIds,
   });
-  validateVerificationRules(pack.id, model.verificationRules);
+  validateVerificationRules(pack.id, model.verificationRules, predicateLocalIds);
   validateRetentionHints({
     packId: pack.id,
     hints: model.retentionHints,
@@ -499,7 +508,11 @@ function validateHintRefs(opts: {
   }
 }
 
-function validateVerificationRules(packId: string, rules: unknown): void {
+function validateVerificationRules(
+  packId: string,
+  rules: unknown,
+  predicateLocalIds: Set<string>,
+): void {
   if (rules === undefined) return;
   assertPresentList({
     packId,
@@ -515,6 +528,7 @@ function validateVerificationRules(packId: string, rules: unknown): void {
         `pack "${packId}" memoryModel verificationRule requires "${String(r.requires)}" must be one of ${[...REQUIRES].join('|')}`,
       );
     }
+    validateAppliesTo(packId, r, predicateLocalIds);
     if (r.claimPattern === undefined) continue;
     assertLiteralText({
       packId,
@@ -528,6 +542,53 @@ function validateVerificationRules(packId: string, rules: unknown): void {
         `pack "${packId}" memoryModel verificationRule claimPattern "${r.claimPattern}" must be a literal substring, not a pattern — regex metacharacters are not allowed`,
       );
     }
+  }
+}
+
+/**
+ * `appliesTo` names the pack's OWN predicate localIds — the same
+ * cannot-squat posture attentionHints.prefer and retentionHints already
+ * hold. A `source_version_match` rule must carry one: it declares WHICH
+ * class of the domain's claims is re-derivable from the external system
+ * of record, and a drift sweep with no declared class would either touch
+ * every claim the pack ever recorded or none of them.
+ */
+function validateAppliesTo(
+  packId: string,
+  rule: Partial<PackVerificationRule>,
+  predicateLocalIds: Set<string>,
+): void {
+  const requires = String(rule.requires);
+  if (rule.appliesTo === undefined) {
+    if (REQUIRES_APPLIES_TO.has(requires)) {
+      throw new DomainPackError(
+        `pack "${packId}" memoryModel verificationRule requires "${requires}" must declare appliesTo — the predicate class it covers`,
+      );
+    }
+    return;
+  }
+  if (
+    !Array.isArray(rule.appliesTo) ||
+    rule.appliesTo.length === 0 ||
+    rule.appliesTo.length > MM_MAX_APPLIES_TO
+  ) {
+    throw new DomainPackError(
+      `pack "${packId}" memoryModel verificationRule appliesTo must be 1..${MM_MAX_APPLIES_TO} predicate localIds`,
+    );
+  }
+  const seen = new Set<string>();
+  for (const local of rule.appliesTo) {
+    if (typeof local !== 'string' || !predicateLocalIds.has(local)) {
+      throw new DomainPackError(
+        `pack "${packId}" memoryModel verificationRule appliesTo references "${String(local)}", which is not a predicate of this pack`,
+      );
+    }
+    if (seen.has(local)) {
+      throw new DomainPackError(
+        `pack "${packId}" memoryModel verificationRule appliesTo lists "${local}" twice`,
+      );
+    }
+    seen.add(local);
   }
 }
 

--- a/src/code-memory/repo-indexer/bundle.ts
+++ b/src/code-memory/repo-indexer/bundle.ts
@@ -22,6 +22,7 @@ import { createHash } from 'node:crypto';
 import { isGroundedSpan, normalizeForGrounding } from '../../ai/extractor-internals/grounding';
 import { CODE_MEMORY_PACK } from '../../ai/domain-packs/code-memory.pack';
 import { isValueShaped } from './modules/config.module';
+import type { SourceVersionStamp } from '../../common/source-version';
 import {
   MAX_ENTITY_NAME_CHARS,
   MAX_FACT_OBJECT_CHARS,
@@ -318,10 +319,38 @@ export interface CandidatePayload {
   indexerId: string;
   entities: SubmittedEntityPayload[];
   facts: SubmittedFactPayload[];
+  /**
+   * The revision of the external system of record this run read
+   * (server: PACK_SOURCE_VERSION_STALENESS). Sent ONLY when the working
+   * tree resolved to a real commit AND a ref — a half-stamp is worse
+   * than none, and the server rejects one anyway. Its absence keeps the
+   * body byte-identical to a pre-stamp submission.
+   */
+  sourceVersion?: SourceVersionStamp;
+}
+
+/**
+ * The stamp for this run, or undefined outside a git checkout. `git` is
+ * hardcoded here and NOWHERE else: the stamp shape is domain-agnostic —
+ * a DMS revision or an EHR study id fills the same four fields — and it
+ * is the INDEXER, the party that actually holds the working tree, that
+ * names its own system of record. The server never learns what git is.
+ */
+export function repoSourceVersion(p: {
+  headSha: string | null;
+  ref: string | null;
+  readAt: string;
+}): SourceVersionStamp | undefined {
+  if (!p.headSha || !p.ref) return undefined;
+  return { system: 'git', ref: p.ref, version: p.headSha, readAt: p.readAt };
 }
 
 /** Build the `POST /v1/documents/:id/candidates` body for one document. */
-export function toCandidatePayload(facts: IdentifiedRepoFact[], packId: string): CandidatePayload {
+export function toCandidatePayload(
+  facts: IdentifiedRepoFact[],
+  packId: string,
+  sourceVersion?: SourceVersionStamp | undefined,
+): CandidatePayload {
   const entityIndex = new Map<string, number>();
   const entities: SubmittedEntityPayload[] = [];
   const payloadFacts: SubmittedFactPayload[] = [];
@@ -342,5 +371,10 @@ export function toCandidatePayload(facts: IdentifiedRepoFact[], packId: string):
       clause: fact.evidence.excerpt.replace(/\s+/g, ' ').trim().slice(0, 1_000),
     });
   }
-  return { indexerId: packId, entities, facts: payloadFacts };
+  return {
+    indexerId: packId,
+    entities,
+    facts: payloadFacts,
+    ...(sourceVersion ? { sourceVersion } : {}),
+  };
 }

--- a/src/code-memory/repo-indexer/repo-source.ts
+++ b/src/code-memory/repo-indexer/repo-source.ts
@@ -43,6 +43,13 @@ export interface RepoSource {
   /** HEAD sha, or null outside a git checkout. */
   head(): string | null;
   /**
+   * The LINE of history HEAD is on — the branch name, or `HEAD` on a
+   * detached checkout, or null outside git. It is half of a source
+   * version stamp's identity: a fact derived on `main` says nothing
+   * about `release/2.x`, so drift is only ever compared within one ref.
+   */
+  ref(): string | null;
+  /**
    * Paths changed in `since..HEAD`, or null when the delta cannot be
    * computed (no git, unknown commit-ish) — the caller then falls back
    * to a full walk rather than silently indexing nothing.
@@ -125,6 +132,11 @@ export class FsRepoSource implements RepoSource {
 
   head(): string | null {
     return this.git(['rev-parse', 'HEAD'])?.trim() ?? null;
+  }
+
+  ref(): string | null {
+    const name = this.git(['rev-parse', '--abbrev-ref', 'HEAD'])?.trim();
+    return name ? name : null;
   }
 
   readCommits(opts: { since?: string | undefined; limit: number }): CommitRecord[] {

--- a/src/code-memory/repo-indexer/run.ts
+++ b/src/code-memory/repo-indexer/run.ts
@@ -25,8 +25,10 @@ import {
   applyShapeFences,
   composeEvidenceDocuments,
   identify,
+  repoSourceVersion,
   toCandidatePayload,
 } from './bundle';
+import type { SourceVersionStamp } from '../../common/source-version';
 import type { BrainClient } from './brain-client';
 import type { RepoSource } from './repo-source';
 import type { DroppedRepoFact, IdentifiedRepoFact, IndexerCaps, RepoFact } from './types';
@@ -56,6 +58,13 @@ export interface RunOptions {
 
 export interface RunSummary {
   headSha: string | null;
+  /**
+   * The stamp sent with every submission of this run — the revision the
+   * derivations were read at. Undefined outside a git checkout, in which
+   * case nothing is version-bound and the server's drift sweep never
+   * runs for this pack.
+   */
+  sourceVersion?: SourceVersionStamp | undefined;
   incremental: boolean;
   filesScanned: number;
   commitsRead: number;
@@ -158,6 +167,13 @@ export async function runIndexer(opts: RunOptions): Promise<RunSummary> {
   let alreadyProcessed = 0;
   let documentCount = 0;
   const occurredAt = new Date().toISOString();
+  // Every claim of this run was read at ONE revision — the head we
+  // walked — so one stamp rides every submission. The derivable claims
+  // (owns / default_value / depends_on_version) become "at commit X, …"
+  // instead of timeless assertions the next merge would falsify; the
+  // interpretation claims carry it too, harmlessly, because the pack —
+  // not the indexer — decides which class drifts.
+  const sourceVersion = repoSourceVersion({ headSha, ref: opts.source.ref(), readAt: occurredAt });
   for (const [i, doc] of documents.entries()) {
     const grounded = applyGroundingFence(doc);
     dropped.push(...grounded.dropped);
@@ -170,7 +186,7 @@ export async function runIndexer(opts: RunOptions): Promise<RunSummary> {
     });
     const outcome = await opts.client.submitCandidates(
       ingested.documentId,
-      toCandidatePayload(grounded.kept, opts.packId),
+      toCandidatePayload(grounded.kept, opts.packId, sourceVersion),
     );
     documentCount += 1;
     if (outcome.alreadyProcessed) {
@@ -186,6 +202,7 @@ export async function runIndexer(opts: RunOptions): Promise<RunSummary> {
 
   return {
     headSha,
+    ...(sourceVersion ? { sourceVersion } : {}),
     incremental,
     filesScanned: paths.length,
     commitsRead: commits.length,

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -1194,6 +1194,19 @@ const KNOWN_BOOLEAN_FLAGS = [
   // PACK_ sits off the ENGINE flag budget (shadow-substrate writer, the
   // SCENES_/EVIDENCE_ precedent).
   'PACK_MEMORY_PROJECTIONS_ENABLED',
+  // Source-version stamps + drift staleness. An external submission may
+  // carry a `sourceVersion` ({system, ref, version, readAt}) naming the
+  // revision of the external system of record it read; the stamp rides
+  // candidate provenance into every committed fact's
+  // source.sourceVersion, and the same submission marks the pack's
+  // DERIVABLE facts (declared via memoryModel.verificationRules with
+  // requires='source_version_match') whose stamp is behind that revision
+  // stale, through the EXISTING 0072 staleAt/staleReason fields. Default
+  // off ⇒ a submitted sourceVersion is rejected 400, no payload or fact
+  // source ever gains the key, and no sweep query runs — byte-identical.
+  // PACK_ sits off the ENGINE flag budget, like the projections flag
+  // above.
+  'PACK_SOURCE_VERSION_STALENESS',
   // Belief promotion (Belief-A, migration 0120): fold ENRICHED scenes of
   // the current effective segmenter version into the shadow
   // semantic_belief substrate via POST /v1/admin/maintenance/scenes/

--- a/src/common/pack-projection-flags.ts
+++ b/src/common/pack-projection-flags.ts
@@ -29,3 +29,35 @@ import { envFlagEnabled } from './env-validation';
 export function packMemoryProjectionsEnabled(): boolean {
   return envFlagEnabled(process.env.PACK_MEMORY_PROJECTIONS_ENABLED);
 }
+
+/**
+ * Source-version stamps + drift staleness master flag —
+ * PACK_SOURCE_VERSION_STALENESS.
+ *
+ * When on, an external candidate submission may carry a `sourceVersion`
+ * stamp ({system, ref, version, readAt} — src/common/source-version.ts)
+ * naming the revision of the external system of record the claims were
+ * derived from. The stamp rides the candidate provenance into every
+ * committed fact's `source.sourceVersion`, and the same submission
+ * sweeps the pack's DERIVABLE facts whose stamp is behind that version,
+ * marking them with the EXISTING staleness fields (staleAt/staleReason,
+ * migration 0072) as candidates for re-verification.
+ *
+ * Which predicates are derivable is DECLARED, never hardcoded: the
+ * pack's manifest `memoryModel.verificationRules` carry
+ * `{ requires: 'source_version_match', appliesTo: [...localIds] }`. An
+ * interpretation (decided/because/gotcha/invariant) is a statement about
+ * the past and does not rot when new commits land, so it is simply not
+ * listed and is never swept.
+ *
+ * The env read lives here in the common layer, NOT inside the engine
+ * dirs (engine-gates S5.2). Read at call time so a flip is
+ * runtime-mutable. Default off ⇒ a submitted `sourceVersion` is rejected
+ * 400, no candidate payload or fact source ever gains the key, and no
+ * sweep query runs — byte-identical prod. PACK_ sits off the ENGINE flag
+ * budget (a pack-declared perception contract, the
+ * PACK_MEMORY_PROJECTIONS_ENABLED precedent).
+ */
+export function packSourceVersionStalenessEnabled(): boolean {
+  return envFlagEnabled(process.env.PACK_SOURCE_VERSION_STALENESS);
+}

--- a/src/common/source-version.ts
+++ b/src/common/source-version.ts
@@ -1,0 +1,119 @@
+/**
+ * The SOURCE-VERSION STAMP — "at which version of the external system of
+ * record was this read?".
+ *
+ * WHY IT EXISTS. Some domains have an external system of record that is
+ * better than our copy: exact, versioned, cheap, and never wrong about
+ * the past. Code has git; legal has the DMS revision; medical has the
+ * study/accession in PACS; fintech has the ledger entry. For those
+ * domains memory should MATERIALIZE only what is not derivable — the
+ * decision, the rationale, the gotcha, the invariant, which exist in
+ * prose and are lost without us — and merely POINT AT what is derivable:
+ * who owns a file, which version a dependency is pinned to, what a
+ * flag's default is. A derivable fact stored as timeless truth is a
+ * promise to start lying the moment the source moves.
+ *
+ * So a derivable claim is not "dependency is 2.0.0". It is "at commit
+ * abc123, dependency is 2.0.0" — a statement that stays TRUE forever,
+ * and whose usefulness we can decide by comparing its stamp against the
+ * source's current version.
+ *
+ * DELIBERATELY NOT GIT-SHAPED. `system` names the system of record,
+ * `ref` the line within it (a branch, a matter, a patient), `version`
+ * the exact revision read, `readAt` when we read it. A DMS revision id
+ * or an EHR study id fits the same four fields with no new vocabulary.
+ *
+ * The stamp is pure data — no I/O, no env read — so both the server
+ * (submission validation, drift sweep) and the operator-side indexers
+ * share one definition and one parser.
+ */
+
+/** One reading of an external system of record. */
+export interface SourceVersionStamp {
+  /** The system of record: 'git', 'dms', 'ehr', 'ledger', … */
+  system: string;
+  /** The line within it: a branch/ref, a matter id, a study series. */
+  ref: string;
+  /** The exact revision the claim was derived from. */
+  version: string;
+  /** When the derivation read it (ISO 8601). */
+  readAt: string;
+}
+
+export const SOURCE_VERSION_MAX_SYSTEM = 32;
+export const SOURCE_VERSION_MAX_REF = 200;
+export const SOURCE_VERSION_MAX_VERSION = 200;
+
+/** snake/kebab-free lowercase token — the system is vocabulary, not prose. */
+const SYSTEM_TOKEN = /^[a-z][a-z0-9_]{1,31}$/;
+
+export type SourceVersionParse =
+  { ok: true; stamp: SourceVersionStamp } | { ok: false; error: string };
+
+/**
+ * Parse + fence an untrusted stamp. Every field is required: a stamp
+ * missing its version cannot answer the only question it exists to
+ * answer, and a half-stamp that silently rode through would be worse
+ * than no stamp at all (a fact that LOOKS bound to a version but is not
+ * can never be swept).
+ */
+export function parseSourceVersionStamp(raw: unknown): SourceVersionParse {
+  if (raw === null || typeof raw !== 'object' || Array.isArray(raw)) {
+    return { ok: false, error: 'sourceVersion must be an object' };
+  }
+  const r = raw as Record<string, unknown>;
+  const system = r['system'];
+  if (typeof system !== 'string' || !SYSTEM_TOKEN.test(system)) {
+    return {
+      ok: false,
+      error: `sourceVersion.system must be a lowercase token of 2..${SOURCE_VERSION_MAX_SYSTEM} chars`,
+    };
+  }
+  const ref = boundedText(r['ref'], SOURCE_VERSION_MAX_REF);
+  if (ref === null) {
+    return {
+      ok: false,
+      error: `sourceVersion.ref must be a non-empty string of at most ${SOURCE_VERSION_MAX_REF} chars`,
+    };
+  }
+  const version = boundedText(r['version'], SOURCE_VERSION_MAX_VERSION);
+  if (version === null) {
+    return {
+      ok: false,
+      error: `sourceVersion.version must be a non-empty string of at most ${SOURCE_VERSION_MAX_VERSION} chars`,
+    };
+  }
+  const readAt = r['readAt'];
+  if (typeof readAt !== 'string' || !Number.isFinite(Date.parse(readAt))) {
+    return { ok: false, error: 'sourceVersion.readAt must be an ISO 8601 datetime' };
+  }
+  return { ok: true, stamp: { system, ref, version, readAt: new Date(readAt).toISOString() } };
+}
+
+function boundedText(v: unknown, max: number): string | null {
+  if (typeof v !== 'string') return null;
+  const trimmed = v.trim();
+  if (trimmed.length === 0 || trimmed.length > max) return null;
+  return trimmed;
+}
+
+/**
+ * Read a stamp back off a stored `source.sourceVersion` (or a candidate
+ * payload) — the same fence, so a row written by an older/looser writer
+ * cannot smuggle a malformed stamp into the drift comparison.
+ */
+export function readSourceVersionStamp(raw: unknown): SourceVersionStamp | null {
+  const parsed = parseSourceVersionStamp(raw);
+  return parsed.ok ? parsed.stamp : null;
+}
+
+/**
+ * Does a stamp describe the SAME line of the SAME system as `current`?
+ * Drift is only meaningful within one line: a fact read on `main` says
+ * nothing about `release/2.x`, and a git commit is not comparable with a
+ * DMS revision at all. Facts on another line are left alone rather than
+ * marked stale on a false comparison.
+ */
+export function sameSourceLine(a: SourceVersionStamp, b: SourceVersionStamp): boolean {
+  return a.system === b.system && a.ref === b.ref;
+}

--- a/src/contracts/documents/documents.schema.ts
+++ b/src/contracts/documents/documents.schema.ts
@@ -224,6 +224,23 @@ export const SubmittedSceneSchema = z.object({
   confidence: z.number().optional(),
 });
 
+/** Mirror of SourceVersionStamp (src/common/source-version.ts). */
+export const SourceVersionSchema = z.object({
+  system: z
+    .string()
+    .max(32)
+    .describe("System of record the claims were read from: 'git', 'dms', 'ehr', 'ledger', …"),
+  ref: z
+    .string()
+    .max(200)
+    .describe('The line within that system — a branch/ref, a matter id, a study series.'),
+  version: z
+    .string()
+    .max(200)
+    .describe('The exact revision read — a commit sha, a document revision id.'),
+  readAt: z.string().describe('ISO 8601 datetime the derivation read that revision.'),
+});
+
 /** Mirror of SubmittedStateDelta (0110). */
 export const SubmittedStateDeltaSchema = z.object({
   sceneIndex: z
@@ -278,6 +295,14 @@ export const SubmitCandidatesRequestSchema = z.object({
         "(sceneIndex). Validated against the pack's memoryModel.stateModels; " +
         'declared transitions stay advisory (never a gate).',
     ),
+  sourceVersion: SourceVersionSchema.optional().describe(
+    'The revision of the external system of record these claims were read ' +
+      'at. Rejected 400 unless PACK_SOURCE_VERSION_STALENESS. Rides into ' +
+      "every committed fact's source.sourceVersion, and sweeps the pack's " +
+      'DERIVABLE facts (memoryModel.verificationRules with requires=' +
+      'source_version_match) that were read at an older revision, marking ' +
+      'them stale for re-verification.',
+  ),
 });
 
 /** Mirror of GroundingDrop (candidate-grounding.ts). */

--- a/src/documents/candidate-merge.ts
+++ b/src/documents/candidate-merge.ts
@@ -13,6 +13,7 @@
  * keys corroboration on originKey, migration 0050). Per-contributor
  * confidences survive in `contributors` for provenance.
  */
+import { readSourceVersionStamp, type SourceVersionStamp } from '../common/source-version';
 import type { CandidateRow } from './candidate-store.service';
 
 export interface MergedEntity {
@@ -31,6 +32,9 @@ export interface FactContributor {
   model: string | null;
   confidence: number;
   chunkSeq: number;
+  /** The external revision this contributor read (0072-adjacent drift
+   *  staleness). Absent unless the staging payload carried one. */
+  sourceVersion?: SourceVersionStamp | undefined;
 }
 
 export interface MergedFact {
@@ -207,6 +211,10 @@ function foldFactIntoGroup(p: {
 }): void {
   const { row } = p;
   const payload = row.payload;
+  // Re-fenced on the way out of storage: a row written by a looser
+  // writer (or hand-edited) must not smuggle a malformed stamp into the
+  // drift comparison. A stamp that fails the fence is simply absent.
+  const stamp = readSourceVersionStamp(payload.sourceVersion);
   const contributor: FactContributor = {
     candidateId: row.id,
     indexerId: String(payload.indexerId ?? 'core'),
@@ -214,6 +222,7 @@ function foldFactIntoGroup(p: {
     model: typeof payload.model === 'string' ? payload.model : null,
     confidence: row.confidence,
     chunkSeq: row.chunkSeq,
+    ...(stamp ? { sourceVersion: stamp } : {}),
   };
   const group = p.factGroups.get(p.groupKey);
   if (!group) {

--- a/src/documents/candidate-store.service.ts
+++ b/src/documents/candidate-store.service.ts
@@ -437,6 +437,11 @@ export class CandidateStoreService {
             packVersion: prov.packVersion,
             executionMode: prov.executionMode,
             model: prov.model,
+            // Source-version stamp (PACK_SOURCE_VERSION_STALENESS): the
+            // KEY IS ABSENT unless the submission carried one under the
+            // flag, so every in-process and every flag-off fact payload
+            // stays byte-identical to today's row.
+            ...(prov.sourceVersion ? { sourceVersion: prov.sourceVersion } : {}),
           },
         })),
         ...batch.relations.map((r) => ({

--- a/src/documents/commit-writer.service.ts
+++ b/src/documents/commit-writer.service.ts
@@ -210,6 +210,7 @@ export class CommitWriterService {
       documentId: doc.id,
       originKey: originKeyOf(doc.contentHash),
       ...(meta ? { meta } : {}),
+      ...sourceVersionOf(mf),
       indexers: mf.contributors.map((c) => ({
         packId: c.indexerId,
         packVersion: c.packVersion,
@@ -250,4 +251,27 @@ export class CommitWriterService {
       },
     ];
   }
+}
+
+/**
+ * The source-version hop (PACK_SOURCE_VERSION_STALENESS): a derivable
+ * claim is bound to the revision of the external system of record it was
+ * read at, so `source.sourceVersion` says "at commit abc123" and the
+ * drift sweep has something to compare against. FLEXIBLE `source` is the
+ * natural home — no migration, exactly the `evidence[]`/`meta`
+ * precedent.
+ *
+ * The LEADER's stamp wins, because the leader is the reading the fact's
+ * value came from; a corroborating contributor from another run may have
+ * read a different commit and its stamp would misdescribe this value.
+ * Falls back to any contributor carrying one only when the leader has
+ * none. Returns `{}` — not a null key — when nothing carries a stamp, so
+ * the flag-off `source` object is byte-identical.
+ */
+export function sourceVersionOf(mf: MergedFact): Record<string, unknown> {
+  const leader = mf.contributors.find((c) => c.candidateId === mf.leaderId);
+  const stamp =
+    leader?.sourceVersion ??
+    mf.contributors.find((c) => c.sourceVersion !== undefined)?.sourceVersion;
+  return stamp ? { sourceVersion: stamp } : {};
 }

--- a/src/documents/documents.module.ts
+++ b/src/documents/documents.module.ts
@@ -8,6 +8,7 @@ import { DocumentsController } from './documents.controller';
 import { DocumentsIngestController } from './documents-ingest.controller';
 import { ExternalCandidatesController } from './external-candidates.controller';
 import { ExternalCandidatesService } from './external-candidates.service';
+import { SourceDriftStalenessService } from './source-drift-staleness.service';
 import { IndexerWorkController } from './indexer-work.controller';
 import { IndexerWorkService } from './indexer-work.service';
 import { IndexerAdminController } from './indexer-admin.controller';
@@ -72,6 +73,7 @@ import { OutcomesModule } from '../outcomes/outcomes.module';
     IndexerOperatorService,
     IndexerWebhookService,
     SceneCandidateWriterService,
+    SourceDriftStalenessService,
   ],
   exports: [
     DocumentIngestService,

--- a/src/documents/dto/submit-candidates.dto.ts
+++ b/src/documents/dto/submit-candidates.dto.ts
@@ -1,4 +1,4 @@
-import { IsArray, IsOptional, IsString, MaxLength } from 'class-validator';
+import { IsArray, IsObject, IsOptional, IsString, MaxLength } from 'class-validator';
 
 /**
  * An EXTERNAL indexer's reading of a stored document — the
@@ -128,4 +128,15 @@ export class SubmitCandidatesDto {
   @IsOptional()
   @IsArray()
   stateDeltas?: SubmittedStateDelta[];
+
+  /**
+   * The revision of the external system of record this submission read
+   * (`{ system, ref, version, readAt }` — src/common/source-version.ts).
+   * Rejected 400 while PACK_SOURCE_VERSION_STALENESS is off (default),
+   * so the flag-off surface is byte-identical. Field shape is
+   * service-validated, like every other nested shape here.
+   */
+  @IsOptional()
+  @IsObject()
+  sourceVersion?: Record<string, unknown>;
 }

--- a/src/documents/external-candidates.service.ts
+++ b/src/documents/external-candidates.service.ts
@@ -11,7 +11,15 @@ import { PACK_NAMESPACE_SEP } from '../ai/domain-packs/manifest';
 import { policyFor } from '../ingest/conflict-resolver';
 import { RETRACT_ADMIN_PREDICATES } from '../facts/facts.service';
 import { envFlagEnabled } from '../common/env-validation';
-import { packMemoryProjectionsEnabled } from '../common/pack-projection-flags';
+import {
+  packMemoryProjectionsEnabled,
+  packSourceVersionStalenessEnabled,
+} from '../common/pack-projection-flags';
+import { parseSourceVersionStamp, type SourceVersionStamp } from '../common/source-version';
+import {
+  SourceDriftStalenessService,
+  type DriftSweepResult,
+} from './source-drift-staleness.service';
 import { sanitizeIngestText } from '../common/text-sanitizer';
 import { MetricsService } from '../metrics/metrics.service';
 import { MemoryModelReaderService } from '../ai/memory-model-reader.service';
@@ -46,6 +54,10 @@ export interface ExternalSubmissionResult {
   dropped: GroundingDrop[];
   /** true when the document has no stored content — spans unverifiable. */
   ungrounded: boolean;
+  /** Drift sweep outcome — present ONLY when the submission carried a
+   *  sourceVersion under PACK_SOURCE_VERSION_STALENESS, so the flag-off
+   *  response stays byte-identical. */
+  sourceDrift?: DriftSweepResult;
 }
 
 /** Abuse bounds on one submission — an external key stages hypotheses,
@@ -87,6 +99,7 @@ export class ExternalCandidatesService {
     private readonly work: IndexerWorkService,
     private readonly memoryModels: MemoryModelReaderService,
     @Optional() private readonly metrics?: MetricsService,
+    @Optional() private readonly sourceDrift?: SourceDriftStalenessService,
   ) {}
 
   async submit(p: {
@@ -107,6 +120,7 @@ export class ExternalCandidatesService {
     const binding = await this.resolveExternalBinding(companyId, dto);
     validateShapes(dto, binding.indexerId);
     await this.validateProjectionShapes(companyId, dto, binding.indexerId);
+    const sourceVersion = resolveSourceVersion(dto);
     const claim = resolveClaimFields(dto);
 
     // Claimed flow: the run row already exists (claimed via the work
@@ -137,6 +151,7 @@ export class ExternalCandidatesService {
       // caller may omit. Keeps candidate/fact provenance in lockstep with
       // the run ledger instead of stamping the '0' fallback.
       packVersion,
+      sourceVersion,
     });
 
     if (runId === undefined) {
@@ -170,6 +185,20 @@ export class ExternalCandidatesService {
       stats: { ...counts, dropped: dropped.length, external: true },
     });
 
+    // Drift sweep (PACK_SOURCE_VERSION_STALENESS). The indexer has just
+    // told us the source's CURRENT revision — the only moment the server
+    // can learn it without touching git — so this is where the pack's
+    // derivable facts that were read at an older revision are marked for
+    // re-verification. Runs AFTER staging, and never fails the
+    // submission: the candidates are already durable.
+    const sourceDrift = sourceVersion
+      ? await this.sourceDrift?.sweep({
+          companyId,
+          packId: binding.indexerId,
+          current: sourceVersion,
+        })
+      : undefined;
+
     return {
       runId,
       packId: binding.indexerId,
@@ -177,6 +206,7 @@ export class ExternalCandidatesService {
       staged: counts,
       dropped,
       ungrounded,
+      ...(sourceDrift ? { sourceDrift } : {}),
     };
   }
 
@@ -252,6 +282,7 @@ export class ExternalCandidatesService {
     doc: StoredDocument;
     dto: SubmitCandidatesDto;
     packVersion: string;
+    sourceVersion: SourceVersionStamp | undefined;
   }): Promise<{
     batch: CandidateBatch;
     dropped: GroundingDrop[];
@@ -293,6 +324,10 @@ export class ExternalCandidatesService {
       packVersion: p.packVersion,
       executionMode: 'external' as const,
       model: null,
+      // Absent unless the submission carried a stamp under
+      // PACK_SOURCE_VERSION_STALENESS — the key never appears otherwise,
+      // so staged payloads stay byte-identical with the flag off.
+      ...(p.sourceVersion ? { sourceVersion: p.sourceVersion } : {}),
     };
 
     if (!doc.hasContent) {
@@ -341,6 +376,30 @@ export class ExternalCandidatesService {
       ungrounded: false,
     };
   }
+}
+
+/**
+ * The source-version stamp: flag fence FIRST (fail-closed), then shape.
+ *
+ * With PACK_SOURCE_VERSION_STALENESS off (default) a submission carrying
+ * `sourceVersion` is REJECTED rather than silently stripped — the same
+ * honest-upgrade posture 0110 took for scenes/stateDeltas. Silent
+ * stripping is how an indexer ships version-bound facts for a month and
+ * only then discovers every one of them was recorded as timeless truth.
+ *
+ * Exported for the unit spec (the validateScenes precedent).
+ */
+export function resolveSourceVersion(dto: SubmitCandidatesDto): SourceVersionStamp | undefined {
+  if (dto.sourceVersion === undefined) return undefined;
+  if (!packSourceVersionStalenessEnabled()) {
+    throw new BadRequestException(
+      'sourceVersion submissions are disabled ' +
+        '(set PACK_SOURCE_VERSION_STALENESS=1 to bind claims to a source revision)',
+    );
+  }
+  const parsed = parseSourceVersionStamp(dto.sourceVersion);
+  if (!parsed.ok) throw new BadRequestException(parsed.error);
+  return parsed.stamp;
 }
 
 /** runId + claimToken travel together, or not at all. */

--- a/src/documents/source-drift-staleness.service.ts
+++ b/src/documents/source-drift-staleness.service.ts
@@ -1,0 +1,217 @@
+/**
+ * STALENESS BY SOURCE DRIFT, not by calendar.
+ *
+ * A recency check asks "how old is this claim?". That is the wrong
+ * question for a domain with an external system of record. A `decided`
+ * fact from 2019 is not stale — it is a statement about 2019, and it is
+ * exactly as true today. A `depends_on_version` fact from yesterday IS
+ * stale if someone merged a bump this morning. Age is noise; DRIFT is
+ * the signal.
+ *
+ * So this service asks the only question that means anything for a
+ * derivable claim: is the revision it was read at still the source's
+ * current revision? A fact whose `source.sourceVersion.version` no
+ * longer matches goes back for re-verification.
+ *
+ * NO GIT LIVES HERE. The server never resolves a ref, never shells out,
+ * never opens a repository — it cannot, and should not be able to. The
+ * CURRENT version is told to it by the party that already has the
+ * working tree: the indexer, on its next submission. That keeps the
+ * asymmetry honest — the external system of record stays external.
+ *
+ * WHICH FACTS ARE DERIVABLE IS DECLARED, NOT INFERRED. The predicate
+ * class comes from the pack's own manifest
+ * (`memoryModel.verificationRules` entries with
+ * `requires: 'source_version_match'`), so a domain that knows its own
+ * ontology decides what rots. The engine never pattern-matches predicate
+ * names.
+ *
+ * MARKING, NOT ACTING — the 0072 contract, word for word: "this
+ * migration marks, and a recompute pass acts". A drifted fact keeps
+ * serving (a stale answer beats the nothing that hiding it would leave)
+ * and carries `staleAt`/`staleReason` so a re-verification pass can find
+ * it. The EXISTING staleness fields carry it with no schema change: they
+ * are plain option<datetime>/option<string> columns on knowledge_fact
+ * with their own index (fact_stale_idx), and the only consumer that
+ * scans them — the recompose pass — is fenced to
+ * `source.kind = 'compaction-summary'`, so drift marks are visible to a
+ * re-verification pass without being swept into summary recomposition.
+ */
+import { Injectable, Logger } from '@nestjs/common';
+import type { Surreal } from 'surrealdb';
+import { SurrealService } from '../db/surreal.service';
+import { MemoryModelReaderService } from '../ai/memory-model-reader.service';
+import { composePredicateId } from '../ai/domain-packs/manifest';
+import { packSourceVersionStalenessEnabled } from '../common/pack-projection-flags';
+import type { SourceVersionStamp } from '../common/source-version';
+
+/** `staleReason` written by this sweep — the fence the clear leg reads. */
+export const SOURCE_DRIFT_REASON = 'source_version_drift';
+
+/** Rows touched per sweep. A submission must not turn into an unbounded
+ *  tenant-wide write; the next run picks up the remainder. */
+const SWEEP_LIMIT = 500;
+
+export interface DriftSweepResult {
+  /** Facts newly marked stale by this sweep. */
+  marked: number;
+  /** Facts whose mark this sweep cleared (they are back at `current`). */
+  cleared: number;
+  /** Namespaced predicates the pack declared as derivable. */
+  predicates: string[];
+}
+
+const NO_OP: DriftSweepResult = { marked: 0, cleared: 0, predicates: [] };
+
+@Injectable()
+export class SourceDriftStalenessService {
+  private readonly logger = new Logger(SourceDriftStalenessService.name);
+
+  constructor(
+    private readonly surreal: SurrealService,
+    private readonly memoryModels: MemoryModelReaderService,
+  ) {}
+
+  /**
+   * The pack's DERIVABLE predicate class, namespaced — read from the
+   * installed manifest's memoryModel, never from a hardcoded list. A
+   * pack that declared no `source_version_match` rule yields [], and the
+   * sweep is a no-op for it (an interpretation-only domain never
+   * drifts).
+   */
+  async derivablePredicates(companyId: string, packId: string): Promise<string[]> {
+    const bindings = await this.memoryModels.installedMemoryModels(companyId);
+    const model = bindings.find((b) => b.packId === packId)?.memoryModel;
+    const locals = new Set<string>();
+    for (const rule of model?.verificationRules ?? []) {
+      if (rule.requires !== 'source_version_match') continue;
+      for (const local of rule.appliesTo ?? []) locals.add(local);
+    }
+    return [...locals].map((local) => composePredicateId(packId, local));
+  }
+
+  /**
+   * Mark the pack's derivable facts that were read at a DIFFERENT
+   * revision of the same source line, and clear the marks this sweep
+   * itself left on facts that are back at `current`.
+   *
+   * Flag off ⇒ returns without running a single query.
+   */
+  async sweep(p: {
+    companyId: string;
+    packId: string;
+    current: SourceVersionStamp;
+  }): Promise<DriftSweepResult> {
+    if (!packSourceVersionStalenessEnabled()) return NO_OP;
+    const predicates = await this.derivablePredicates(p.companyId, p.packId);
+    if (predicates.length === 0) return NO_OP;
+    try {
+      return await this.surreal.withCompany(p.companyId, async (db) => {
+        const marked = await this.mark(db, predicates, p.current);
+        const cleared = await this.clear(db, predicates, p.current);
+        return { marked, cleared, predicates };
+      });
+    } catch (e) {
+      // A drift sweep is a maintenance signal riding a submission that
+      // has ALREADY staged its candidates. Failing the submission over
+      // it would lose real work to a bookkeeping error.
+      this.logger.warn(`source-drift sweep failed (non-fatal): ${(e as Error).message}`);
+      return { ...NO_OP, predicates };
+    }
+  }
+
+  /**
+   * SurrealDB 3.2.4 discipline: SELECT the ids, then write BY id.
+   * `staleAt` is covered by fact_stale_idx and `predicate` by
+   * fact_predicate_idx, and an UPDATE ... WHERE over an indexed field is
+   * the reproduced silent planner no-op (the 0116 header, the
+   * support-edge mirror). The LET-select-ids → UPDATE $ids form is a
+   * primary-key write and is immune to it.
+   *
+   * The comparison is fenced to the SAME system AND the SAME ref: a fact
+   * read on `main` says nothing about `release/2.x`, and a git commit is
+   * not comparable with a DMS revision at all. Facts on another line are
+   * left alone rather than marked on a false comparison. `staleAt IS
+   * NONE` makes the sweep idempotent exactly as it does in
+   * fn::mark_derived_stale, and `status = 'active'` keeps history
+   * (superseded/compacted rows) out of it — a superseded fact is already
+   * not the current answer.
+   */
+  private async mark(
+    db: Surreal,
+    predicates: string[],
+    current: SourceVersionStamp,
+  ): Promise<number> {
+    return countWritten(
+      db,
+      `LET $ids = (SELECT VALUE id FROM knowledge_fact
+         WHERE predicate INSIDE $predicates
+           AND status = 'active'
+           AND retractedAt IS NONE
+           AND staleAt IS NONE
+           AND source.sourceVersion.system = $system
+           AND source.sourceVersion.ref = $ref
+           AND source.sourceVersion.version != $version
+         LIMIT ${SWEEP_LIMIT});
+       UPDATE $ids SET staleAt = time::now(), staleReason = $reason RETURN id;`,
+      {
+        predicates,
+        system: current.system,
+        ref: current.ref,
+        version: current.version,
+        reason: SOURCE_DRIFT_REASON,
+      },
+    );
+  }
+
+  /**
+   * The other half of honesty: a fact re-read at the CURRENT revision is
+   * no longer drifted, so its mark goes away. Fenced to `staleReason =
+   * SOURCE_DRIFT_REASON` — this sweep clears only what this sweep wrote,
+   * never a derived-parent mark left by fn::mark_derived_stale (which
+   * means something entirely different and is a different pass's to
+   * clear).
+   */
+  private async clear(
+    db: Surreal,
+    predicates: string[],
+    current: SourceVersionStamp,
+  ): Promise<number> {
+    return countWritten(
+      db,
+      `LET $ids = (SELECT VALUE id FROM knowledge_fact
+         WHERE predicate INSIDE $predicates
+           AND status = 'active'
+           AND retractedAt IS NONE
+           AND staleReason = $reason
+           AND source.sourceVersion.system = $system
+           AND source.sourceVersion.ref = $ref
+           AND source.sourceVersion.version = $version
+         LIMIT ${SWEEP_LIMIT});
+       UPDATE $ids SET staleAt = NONE, staleReason = NONE RETURN id;`,
+      {
+        predicates,
+        system: current.system,
+        ref: current.ref,
+        version: current.version,
+        reason: SOURCE_DRIFT_REASON,
+      },
+    );
+  }
+}
+
+/**
+ * Rows written by the LAST statement of a multi-statement query. The
+ * LET-select-ids form means the FIRST result belongs to the LET, so the
+ * queryRows helper (which reads result 0) would report the selection,
+ * not the write.
+ */
+async function countWritten(
+  db: Surreal,
+  sql: string,
+  vars: Record<string, unknown>,
+): Promise<number> {
+  const results = (await db.query(sql, vars)) as unknown[];
+  const last = results[results.length - 1];
+  return Array.isArray(last) ? last.length : 0;
+}

--- a/src/indexers/candidate.types.ts
+++ b/src/indexers/candidate.types.ts
@@ -13,6 +13,7 @@ import type {
   ExtractedFact,
   ExtractedEdge,
 } from '../ai/extractor-internals/types';
+import type { SourceVersionStamp } from '../common/source-version';
 
 /** The pack-less generalist (union) pass — today's extractor, as an indexer. */
 export const GENERAL_INDEXER_ID = '_general';
@@ -33,6 +34,17 @@ export interface CandidateProvenance {
   packVersion: string;
   executionMode: IndexerExecutionMode;
   model: string | null;
+  /**
+   * The revision of the EXTERNAL system of record these candidates were
+   * derived from (PACK_SOURCE_VERSION_STALENESS). Present only on
+   * external submissions that carried a `sourceVersion` while the flag
+   * was on; it rides into every committed fact's `source.sourceVersion`,
+   * so a derivable claim reads "at commit abc123, X is Y" rather than
+   * the timeless — and eventually false — "X is Y". Absent on every
+   * in-process batch and on every flag-off submission, which keeps those
+   * payloads byte-identical.
+   */
+  sourceVersion?: SourceVersionStamp | undefined;
 }
 
 /**

--- a/test/code-repo-indexer.unit-spec.ts
+++ b/test/code-repo-indexer.unit-spec.ts
@@ -82,6 +82,7 @@ class FakeRepoSource implements RepoSource {
     private readonly commits: CommitRecord[] = [],
     private readonly headSha: string | null = 'head0000',
     private readonly changed: string[] | null = null,
+    private readonly refName: string | null = 'main',
   ) {}
 
   listFiles(): RepoFileRef[] {
@@ -98,6 +99,10 @@ class FakeRepoSource implements RepoSource {
 
   head(): string | null {
     return this.headSha;
+  }
+
+  ref(): string | null {
+    return this.refName;
   }
 
   changedSince(): string[] | null {
@@ -817,6 +822,63 @@ describe('runIndexer', () => {
     expect(summary.filesScanned).toBe(Object.keys(RUNNER_FILES).length);
     expect(lines.join(' ')).toContain('falling back to a full walk');
   });
+
+  // ── source-version stamp ───────────────────────────────────────────
+  //
+  // The claim a derivable fact makes is not "X is Y" but "at commit
+  // abc123, X is Y". These pin that the stamp is composed from the
+  // revision actually walked and rides EVERY submission of the run.
+
+  it('stamps every submission with the commit and ref it read', async () => {
+    const client = new StubBrainClient();
+    const summary = await runIndexer(
+      runnerOptions({
+        client,
+        source: new FakeRepoSource(RUNNER_FILES, [], 'abc123', null, 'release/2.x'),
+      }),
+    );
+    expect(summary.sourceVersion).toEqual({
+      system: 'git',
+      ref: 'release/2.x',
+      version: 'abc123',
+      readAt: expect.any(String),
+    });
+    expect(client.payloads.length).toBeGreaterThan(0);
+    for (const payload of client.payloads) {
+      expect(payload.sourceVersion).toEqual(summary.sourceVersion);
+    }
+    // Generic by construction: the shape names a system of record, not
+    // git — the server never learns what a commit is.
+    expect(Object.keys(summary.sourceVersion ?? {}).sort()).toEqual([
+      'readAt',
+      'ref',
+      'system',
+      'version',
+    ]);
+  });
+
+  it('sends no stamp at all outside a git checkout — a half-stamp is worse than none', async () => {
+    const client = new StubBrainClient();
+    const noHead = await runIndexer(
+      runnerOptions({ client, source: new FakeRepoSource(RUNNER_FILES, [], null, null, 'main') }),
+    );
+    expect(noHead.sourceVersion).toBeUndefined();
+    for (const payload of client.payloads) {
+      expect('sourceVersion' in payload).toBe(false);
+    }
+
+    const noRef = new StubBrainClient();
+    const detached = await runIndexer(
+      runnerOptions({
+        client: noRef,
+        source: new FakeRepoSource(RUNNER_FILES, [], 'abc123', null, null),
+      }),
+    );
+    expect(detached.sourceVersion).toBeUndefined();
+    for (const payload of noRef.payloads) {
+      expect('sourceVersion' in payload).toBe(false);
+    }
+  });
 });
 
 // ── the filesystem/git layer ─────────────────────────────────────────
@@ -902,6 +964,9 @@ describe('parseCommitLog', () => {
     expect(commits[0]?.authorName).toBe('Ada');
     expect(source.changedSince('HEAD~1')).toEqual(['src/third.ts']);
     expect(source.changedSince('no-such-ref')).toBeNull();
+    // The line of history, not just the point on it: drift is only ever
+    // compared within one ref.
+    expect(source.ref()).toBe('main');
   });
 
   it('derives a commit decision anchored on the single changed file', () => {

--- a/test/domain-pack.unit-spec.ts
+++ b/test/domain-pack.unit-spec.ts
@@ -510,7 +510,7 @@ describe('code-memory pack', () => {
     expect(defaultValue?.description).toContain('value-shaped');
   });
 
-  it('declares the perception contract: three lifecycles, hints, one recency rule', () => {
+  it('declares the perception contract: three lifecycles, hints, recency + drift rules', () => {
     const mm = CODE_MEMORY_PACK.memoryModel;
     expect(mm?.stateModels?.map((m) => m.id).sort()).toEqual([
       'change_lifecycle',
@@ -520,7 +520,18 @@ describe('code-memory pack', () => {
     const flag = mm?.stateModels?.find((m) => m.id === 'flag_lifecycle');
     expect(flag?.states).toEqual(['declared', 'enabled', 'deprecated', 'removed']);
     expect(mm?.attentionHints?.length ?? 0).toBeGreaterThanOrEqual(5);
-    expect(mm?.verificationRules).toEqual([{ claimPattern: 'default', requires: 'recency_check' }]);
+    // 0.7.0 adds the DERIVABLE-CLASS declaration alongside the recency
+    // rule. The full list stays pinned — a new rule must be a deliberate
+    // edit here — and the interpretation predicates must stay OUT of it:
+    // `decided`/`because`/`gotcha`/`invariant` are statements about the
+    // past and never drift with the repository.
+    expect(mm?.verificationRules).toEqual([
+      { claimPattern: 'default', requires: 'recency_check' },
+      {
+        requires: 'source_version_match',
+        appliesTo: ['owns', 'default_value', 'depends_on_version'],
+      },
+    ]);
     expect(mm?.retentionHints?.some((h) => h.predicateOrScene === 'gotcha')).toBe(true);
   });
 
@@ -612,12 +623,14 @@ const MEDIA_CONTRACT: MediaExpectation[] = [
   },
   {
     pack: CODE_MEMORY_PACK,
-    // 0.6.0 carries TWO independent changes that landed in the same
-    // release window: the `invariant` semantics correction
-    // (single_active → append_only) and the `ocr` media declaration. One
-    // bump, not two stacked — 0.5.0 is the last version either was
-    // absent from, so a tenant re-accepts modalities once.
-    version: '0.6.0',
+    // 0.7.0: the derivable-class declaration (a source_version_match
+    // verificationRule over owns / default_value / depends_on_version),
+    // after 0.6.0, which carried TWO independent changes of its own in
+    // one bump rather than two stacked — the `invariant` semantics
+    // correction (single_active → append_only) and the `ocr` media
+    // declaration. The media contract itself is unchanged from 0.6.0 —
+    // this pin just has to move deliberately on every version bump.
+    version: '0.7.0',
     modalities: ['text', 'image', 'document'],
     processors: [IMAGE_METADATA, DOCUMENT_TEXT, IMAGE_OCR],
     rawEvidence: undefined, // a builtin seeds into every tenant unasked

--- a/test/source-version-staleness.unit-spec.ts
+++ b/test/source-version-staleness.unit-spec.ts
@@ -1,0 +1,436 @@
+/**
+ * Source-version stamps and drift-based staleness — the pure seams.
+ *
+ * THE PRINCIPLE UNDER TEST. Code has an external system of record (git)
+ * that is better than our copy: exact, versioned, cheap, never wrong
+ * about the past. So memory MATERIALIZES what is not derivable (a
+ * decision, its rationale, a gotcha, an invariant — prose that is lost
+ * without us) and merely POINTS AT what is derivable (who owns a file,
+ * which version a dependency is pinned to, what a flag defaults to —
+ * re-derivable at any moment, and a lie waiting to happen if stored as
+ * timeless truth).
+ *
+ * Two things follow, and both are pinned here:
+ *
+ *   1. a derivable fact must carry the revision it was READ at, all the
+ *      way from the indexer's candidate to the committed fact's
+ *      `source`;
+ *   2. staleness for that class is DRIFT, not calendar age — and the
+ *      split between the two classes is DECLARED by the pack, not
+ *      pattern-matched by the engine.
+ */
+import { BadRequestException } from '@nestjs/common';
+import {
+  parseSourceVersionStamp,
+  readSourceVersionStamp,
+  sameSourceLine,
+  type SourceVersionStamp,
+} from '../src/common/source-version';
+import { packSourceVersionStalenessEnabled } from '../src/common/pack-projection-flags';
+import { resolveSourceVersion } from '../src/documents/external-candidates.service';
+import { mergeCandidates } from '../src/documents/candidate-merge';
+import { sourceVersionOf } from '../src/documents/commit-writer.service';
+import {
+  SourceDriftStalenessService,
+  SOURCE_DRIFT_REASON,
+} from '../src/documents/source-drift-staleness.service';
+import { toCandidatePayload } from '../src/code-memory/repo-indexer/bundle';
+import { CODE_MEMORY_PACK } from '../src/ai/domain-packs/code-memory.pack';
+import { validateMemoryModel } from '../src/ai/domain-packs/validate-memory-model';
+import type { DomainPackManifest, PackMemoryModel } from '../src/ai/domain-packs/manifest';
+import type { CandidateRow } from '../src/documents/candidate-store.service';
+import type { IdentifiedRepoFact } from '../src/code-memory/repo-indexer/types';
+import type { SubmitCandidatesDto } from '../src/documents/dto/submit-candidates.dto';
+
+const STAMP: SourceVersionStamp = {
+  system: 'git',
+  ref: 'main',
+  version: 'abc123',
+  readAt: '2026-09-08T00:00:00.000Z',
+};
+
+// ── the stamp shape ──────────────────────────────────────────────────
+
+describe('source-version stamp', () => {
+  it('is domain-agnostic — a DMS revision and an EHR study fit the same four fields', () => {
+    for (const raw of [
+      { system: 'dms', ref: 'matter/2026-114', version: 'rev-17', readAt: STAMP.readAt },
+      { system: 'ehr', ref: 'patient/8812', version: 'study:1.2.840.113', readAt: STAMP.readAt },
+    ]) {
+      const parsed = parseSourceVersionStamp(raw);
+      expect(parsed.ok).toBe(true);
+    }
+  });
+
+  it('rejects a half-stamp — a claim that LOOKS version-bound but is not can never be swept', () => {
+    const cases: Array<[unknown, string]> = [
+      [{ ref: 'main', version: 'abc', readAt: STAMP.readAt }, 'system'],
+      [{ system: 'git', version: 'abc', readAt: STAMP.readAt }, 'ref'],
+      [{ system: 'git', ref: 'main', readAt: STAMP.readAt }, 'version'],
+      [{ system: 'git', ref: 'main', version: 'abc' }, 'readAt'],
+      [{ system: 'GIT', ref: 'main', version: 'abc', readAt: STAMP.readAt }, 'system'],
+      [{ system: 'git', ref: 'main', version: 'abc', readAt: 'yesterday' }, 'readAt'],
+      ['abc123', 'object'],
+      [['abc123'], 'object'],
+      [null, 'object'],
+    ];
+    for (const [raw, field] of cases) {
+      const parsed = parseSourceVersionStamp(raw);
+      expect(parsed.ok).toBe(false);
+      if (!parsed.ok) expect(parsed.error).toContain(field);
+    }
+  });
+
+  it('re-fences a stored stamp on the way back out', () => {
+    expect(readSourceVersionStamp(STAMP)).toEqual(STAMP);
+    expect(readSourceVersionStamp({ system: 'git', ref: 'main' })).toBeNull();
+    expect(readSourceVersionStamp(undefined)).toBeNull();
+  });
+
+  it('compares drift only within one system AND one line of it', () => {
+    expect(sameSourceLine(STAMP, { ...STAMP, version: 'def456' })).toBe(true);
+    // A fact read on release/2.x says nothing about main.
+    expect(sameSourceLine(STAMP, { ...STAMP, ref: 'release/2.x' })).toBe(false);
+    // A git commit is not comparable with a DMS revision at all.
+    expect(sameSourceLine(STAMP, { ...STAMP, system: 'dms' })).toBe(false);
+  });
+});
+
+// ── the derivable / interpretation split, as the pack declares it ─────
+
+describe('the declared derivable class', () => {
+  const memoryModel = CODE_MEMORY_PACK.memoryModel as PackMemoryModel;
+  const rule = (memoryModel.verificationRules ?? []).find(
+    (r) => r.requires === 'source_version_match',
+  );
+
+  it('code_memory declares exactly the re-derivable predicates', () => {
+    expect(rule?.appliesTo?.slice().sort()).toEqual([
+      'default_value',
+      'depends_on_version',
+      'owns',
+    ]);
+  });
+
+  it('never lists an interpretation predicate — the past does not rot', () => {
+    // decided / because / invariant / gotcha / superseded_by exist ONLY
+    // in prose. A thousand commits later they are exactly as true.
+    for (const interpretation of ['decided', 'because', 'invariant', 'gotcha', 'superseded_by']) {
+      expect(rule?.appliesTo).not.toContain(interpretation);
+    }
+  });
+
+  it('the pack minor is bumped for the new declaration', () => {
+    expect(CODE_MEMORY_PACK.version).toBe('0.7.0');
+  });
+
+  it('a source_version_match rule MUST name its predicate class', () => {
+    // Without appliesTo a drift sweep would either touch every claim the
+    // pack ever recorded or none of them — both are wrong, so the
+    // manifest validator refuses the rule outright.
+    expect(() => validateRule({ requires: 'source_version_match' })).toThrow(
+      /must declare appliesTo/,
+    );
+  });
+
+  it('appliesTo cannot reference another pack’s vocabulary', () => {
+    expect(() =>
+      validateRule({ requires: 'source_version_match', appliesTo: ['legal__clause'] }),
+    ).toThrow(/not a predicate of this pack/);
+    expect(() =>
+      validateRule({ requires: 'source_version_match', appliesTo: ['owns', 'owns'] }),
+    ).toThrow(/twice/);
+  });
+
+  it('the pre-existing rule kinds still validate without appliesTo', () => {
+    expect(() =>
+      validateRule({ claimPattern: 'default', requires: 'recency_check' }),
+    ).not.toThrow();
+  });
+});
+
+/** Validate a memoryModel carrying exactly the one rule under test,
+ *  against a minimal pack whose only predicate is `owns`. */
+function validateRule(rule: Record<string, unknown>): void {
+  const pack = {
+    id: 'probe',
+    version: '1.0.0',
+    description: 'probe pack',
+    predicates: [
+      {
+        localId: 'owns',
+        label: 'owns',
+        description: 'ownership',
+        objectType: 'string',
+        semantics: 'single_active',
+      },
+    ],
+  } as unknown as DomainPackManifest;
+  validateMemoryModel(pack, { verificationRules: [rule] });
+}
+
+// ── the stamp rides candidate → document → fact ──────────────────────
+
+describe('the stamp rides from the indexer candidate to the committed fact', () => {
+  const fact = (kind: string, subject: string, object: string): IdentifiedRepoFact =>
+    ({
+      candidateId: `cand-${kind}-${subject}`,
+      producer: 'core:probe',
+      subject,
+      subjectType: 'asset',
+      kind,
+      object,
+      derivation: 'probe',
+      evidence: { path: 'package.json', startLine: 1, endLine: 1, excerpt: object },
+      confidence: 0.9,
+    }) as IdentifiedRepoFact;
+
+  it('the indexer payload carries it, and omits the key entirely without one', () => {
+    const facts = [fact('depends_on_version', 'left-pad', '2.0.0')];
+    expect(toCandidatePayload(facts, 'code_memory', STAMP).sourceVersion).toEqual(STAMP);
+    expect('sourceVersion' in toCandidatePayload(facts, 'code_memory')).toBe(false);
+  });
+
+  it('the merge carries it onto the fact’s contributors, and the writer onto source', () => {
+    const merged = mergeCandidates([
+      entityRow('e1', 'left-pad'),
+      factRow('f1', 'code_memory__depends_on_version', '2.0.0', STAMP),
+    ]);
+    const [mf] = merged.facts;
+    expect(mf?.contributors[0]?.sourceVersion).toEqual(STAMP);
+    // "at commit abc123, left-pad is 2.0.0" — not the timeless, and
+    // eventually false, "left-pad is 2.0.0".
+    expect(sourceVersionOf(mf!)).toEqual({ sourceVersion: STAMP });
+  });
+
+  it('the LEADER’s reading wins when two runs read different revisions', () => {
+    // A corroborating contributor from an older run read a DIFFERENT
+    // commit; stamping the fact with ITS revision would misdescribe the
+    // value the fact actually holds.
+    const older: SourceVersionStamp = { ...STAMP, version: 'old999' };
+    const merged = mergeCandidates([
+      entityRow('e1', 'left-pad'),
+      factRow('weak', 'code_memory__depends_on_version', '2.0.0', older, 0.4),
+      factRow('leader', 'code_memory__depends_on_version', '2.0.0', STAMP, 0.9),
+    ]);
+    const [mf] = merged.facts;
+    expect(mf?.leaderId).toBe('leader');
+    expect(sourceVersionOf(mf!)).toEqual({ sourceVersion: STAMP });
+  });
+
+  it('LEGACY SAFETY: an unstamped fact’s source is byte-identical to today’s', () => {
+    const merged = mergeCandidates([
+      entityRow('e1', 'left-pad'),
+      factRow('f1', 'code_memory__depends_on_version', '2.0.0', undefined),
+    ]);
+    const [mf] = merged.facts;
+    expect(mf?.contributors[0]).not.toHaveProperty('sourceVersion');
+    // {} — not `{ sourceVersion: null }`. A null key would change every
+    // stored source object in the system.
+    expect(sourceVersionOf(mf!)).toEqual({});
+  });
+
+  it('a malformed stored stamp is dropped rather than smuggled into the comparison', () => {
+    const merged = mergeCandidates([
+      entityRow('e1', 'left-pad'),
+      factRow('f1', 'code_memory__depends_on_version', '2.0.0', {
+        system: 'git',
+        version: 'abc123',
+      } as unknown as SourceVersionStamp),
+    ]);
+    expect(sourceVersionOf(merged.facts[0]!)).toEqual({});
+  });
+});
+
+function entityRow(id: string, name: string): CandidateRow {
+  return {
+    id,
+    runId: 'run1',
+    chunkSeq: 0,
+    kind: 'entity',
+    confidence: 0.5,
+    status: 'pending',
+    payload: { entityIndex: 0, name, type: 'asset', indexerId: 'code_memory' },
+  };
+}
+
+function factRow(
+  id: string,
+  predicate: string,
+  object: string,
+  sourceVersion: SourceVersionStamp | undefined,
+  confidence = 0.9,
+): CandidateRow {
+  return {
+    id,
+    runId: 'run1',
+    chunkSeq: 0,
+    kind: 'fact',
+    confidence,
+    status: 'pending',
+    payload: {
+      entityIndex: 0,
+      predicate,
+      object,
+      indexerId: 'code_memory',
+      packVersion: '0.7.0',
+      executionMode: 'external',
+      model: null,
+      ...(sourceVersion ? { sourceVersion } : {}),
+    },
+  };
+}
+
+// ── the submission fence ─────────────────────────────────────────────
+
+describe('the submission fence', () => {
+  const dto = (sourceVersion?: unknown): SubmitCandidatesDto =>
+    ({
+      indexerId: 'code_memory',
+      entities: [],
+      facts: [],
+      ...(sourceVersion === undefined ? {} : { sourceVersion }),
+    }) as unknown as SubmitCandidatesDto;
+
+  afterEach(() => {
+    delete process.env.PACK_SOURCE_VERSION_STALENESS;
+  });
+
+  it('FLAG OFF (default) rejects a stamp rather than silently stripping it', () => {
+    expect(packSourceVersionStalenessEnabled()).toBe(false);
+    expect(() => resolveSourceVersion(dto(STAMP))).toThrow(BadRequestException);
+    expect(() => resolveSourceVersion(dto(STAMP))).toThrow(/PACK_SOURCE_VERSION_STALENESS/);
+  });
+
+  it('FLAG OFF: a submission that carries no stamp is untouched', () => {
+    expect(resolveSourceVersion(dto())).toBeUndefined();
+  });
+
+  it('FLAG ON: a well-formed stamp resolves, a malformed one is a 400', () => {
+    process.env.PACK_SOURCE_VERSION_STALENESS = '1';
+    expect(resolveSourceVersion(dto(STAMP))).toEqual(STAMP);
+    expect(() => resolveSourceVersion(dto({ system: 'git' }))).toThrow(BadRequestException);
+  });
+});
+
+// ── the drift sweep ──────────────────────────────────────────────────
+
+interface CapturedQuery {
+  sql: string;
+  vars: Record<string, unknown> | undefined;
+}
+
+function driftService(rows: unknown[][], model: PackMemoryModel | undefined) {
+  const queries: CapturedQuery[] = [];
+  let call = 0;
+  const db = {
+    query: (sql: string, vars?: Record<string, unknown>) => {
+      queries.push({ sql, vars });
+      return Promise.resolve([[], rows[call++] ?? []]);
+    },
+  };
+  const surreal = {
+    withCompany: <T>(_c: string, fn: (db: unknown) => Promise<T>): Promise<T> => fn(db),
+  };
+  const memoryModels = {
+    installedMemoryModels: () =>
+      Promise.resolve(
+        model ? [{ packId: 'code_memory', packVersion: '0.7.0', memoryModel: model }] : [],
+      ),
+  };
+  const service = new SourceDriftStalenessService(surreal as never, memoryModels as never);
+  return { service, queries };
+}
+
+describe('drift sweep', () => {
+  const model = CODE_MEMORY_PACK.memoryModel as PackMemoryModel;
+
+  afterEach(() => {
+    delete process.env.PACK_SOURCE_VERSION_STALENESS;
+  });
+
+  it('FLAG OFF: not a single query runs', async () => {
+    const { service, queries } = driftService([], model);
+    const out = await service.sweep({ companyId: 'c1', packId: 'code_memory', current: STAMP });
+    expect(out).toEqual({ marked: 0, cleared: 0, predicates: [] });
+    expect(queries).toHaveLength(0);
+  });
+
+  it('sweeps ONLY the pack’s declared derivable predicates', async () => {
+    process.env.PACK_SOURCE_VERSION_STALENESS = '1';
+    const { service } = driftService([], model);
+    const predicates = await service.derivablePredicates('c1', 'code_memory');
+    expect(predicates.slice().sort()).toEqual([
+      'code_memory__default_value',
+      'code_memory__depends_on_version',
+      'code_memory__owns',
+    ]);
+    // The interpretation class is not merely deprioritised — it is not
+    // in the query's parameter list at all.
+    for (const interpretation of ['decided', 'because', 'invariant', 'gotcha']) {
+      expect(predicates).not.toContain(`code_memory__${interpretation}`);
+    }
+  });
+
+  it('a pack with no source_version_match rule never sweeps', async () => {
+    process.env.PACK_SOURCE_VERSION_STALENESS = '1';
+    const { service, queries } = driftService([], {
+      verificationRules: [{ claimPattern: 'default', requires: 'recency_check' }],
+    });
+    const out = await service.sweep({ companyId: 'c1', packId: 'code_memory', current: STAMP });
+    expect(out.marked).toBe(0);
+    expect(queries).toHaveLength(0);
+  });
+
+  it('marks behind-stamp facts, clears re-read ones, and never touches an unstamped fact', async () => {
+    process.env.PACK_SOURCE_VERSION_STALENESS = '1';
+    const { service, queries } = driftService([[{ id: 'a' }, { id: 'b' }], [{ id: 'c' }]], model);
+    const out = await service.sweep({ companyId: 'c1', packId: 'code_memory', current: STAMP });
+    expect(out).toEqual({
+      marked: 2,
+      cleared: 1,
+      predicates: expect.arrayContaining(['code_memory__owns']),
+    });
+
+    const [mark, clear] = queries;
+    // SurrealDB 3.2.4: LET-select-ids, then write BY id. An
+    // UPDATE ... WHERE over the indexed staleAt/predicate fields is the
+    // reproduced silent planner no-op.
+    for (const q of [mark, clear]) {
+      expect(q?.sql).toContain('LET $ids = (SELECT VALUE id FROM knowledge_fact');
+      expect(q?.sql).toContain('UPDATE $ids SET');
+      expect(q?.sql).not.toMatch(/UPDATE knowledge_fact\s+SET/);
+      // LEGACY SAFETY, enforced by the query itself: a fact with no
+      // stamp cannot satisfy an equality on source.sourceVersion.system,
+      // so pre-stamp memory is untouchable by this sweep.
+      expect(q?.sql).toContain('source.sourceVersion.system = $system');
+      expect(q?.sql).toContain('source.sourceVersion.ref = $ref');
+      expect(q?.vars?.['predicates']).toEqual(expect.arrayContaining(['code_memory__owns']));
+    }
+    // Behind the current revision ⇒ marked; back at it ⇒ cleared.
+    expect(mark?.sql).toContain('source.sourceVersion.version != $version');
+    expect(mark?.sql).toContain('staleAt IS NONE');
+    expect(mark?.vars?.['reason']).toBe(SOURCE_DRIFT_REASON);
+    expect(clear?.sql).toContain('source.sourceVersion.version = $version');
+    // The clear leg touches ONLY marks this sweep wrote — a
+    // derived-parent mark from fn::mark_derived_stale means something
+    // else entirely and is a different pass's to clear.
+    expect(clear?.sql).toContain('staleReason = $reason');
+    expect(clear?.sql).toContain('staleAt = NONE, staleReason = NONE');
+  });
+
+  it('a sweep failure never fails the submission that has already staged', async () => {
+    process.env.PACK_SOURCE_VERSION_STALENESS = '1';
+    const surreal = {
+      withCompany: (): Promise<never> => Promise.reject(new Error('planner said no')),
+    };
+    const memoryModels = {
+      installedMemoryModels: () =>
+        Promise.resolve([{ packId: 'code_memory', packVersion: '0.7.0', memoryModel: model }]),
+    };
+    const service = new SourceDriftStalenessService(surreal as never, memoryModels as never);
+    await expect(
+      service.sweep({ companyId: 'c1', packId: 'code_memory', current: STAMP }),
+    ).resolves.toMatchObject({ marked: 0, cleared: 0 });
+  });
+});


### PR DESCRIPTION
Code has an EXTERNAL system of record — git — that is better than our copy: exact, versioned, cheap, never wrong about the past. So memory should **materialize** what is not derivable (decisions, rationale, gotchas, invariants — they exist only in prose and are lost without us) and merely **point at** what is derivable (who owns a file, what a flag defaults to, which version a dependency is pinned to). Storing the second class as timeless truth is a promise to start lying the moment the repository moves on.

The same split exists in other domains — legal → DMS, medical → EHR/PACS, fintech → ledger. Code is just where it is starkest, and where we now have a producer (`scripts/index-repo.ts`, #496) to prove it end to end.

Two gaps, both default-off behind `PACK_SOURCE_VERSION_STALENESS`.

## 1. Derivable facts are bound to the revision they were read at

The repo indexer knew the commit it walked; the resulting fact did not. It now composes one stamp per run and sends it with every submission:

```json
{ "system": "git", "ref": "main", "version": "9f2c1ab…", "readAt": "2026-09-08T05:11:00Z" }
```

`"left-pad is 2.0.0"` becomes `"at commit 9f2c1ab, left-pad is 2.0.0"` — a statement that stays true forever, and whose *usefulness* we can decide by comparison instead of guessing.

**Generic, not git-shaped.** `system` names the system of record, `ref` the line within it, `version` the exact revision, `readAt` when we read it. A DMS revision id or an EHR study id fills the same four fields with no new vocabulary; the word "git" appears in exactly one place, the indexer, which is the only party that holds a working tree.

**No migration.** The stamp rides the provenance the external-candidate → document → fact path already carries: `CandidateProvenance` → candidate payload → `FactContributor` → the FLEXIBLE `source.sourceVersion`. That object is the natural home, exactly as `evidence[]` (0111) and `meta` already are. The leader contributor's stamp wins — a corroborating contributor from an older run may have read a different commit, and stamping the fact with *its* revision would misdescribe the value the fact holds.

A half-stamp is a 400, never a partial write: a fact that *looks* version-bound but is not can never be swept, which is worse than no stamp at all.

## 2. Staleness by source drift, not by calendar

Age is the wrong question here. A `decided` fact from 2019 is a statement *about 2019* and is exactly as true today; a `depends_on_version` fact from yesterday is wrong if someone merged a bump this morning. Age is noise, drift is the signal.

**The split is declared, never inferred.** `PackVerificationRule` gains `requires: 'source_version_match'` and a mandatory `appliesTo` naming the pack's own predicate localIds (the same cannot-squat posture `attentionHints.prefer` and `retentionHints` already hold). `code_memory` 0.7.0:

```ts
verificationRules: [
  { claimPattern: 'default', requires: 'recency_check' },
  { requires: 'source_version_match',
    appliesTo: ['owns', 'default_value', 'depends_on_version'] },
]
```

`decided` / `because` / `invariant` / `gotcha` / `superseded_by` are deliberately absent — the engine never pattern-matches predicate names, and a domain that knows its own ontology decides what rots. `appliesTo` is *required* for this rule kind: a drift sweep with no declared class would either touch every claim the pack ever recorded or none of them, and both are wrong.

**No server-side git.** The current revision is told to the server by the indexer on its next submission — the one moment it can be learned without opening a repository. The sweep runs after staging and never fails the submission; the candidates are already durable.

## Did the existing staleness mechanism suffice? Yes.

`staleAt` / `staleReason` (0072) are plain `option<datetime>` / `option<string>` columns with their own index, and the only pass that scans them — recompose — is fenced to `source.kind = 'compaction-summary'`, so drift marks are visible to a re-verification pass without being swept into summary recomposition. **No new migration** (0131 stays free).

The sweep marks and clears; it does not act. That is 0072's own contract word for word — *"this migration marks, and a recompute pass acts"* — and it is the honest scope: a drifted fact keeps serving, because a stale answer beats the nothing that hiding it would leave. The clear leg is fenced to `staleReason = 'source_version_drift'`, so it can only undo what it wrote and never touches a derived-parent mark left by `fn::mark_derived_stale`.

**SurrealDB 3.2.4 discipline:** `LET $ids = (SELECT VALUE id …); UPDATE $ids SET …`. `staleAt` and `predicate` are both indexed, and `UPDATE … WHERE` over an indexed field is the reproduced silent planner no-op (the 0116 header, the support-edge mirror).

**Legacy safety is structural, not a guard clause:** the sweep's equality on `source.sourceVersion.system` cannot match a fact that carries no stamp. Pre-stamp memory is untouchable by construction.

## Default-off

`PACK_SOURCE_VERSION_STALENESS` — the `PACK_` family (a pack-declared perception contract, the `PACK_MEMORY_PROJECTIONS_ENABLED` precedent), off the engine flag budget. `SCENES_`/`INGEST_`/`EXTRACTOR_` would all have been the wrong shelf.

Off ⇒ a submitted `sourceVersion` is **rejected 400** rather than silently stripped (the 0110 honest-upgrade posture — silent stripping is how an indexer ships version-bound facts for a month before noticing they were recorded as timeless truth), no candidate payload or fact `source` ever gains the key, and not one sweep query runs.

## Tests

`test/source-version-staleness.unit-spec.ts` (new) + `test/code-repo-indexer.unit-spec.ts` (extended):

- the stamp rides indexer payload → merge → `source.sourceVersion`, and the leader's reading wins over an older corroborator's;
- interpretation-class predicates are never in the sweep's parameter list, derivable ones always are;
- an unstamped fact yields `{}`, not `{ sourceVersion: null }` — a null key would change every stored `source` object in the system;
- flag off = byte-identical: rejection, no key, zero queries (pinned);
- a malformed stored stamp is dropped rather than smuggled into the comparison;
- `FsRepoSource.ref()` against a real `git init` checkout.

Two `domain-pack.unit-spec.ts` assertions became genuinely obsolete (the pack gained a rule and a minor). Both were **extended, not weakened** — the full `verificationRules` list stays pinned, so a future rule is still a deliberate edit.

Gates: `pnpm typecheck` ✅ · full unit suite 387/387, 4657 tests ✅ · `pnpm lint:ci` ✅ · `pnpm format:check` ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB
