### PR TITLE
ci: raise the build-test ceiling and stop superseded runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,12 +33,21 @@ permissions:
 jobs:
   build-test:
     runs-on: ubuntu-latest
-    # 30, not 20: the serialized e2e suite (maxWorkers 1, 2026-08 CI-stability
-    # fix) plus the growing suite count runs 18-20+ min on cold runners, and
-    # jobs were dying at exactly 20:00 as spurious "cancelled" conclusions.
-    # Two testcontainer lifecycles + cold installs need headroom; forceExit
-    # (jest configs) prevents the post-suite hang.
-    timeout-minutes: 30
+    # 45, not 30 — the same wall this job hit at 20 minutes in 2026-08, moved
+    # up by a wave of new suites (evidence plane, scenes, OCR, indexers). A
+    # timed-out job reports conclusion "cancelled", which reads like runner
+    # contention and is not: measured on main 2026-09-08, the successful runs
+    # sit at 26:38 / 27:09 / 28:09 and the failures all die at exactly 30:0x,
+    # i.e. on the cap, with no hang signature. Roughly half of all runs were
+    # being lost that way, which blocks every PR behind them.
+    #
+    # The cost of the ceiling is bounded: jest runs with forceExit, so a true hang
+    # cannot idle here for the full 45 — it is the serialized e2e suite
+    # (maxWorkers 1, the 2026-08 CI-stability fix) plus two testcontainer
+    # lifecycles and a cold install that legitimately need the headroom.
+    # Raise this again only with measured durations, never on a hunch; if the
+    # median crosses ~35 the answer is to shard the suite, not a bigger number.
+    timeout-minutes: 45
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,23 @@ on:
 permissions:
   contents: read
 
+# Supersede a PR's own in-flight run when a new commit lands on the same
+# branch. deploy-brain.yml has had this since it was written; CI never did,
+# so every rebase or force-push — which this repo does on essentially every
+# PR, to pick up main — left a 28-minute run burning a runner for a commit
+# nobody would merge. The queue is shared, so those zombies delayed every
+# other PR too.
+#
+# Keyed on ref, not on the PR number, so a push and its pull_request event
+# collapse into one group instead of racing each other.
+#
+# main is deliberately excluded from cancellation: a push there is what the
+# deploy and the release ride on, and a superseded merge must still report
+# its own result rather than vanish as "cancelled".
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 jobs:
   build-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Two changes to the same problem: CI runs were being lost, and lost runs block everything behind them.

## 1. `build-test` was dying on its own cap

It reports the conclusion **cancelled**, which reads like infrastructure trouble and is not — it is a timeout. Measured on `main` today:

| run | build-test | outcome |
| --- | --- | --- |
| 08:15 | 30:17 | cancelled (cap) |
| 07:57 | 27:09 | success |
| 07:27 | 26:38 | success |
| 07:19 | 28:09 | success |
| 07:18 | 30:18 | cancelled (cap) |
| 07:18 | 30:16 | cancelled (cap) |

The runs that finish take 26-28 minutes; the ones that do not all stop on the cap. Half of recent runs were lost that way.

Same wall the job hit at 20 minutes in 2026-08, pushed back up by the suites added this wave (evidence plane, scenes, OCR, indexers). The suite is not hanging: jest runs with `forceExit` and the failures show no hang signature — it is the serialized e2e run (`maxWorkers 1`, the 2026-08 CI-stability fix) plus two testcontainer lifecycles and a cold install that have grown past the line.

Ceiling goes to 45, with the measurements recorded in the comment so the next person moves it on evidence. If the median crosses ~35, the answer is to shard the suite, not a bigger number.

## 2. CI had no concurrency group

`deploy-brain.yml` has had `cancel-in-progress` since it was written; CI never did. Every push to a PR branch started a fresh 28-minute run and left the previous one running to completion. This repo rebases constantly to pick up `main`, so a single PR could hold two or three runners at once for commits nobody would merge — and the queue is shared, so the delay landed on every other PR.

Keyed on ref rather than PR number, so a push and its `pull_request` event collapse into one group instead of racing. `main` is excluded from cancellation: a push there carries the deploy and the release, and a superseded merge must report its own result rather than vanish as "cancelled".

## Correction

An earlier revision of this description said the runs serialize on a self-hosted runner. That is wrong — the repo has no self-hosted runners registered; CI runs on GitHub-hosted `ubuntu-latest`, and only the deploy workflows use the self-hosted `sfo` pool. The queueing is ordinary shared-concurrency contention, which is exactly what change 2 addresses. The timeout measurements above are unaffected.

## Not in scope

`build-test` spends **23 of its ~28 minutes in the single in-process e2e step**; every other step is 3 minutes or less. Splitting the job by concern would therefore buy about four minutes and is not the lever. The real candidates — a jest transform cache, dropping ts-jest's redundant per-spec typechecking (the `typecheck` step already covers it), and path-filtering the landing steps — want their own PR with before/after numbers.

No product change; workflow config only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB