### PR TITLE
feat(eval): eval:evidence — mechanical battery over the evidence plane

### DIFF
--- a/docs/eval-methodology.md
+++ b/docs/eval-methodology.md
@@ -171,6 +171,18 @@ spend is the stand's own normal serving cost.
   marker-first: an honest decline never fails a serve check by itself.
 - **`eval:domain-packs`** — a pack-conformance battery in the same
   family, landing in a separate in-flight PR.
+- **`pnpm eval:evidence`** (`test/eval/evidence/`) — 29 checks over the
+  evidence plane end to end (upload → quarantine → processing_run →
+  fragment → citation → signed-URL gateway → grants → GC → GDPR
+  erasure), scored on 8 dimensions: E1 ingest & identity, E2 quarantine,
+  E3 processing, E4 fragments, E5 citations (the unrollability north
+  star: a citation must resolve to the exact fragment AND blob), E6
+  access, E7 GC, E8 GDPR. Unlike its four siblings it spends **nothing**
+  on models — no path on this plane calls one — and its capability gates
+  are read from the live stand (`GET /v1/admin/config`, a probe of the
+  orphan-GC route, the fixture-pack install result), so an absent
+  capability reports `skipped` with the observed reason instead of a
+  silent pass.
 
 Methodology: each battery runs against a **fresh tenant per run**
 (`BRAIN_COMPANY_ID` is operator-supplied; every scenario seeds its own

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "eval:state-transitions": "ts-node -T test/eval/state-transitions/runner.ts",
     "eval:domain-packs": "ts-node -T test/eval/domain-packs/runner.ts",
     "eval:code-memory": "ts-node -T test/eval/code-memory/runner.ts",
+    "eval:evidence": "ts-node -T test/eval/evidence/runner.ts",
     "eval:transition-calibration": "ts-node -T test/eval/transition-calibration/runner.ts",
     "openapi:build": "ts-node -T scripts/build-openapi.ts",
     "mri:report": "ts-node -T scripts/mri-report.ts",

--- a/test/eval/evidence/README.md
+++ b/test/eval/evidence/README.md
@@ -1,0 +1,183 @@
+# Evidence battery
+
+Fifth mechanical battery, sibling of
+[`test/eval/memory-fitness`](../memory-fitness/README.md) (first-person
+memory fitness), [`test/eval/state-transitions`](../state-transitions/README.md)
+(mutable world-state), [`test/eval/domain-packs`](../domain-packs/README.md)
+(installed industry packs) and [`test/eval/code-memory`](../code-memory/README.md)
+(the builtin coding pack). This one isolates a different claim from all
+four: **bytes handed to the brain stay accountable end to end.**
+
+The chain under test is the evidence plane in order —
+
+```
+upload → quarantine scan → processing_run → fragment → citation
+       → signed-URL gateway → grants → GC → GDPR erasure
+```
+
+— across migrations 0114 (blob-GC outbox), 0121 (broker / processing_run
+/ quarantine), 0122 (grants), 0124 (fragment content search) and 0125
+(access audit + signed URLs).
+
+Two things make it different from the four siblings:
+
+- **Zero model spend.** Nothing on the evidence plane calls a model, so
+  the whole battery scores against a stand booted with a placeholder
+  `OPENAI_API_KEY`. The one exception — the serving leg of E4, which can
+  only be read through `synthesize` — is opt-in behind
+  `EVEV_ALLOW_SYNTHESIZE=1` and skipped by default.
+- **It brings its own pack.** The plane is gated on pack DECLARATIONS,
+  not just on flags: the broker dispatches only capabilities a pack's
+  `memoryModel.processors` asked for, and the raw-read gateway serves
+  bytes only for a tenant holding current consent to a pack declaring
+  `memoryModel.rawEvidence.serve`. **No installable pack can supply that
+  today.** Five of the six builtins omit `rawEvidence` deliberately
+  (omission = deny); the sixth, `real_estate`, declares it — but the
+  gateway's consent fold reads `domain_pack` rows, and a builtin never
+  writes one (it is seeded globally through `SEED_PREDICATES`, and
+  install rejects its id), so it can never carry the
+  `acceptedModalities` + checksum pair the fold requires. Without a
+  fixture pack the entire read half would therefore be unreachable
+  rather than measured. `fixtures.ts` installs a run-scoped probe pack
+  (and a deny twin, for the negative dispatch case).
+
+## Dimensions
+
+| id  | name              | what a failure would mean                                                                                |
+| --- | ----------------- | -------------------------------------------------------------------------------------------------------- |
+| E1  | ingest & identity | bytes are not content-addressed, dedup forks a row, or a bad blob is stored instead of refused            |
+| E2  | quarantine        | external bytes enter without the scan seam, or a flagged blob becomes evidence                            |
+| E3  | processing        | a declared processor need does not reach a terminal run, replays non-idempotently, or fails silently      |
+| E4  | fragments         | a citation target cannot be attached over real bytes, or a bad locator writes rows                        |
+| E5  | citations         | **the north star** — a citation does not unroll to the exact fragment and blob it names                   |
+| E6  | access            | a signed URL outlives its TTL, crosses a tenant, survives revocation, or its signing key is readable      |
+| E7  | gc                | a referenced blob is collected, or an orphan is not                                                       |
+| E8  | gdpr              | erasure leaves a user's evidence behind, or takes a co-owner's / co-tenant's with it                      |
+
+## Check battery
+
+All mechanical: status codes, sha256 comparisons and documented response
+counters. No LLM judge (`checks-plane.ts` for E1–E4, `checks-access.ts`
+for E5–E8; `checks.ts` is the ordered table).
+
+| id                                | dim | gap-gated | What would falsify the claim                                                              |
+| --------------------------------- | --- | --------- | ------------------------------------------------------------------------------------------ |
+| e01-blob-upload                   | E1  |           | the server trusts a caller's hash, lands the blob outside the tenant, or not `hot`         |
+| e02-content-dedup                 | E1  |           | identical bytes from one owner mint a second row/blob                                      |
+| e03-dedup-probe-closed            | E1  |           | the 409 on a foreign principal's known hash names the stored row (existence oracle)        |
+| e04-empty-part-rejected           | E1  |           | a zero-byte part becomes an observation                                                    |
+| e05-media-type-matrix             | E1  |           | `text/plain` bytes register as modality `image` (silent re-classification)                 |
+| e06-size-cap                      | E1  |           | a blob over `EVIDENCE_MAX_BYTES` is stored                                                 |
+| e07-external-ingest-fence         | E2  |           | bytes over HTTP enter without a quarantine stamp — or, seam off, are not refused           |
+| e08-scan-hook-rejects             | E2  | yes       | a scanner-flagged blob is accepted (today: the platform ships only the allow-all stub)     |
+| e09-rejected-stays-rejected       | E2  | yes       | a rejected upload leaves a row a re-upload could resurrect                                 |
+| e10-dispatch-terminal             | E3  |           | a declared `document → text` need produces no run, or one that failed/was denied           |
+| e11-dispatch-idempotent           | E3  |           | re-dispatching the same key re-runs the adapter instead of replaying                       |
+| e12-undeclared-capability-denied  | E3  |           | a need no adapter can serve is silently skipped instead of denied with a reason            |
+| e13-failed-run-visible            | E3  | yes       | a failed processing run is invisible to an operator (no read surface exists)               |
+| e14-fragment-append               | E4  |           | a citation target cannot be attached to already-stored bytes via the dedup path            |
+| e15-locator-matrix                | E4  |           | a `charRange` on an image is stored instead of failing the whole request                   |
+| e16-fragment-served               | E4  | yes       | fragment text is not searchable where the contract says (lane + citations default-off)     |
+| e17-fragment-unrolls-to-blob      | E5  |           | **the north star** — a fragment does not stream its asset's exact bytes, or drops a header |
+| e18-signed-unroll                 | E5  |           | the same unroll fails through a signed URL                                                 |
+| e19-citation-target-fence         | E5  |           | a fragment unrolls to another asset's bytes, or an unknown id is distinguishable           |
+| e20-signed-url-expiry             | E6  |           | a token outlives `EVIDENCE_SIGNED_URL_TTL_SECONDS`                                         |
+| e21-cross-tenant-refusal          | E6  |           | tenant B can stream or mint over tenant A's asset                                          |
+| e22-grant-revocation-backstop     | E6  |           | revoking every grant leaves the read open, or a pre-revocation token still redeems         |
+| e23-signing-secret-not-readable   | E6  |           | `GET /v1/admin/config` hands the raw signed-URL HMAC key to any `brain:admin` key          |
+| e24-orphan-gc-referenced-blob     | E7  | yes       | an orphan sweep touches a referenced blob (today: no sweep exists — PR #481)               |
+| e25-shared-asset-survives-forget  | E7  |           | a co-owned asset loses its row, fragments or bytes when one owner is erased                |
+| e26-shared-blob-drainer           | E7  | yes       | two rows sharing one blob lose the survivor's bytes (unreachable over HTTP — see below)    |
+| e27-forget-erases-user-evidence   | E8  |           | erasure leaves the user's assets, fragments, representations, grants or citations behind   |
+| e28-co-owner-grant-survives       | E8  |           | the co-owner's grant dies with the erased user's, or the erased user's grant survives      |
+| e29-co-tenant-bytes-survive       | E8  |           | a second tenant's byte-identical content is destroyed by the first tenant's erasure        |
+
+## Honest-baseline policy (`expectedUnknown`)
+
+Same rule as the domain-pack and code-memory siblings, and the reason the
+gates are **computed from the live stand** (`GET /v1/admin/config`, a
+probe of the orphan-GC route, the install result of the fixture packs)
+rather than hardcoded: a check that cannot run reports `skipped` with the
+reason it OBSERVED, never a silent pass. The standing gaps:
+
+- **e08 / e09** — the only `EvidenceScanHook` the platform ships is
+  `AllowAllScanHook`. The battery does not assume this: it uploads the
+  EICAR test string and reports what came back. A `rejected` verdict
+  flips both checks to real assertions with no edit here.
+- **e13** — 0121 ships the `processing_run` lifecycle but no read
+  surface. The dispatch sweep returns counters
+  (`assets/dispatched/runs/denied/failed`) in which a failed run is
+  indistinguishable from a succeeded one, so "recorded as failed, not
+  silently dropped" cannot be observed over HTTP at all.
+- **e16** — `RETRIEVAL_FRAGMENT_LANE` and `EVIDENCE_FRAGMENT_CITATIONS`
+  are default-off, and the only reader is a generator call.
+- **e24** — the orphan-blob GC sweep is not in `main` (it lands with
+  PR #481). Today an unreferenced blob is never collected at all.
+- **e26** — the defect is real and named in PR #481's own follow-up note:
+  the 0114 drainer (and the user-forget cascade) delete a queued
+  `storageRef` **unconditionally**, so a blob shared by two asset rows
+  loses its bytes when one row dies. Its precondition cannot be built
+  over HTTP — `byteHash` is UNIQUE per tenant and the upload path derives
+  the ref from the hash, so two rows never share one ref through any
+  sequence of API calls. It is recorded here as an open finding rather
+  than quietly dropped; closing it needs a test at the service seam.
+
+e25 is the reachable half of the same law and is **not** gap-gated: a
+co-owned asset (two live grants, one owner erased) must keep its row, its
+fragments and its bytes.
+
+## Running against a local stand
+
+Never run in CI — the runner exits with a usage message when
+`BRAIN_BASE_URL` is unset.
+
+- **A FRESH tenant per run** (`BRAIN_COMPANY_ID`). Every user handle,
+  pack id and byte payload is salted with the run id, so re-runs cannot
+  dedupe onto an earlier run's content-addressed rows — but the erasure
+  phase is real, so do not point this at a tenant holding anything you
+  want.
+- The key needs `brain:read + brain:write + brain:admin`. Deliberately
+  **not** `brain:read_media`: every fixture registers `piiClasses` as
+  `[]` ("classified clean"), so the media-PII gate is exercised in its
+  open state without widening the credential.
+
+Stand flags that shape coverage (all read back through
+`GET /v1/admin/config` and reported in the scorecard's `setup` trail):
+
+| knob                              | needed for                            |
+| --------------------------------- | ------------------------------------- |
+| `EVIDENCE_SUBSTRATE_ENABLED=1`    | everything (the write seam)           |
+| `EVIDENCE_BLOB_UPLOAD_ENABLED=1`  | E1, E2 — the byte surface             |
+| `EVIDENCE_QUARANTINE=1`           | E2, and any external ingest at all    |
+| `EVIDENCE_INGEST_ENABLED=1`       | E4, E5 — fragments over stored bytes  |
+| `EVIDENCE_PROCESSOR_BROKER=1`     | E3                                    |
+| `EVIDENCE_RAW_READ_ENABLED=1`     | E5, E6, E7, E8 reads                  |
+| `EVIDENCE_SIGNED_URL_SECRET`      | E5's signed leg and E6 (≥ 32 chars)   |
+| `EVIDENCE_GRANTS_API_ENABLED=1`   | E6's revocation leg, E8's owner list  |
+| `EVIDENCE_FS_ROOT=<dir>`          | the fs storage adapter                |
+| `EVIDENCE_MAX_BYTES=1048576`      | e06 (a 1 GiB default is not probeable)|
+| `EVIDENCE_SIGNED_URL_TTL_SECONDS` | e20 (≤ `EVEV_MAX_WAIT_S`, default 90) |
+
+Then:
+
+```bash
+BRAIN_BASE_URL=http://localhost:3055 \
+BRAIN_API_KEY=... \
+BRAIN_COMPANY_ID=<fresh tenant> \
+EVEV_TENANT_B_ID=<second tenant> EVEV_TENANT_B_KEY=... \
+pnpm eval:evidence
+```
+
+Knobs (`EVEV_` prefix, mirroring the siblings' `MEMFIT_` / `STEV_` /
+`DPEV_` / `CMEV_`): `EVEV_RUN_ID` (default time-derived),
+`EVEV_TENANT_B_ID` + `EVEV_TENANT_B_KEY` (without them the two
+cross-tenant checks are SKIPPED, never passed), `EVEV_MAX_WAIT_S`
+(default 90 — the ceiling on waiting out a signed-URL TTL),
+`EVEV_ALLOW_SYNTHESIZE=1`, `EVEV_REPORT_DIR` (default `var/evidence/`).
+
+The JSON scorecard lands in `var/evidence/evidence-<runId>.json` — the
+per-dimension tallies, the phase-0 setup trail (live knob values, pack
+install outcome, orphan-GC probe status, every minted asset id, the
+dispatch counters, the erasure result), the gap-gated id list, and every
+verdict with its detail, so any line is reproducible from the report file
+alone. The battery always exits 0: it reports, it does not gate CI.

--- a/test/eval/evidence/checks-access.ts
+++ b/test/eval/evidence/checks-access.ts
@@ -1,0 +1,374 @@
+/**
+ * E5–E8: the read half — whether a stored observation can be unrolled
+ * back to its exact bytes by the people entitled to it, and only by them,
+ * and whether it disappears when it must.
+ *
+ * The north-star property lives here: a citation target (an
+ * `evidence_fragment`) must resolve to the EXACT blob it points at, both
+ * through the authenticated gateway and through a signed URL. Everything
+ * else on this side is a fence around that: grants, tenant pinning,
+ * expiry, GC and GDPR erasure.
+ *
+ * Same gap-gating rule as the write half — a check whose precondition the
+ * stand cannot produce reports `skipped` with the reason it observed.
+ */
+import type { Ctx } from './context';
+import { Findings, knob, knobOn } from './context';
+import type { MintedAsset, Verdict } from './types';
+import { fail, pass, skip } from './types';
+import { arr, bytes, call, num, sha256, sleep, str } from './wire';
+
+/** A record id shaped like the real thing but that no writer can mint. */
+const ABSENT_FRAGMENT = 'evidence_fragment:evevbatterynosuchfragment000';
+
+/** Slack allowed between a minted `expiresAt` and the configured TTL. */
+const TTL_SLACK_MS = 15_000;
+
+/** Guard against a stand that never expires the token we are waiting on. */
+const EXPIRY_POLL_MS = 2_000;
+
+const rawPath = (asset: MintedAsset): string => `/v1/evidence/${asset.assetId}/raw`;
+const fragmentRawPath = (fragmentId: string): string => `/v1/evidence/fragments/${fragmentId}/raw`;
+
+// ── E5 · citations ──────────────────────────────────────────────────
+
+export async function e17FragmentUnrolls(ctx: Ctx): Promise<Verdict> {
+  const asset = ctx.stand.primary;
+  if (!knobOn(ctx, 'EVIDENCE_RAW_READ_ENABLED')) return skip('EVIDENCE_RAW_READ_ENABLED is off');
+  if (!asset?.fragmentId) return skip('no fragment was created on the primary asset');
+  const res = await bytes(ctx.wire, { path: fragmentRawPath(asset.fragmentId) });
+  if (res.status !== 200) {
+    return fail(
+      `the fragment raw read answered HTTP ${res.status} (a uniform 404 covers every ladder ` +
+        `deny: tenant, availability, grant, consent, media PII, blob head)`,
+    );
+  }
+  const f = new Findings();
+  f.ok(
+    sha256(res.body) === asset.byteHash,
+    'the citation target unrolled to exactly the registered blob',
+    `served bytes hash ${sha256(res.body)} != the asset identity ${asset.byteHash}`,
+  );
+  f.ok(
+    res.headers.get('x-content-type-options') === 'nosniff',
+    'nosniff set',
+    `x-content-type-options='${String(res.headers.get('x-content-type-options'))}'`,
+  );
+  f.ok(
+    (res.headers.get('cache-control') ?? '').includes('no-store'),
+    'no-store set',
+    `cache-control='${String(res.headers.get('cache-control'))}'`,
+  );
+  f.ok(
+    (res.headers.get('content-disposition') ?? '').includes('attachment'),
+    'attachment disposition set',
+    `content-disposition='${String(res.headers.get('content-disposition'))}'`,
+  );
+  return f.verdict();
+}
+
+export async function e18SignedUnroll(ctx: Ctx): Promise<Verdict> {
+  const asset = ctx.stand.primary;
+  if (!knobOn(ctx, 'EVIDENCE_RAW_READ_ENABLED')) return skip('EVIDENCE_RAW_READ_ENABLED is off');
+  if (!asset?.fragmentId) return skip('no fragment was created on the primary asset');
+  const mint = await call(ctx.wire, {
+    method: 'GET',
+    path: `/v1/evidence/fragments/${asset.fragmentId}/raw-url`,
+  });
+  if (mint.status === 503) return skip(`mint refused 503 — ${mint.text}`);
+  if (mint.status !== 200) return fail(`raw-url mint answered HTTP ${mint.status} — ${mint.text}`);
+  const url = str(mint.json, 'url');
+  if (url === null) return fail(`mint returned no url — ${mint.text}`);
+  const redeemed = await bytes(ctx.wire, { path: url, auth: false });
+  if (redeemed.status !== 200) {
+    return fail(`the unauthenticated redeem answered HTTP ${redeemed.status}`);
+  }
+  return sha256(redeemed.body) === asset.byteHash
+    ? pass('the signed URL unrolled the citation to the same blob as the authenticated read')
+    : fail(`redeemed bytes hash ${sha256(redeemed.body)} != ${asset.byteHash}`);
+}
+
+export async function e19CitationTargetFence(ctx: Ctx): Promise<Verdict> {
+  const spare = ctx.stand.spare;
+  const primary = ctx.stand.primary;
+  if (!knobOn(ctx, 'EVIDENCE_RAW_READ_ENABLED')) return skip('EVIDENCE_RAW_READ_ENABLED is off');
+  if (!primary?.fragmentId || !spare?.fragmentId) {
+    return skip('the two-asset fixture (primary + spare, each with a fragment) is incomplete');
+  }
+  const unknown = await bytes(ctx.wire, { path: fragmentRawPath(ABSENT_FRAGMENT) });
+  const spareRead = await bytes(ctx.wire, { path: fragmentRawPath(spare.fragmentId) });
+  const f = new Findings();
+  f.ok(
+    unknown.status === 404,
+    'an unknown fragment id answers a bare 404',
+    `unknown id answered HTTP ${unknown.status}`,
+  );
+  f.ok(
+    spareRead.status === 200 && sha256(spareRead.body) === spare.byteHash,
+    "a second asset's fragment unrolls to ITS bytes, not the primary's",
+    `the spare fragment answered HTTP ${spareRead.status} with hash ${sha256(spareRead.body)} ` +
+      `(want ${spare.byteHash}, must not be ${primary.byteHash})`,
+  );
+  f.ok(
+    spare.byteHash !== primary.byteHash,
+    'the two fixtures are distinguishable by content',
+    'the fixture payloads collided — the fence cannot be measured',
+  );
+  return f.verdict();
+}
+
+// ── E6 · access ─────────────────────────────────────────────────────
+
+export async function e20SignedUrlExpiry(ctx: Ctx): Promise<Verdict> {
+  const token = ctx.stand.agingToken;
+  if (!knobOn(ctx, 'EVIDENCE_RAW_READ_ENABLED')) return skip('EVIDENCE_RAW_READ_ENABLED is off');
+  if (token === null) return skip('no token was minted in the setup phase');
+  const ttl = Number(knob(ctx, 'EVIDENCE_SIGNED_URL_TTL_SECONDS') || '300');
+  const mintedFor = ctx.stand.agingTokenExpiresAt - Date.now();
+  if (mintedFor > ttl * 1000 + TTL_SLACK_MS) {
+    return fail(
+      `expiresAt is ${Math.round(mintedFor / 1000)}s away but EVIDENCE_SIGNED_URL_TTL_SECONDS ` +
+        `is ${ttl} — the mint outlives its configured lifetime`,
+    );
+  }
+  if (ttl > ctx.maxWaitSeconds) {
+    return skip(
+      `EVIDENCE_SIGNED_URL_TTL_SECONDS is ${ttl}s, above the battery's ${ctx.maxWaitSeconds}s wait ` +
+        'ceiling (EVEV_MAX_WAIT_S) — the expiry half was not measured',
+    );
+  }
+  while (Date.now() < ctx.stand.agingTokenExpiresAt + EXPIRY_POLL_MS) {
+    await sleep(EXPIRY_POLL_MS);
+  }
+  const res = await bytes(ctx.wire, { path: `/v1/evidence/redeem/${token}`, auth: false });
+  return res.status === 404
+    ? pass(`a token past its ${ttl}s lifetime redeems to a bare 404`)
+    : fail(`an expired token still answered HTTP ${res.status} — the TTL is not enforced`);
+}
+
+export async function e21CrossTenantRefusal(ctx: Ctx): Promise<Verdict> {
+  const asset = ctx.stand.primary;
+  if (ctx.wireB === null) {
+    return skip('no second tenant configured — set EVEV_TENANT_B_ID and EVEV_TENANT_B_KEY');
+  }
+  if (!asset) return skip('no primary asset — the first upload failed');
+  const stream = await bytes(ctx.wireB, { path: rawPath(asset) });
+  const mint = await call(ctx.wireB, {
+    method: 'GET',
+    path: `/v1/evidence/${asset.assetId}/raw-url`,
+  });
+  const f = new Findings();
+  f.ok(
+    stream.status === 404,
+    "tenant B cannot stream tenant A's asset",
+    `tenant B streaming A's asset answered HTTP ${stream.status}`,
+  );
+  f.ok(
+    mint.status === 404,
+    "tenant B cannot mint a signed URL over tenant A's asset",
+    `tenant B minting over A's asset answered HTTP ${mint.status} — ${mint.text}`,
+  );
+  return f.verdict();
+}
+
+export async function e22GrantRevocationBackstop(ctx: Ctx): Promise<Verdict> {
+  const spare = ctx.stand.spare;
+  const token = ctx.stand.spareToken;
+  if (!knobOn(ctx, 'EVIDENCE_GRANTS_API_ENABLED'))
+    return skip('EVIDENCE_GRANTS_API_ENABLED is off');
+  if (!spare) return skip('the spare asset was not created');
+  const listed = await call(ctx.wire, {
+    method: 'GET',
+    path: `/v1/evidence/${spare.assetId}/grants`,
+  });
+  if (listed.status !== 200)
+    return fail(`grant list answered HTTP ${listed.status} — ${listed.text}`);
+  const grants = arr(listed.json, 'grants');
+  if (grants.length === 0)
+    return fail('a freshly registered asset carries no live ownership grant');
+  const before = await bytes(ctx.wire, { path: rawPath(spare) });
+  for (const grant of grants) {
+    const id = str(grant, 'grantId');
+    if (id === null) continue;
+    await call(ctx.wire, { method: 'DELETE', path: `/v1/evidence/grants/${id}` });
+  }
+  const after = await bytes(ctx.wire, { path: rawPath(spare) });
+  const f = new Findings();
+  f.ok(
+    before.status === 200,
+    `${grants.length} live grant(s) served the bytes`,
+    `the owned asset answered HTTP ${before.status} before revocation`,
+  );
+  f.ok(
+    after.status === 404,
+    'revoking every grant closed the authenticated read',
+    `the read still answered HTTP ${after.status} after every grant was revoked`,
+  );
+  if (token !== null) {
+    const redeemed = await bytes(ctx.wire, { path: `/v1/evidence/redeem/${token}`, auth: false });
+    f.ok(
+      redeemed.status === 404,
+      'a URL minted before revocation stopped redeeming — the live-grant backstop holds',
+      `a token minted before revocation still answered HTTP ${redeemed.status}`,
+    );
+  }
+  return f.verdict();
+}
+
+export function e23SigningSecretNotReadable(ctx: Ctx): Verdict {
+  const value = ctx.gates.config.get('EVIDENCE_SIGNED_URL_SECRET');
+  const masked = ctx.gates.secretKeys.has('EVIDENCE_SIGNED_URL_SECRET');
+  if (value === undefined) {
+    return pass('GET /v1/admin/config does not surface the signed-URL secret at all');
+  }
+  if (masked || value === '' || value === '∅' || value === '••• set') {
+    return pass(`the config viewer masks the signed-URL secret (reads '${value}')`);
+  }
+  return fail(
+    'GET /v1/admin/config returns EVIDENCE_SIGNED_URL_SECRET VERBATIM — the catalog entry ' +
+      '(src/admin/config-catalog.data.ts) omits `secret: true`, unlike OPENAI_API_KEY. Any ' +
+      'brain:admin key can read the HMAC key that signs raw-evidence URLs and forge tokens ' +
+      `over any asset in reach (observed ${value.length} plaintext characters).`,
+  );
+}
+
+// ── E7 · garbage collection ─────────────────────────────────────────
+
+export async function e24OrphanGcSurface(ctx: Ctx): Promise<Verdict> {
+  if (!ctx.gates.orphanGcRoute.present) {
+    return skip(
+      'POST /v1/admin/maintenance/evidence/orphan-blob-gc answers ' +
+        `HTTP ${ctx.gates.orphanGcRoute.status} — the orphan-blob GC sweep is not in this build ` +
+        '(it lands with PR #481), so an unreferenced blob is never collected here',
+    );
+  }
+  const asset = ctx.stand.primary;
+  if (!asset) return skip('no primary asset — the first upload failed');
+  const res = await call(ctx.wire, {
+    method: 'POST',
+    path: '/v1/admin/maintenance/evidence/orphan-blob-gc',
+    body: { dryRun: true },
+  });
+  if (res.status !== 200 && res.status !== 201) {
+    return fail(`the orphan sweep answered HTTP ${res.status} — ${res.text}`);
+  }
+  const deleted = num(res.json, 'deleted') ?? 0;
+  return res.text.includes(asset.storageRef) || deleted > 0
+    ? fail(`a dry-run sweep reported work over a REFERENCED blob: ${res.text}`)
+    : pass(`dry-run sweep left the referenced blob ${asset.storageRef} alone — ${res.text}`);
+}
+
+export async function e25SharedAssetSurvivesForget(ctx: Ctx): Promise<Verdict> {
+  const shared = ctx.stand.shared;
+  if (ctx.stand.forget === null) return skip('the GDPR erasure phase did not run');
+  if (!shared) return skip('the co-owned asset was not created');
+  if (!knobOn(ctx, 'EVIDENCE_RAW_READ_ENABLED')) return skip('EVIDENCE_RAW_READ_ENABLED is off');
+  const res = await bytes(ctx.wire, { path: rawPath(shared) });
+  if (res.status !== 200) {
+    return fail(
+      `an asset still owned by ${ctx.survivorUserId} stopped serving (HTTP ${res.status}) after ` +
+        `${ctx.forgetUserId} was erased — a surviving reference lost its bytes`,
+    );
+  }
+  return sha256(res.body) === shared.byteHash
+    ? pass("the co-owner's asset kept its bytes through the other owner's erasure")
+    : fail(
+        `the surviving asset now serves different bytes (${sha256(res.body)} != ${shared.byteHash})`,
+      );
+}
+
+export function e26SharedBlobDrainer(): Verdict {
+  return skip(
+    'PRECONDITION UNREACHABLE OVER HTTP. The defect (PR #481, "Follow-up spotted, not fixed ' +
+      'here"): the 0114 drainer and the user-forget cascade delete a queued storageRef ' +
+      'UNCONDITIONALLY, so a blob shared by two asset rows loses its bytes when one row dies. ' +
+      'Two rows can only share a ref through a service-level registerAsset with a foreign ' +
+      'storageRef — byteHash is UNIQUE per tenant and the upload path derives the ref from the ' +
+      'hash, so no sequence of HTTP calls constructs the shared-ref state. Encoded here as an ' +
+      'open finding rather than a green check; closing it needs a unit/e2e test at the seam.',
+  );
+}
+
+// ── E8 · GDPR ───────────────────────────────────────────────────────
+
+export async function e27ForgetErasesUserEvidence(ctx: Ctx): Promise<Verdict> {
+  const forget = ctx.stand.forget;
+  const sole = ctx.stand.sole;
+  if (forget === null) return skip('the GDPR erasure phase did not run');
+  if (forget.status !== 200 && forget.status !== 201) {
+    return fail(`POST /v1/users/${ctx.forgetUserId}/forget answered HTTP ${forget.status}`);
+  }
+  if (!sole) return skip('the sole-owned asset was not created');
+  const f = new Findings();
+  for (const key of [
+    'evidenceAssetsDeleted',
+    'evidenceFragmentsDeleted',
+    'representationsDeleted',
+    'evidenceGrantsDeleted',
+  ]) {
+    const count = num(forget.json, key) ?? 0;
+    f.ok(count >= 1, `${key}=${count}`, `${key}=${count} — the cascade erased nothing there`);
+  }
+  const asset = await bytes(ctx.wire, { path: rawPath(sole) });
+  f.ok(
+    asset.status === 404,
+    'the erased asset no longer serves',
+    `the erased asset still answered HTTP ${asset.status}`,
+  );
+  if (sole.fragmentId !== null) {
+    const frag = await bytes(ctx.wire, { path: fragmentRawPath(sole.fragmentId) });
+    f.ok(
+      frag.status === 404,
+      'its citation target died with it',
+      `the erased fragment still answered HTTP ${frag.status}`,
+    );
+  }
+  return f.verdict();
+}
+
+export async function e28CoOwnerGrantSurvives(ctx: Ctx): Promise<Verdict> {
+  const shared = ctx.stand.shared;
+  if (ctx.stand.forget === null) return skip('the GDPR erasure phase did not run');
+  if (!shared) return skip('the co-owned asset was not created');
+  if (!knobOn(ctx, 'EVIDENCE_GRANTS_API_ENABLED'))
+    return skip('EVIDENCE_GRANTS_API_ENABLED is off');
+  const listed = await call(ctx.wire, {
+    method: 'GET',
+    path: `/v1/evidence/${shared.assetId}/grants`,
+  });
+  if (listed.status !== 200) {
+    return fail(`the survivor's asset no longer lists its grants (HTTP ${listed.status})`);
+  }
+  const owners = arr(listed.json, 'grants').map((g) => str(g, 'ownerId') ?? '');
+  const f = new Findings();
+  f.ok(
+    owners.includes(ctx.survivorUserId),
+    `${ctx.survivorUserId} still owns it`,
+    `the surviving owner is gone (owners: ${owners.join(', ') || 'none'})`,
+  );
+  f.ok(
+    !owners.includes(ctx.forgetUserId),
+    "the erased user's grant is gone",
+    `the erased user ${ctx.forgetUserId} still holds a live grant`,
+  );
+  return f.verdict();
+}
+
+export async function e29CoTenantBytesSurvive(ctx: Ctx): Promise<Verdict> {
+  const twin = ctx.stand.tenantB;
+  if (ctx.wireB === null) {
+    return skip('no second tenant configured — set EVEV_TENANT_B_ID and EVEV_TENANT_B_KEY');
+  }
+  if (ctx.stand.forget === null) return skip('the GDPR erasure phase did not run');
+  if (!twin) return skip("tenant B's copy of the bytes was not registered");
+  const res = await bytes(ctx.wireB, { path: rawPath(twin) });
+  if (res.status !== 200) {
+    return fail(
+      `tenant B's identical-bytes asset stopped serving (HTTP ${res.status}) after tenant A ` +
+        'erased its owner — content-addressed storage leaked across the tenant fence',
+    );
+  }
+  return sha256(res.body) === twin.byteHash
+    ? pass("a co-tenant's identical bytes survived the other tenant's erasure intact")
+    : fail(`tenant B's bytes changed (${sha256(res.body)} != ${twin.byteHash})`);
+}

--- a/test/eval/evidence/checks-plane.ts
+++ b/test/eval/evidence/checks-plane.ts
@@ -1,0 +1,393 @@
+/**
+ * E1–E4: the write half of the evidence plane — what happens between a
+ * caller handing over bytes and those bytes becoming a citable fragment.
+ *
+ * Every assertion here is a status code, a hash comparison or a counter
+ * off a documented response shape; nothing consults a model, and nothing
+ * reaches into the database. If a check cannot run because a knob is off,
+ * a route is dark or a fixture failed to install, it returns `skipped`
+ * with the OBSERVED reason — the gap-gating doctrine of
+ * `eval:code-memory`, applied to capabilities instead of to pack
+ * ontology.
+ */
+import type { Ctx } from './context';
+import { Findings, expectOneOf, expectStatus, knob, knobOn } from './context';
+import { eicarProbe, oversizeDocument, primaryDocument, uploadFields } from './fixtures';
+import type { Verdict } from './types';
+import { fail, pass, skip } from './types';
+import { arr, bool, call, num, sha256, str, upload } from './wire';
+
+/** Above this the size-cap probe would push real megabytes over the wire. */
+const SIZE_PROBE_CEILING = 4 * 1024 * 1024;
+
+// ── E1 · ingest & identity ──────────────────────────────────────────
+
+export function e01BlobUpload(ctx: Ctx): Verdict {
+  const asset = ctx.stand.primary;
+  if (!asset) {
+    return fail(
+      `the primary blob upload did not produce an asset (HTTP ${ctx.stand.primaryUploadStatus})`,
+    );
+  }
+  const f = new Findings();
+  f.ok(
+    ctx.stand.primaryUploadStatus === 201 || ctx.stand.primaryUploadStatus === 200,
+    `upload accepted (HTTP ${ctx.stand.primaryUploadStatus})`,
+    `upload answered HTTP ${ctx.stand.primaryUploadStatus}`,
+  );
+  f.ok(
+    asset.byteHash === sha256(asset.bytes),
+    'byteHash is the sha256 the server measured over the received bytes',
+    `byteHash ${asset.byteHash} != sha256(sent bytes) ${sha256(asset.bytes)}`,
+  );
+  f.ok(
+    asset.availability === 'hot',
+    "availability derived 'hot'",
+    `availability '${asset.availability}', expected 'hot'`,
+  );
+  f.ok(
+    asset.deduped === false,
+    'first registration is not a dedup',
+    'a fresh run-scoped payload reported deduped=true',
+  );
+  f.ok(
+    asset.storageRef.startsWith(`fs://${ctx.wire.companyId}/`),
+    `storageRef is tenant-scoped (${asset.storageRef})`,
+    `storageRef '${asset.storageRef}' is not tenant-scoped under fs://${ctx.wire.companyId}/`,
+  );
+  return f.verdict();
+}
+
+export async function e02ContentDedup(ctx: Ctx): Promise<Verdict> {
+  const asset = ctx.stand.primary;
+  if (!asset) return skip('no primary asset — the first upload failed');
+  const res = await upload(
+    ctx.wire,
+    { data: asset.bytes, filename: 'primary.txt', contentType: 'text/plain' },
+    uploadFields({ userId: ctx.ownerUserId, runId: ctx.runId }),
+  );
+  if (res.status !== 200 && res.status !== 201) {
+    return fail(`re-upload of identical bytes answered HTTP ${res.status} — ${res.text}`);
+  }
+  const f = new Findings();
+  f.ok(
+    bool(res.json, 'deduped') === true,
+    'deduped=true',
+    'the second upload reported deduped=false',
+  );
+  f.ok(
+    str(res.json, 'assetId') === asset.assetId,
+    'the same content-addressed asset row was returned',
+    `a second row appeared: ${String(str(res.json, 'assetId'))} != ${asset.assetId}`,
+  );
+  f.ok(
+    str(res.json, 'byteHash') === asset.byteHash,
+    'one blob, one identity',
+    'the dedup path returned a different byteHash',
+  );
+  return f.verdict();
+}
+
+export async function e03DedupProbeClosed(ctx: Ctx): Promise<Verdict> {
+  const asset = ctx.stand.primary;
+  if (!asset) return skip('no primary asset — the first upload failed');
+  const res = await upload(
+    ctx.wire,
+    { data: asset.bytes, filename: 'probe.txt', contentType: 'text/plain' },
+    uploadFields({ userId: `${ctx.ownerUserId}-stranger`, runId: ctx.runId }),
+  );
+  if (res.status !== 409) {
+    return fail(
+      `a foreign principal re-registering a known byteHash got HTTP ${res.status}, expected 409 — ${res.text}`,
+    );
+  }
+  const leaked = [asset.assetId, asset.storageRef, ctx.ownerUserId].filter((secret) =>
+    res.text.includes(secret),
+  );
+  if (leaked.length > 0) {
+    return fail(`the 409 body leaked stored-row metadata: ${leaked.join(', ')}`);
+  }
+  return pass('409 with no stored-row metadata — the dedup-probe oracle stays closed');
+}
+
+export async function e04EmptyPartRejected(ctx: Ctx): Promise<Verdict> {
+  const res = await upload(
+    ctx.wire,
+    { data: Buffer.alloc(0), filename: 'empty.txt', contentType: 'text/plain' },
+    uploadFields({ userId: ctx.ownerUserId, runId: ctx.runId }),
+  );
+  return expectStatus(res, 400, 'empty file part');
+}
+
+export async function e05MediaTypeMatrix(ctx: Ctx): Promise<Verdict> {
+  const res = await upload(
+    ctx.wire,
+    {
+      data: primaryDocument(`${ctx.runId}-mismatch`),
+      filename: 'x.txt',
+      contentType: 'text/plain',
+    },
+    { ...uploadFields({ userId: ctx.ownerUserId, runId: ctx.runId }), modality: 'image' },
+  );
+  if (res.status !== 400) {
+    return fail(
+      `text/plain bytes declared as modality 'image' answered HTTP ${res.status}, expected 400 — ${res.text}`,
+    );
+  }
+  return pass(`(modality, mediaType) pairing refused: ${res.text}`);
+}
+
+export async function e06SizeCap(ctx: Ctx): Promise<Verdict> {
+  const raw = knob(ctx, 'EVIDENCE_MAX_BYTES');
+  const cap = Number(raw);
+  if (!Number.isInteger(cap) || cap <= 0) {
+    return skip(`EVIDENCE_MAX_BYTES reads '${raw}' — no probeable cap`);
+  }
+  if (cap > SIZE_PROBE_CEILING) {
+    return skip(
+      `EVIDENCE_MAX_BYTES is ${cap}; probing it would push ${cap + 1024} bytes over the wire ` +
+        `(ceiling ${SIZE_PROBE_CEILING}). Lower the knob on the stand to measure this.`,
+    );
+  }
+  const res = await upload(
+    ctx.wire,
+    { data: oversizeDocument(cap), filename: 'big.txt', contentType: 'text/plain' },
+    uploadFields({ userId: ctx.ownerUserId, runId: ctx.runId }),
+  );
+  return expectOneOf(res, [400, 413], `blob of ${cap + 1024} bytes over a ${cap}-byte cap`);
+}
+
+// ── E2 · quarantine ─────────────────────────────────────────────────
+
+export function e07ExternalIngestFence(ctx: Ctx): Verdict {
+  const on = knobOn(ctx, 'EVIDENCE_QUARANTINE');
+  if (!on) {
+    // Fail closed: bytes over HTTP are external ingest by definition, and
+    // the write seam must refuse them outright without the scan seam.
+    return ctx.stand.primaryUploadStatus === 503
+      ? pass('EVIDENCE_QUARANTINE off and the byte surface refused 503 — no external bytes entered')
+      : fail(
+          `EVIDENCE_QUARANTINE off but the upload answered HTTP ${ctx.stand.primaryUploadStatus} ` +
+            '— external bytes entered without the scan seam',
+        );
+  }
+  const stamp = ctx.stand.primaryQuarantineStatus;
+  if (stamp === 'clean' || stamp === 'scanning') {
+    return pass(`quarantine seam stamped the upload '${stamp}'`);
+  }
+  return fail(
+    `EVIDENCE_QUARANTINE on but the upload reported quarantineStatus ${JSON.stringify(stamp)} ` +
+      "— expected 'clean' or 'scanning'",
+  );
+}
+
+export async function e08ScanHookRejects(ctx: Ctx): Promise<Verdict> {
+  if (!knobOn(ctx, 'EVIDENCE_QUARANTINE')) return skip('EVIDENCE_QUARANTINE is off');
+  const res = await upload(
+    ctx.wire,
+    { data: eicarProbe(ctx.runId), filename: 'probe.txt', contentType: 'text/plain' },
+    uploadFields({ userId: `${ctx.ownerUserId}-scan`, runId: ctx.runId }),
+  );
+  if (res.status === 422) {
+    return pass('the scan hook rejected the EICAR test string — a real scanner is installed');
+  }
+  if (res.status === 200 || res.status === 201) {
+    const stamp = str(res.json, 'quarantineStatus') ?? '(absent)';
+    return skip(
+      `the stand cleared the EICAR test string (quarantineStatus '${stamp}') — the platform ` +
+        'still ships the allow-all scan stub, so no upload can reach the rejected branch',
+    );
+  }
+  return fail(
+    `the EICAR upload answered HTTP ${res.status}, expected 422 or a clean pass — ${res.text}`,
+  );
+}
+
+export async function e09RejectedStaysRejected(ctx: Ctx): Promise<Verdict> {
+  if (!knobOn(ctx, 'EVIDENCE_QUARANTINE')) return skip('EVIDENCE_QUARANTINE is off');
+  const first = await upload(
+    ctx.wire,
+    { data: eicarProbe(ctx.runId), filename: 'probe.txt', contentType: 'text/plain' },
+    uploadFields({ userId: `${ctx.ownerUserId}-scan`, runId: ctx.runId }),
+  );
+  if (first.status !== 422) {
+    return skip(
+      'no upload reaches a rejected verdict on this stand (see the scan-hook check) — a ' +
+        'rejected asset cannot be observed, so "never becomes a fragment" is unmeasurable here',
+    );
+  }
+  const second = await upload(
+    ctx.wire,
+    { data: eicarProbe(ctx.runId), filename: 'probe.txt', contentType: 'text/plain' },
+    uploadFields({ userId: `${ctx.ownerUserId}-scan`, runId: ctx.runId }),
+  );
+  return expectStatus(second, 422, 're-upload of rejected bytes');
+}
+
+// ── E3 · processing ─────────────────────────────────────────────────
+
+/** POST the operator dispatch sweep for one pack over one asset. */
+async function dispatch(
+  ctx: Ctx,
+  target: { packId: string; assetId: string },
+): Promise<{ status: number; text: string; counts: Record<string, number> }> {
+  const res = await call(ctx.wire, {
+    method: 'POST',
+    path: '/v1/admin/maintenance/evidence/dispatch',
+    body: { packId: target.packId, assetId: target.assetId },
+  });
+  const counts: Record<string, number> = {};
+  for (const key of ['assets', 'dispatched', 'runs', 'denied', 'failed']) {
+    counts[key] = num(res.json, key) ?? -1;
+  }
+  return { status: res.status, text: res.text, counts };
+}
+
+export async function e10DispatchTerminal(ctx: Ctx): Promise<Verdict> {
+  const { packId } = ctx.gates;
+  const asset = ctx.stand.primary;
+  if (packId === null) return skip(`probe pack not installed: ${ctx.gates.packError ?? 'unknown'}`);
+  if (!asset) return skip('no primary asset — the first upload failed');
+  if (!knobOn(ctx, 'EVIDENCE_PROCESSOR_BROKER')) return skip('EVIDENCE_PROCESSOR_BROKER is off');
+  const out = await dispatch(ctx, { packId, assetId: asset.assetId });
+  if (out.status !== 200 && out.status !== 201) {
+    return fail(`dispatch answered HTTP ${out.status} — ${out.text}`);
+  }
+  ctx.stand.firstDispatch = out.counts;
+  const f = new Findings();
+  f.ok(
+    out.counts.assets === 1,
+    'the targeted sweep considered exactly the named asset',
+    `assets=${out.counts.assets}`,
+  );
+  f.ok(out.counts.dispatched === 1, 'dispatch completed', `dispatched=${out.counts.dispatched}`);
+  f.ok(
+    (out.counts.runs ?? 0) >= 1,
+    `runs=${out.counts.runs}`,
+    'the declared document→text need produced no processing run',
+  );
+  f.ok(out.counts.denied === 0, 'nothing denied', `denied=${out.counts.denied}`);
+  f.ok(out.counts.failed === 0, 'nothing failed', `failed=${out.counts.failed}`);
+  return f.verdict();
+}
+
+export async function e11DispatchIdempotent(ctx: Ctx): Promise<Verdict> {
+  const { packId } = ctx.gates;
+  const asset = ctx.stand.primary;
+  const first = ctx.stand.firstDispatch;
+  if (packId === null || !asset || first === null) return skip('the first dispatch did not run');
+  const out = await dispatch(ctx, { packId, assetId: asset.assetId });
+  if (out.status !== 200 && out.status !== 201) {
+    return fail(`the replay dispatch answered HTTP ${out.status} — ${out.text}`);
+  }
+  const drift = ['runs', 'denied', 'failed'].filter((k) => out.counts[k] !== first[k]);
+  if (drift.length > 0) {
+    return fail(
+      `replay is not idempotent — ${drift
+        .map((k) => `${k}: ${first[k]} then ${out.counts[k]}`)
+        .join(', ')}`,
+    );
+  }
+  return pass(`replay returned the recorded outcome unchanged (runs=${out.counts.runs}, failed=0)`);
+}
+
+export async function e12UndeclaredCapabilityDenied(ctx: Ctx): Promise<Verdict> {
+  const { denyPackId } = ctx.gates;
+  const asset = ctx.stand.primary;
+  if (denyPackId === null) return skip('the deny pack could not be installed');
+  if (!asset) return skip('no primary asset — the first upload failed');
+  const out = await dispatch(ctx, { packId: denyPackId, assetId: asset.assetId });
+  if (out.status !== 200 && out.status !== 201) {
+    return fail(`dispatch answered HTTP ${out.status} — ${out.text}`);
+  }
+  const f = new Findings();
+  f.ok(
+    (out.counts.denied ?? 0) >= 1,
+    `the unservable document→caption need was denied (denied=${out.counts.denied})`,
+    'a capability no installed adapter serves produced no denial — the gate is silent',
+  );
+  f.ok(out.counts.runs === 0, 'no run was created', `runs=${out.counts.runs}, expected 0`);
+  return f.verdict();
+}
+
+export function e13FailedRunVisible(): Verdict {
+  return skip(
+    'no read surface exposes processing_run rows: 0121 ships the lifecycle but no admin list ' +
+      'route, and POST /v1/admin/maintenance/evidence/dispatch answers with counters only ' +
+      '(assets/dispatched/runs/denied/failed), where a failed run is indistinguishable from a ' +
+      'succeeded one. "Recorded as failed, not silently dropped" is therefore unobservable over HTTP.',
+  );
+}
+
+// ── E4 · fragments ──────────────────────────────────────────────────
+
+export function e14FragmentAppend(ctx: Ctx): Verdict {
+  const asset = ctx.stand.primary;
+  if (!asset) return skip('no primary asset — the first upload failed');
+  if (!knobOn(ctx, 'EVIDENCE_INGEST_ENABLED')) return skip('EVIDENCE_INGEST_ENABLED is off');
+  if (asset.fragmentId === null) {
+    return fail('registering the primary byteHash with fragments produced no fragment id');
+  }
+  return pass(`fragment ${asset.fragmentId} appended to the deduped asset ${asset.assetId}`);
+}
+
+export async function e15LocatorMatrix(ctx: Ctx): Promise<Verdict> {
+  const asset = ctx.stand.primary;
+  if (!asset) return skip('no primary asset — the first upload failed');
+  if (!knobOn(ctx, 'EVIDENCE_INGEST_ENABLED')) return skip('EVIDENCE_INGEST_ENABLED is off');
+  const res = await call(ctx.wire, {
+    method: 'POST',
+    path: '/v1/ingest/evidence-asset',
+    body: {
+      modality: 'image',
+      mediaType: 'image/png',
+      byteHash: asset.byteHash,
+      byteLength: asset.bytes.byteLength,
+      occurredAt: new Date().toISOString(),
+      originUri: `https://example.invalid/${ctx.runId}`,
+      vertical: 'evidence_eval',
+      userId: ctx.ownerUserId,
+      piiClasses: [],
+      fragments: [{ locator: { kind: 'charRange', start: 0, end: 8 } }],
+    },
+  });
+  if (res.status !== 400) {
+    return fail(
+      `a charRange locator on an image answered HTTP ${res.status}, expected 400 — ${res.text}`,
+    );
+  }
+  if (!res.text.includes('fragments[0].locator')) {
+    return fail(`400 raised, but not by the locator matrix: ${res.text}`);
+  }
+  return pass('charRange on modality image refused before any row was written');
+}
+
+export async function e16FragmentServed(ctx: Ctx): Promise<Verdict> {
+  const lane = knobOn(ctx, 'RETRIEVAL_FRAGMENT_LANE');
+  const cites = knobOn(ctx, 'EVIDENCE_FRAGMENT_CITATIONS');
+  if (!lane || !cites) {
+    return skip(
+      `RETRIEVAL_FRAGMENT_LANE=${knob(ctx, 'RETRIEVAL_FRAGMENT_LANE')}, ` +
+        `EVIDENCE_FRAGMENT_CITATIONS=${knob(ctx, 'EVIDENCE_FRAGMENT_CITATIONS')} — ` +
+        'no serving reader of fragments is enabled on this stand',
+    );
+  }
+  if (!ctx.allowSynthesize) {
+    return skip(
+      'the only reader of fragment text is the synthesize fragment lane, which spends model ' +
+        'budget; set EVEV_ALLOW_SYNTHESIZE=1 to measure it',
+    );
+  }
+  const res = await call(ctx.wire, {
+    method: 'POST',
+    path: '/v1/synthesize',
+    body: { query: 'what was the invoice total', limit: 10, userId: ctx.ownerUserId },
+  });
+  const citations = arr(res.json, 'evidenceCitations');
+  const mine = citations.filter((c) => str(c, 'assetId') === ctx.stand.primary?.assetId);
+  return mine.length > 0
+    ? pass(`the served answer cited ${mine.length} fragment(s) of the seeded asset`)
+    : fail(
+        `no fragment-arm citation named the seeded asset (${citations.length} citations) — ${res.text}`,
+      );
+}

--- a/test/eval/evidence/checks.ts
+++ b/test/eval/evidence/checks.ts
@@ -1,0 +1,259 @@
+/**
+ * The evidence battery's check table — id, dimension, intent and
+ * assertion in one place, so the README table and the JSON report are
+ * generated from the same source rather than kept in sync by hand.
+ *
+ * The list is SPLIT around the one irreversible act on the plane: GDPR
+ * erasure. Everything in `CHECKS_BEFORE_FORGET` runs against a live
+ * corpus; the runner then erases one user; `CHECKS_AFTER_FORGET` measures
+ * the aftermath. A single flat list would have made the ordering
+ * dependency invisible and one reordering away from meaningless.
+ */
+import type { Ctx } from './context';
+import * as plane from './checks-plane';
+import * as access from './checks-access';
+import type { CheckDef, Verdict } from './types';
+
+export interface Check extends CheckDef {
+  run: (ctx: Ctx) => Verdict | Promise<Verdict>;
+}
+
+export const CHECKS_BEFORE_FORGET: Check[] = [
+  {
+    id: 'e01-blob-upload',
+    dimension: 'E1',
+    intent:
+      'bytes handed to POST /v1/ingest/evidence-blob land hot, content-addressed under the ' +
+      "caller's own tenant, with the server measuring the identity instead of trusting it",
+    run: plane.e01BlobUpload,
+  },
+  {
+    id: 'e02-content-dedup',
+    dimension: 'E1',
+    intent: 'the same bytes from the same owner produce one blob and one row, not two',
+    run: plane.e02ContentDedup,
+  },
+  {
+    id: 'e03-dedup-probe-closed',
+    dimension: 'E1',
+    intent:
+      'a foreign principal registering a known byteHash gets a bare 409 that names nothing — ' +
+      'content identity is not an existence oracle',
+    run: plane.e03DedupProbeClosed,
+  },
+  {
+    id: 'e04-empty-part-rejected',
+    dimension: 'E1',
+    intent: 'an empty file part is a 400, never a zero-byte observation',
+    run: plane.e04EmptyPartRejected,
+  },
+  {
+    id: 'e05-media-type-matrix',
+    dimension: 'E1',
+    intent:
+      'the (modality, mediaType) pairing is enforced — modality drives pack consent, the ' +
+      'dispatch gate and the locator matrix, so a mismatch must be a 400, not a re-classification',
+    run: plane.e05MediaTypeMatrix,
+  },
+  {
+    id: 'e06-size-cap',
+    dimension: 'E1',
+    intent: 'a blob over EVIDENCE_MAX_BYTES is refused rather than stored',
+    run: plane.e06SizeCap,
+  },
+  {
+    id: 'e07-external-ingest-fence',
+    dimension: 'E2',
+    intent:
+      'bytes arriving over HTTP are external ingest: with the quarantine seam on they carry a ' +
+      'scan stamp, with it off the surface refuses outright (fail closed)',
+    run: plane.e07ExternalIngestFence,
+  },
+  {
+    id: 'e08-scan-hook-rejects',
+    dimension: 'E2',
+    intent: 'a blob a scanner flags is rejected before it can become evidence',
+    expectedUnknown:
+      'the platform ships only AllowAllScanHook (every asset scans clean); a real scanner is ' +
+      'an infra follow-up, so the rejection branch has no HTTP path until one is installed',
+    run: plane.e08ScanHookRejects,
+  },
+  {
+    id: 'e09-rejected-stays-rejected',
+    dimension: 'E2',
+    intent:
+      'a rejected upload leaves nothing behind that a re-upload could resurrect — no row, no ' +
+      'processor dispatch, no fragment',
+    expectedUnknown: 'depends on a scan hook that can reject (see e08)',
+    run: plane.e09RejectedStaysRejected,
+  },
+  {
+    id: 'e10-dispatch-terminal',
+    dimension: 'E3',
+    intent:
+      "a pack's declared document→text need reaches a terminal processing run over a clean, " +
+      'hot asset, with nothing denied and nothing failed',
+    run: plane.e10DispatchTerminal,
+  },
+  {
+    id: 'e11-dispatch-idempotent',
+    dimension: 'E3',
+    intent:
+      're-dispatching the same (asset, capability, processor version) replays the recorded ' +
+      'outcome instead of running the adapter again',
+    run: plane.e11DispatchIdempotent,
+  },
+  {
+    id: 'e12-undeclared-capability-denied',
+    dimension: 'E3',
+    intent:
+      'a declared need no installed adapter can serve is DENIED with a reason, not silently ' +
+      'skipped — the anti-DSL broker must say why it did nothing',
+    run: plane.e12UndeclaredCapabilityDenied,
+  },
+  {
+    id: 'e13-failed-run-visible',
+    dimension: 'E3',
+    intent: 'a failing processor is recorded as failed and an operator can see that it failed',
+    expectedUnknown:
+      'no read surface exposes processing_run rows; the sweep returns counters in which a ' +
+      'failed run is indistinguishable from a succeeded one',
+    run: plane.e13FailedRunVisible,
+  },
+  {
+    id: 'e14-fragment-append',
+    dimension: 'E4',
+    intent:
+      'a citation target can be attached to an already-stored blob: re-registering its byteHash ' +
+      'dedupes onto the same asset and still appends the requested fragments',
+    run: plane.e14FragmentAppend,
+  },
+  {
+    id: 'e15-locator-matrix',
+    dimension: 'E4',
+    intent:
+      'a locator kind that does not apply to the asset modality fails the whole request before ' +
+      'a single row is written',
+    run: plane.e15LocatorMatrix,
+  },
+  {
+    id: 'e16-fragment-served',
+    dimension: 'E4',
+    intent: 'fragment text is searchable where the contract says it is (the serving fragment lane)',
+    expectedUnknown:
+      'the lane (RETRIEVAL_FRAGMENT_LANE) and its citation arm (EVIDENCE_FRAGMENT_CITATIONS) ' +
+      'are default-off, and the only reader is a generator call — the one place on this plane ' +
+      'that would spend model budget',
+    run: plane.e16FragmentServed,
+  },
+  {
+    id: 'e17-fragment-unrolls-to-blob',
+    dimension: 'E5',
+    intent:
+      'THE NORTH STAR — a citation target resolves to the exact bytes it points at, served with ' +
+      'the defensive header set',
+    run: access.e17FragmentUnrolls,
+  },
+  {
+    id: 'e18-signed-unroll',
+    dimension: 'E5',
+    intent: 'the same unroll works through a signed URL a third party can redeem without a key',
+    run: access.e18SignedUnroll,
+  },
+  {
+    id: 'e19-citation-target-fence',
+    dimension: 'E5',
+    intent:
+      "a fragment unrolls to ITS asset's bytes and nothing else; an unknown target answers a " +
+      'bare 404 rather than teaching the id space',
+    run: access.e19CitationTargetFence,
+  },
+  {
+    id: 'e20-signed-url-expiry',
+    dimension: 'E6',
+    intent:
+      'a minted URL lives no longer than EVIDENCE_SIGNED_URL_TTL_SECONDS and stops redeeming ' +
+      'when it expires',
+    run: access.e20SignedUrlExpiry,
+  },
+  {
+    id: 'e21-cross-tenant-refusal',
+    dimension: 'E6',
+    intent: "one tenant's key can neither stream nor mint over another tenant's asset",
+    run: access.e21CrossTenantRefusal,
+  },
+  {
+    id: 'e22-grant-revocation-backstop',
+    dimension: 'E6',
+    intent:
+      'grants gate what they claim to gate: revoking every live grant closes the authenticated ' +
+      'read AND kills a URL minted before the revocation',
+    run: access.e22GrantRevocationBackstop,
+  },
+  {
+    id: 'e23-signing-secret-not-readable',
+    dimension: 'E6',
+    intent:
+      'the HMAC key that signs raw-evidence URLs is not readable through the operator config ' +
+      'viewer — a readable signing key makes every signed URL forgeable',
+    run: access.e23SigningSecretNotReadable,
+  },
+  {
+    id: 'e24-orphan-gc-referenced-blob',
+    dimension: 'E7',
+    intent: 'an orphan sweep never reports a blob a live row still references',
+    expectedUnknown:
+      'the orphan-blob GC sweep is not in this build (PR #481) — an unreferenced blob is not ' +
+      'collected at all today',
+    run: access.e24OrphanGcSurface,
+  },
+];
+
+export const CHECKS_AFTER_FORGET: Check[] = [
+  {
+    id: 'e25-shared-asset-survives-forget',
+    dimension: 'E7',
+    intent:
+      'an asset a second owner still holds keeps its row, its fragments AND its bytes when the ' +
+      'first owner is erased',
+    run: access.e25SharedAssetSurvivesForget,
+  },
+  {
+    id: 'e26-shared-blob-drainer',
+    dimension: 'E7',
+    intent:
+      'two asset rows sharing one content-addressed blob must not lose the survivor bytes when ' +
+      'one row dies through user-forget',
+    expectedUnknown:
+      'the defect is real (PR #481 follow-up: the 0114 drainer deletes a queued ref ' +
+      'unconditionally) but its precondition cannot be built over HTTP — byteHash is UNIQUE ' +
+      'per tenant and the upload path derives storageRef from the hash',
+    run: access.e26SharedBlobDrainer,
+  },
+  {
+    id: 'e27-forget-erases-user-evidence',
+    dimension: 'E8',
+    intent:
+      "user-forget destroys the user's sole-owned assets, their fragments, their derived " +
+      'representations and their grants — and the citation targets stop resolving',
+    run: access.e27ForgetErasesUserEvidence,
+  },
+  {
+    id: 'e28-co-owner-grant-survives',
+    dimension: 'E8',
+    intent:
+      "the erased user's ownership row is gone while the co-owner's is untouched — erasure is " +
+      'per-principal, not per-asset',
+    run: access.e28CoOwnerGrantSurvives,
+  },
+  {
+    id: 'e29-co-tenant-bytes-survive',
+    dimension: 'E8',
+    intent:
+      "a second tenant holding byte-identical content is unaffected by the first tenant's " +
+      'erasure — content addressing must not cross the tenant fence',
+    run: access.e29CoTenantBytesSurvive,
+  },
+];
+
+export const ALL_CHECKS: Check[] = [...CHECKS_BEFORE_FORGET, ...CHECKS_AFTER_FORGET];

--- a/test/eval/evidence/context.ts
+++ b/test/eval/evidence/context.ts
@@ -1,0 +1,89 @@
+/**
+ * The execution context every evidence check receives, plus the handful
+ * of assertions they share.
+ *
+ * Kept apart from the check tables so the two halves of the battery
+ * (`checks-plane.ts` for ingest→fragments, `checks-access.ts` for
+ * citations→erasure) can be read on their own and neither file grows past
+ * the repo's 800-line gate.
+ *
+ * Identity discipline (the #456 hermeticity doctrine): NOTHING here has a
+ * fixed default. Every user handle, pack id and byte payload is salted
+ * with the run id by the runner before it lands in this context, so a
+ * second run against the same tenant can neither dedupe onto the first
+ * run's content-addressed rows nor inherit its grants.
+ */
+import type { Gates, Stand, Verdict } from './types';
+import { fail, pass } from './types';
+import type { Wire } from './wire';
+
+export interface Ctx {
+  /** Tenant A — the tenant under test. */
+  wire: Wire;
+  /** Tenant B, when the operator supplied a second credential. */
+  wireB: Wire | null;
+  runId: string;
+  /** Owner of the primary + spare assets. */
+  ownerUserId: string;
+  /** The user GDPR erasure destroys in phase 3. */
+  forgetUserId: string;
+  /** Co-owner of the shared asset; must outlive the erasure. */
+  survivorUserId: string;
+  /** Ceiling on any deliberate wait (signed-URL expiry), in seconds. */
+  maxWaitSeconds: number;
+  /** Whether the operator opted into model spend for the serving leg. */
+  allowSynthesize: boolean;
+  gates: Gates;
+  stand: Stand;
+}
+
+/** Live value of one env knob as the stand reports it, or '' when absent. */
+export const knob = (ctx: Ctx, key: string): string => ctx.gates.config.get(key) ?? '';
+
+/** Whether a knob reads as enabled — the stand prints booleans as 0/1. */
+export const knobOn = (ctx: Ctx, key: string): boolean => {
+  const raw = knob(ctx, key).trim().toLowerCase();
+  return raw === '1' || raw === 'true' || raw === 'yes' || raw === 'on';
+};
+
+/** Verdict helper: one expected status, with the body in the detail. */
+export function expectStatus(
+  observed: { status: number; text: string },
+  want: number,
+  label: string,
+): Verdict {
+  if (observed.status === want) return pass(`${label}: HTTP ${want}`);
+  return fail(`${label}: expected HTTP ${want}, got ${observed.status} — ${observed.text}`);
+}
+
+/** Verdict helper: the status must be one of a small allowed set. */
+export function expectOneOf(
+  observed: { status: number; text: string },
+  want: readonly number[],
+  label: string,
+): Verdict {
+  if (want.includes(observed.status)) return pass(`${label}: HTTP ${observed.status}`);
+  return fail(
+    `${label}: expected HTTP ${want.join('|')}, got ${observed.status} — ${observed.text}`,
+  );
+}
+
+/**
+ * Collect failures as prose. A check that asserts five things about one
+ * response should say which of them broke, not merely that one did — the
+ * report file is meant to be reproducible from its detail line alone.
+ */
+export class Findings {
+  private readonly problems: string[] = [];
+  private readonly confirmed: string[] = [];
+
+  ok(condition: boolean, whenTrue: string, whenFalse: string): void {
+    if (condition) this.confirmed.push(whenTrue);
+    else this.problems.push(whenFalse);
+  }
+
+  verdict(): Verdict {
+    if (this.problems.length === 0) return pass(this.confirmed.join('; '));
+    return fail(this.problems.join('; '));
+  }
+}

--- a/test/eval/evidence/fixtures.ts
+++ b/test/eval/evidence/fixtures.ts
@@ -1,0 +1,187 @@
+/**
+ * Corpus of the evidence battery: two run-scoped pack manifests and the
+ * byte payloads the checks upload.
+ *
+ * WHY A PACK AT ALL. The evidence plane is gated on pack DECLARATIONS,
+ * not just on flags — the processor broker dispatches only capabilities a
+ * pack's `memoryModel.processors` asked for, and the raw-read gateway
+ * serves bytes only for a tenant holding current consent to a pack that
+ * declares `memoryModel.rawEvidence.serve`. No installable pack supplies
+ * that today: five builtins omit rawEvidence on purpose (omission =
+ * deny), and the one that declares it (`real_estate`) is a BUILTIN, so it
+ * never writes the `domain_pack` row the consent fold reads. The battery
+ * must therefore bring its own declaration or measure an unreachable
+ * surface. The probe pack is that fixture, installed per run under a
+ * run-scoped id so two runs never share consent state.
+ *
+ * The deny pack is its negative twin: same modality, a capability
+ * (`document → caption`) that NO installed adapter serves, and no
+ * rawEvidence at all. Dispatching it must be DENIED with a reason, which
+ * is how E3 measures that an undeclared/unservable need fails loudly
+ * instead of silently doing nothing.
+ *
+ * The payloads are deliberately boring: `text/plain` documents, because
+ * `text-extraction-passthrough.adapter.ts` turns them into a derived
+ * `text` representation with no model call — the whole battery costs zero
+ * model spend, which is what lets it run on a stand with a dummy key.
+ */
+import { createHash } from 'node:crypto';
+
+/** Minimal valid predicate — a pack must declare at least one. */
+const PROBE_PREDICATE = {
+  localId: 'observation_note',
+  displayLabel: 'observation note',
+  description: 'A note attached to an observation by the evidence battery.',
+  datatype: 'string',
+  semantics: 'append_only',
+  decayHalfLifeDays: null,
+  piiClass: 'none',
+  status: 'active',
+} as const;
+
+/**
+ * The pack that opens the plane: declares the `document` modality, the
+ * `document → text` processor need the platform's passthrough adapter can
+ * serve, and the raw-evidence capability the read gateway demands.
+ */
+export function probePackManifest(runId: string): Record<string, unknown> {
+  return {
+    id: `evev_probe_${runId}`,
+    version: '1.0.0',
+    description: 'Evidence battery probe pack: document text processing + raw-evidence serving.',
+    predicates: [PROBE_PREDICATE],
+    memoryModel: {
+      modalities: ['text', 'document'],
+      processors: [{ id: 'document_text', modality: 'document', produces: ['text'] }],
+      rawEvidence: { serve: true },
+    },
+  };
+}
+
+/**
+ * The negative twin: a declared need no adapter can satisfy for this
+ * modality. Carries NO rawEvidence, so installing it cannot accidentally
+ * grant the consent the read checks are measuring.
+ */
+export function denyPackManifest(runId: string): Record<string, unknown> {
+  return {
+    id: `evev_deny_${runId}`,
+    version: '1.0.0',
+    description: 'Evidence battery deny pack: declares a capability no installed adapter serves.',
+    predicates: [PROBE_PREDICATE],
+    memoryModel: {
+      modalities: ['document'],
+      processors: [{ id: 'document_caption', modality: 'document', produces: ['caption'] }],
+    },
+  };
+}
+
+/**
+ * The primary document. Run-scoped so its sha256 — and therefore the
+ * 0109 asset identity and the `fs://<tenant>/<hash>` storage ref — is
+ * unique to this run: a re-run on the same tenant must not dedupe onto
+ * the previous run's row (the #456 hermeticity doctrine, applied to
+ * content-addressed bytes instead of to a userId).
+ */
+export function primaryDocument(runId: string): Buffer {
+  return Buffer.from(
+    [
+      `# evidence battery ${runId}`,
+      '',
+      'The quick brown fox jumps over the lazy dog.',
+      'Fragment anchor: the invoice total was 4217 EUR on 2026-03-11.',
+      'Second paragraph exists so a charRange locator has something to point at.',
+      '',
+    ].join('\n'),
+    'utf8',
+  );
+}
+
+/** A distinct document — the destructive grant checks need their own. */
+export function spareDocument(runId: string): Buffer {
+  return Buffer.from(`spare observation for run ${runId}\nrevocation subject\n`, 'utf8');
+}
+
+/** Sole-owned by the forget subject: the asset GDPR erasure must destroy. */
+export function soleDocument(runId: string): Buffer {
+  return Buffer.from(`sole-owned observation for run ${runId}\n`, 'utf8');
+}
+
+/** Co-owned: erasing one owner must leave this asset and its bytes whole. */
+export function sharedDocument(runId: string): Buffer {
+  return Buffer.from(`co-owned observation for run ${runId}\n`, 'utf8');
+}
+
+/** The 68-character EICAR body, assembled at runtime so the literal never
+ *  sits contiguously in this repo's source (a checked-in EICAR string
+ *  trips scanners on developer machines and in CI artifact upload). */
+function eicarBody(): string {
+  const head = 'X5O!P%@AP[4\\PZX54(P^)7CC)7}';
+  const body = '$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!';
+  return `${head}${body}$H+H*`;
+}
+
+/** Whitespace the EICAR spec permits after the body, keyed to the run. */
+const EICAR_WHITESPACE = [' ', '\t', '\r', '\n'] as const;
+/** 68 body chars + 60 padding = 128, the spec's ceiling. */
+const EICAR_PAD = 60;
+
+/**
+ * The EICAR anti-malware test file — the industry-standard payload every
+ * real scanner is required to flag, and inert as a file. Uploading it is
+ * how the battery ASKS the stand whether a real scan hook is installed
+ * instead of assuming the answer: a 'clean' verdict on these bytes is the
+ * observation that the platform still ships the allow-all stub, which is
+ * what gap-gates the quarantine-rejection checks.
+ *
+ * RUN-SCOPED, and it has to be. The standard body is a fixed 68 bytes, so
+ * a second run on the same tenant would re-register a byteHash the first
+ * run already owns and get the dedup 409 instead of a scan verdict —
+ * measured, on the second run of the very first stand this battery was
+ * built against. The spec explicitly allows the body to be followed by
+ * whitespace up to 128 characters total, so the padding carries the run
+ * salt: still a conforming EICAR file that any real scanner flags, and a
+ * distinct content address per run.
+ */
+export function eicarProbe(runId: string): Buffer {
+  const digest = createHash('sha256').update(runId).digest();
+  let pad = '';
+  for (let i = 0; i < EICAR_PAD; i += 1) {
+    pad += EICAR_WHITESPACE[(digest[i % digest.length] ?? 0) % EICAR_WHITESPACE.length];
+  }
+  return Buffer.from(`${eicarBody()}${pad}`, 'utf8');
+}
+
+/** A blob guaranteed to exceed a (small) declared EVIDENCE_MAX_BYTES. */
+export function oversizeDocument(capBytes: number): Buffer {
+  return Buffer.alloc(capBytes + 1024, 0x61);
+}
+
+/** Multipart text parts shared by every upload the battery performs. */
+export function uploadFields(opts: {
+  userId: string;
+  runId: string;
+  packId?: string | undefined;
+}): {
+  modality: string;
+  occurredAt: string;
+  vertical: string;
+  userId: string;
+  piiClasses: string;
+  recorder: string;
+  packId?: string;
+} {
+  return {
+    modality: 'document',
+    occurredAt: new Date().toISOString(),
+    vertical: 'evidence_eval',
+    userId: opts.userId,
+    // '' means "a classifier looked and found nothing" — the ONLY value
+    // that opens the media-PII gate without brain:read_media. Absent
+    // would mean unclassified, which fails closed and would make every
+    // read check skip for the wrong reason.
+    piiClasses: '',
+    recorder: `evidence-battery-${opts.runId}`,
+    ...(opts.packId !== undefined ? { packId: opts.packId } : {}),
+  };
+}

--- a/test/eval/evidence/runner.ts
+++ b/test/eval/evidence/runner.ts
@@ -1,0 +1,309 @@
+/**
+ * Evidence battery runner — drives the whole evidence plane through the
+ * real wire, mirroring the memory-fitness / state-transitions /
+ * domain-packs / code-memory siblings:
+ *
+ *   REST  GET  /v1/admin/config                          (phase 0 gates)
+ *   REST  POST /v1/admin/packs                           (fixture packs)
+ *   REST  POST /v1/ingest/evidence-blob                  (bytes)
+ *   REST  POST /v1/ingest/evidence-asset                 (fragments)
+ *   REST  POST /v1/admin/maintenance/evidence/dispatch   (processing)
+ *   REST  GET  /v1/evidence/{id}/raw | raw-url | redeem  (gateway)
+ *   REST  POST|GET|DELETE /v1/evidence/.../grants        (sharing)
+ *   REST  POST /v1/users/{id}/forget                     (erasure)
+ *
+ * Scoring is fully mechanical — status codes, sha256 comparisons and
+ * documented response counters. Unlike the four siblings this battery
+ * spends NOTHING on models: no path it exercises calls one, so a stand
+ * booted with a placeholder OPENAI_API_KEY scores every dimension. The
+ * single exception (E4's serving leg) is opt-in behind EVEV_ALLOW_SYNTHESIZE
+ * and skipped by default.
+ *
+ * Run: pnpm eval:evidence   (see README.md for stand flags)
+ */
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { Check } from './checks';
+import { ALL_CHECKS, CHECKS_AFTER_FORGET, CHECKS_BEFORE_FORGET } from './checks';
+import type { Ctx } from './context';
+import { primaryDocument, sharedDocument, soleDocument, spareDocument } from './fixtures';
+import {
+  appendFragment,
+  buildGates,
+  mintAsset,
+  mintToken,
+  runForget,
+  setupTrail,
+  shareWith,
+} from './setup';
+import type { CheckResult, Dimension, Scorecard, Stand, Tally } from './types';
+import { DIMENSION_LABELS } from './types';
+import type { Wire } from './wire';
+import { str } from './wire';
+
+interface Config {
+  wire: Wire;
+  wireB: Wire | null;
+  runId: string;
+  maxWaitSeconds: number;
+  allowSynthesize: boolean;
+  reportDir: string;
+}
+
+const USAGE = [
+  'evidence: BRAIN_BASE_URL is not set — nothing to run against.',
+  'This battery drives a LIVE brain stand over REST and is intentionally never run in CI.',
+  '',
+  'Required env:',
+  '  BRAIN_BASE_URL   e.g. http://localhost:3055  (BRAIN_URL also accepted)',
+  '  BRAIN_API_KEY    tenant M2M key with brain:read + brain:write + brain:admin',
+  '  BRAIN_COMPANY_ID tenant id — use a FRESH tenant per run (see README.md)',
+  '',
+  'Optional env: EVEV_RUN_ID (default time-derived; every user handle, pack id and',
+  'byte payload is salted with it, so re-runs never collide), EVEV_TENANT_B_ID +',
+  'EVEV_TENANT_B_KEY (a second tenant — without it the two cross-tenant checks are',
+  'SKIPPED, never passed), EVEV_MAX_WAIT_S (default 90 — the ceiling on waiting out',
+  'a signed-URL TTL), EVEV_ALLOW_SYNTHESIZE=1 (opt into the one model-spending',
+  'check), EVEV_REPORT_DIR (default var/evidence).',
+].join('\n');
+
+function loadConfig(): Config {
+  const baseUrl = process.env.BRAIN_BASE_URL ?? process.env.BRAIN_URL;
+  const apiKey = process.env.BRAIN_API_KEY;
+  const companyId = process.env.BRAIN_COMPANY_ID;
+  if (baseUrl === undefined || baseUrl === '') {
+    console.error(USAGE);
+    process.exit(1);
+  }
+  if (apiKey === undefined || apiKey === '') {
+    console.error('evidence: BRAIN_API_KEY is not set.');
+    process.exit(1);
+  }
+  if (companyId === undefined || companyId === '') {
+    console.error('evidence: BRAIN_COMPANY_ID is not set.');
+    process.exit(1);
+  }
+  const base = baseUrl.replace(/\/$/, '');
+  const tenantBId = process.env.EVEV_TENANT_B_ID;
+  const tenantBKey = process.env.EVEV_TENANT_B_KEY;
+  const wait = Number(process.env.EVEV_MAX_WAIT_S ?? '90');
+  return {
+    wire: { baseUrl: base, apiKey, companyId },
+    wireB:
+      tenantBId && tenantBKey ? { baseUrl: base, apiKey: tenantBKey, companyId: tenantBId } : null,
+    runId: process.env.EVEV_RUN_ID ?? `ev${Date.now().toString(36)}`,
+    maxWaitSeconds: Number.isFinite(wait) && wait > 0 ? wait : 90,
+    allowSynthesize: process.env.EVEV_ALLOW_SYNTHESIZE === '1',
+    reportDir: process.env.EVEV_REPORT_DIR ?? join('var', 'evidence'),
+  };
+}
+
+const emptyStand = (): Stand => ({
+  primary: null,
+  primaryUploadStatus: 0,
+  primaryQuarantineStatus: null,
+  spare: null,
+  sole: null,
+  shared: null,
+  tenantB: null,
+  firstDispatch: null,
+  agingToken: null,
+  agingTokenExpiresAt: 0,
+  spareToken: null,
+  forget: null,
+});
+
+/** Phase 1 — mint every fixture asset the checks read. */
+async function mintFixtures(ctx: Ctx): Promise<void> {
+  const owner = { userId: ctx.ownerUserId, runId: ctx.runId };
+  const subject = { userId: ctx.forgetUserId, runId: ctx.runId };
+
+  const primary = await mintAsset(ctx.wire, primaryDocument(ctx.runId), owner);
+  ctx.stand.primary = primary.asset;
+  ctx.stand.primaryUploadStatus = primary.res.status;
+  ctx.stand.primaryQuarantineStatus = str(primary.res.json, 'quarantineStatus');
+  if (primary.asset) {
+    primary.asset.fragmentId = await appendFragment(ctx.wire, primary.asset, owner);
+    const token = await mintToken(ctx.wire, primary.asset.assetId);
+    ctx.stand.agingToken = token?.token ?? null;
+    ctx.stand.agingTokenExpiresAt = token?.expiresAt ?? 0;
+  }
+
+  const spare = await mintAsset(ctx.wire, spareDocument(ctx.runId), owner);
+  ctx.stand.spare = spare.asset;
+  if (spare.asset) {
+    spare.asset.fragmentId = await appendFragment(ctx.wire, spare.asset, owner);
+    ctx.stand.spareToken = (await mintToken(ctx.wire, spare.asset.assetId))?.token ?? null;
+  }
+
+  const sole = await mintAsset(ctx.wire, soleDocument(ctx.runId), subject);
+  ctx.stand.sole = sole.asset;
+  if (sole.asset) sole.asset.fragmentId = await appendFragment(ctx.wire, sole.asset, subject);
+
+  const shared = await mintAsset(ctx.wire, sharedDocument(ctx.runId), subject);
+  ctx.stand.shared = shared.asset;
+  if (shared.asset) {
+    shared.asset.fragmentId = await appendFragment(ctx.wire, shared.asset, subject);
+    await shareWith(ctx.wire, shared.asset.assetId, ctx.survivorUserId);
+  }
+
+  if (ctx.wireB !== null) {
+    await buildTenantB(ctx);
+  }
+  console.error(`[setup] ${JSON.stringify(setupTrail(ctx).assets)}`);
+}
+
+/**
+ * Tenant B holds BYTE-IDENTICAL content to tenant A's primary asset. It
+ * needs its own probe-pack install because modality consent is a
+ * per-tenant row — without it B's raw read would 404 for the wrong
+ * reason and the co-tenant survival check would read as a failure.
+ */
+async function buildTenantB(ctx: Ctx): Promise<void> {
+  if (ctx.wireB === null) return;
+  await buildGates({ wire: ctx.wireB, wireB: null, runId: ctx.runId });
+  const twin = await mintAsset(ctx.wireB, primaryDocument(ctx.runId), {
+    userId: ctx.ownerUserId,
+    runId: ctx.runId,
+  });
+  ctx.stand.tenantB = twin.asset;
+}
+
+async function runGroup(ctx: Ctx, group: Check[]): Promise<CheckResult[]> {
+  const results: CheckResult[] = [];
+  for (const check of group) {
+    const started = Date.now();
+    let verdict;
+    try {
+      verdict = await check.run(ctx);
+    } catch (err) {
+      verdict = { status: 'fail' as const, detail: `runner error: ${String(err)}` };
+    }
+    const { run: _run, ...def } = check;
+    const result: CheckResult = {
+      ...def,
+      status: verdict.status,
+      detail: verdict.detail,
+      latencyMs: Date.now() - started,
+    };
+    results.push(result);
+    const note =
+      verdict.status === 'fail' && check.expectedUnknown !== undefined
+        ? ' (gap-gated finding)'
+        : '';
+    console.error(
+      `[check] ${check.id} ${verdict.status}${note} ${result.latencyMs}ms — ${verdict.detail}`,
+    );
+  }
+  return results;
+}
+
+const emptyTally = (): Tally => ({ pass: 0, fail: 0, skipped: 0 });
+
+function buildScorecard(
+  cfg: Config,
+  ctx: Ctx,
+  span: { startedAt: string; results: CheckResult[] },
+): Scorecard {
+  const dimensions = Object.fromEntries(
+    (Object.keys(DIMENSION_LABELS) as Dimension[]).map((d) => [d, emptyTally()]),
+  ) as Record<Dimension, Tally>;
+  const overall = { pass: 0, fail: 0, skipped: 0, total: 0, failedExpectedUnknown: 0 };
+  for (const r of span.results) {
+    dimensions[r.dimension][r.status] += 1;
+    overall[r.status] += 1;
+    overall.total += 1;
+    if (r.status === 'fail' && r.expectedUnknown !== undefined) overall.failedExpectedUnknown += 1;
+  }
+  return {
+    runId: cfg.runId,
+    baseUrl: cfg.wire.baseUrl,
+    companyId: cfg.wire.companyId,
+    ownerUserId: ctx.ownerUserId,
+    startedAt: span.startedAt,
+    finishedAt: new Date().toISOString(),
+    setup: setupTrail(ctx),
+    dimensions,
+    overall,
+    gapGatedChecks: ALL_CHECKS.filter((c) => c.expectedUnknown !== undefined).map((c) => c.id),
+    results: span.results,
+  };
+}
+
+function printScorecard(card: Scorecard): void {
+  console.log('');
+  console.log(`evidence scorecard — run ${card.runId} (tenant ${card.companyId})`);
+  console.log('─'.repeat(72));
+  for (const d of Object.keys(DIMENSION_LABELS) as Dimension[]) {
+    const t = card.dimensions[d];
+    console.log(
+      `${d}  ${DIMENSION_LABELS[d].padEnd(20)} pass ${t.pass}  fail ${t.fail}` +
+        (t.skipped > 0 ? `  skipped ${t.skipped}` : ''),
+    );
+  }
+  console.log('─'.repeat(72));
+  const scored = card.overall.pass + card.overall.fail;
+  const pct = scored === 0 ? 0 : Math.round((card.overall.pass / scored) * 1000) / 10;
+  console.log(
+    `overall: ${card.overall.pass}/${scored} scored (${pct}%), ` +
+      `${card.overall.skipped} skipped of ${card.overall.total}` +
+      (card.overall.failedExpectedUnknown > 0
+        ? ` — ${card.overall.failedExpectedUnknown} fail(s) are gap-gated findings, not regressions`
+        : ''),
+  );
+  console.log(
+    `gap-gated (expectedUnknown): ${card.gapGatedChecks.join(', ')} — a skip or fail there is ` +
+      'the recorded gap; a pass is the measured signal the capability landed.',
+  );
+}
+
+async function main(): Promise<void> {
+  const cfg = loadConfig();
+  const startedAt = new Date().toISOString();
+  console.error(
+    `evidence: run ${cfg.runId} against ${cfg.wire.baseUrl} (tenant ${cfg.wire.companyId})`,
+  );
+
+  const gates = await buildGates({ wire: cfg.wire, wireB: cfg.wireB, runId: cfg.runId });
+  console.error(
+    `[setup] probe pack ${gates.packId ?? `NOT INSTALLED (${gates.packError ?? '?'})`}; ` +
+      `orphan-gc route ${gates.orphanGcRoute.present ? 'present' : `absent (${gates.orphanGcRoute.status})`}`,
+  );
+
+  const ctx: Ctx = {
+    wire: cfg.wire,
+    wireB: cfg.wireB,
+    runId: cfg.runId,
+    // Run-scoped identities (the #456 hermeticity doctrine): a fixed
+    // default owner would inherit the previous run's grants and assets on
+    // the same tenant, and the erasure phase would then destroy them.
+    ownerUserId: `evev-owner-${cfg.runId}`,
+    forgetUserId: `evev-subject-${cfg.runId}`,
+    survivorUserId: `evev-keeper-${cfg.runId}`,
+    maxWaitSeconds: cfg.maxWaitSeconds,
+    allowSynthesize: cfg.allowSynthesize,
+    gates,
+    stand: emptyStand(),
+  };
+
+  await mintFixtures(ctx);
+  const results = await runGroup(ctx, CHECKS_BEFORE_FORGET);
+  ctx.stand.forget = await runForget(ctx);
+  console.error(`[forget] ${ctx.forgetUserId} → HTTP ${ctx.stand.forget.status}`);
+  results.push(...(await runGroup(ctx, CHECKS_AFTER_FORGET)));
+
+  const card = buildScorecard(cfg, ctx, { startedAt, results });
+  mkdirSync(cfg.reportDir, { recursive: true });
+  const reportPath = join(cfg.reportDir, `evidence-${cfg.runId}.json`);
+  writeFileSync(reportPath, `${JSON.stringify(card, null, 2)}\n`);
+  printScorecard(card);
+  console.log(`report: ${reportPath}`);
+}
+
+// A failing CHECK is a finding, not a runner error — the battery reports,
+// it does not gate CI, so the process still exits 0. Only an unexpected
+// throw (a battery bug) sets a non-zero code.
+void main().catch((err: unknown) => {
+  console.error('evidence: runner failed:', err);
+  process.exitCode = 1;
+});

--- a/test/eval/evidence/setup.ts
+++ b/test/eval/evidence/setup.ts
@@ -1,0 +1,221 @@
+/**
+ * Phase 0 (gates) and phase 1 (fixtures) of the evidence battery, plus
+ * the single irreversible phase 3 act (GDPR erasure).
+ *
+ * PHASE 0 reads the stand instead of assuming it: every EVIDENCE_* knob
+ * comes from GET /v1/admin/config, the orphan-GC maintenance route is
+ * PROBED rather than presumed, and the fixture packs are installed and
+ * their failure recorded. Those observations become the skip reasons of
+ * every dependent check, which is what keeps a missing capability from
+ * reading as a pass.
+ *
+ * PHASE 1 mints four assets in tenant A and (optionally) one in tenant B.
+ * They are separate on purpose: the grant-revocation check administratively
+ * KILLS its asset and the erasure phase destroys another, so sharing one
+ * fixture between them would make later checks measure earlier checks'
+ * damage instead of the platform.
+ */
+import type { Ctx } from './context';
+import { denyPackManifest, probePackManifest, uploadFields } from './fixtures';
+import type { Gates, MintedAsset } from './types';
+import type { JsonResult, Wire } from './wire';
+import { arr, bool, call, num, sha256, str, upload } from './wire';
+
+/** Env names whose live value the gates keep (everything else is noise). */
+const GATE_PREFIXES = ['EVIDENCE_', 'RETRIEVAL_FRAGMENT_LANE', 'FOVEA_FRAGMENT_ZOOM'];
+
+interface ConfigEntry {
+  key?: unknown;
+  currentValue?: unknown;
+  secret?: unknown;
+}
+
+/** GET /v1/admin/config → the live knob map plus the masked-secret set. */
+async function readConfig(
+  wire: Wire,
+): Promise<{ config: Map<string, string>; secretKeys: Set<string> }> {
+  const config = new Map<string, string>();
+  const secretKeys = new Set<string>();
+  const res = await call(wire, { method: 'GET', path: '/v1/admin/config' });
+  for (const raw of arr(res.json, 'entries')) {
+    const entry = raw as ConfigEntry;
+    if (typeof entry.key !== 'string') continue;
+    if (!GATE_PREFIXES.some((p) => entry.key === p || String(entry.key).startsWith(p))) continue;
+    config.set(entry.key, typeof entry.currentValue === 'string' ? entry.currentValue : '');
+    if (entry.secret === true) secretKeys.add(entry.key);
+  }
+  return { config, secretKeys };
+}
+
+/** Install one fixture pack; returns its id, or null with the reason. */
+async function installPack(
+  wire: Wire,
+  manifest: Record<string, unknown>,
+): Promise<{ packId: string | null; error: string | null }> {
+  const res = await call(wire, {
+    method: 'POST',
+    path: '/v1/admin/packs',
+    body: { manifest, acceptModalities: true },
+  });
+  if (res.status === 200 || res.status === 201) {
+    return { packId: String(manifest.id), error: null };
+  }
+  return { packId: null, error: `HTTP ${res.status} — ${res.text}` };
+}
+
+export async function buildGates(ctx: {
+  wire: Wire;
+  wireB: Wire | null;
+  runId: string;
+}): Promise<Gates> {
+  const { config, secretKeys } = await readConfig(ctx.wire);
+  const probe = await call(ctx.wire, {
+    method: 'POST',
+    path: '/v1/admin/maintenance/evidence/orphan-blob-gc',
+    body: { dryRun: true },
+  });
+  const installed = await installPack(ctx.wire, probePackManifest(ctx.runId));
+  const deny = await installPack(ctx.wire, denyPackManifest(ctx.runId));
+  return {
+    config,
+    secretKeys,
+    orphanGcRoute: { present: probe.status !== 404, status: probe.status },
+    packId: installed.packId,
+    packError: installed.error,
+    denyPackId: deny.packId,
+    tenantB: ctx.wireB ? { companyId: ctx.wireB.companyId, apiKey: ctx.wireB.apiKey } : null,
+  };
+}
+
+/** Turn one upload response into a MintedAsset, or null when it failed. */
+function assetOf(res: JsonResult, data: Buffer): MintedAsset | null {
+  const assetId = str(res.json, 'assetId');
+  if (assetId === null) return null;
+  return {
+    assetId,
+    byteHash: str(res.json, 'byteHash') ?? sha256(data),
+    bytes: data,
+    storageRef: str(res.json, 'storageRef') ?? '',
+    availability: str(res.json, 'availability') ?? '',
+    deduped: bool(res.json, 'deduped') ?? false,
+    fragmentId: null,
+  };
+}
+
+/** Upload one document blob as a named owner. */
+export async function mintAsset(
+  wire: Wire,
+  data: Buffer,
+  owner: { userId: string; runId: string },
+): Promise<{ asset: MintedAsset | null; res: JsonResult }> {
+  const res = await upload(
+    wire,
+    { data, filename: `${owner.runId}.txt`, contentType: 'text/plain' },
+    uploadFields({ userId: owner.userId, runId: owner.runId }),
+  );
+  return { asset: assetOf(res, data), res };
+}
+
+/**
+ * Attach a citation target to an already-stored blob through the dedup
+ * path: the metadata surface takes no bytes, so re-registering the SAME
+ * byteHash as the SAME owner returns the existing blob-backed row and
+ * appends the fragments to it. This is the only route by which a
+ * caller-asserted fragment ends up over real bytes.
+ */
+export async function appendFragment(
+  wire: Wire,
+  asset: MintedAsset,
+  owner: { userId: string; runId: string },
+): Promise<string | null> {
+  const res = await call(wire, {
+    method: 'POST',
+    path: '/v1/ingest/evidence-asset',
+    body: {
+      modality: 'document',
+      mediaType: 'text/plain',
+      byteHash: asset.byteHash,
+      byteLength: asset.bytes.byteLength,
+      occurredAt: new Date().toISOString(),
+      originUri: `https://example.invalid/${owner.runId}/${asset.byteHash.slice(0, 12)}`,
+      vertical: 'evidence_eval',
+      userId: owner.userId,
+      piiClasses: [],
+      recorder: `evidence-battery-${owner.runId}`,
+      fragments: [
+        {
+          locator: { kind: 'charRange', start: 0, end: 32 },
+          label: 'battery anchor',
+          piiClasses: [],
+          excerpt: asset.bytes.subarray(0, 32).toString('utf8'),
+          lang: 'en',
+        },
+      ],
+    },
+  });
+  const first = arr(res.json, 'fragments')[0];
+  return first === undefined ? null : str(first, 'fragmentId');
+}
+
+/** Mint a signed URL token over an asset; null when the mint refused. */
+export async function mintToken(
+  wire: Wire,
+  assetId: string,
+): Promise<{ token: string; expiresAt: number } | null> {
+  const res = await call(wire, { method: 'GET', path: `/v1/evidence/${assetId}/raw-url` });
+  const token = str(res.json, 'token');
+  const expiresAt = str(res.json, 'expiresAt');
+  if (token === null) return null;
+  const at = expiresAt === null ? Date.now() : new Date(expiresAt).getTime();
+  return { token, expiresAt: Number.isNaN(at) ? Date.now() : at };
+}
+
+/** Share an asset with one more owner (the co-ownership fixture). */
+export async function shareWith(wire: Wire, assetId: string, ownerId: string): Promise<number> {
+  const res = await call(wire, {
+    method: 'POST',
+    path: `/v1/evidence/${assetId}/grants`,
+    body: { ownerKind: 'user', ownerId, purpose: 'share' },
+  });
+  return res.status;
+}
+
+/** Phase 3: the one irreversible act, run between the two check groups. */
+export async function runForget(ctx: Ctx): Promise<{ status: number; json: unknown }> {
+  const res = await call(ctx.wire, {
+    method: 'POST',
+    path: `/v1/users/${encodeURIComponent(ctx.forgetUserId)}/forget`,
+  });
+  return { status: res.status, json: res.json };
+}
+
+/** Human-readable trail of what phase 0/1 observed, for the report file. */
+export function setupTrail(ctx: Ctx): Record<string, string> {
+  const g = ctx.gates;
+  const knobs = [...g.config.entries()]
+    .filter(([k]) => k.startsWith('EVIDENCE_') && !k.includes('SECRET') && !k.includes('FS_ROOT'))
+    .map(([k, v]) => `${k}=${v}`)
+    .join(' ');
+  return {
+    knobs,
+    probePack: g.packId ?? `NOT INSTALLED (${g.packError ?? 'unknown'})`,
+    denyPack: g.denyPackId ?? 'NOT INSTALLED',
+    orphanGcRoute: g.orphanGcRoute.present ? 'present' : `absent (HTTP ${g.orphanGcRoute.status})`,
+    tenantB: g.tenantB ? g.tenantB.companyId : 'not configured',
+    assets: [
+      `primary=${ctx.stand.primary?.assetId ?? 'none'}`,
+      `spare=${ctx.stand.spare?.assetId ?? 'none'}`,
+      `sole=${ctx.stand.sole?.assetId ?? 'none'}`,
+      `shared=${ctx.stand.shared?.assetId ?? 'none'}`,
+      `tenantB=${ctx.stand.tenantB?.assetId ?? 'none'}`,
+    ].join(' '),
+    dispatchCounters: ctx.stand.firstDispatch
+      ? Object.entries(ctx.stand.firstDispatch)
+          .map(([k, v]) => `${k}=${v}`)
+          .join(' ')
+      : 'not dispatched',
+    forget: ctx.stand.forget
+      ? `HTTP ${ctx.stand.forget.status} assets=${num(ctx.stand.forget.json, 'evidenceAssetsDeleted') ?? '?'}`
+      : 'not run',
+  };
+}

--- a/test/eval/evidence/types.ts
+++ b/test/eval/evidence/types.ts
@@ -1,0 +1,156 @@
+/**
+ * Shared shapes of the evidence battery — the fifth mechanical sibling of
+ * test/eval/memory-fitness (first-person memory fitness),
+ * test/eval/state-transitions (mutable world-state),
+ * test/eval/domain-packs (installed industry packs) and
+ * test/eval/code-memory (the builtin coding pack).
+ *
+ * This one isolates ONE claim: **bytes handed to the brain stay
+ * accountable end to end** — upload → quarantine → processing run →
+ * fragment → citation → signed-URL gateway → grants → GC → erasure. Every
+ * assertion is mechanical (status codes, byte hashes, row counts); there
+ * is NO LLM judge and, unlike the four siblings, no model spend at all:
+ * nothing on the evidence plane calls a model, so a stand booted with a
+ * dummy OPENAI_API_KEY scores the whole battery.
+ *
+ * Dimensions mirror memory-fitness's D1..D8 — one scorecard line each:
+ *   E1 ingest & identity   E2 quarantine      E3 processing
+ *   E4 fragments           E5 citations       E6 access
+ *   E7 GC                  E8 GDPR
+ */
+
+export type Dimension = 'E1' | 'E2' | 'E3' | 'E4' | 'E5' | 'E6' | 'E7' | 'E8';
+
+export const DIMENSION_LABELS: Record<Dimension, string> = {
+  E1: 'ingest & identity',
+  E2: 'quarantine',
+  E3: 'processing',
+  E4: 'fragments',
+  E5: 'citations',
+  E6: 'access',
+  E7: 'gc',
+  E8: 'gdpr',
+};
+
+export type CheckStatus = 'pass' | 'fail' | 'skipped';
+
+/**
+ * One check's identity, authored next to its assertion so the report and
+ * the README can be generated from the same table.
+ */
+export interface CheckDef {
+  /** Stable key (`e01-blob-upload`…) used in the scorecard and report. */
+  id: string;
+  dimension: Dimension;
+  /** One line: what falsifying this check would mean. */
+  intent: string;
+  /**
+   * Honest-baseline annotation (the domain-pack / code-memory
+   * `expectedUnknown` pattern): the outcome depends on work that has not
+   * landed. The runner still EXECUTES the check when its preconditions
+   * exist; a fail is recorded as a finding and tallied separately
+   * (`failedExpectedUnknown`), never forced green.
+   */
+  expectedUnknown?: string;
+}
+
+/** A check's verdict before the runner stamps timing onto it. */
+export interface Verdict {
+  status: CheckStatus;
+  detail: string;
+}
+
+export const pass = (detail: string): Verdict => ({ status: 'pass', detail });
+export const fail = (detail: string): Verdict => ({ status: 'fail', detail });
+export const skip = (detail: string): Verdict => ({ status: 'skipped', detail });
+
+export interface CheckResult extends CheckDef {
+  status: CheckStatus;
+  detail: string;
+  latencyMs: number;
+}
+
+export interface Tally {
+  pass: number;
+  fail: number;
+  skipped: number;
+}
+
+/**
+ * Live capability state, read from the stand rather than assumed — the
+ * `eval:code-memory` gate doctrine applied to the EVIDENCE_ family: a
+ * check that cannot run because a knob is off, a route is absent or a
+ * fixture could not be installed reports `skipped` with the observed
+ * reason, never a silent pass.
+ */
+export interface Gates {
+  /** GET /v1/admin/config, keyed by env name (`currentValue`). */
+  config: Map<string, string>;
+  /** Env names the config viewer declared `secret: true` (value masked). */
+  secretKeys: Set<string>;
+  /** Whether the orphan-blob GC maintenance route exists (probe status). */
+  orphanGcRoute: { present: boolean; status: number };
+  /** The run-scoped fixture pack, when its install succeeded. */
+  packId: string | null;
+  /** Install failure detail, for the skip reasons of dependent checks. */
+  packError: string | null;
+  /** The pack that declares a capability no adapter can serve. */
+  denyPackId: string | null;
+  /** Second tenant credentials, when the operator supplied them. */
+  tenantB: { companyId: string; apiKey: string } | null;
+}
+
+/** One asset the battery minted: its id, its bytes and their identity. */
+export interface MintedAsset {
+  assetId: string;
+  byteHash: string;
+  bytes: Buffer;
+  /** Server-minted content address, `fs://<tenant>/<hash>` for the fs adapter. */
+  storageRef: string;
+  availability: string;
+  deduped: boolean;
+  /** Citation target appended through the dedup path, when one was made. */
+  fragmentId: string | null;
+}
+
+/** Everything the setup phases minted, threaded through the checks. */
+export interface Stand {
+  /** Primary blob-backed asset (owner user, document/text-plain). */
+  primary: MintedAsset | null;
+  /** Raw response of the primary upload — E2 reads its quarantine stamp. */
+  primaryUploadStatus: number;
+  primaryQuarantineStatus: string | null;
+  /** A second asset, sacrificed by the destructive grant-revocation check. */
+  spare: MintedAsset | null;
+  /** Sole-owned by the forget subject — GDPR erasure must destroy it. */
+  sole: MintedAsset | null;
+  /** Co-owned by the forget subject and a survivor — must survive whole. */
+  shared: MintedAsset | null;
+  /** Tenant B's copy of the primary bytes (co-tenant survival check). */
+  tenantB: MintedAsset | null;
+  /** First dispatch counters — the idempotence check compares against them. */
+  firstDispatch: Record<string, number> | null;
+  /** A signed token minted early so the expiry check need not sleep a TTL. */
+  agingToken: string | null;
+  agingTokenExpiresAt: number;
+  /** A token minted over the spare asset BEFORE its grants were revoked. */
+  spareToken: string | null;
+  /** POST /v1/users/:id/forget outcome, once phase 3 has run it. */
+  forget: { status: number; json: unknown } | null;
+}
+
+export interface Scorecard {
+  runId: string;
+  baseUrl: string;
+  companyId: string;
+  ownerUserId: string;
+  startedAt: string;
+  finishedAt: string;
+  /** Phase-0 trail: the live knob values and probes the gates came from. */
+  setup: Record<string, string>;
+  dimensions: Record<Dimension, Tally>;
+  overall: Tally & { total: number; failedExpectedUnknown: number };
+  /** Ids of gap-gated checks (expectedUnknown), pass or fail. */
+  gapGatedChecks: string[];
+  results: CheckResult[];
+}

--- a/test/eval/evidence/wire.ts
+++ b/test/eval/evidence/wire.ts
@@ -1,0 +1,175 @@
+/**
+ * The evidence battery's wire layer — extracted for the same reason
+ * test/eval/memory-fitness/interleave.ts and
+ * test/eval/domain-packs/scorers.ts are: the runner is a scoring
+ * narrative, and HTTP plumbing that never makes a decision does not
+ * belong inside it (also the 800-line file gate).
+ *
+ * Three things live here and nothing else:
+ *
+ *  - `call` — a NON-THROWING JSON request. Every check on this plane
+ *    asserts a STATUS (404 for a dark route, 409 for the dedup-probe
+ *    fence, 400 for a bad locator, 413 for an over-cap blob), so a client
+ *    that throws on non-2xx would turn the thing under test into an
+ *    exception. It returns `{ status, json }` and lets the caller decide.
+ *  - `bytes` — the same, for the raw-read gateway: the response BODY is
+ *    the evidence, so the buffer and the security headers come back
+ *    verbatim, unparsed.
+ *  - `upload` — `multipart/form-data` through the platform `FormData` /
+ *    `Blob` globals (Node >= 18). No new dependency: the battery ships
+ *    with the repo and must run from a bare checkout.
+ *
+ * Credentials travel as an explicit `Wire` argument rather than module
+ * state because two of the checks are cross-tenant: the same helper is
+ * called with tenant A's key and tenant B's, and a hidden default would
+ * make the tenant fence untestable.
+ */
+import { createHash } from 'node:crypto';
+
+/** Who to call as — one tenant's base URL + bearer key. */
+export interface Wire {
+  baseUrl: string;
+  apiKey: string;
+  companyId: string;
+}
+
+export interface JsonResult {
+  status: number;
+  /** Parsed body, or null when the response carried no JSON. */
+  json: unknown;
+  /** Raw body text, capped — the detail line of a failing check. */
+  text: string;
+}
+
+export interface BytesResult {
+  status: number;
+  body: Buffer;
+  headers: Headers;
+}
+
+/** Body text kept in a report line — a 404 page must not flood the JSON. */
+const TEXT_MAX = 400;
+
+export const sha256 = (data: Buffer | string): string =>
+  createHash('sha256').update(data).digest('hex');
+
+/**
+ * One JSON request. `auth: false` omits the Authorization header (the
+ * redeem route is unauthenticated by design and must stay that way).
+ */
+export async function call(
+  wire: Wire,
+  req: {
+    method: 'GET' | 'POST' | 'DELETE';
+    path: string;
+    body?: unknown;
+    auth?: boolean;
+  },
+): Promise<JsonResult> {
+  const headers: Record<string, string> = { Accept: 'application/json' };
+  if (req.auth !== false) headers.Authorization = `Bearer ${wire.apiKey}`;
+  if (req.body !== undefined) headers['Content-Type'] = 'application/json';
+  const res = await fetch(`${wire.baseUrl}${req.path}`, {
+    method: req.method,
+    headers,
+    ...(req.body !== undefined ? { body: JSON.stringify(req.body) } : {}),
+  });
+  const text = await res.text();
+  let json: unknown = null;
+  try {
+    json = text === '' ? null : JSON.parse(text);
+  } catch {
+    json = null;
+  }
+  return { status: res.status, json, text: text.slice(0, TEXT_MAX) };
+}
+
+/** A raw byte read — body and headers verbatim (no JSON parse). */
+export async function bytes(
+  wire: Wire,
+  req: { path: string; auth?: boolean },
+): Promise<BytesResult> {
+  const headers: Record<string, string> = {};
+  if (req.auth !== false) headers.Authorization = `Bearer ${wire.apiKey}`;
+  const res = await fetch(`${wire.baseUrl}${req.path}`, { method: 'GET', headers });
+  const buf = Buffer.from(await res.arrayBuffer());
+  return { status: res.status, body: buf, headers: res.headers };
+}
+
+/** The metadata half of a blob upload — every value rides as a text part. */
+export interface UploadFields {
+  modality: string;
+  mediaType?: string | undefined;
+  occurredAt: string;
+  vertical: string;
+  userId?: string | undefined;
+  /** '' is load-bearing: it means "classified clean", not "unclassified". */
+  piiClasses?: string | undefined;
+  recorder?: string | undefined;
+  packId?: string | undefined;
+}
+
+/**
+ * POST /v1/ingest/evidence-blob. `contentType` is what the FILE PART
+ * declares; `fields.mediaType` (when set) is the caller's override — the
+ * two are separate on purpose, because the allowlist check reads the
+ * override first and one of the checks needs them to disagree.
+ */
+export async function upload(
+  wire: Wire,
+  blob: { data: Buffer; filename: string; contentType: string },
+  fields: UploadFields,
+): Promise<JsonResult> {
+  const form = new FormData();
+  for (const [key, value] of Object.entries(fields)) {
+    if (value !== undefined) form.append(key, value);
+  }
+  form.append(
+    'file',
+    new Blob([new Uint8Array(blob.data)], { type: blob.contentType }),
+    blob.filename,
+  );
+  const res = await fetch(`${wire.baseUrl}/v1/ingest/evidence-blob`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${wire.apiKey}`, Accept: 'application/json' },
+    body: form,
+  });
+  const text = await res.text();
+  let json: unknown = null;
+  try {
+    json = text === '' ? null : JSON.parse(text);
+  } catch {
+    json = null;
+  }
+  return { status: res.status, json, text: text.slice(0, TEXT_MAX) };
+}
+
+/** Read one string field off an untrusted wire object. */
+export function str(value: unknown, key: string): string | null {
+  if (value === null || typeof value !== 'object') return null;
+  const v = (value as Record<string, unknown>)[key];
+  return typeof v === 'string' ? v : null;
+}
+
+/** Read one number field off an untrusted wire object. */
+export function num(value: unknown, key: string): number | null {
+  if (value === null || typeof value !== 'object') return null;
+  const v = (value as Record<string, unknown>)[key];
+  return typeof v === 'number' ? v : null;
+}
+
+/** Read one boolean field off an untrusted wire object. */
+export function bool(value: unknown, key: string): boolean | null {
+  if (value === null || typeof value !== 'object') return null;
+  const v = (value as Record<string, unknown>)[key];
+  return typeof v === 'boolean' ? v : null;
+}
+
+/** Read one array field off an untrusted wire object. */
+export function arr(value: unknown, key: string): unknown[] {
+  if (value === null || typeof value !== 'object') return [];
+  const v = (value as Record<string, unknown>)[key];
+  return Array.isArray(v) ? v : [];
+}
+
+export const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));

--- a/test/evidence-eval-gates.unit-spec.ts
+++ b/test/evidence-eval-gates.unit-spec.ts
@@ -1,0 +1,162 @@
+/**
+ * Unit pins for the evidence battery's PURE parts (test/eval/evidence).
+ *
+ * The battery itself only runs against a live stand, so nothing here
+ * boots anything: this covers the pieces that decide verdicts without
+ * I/O — the knob reader, the status assertions, the multi-assertion
+ * collector — plus two structural invariants the battery cannot be
+ * allowed to violate silently:
+ *
+ *   1. the fixture packs must satisfy the real `validatePack`, so a
+ *      malformed manifest fails HERE rather than as an unexplained skip
+ *      of every read-side check on someone's stand;
+ *   2. the check table must be internally consistent (unique ids, a
+ *      declared dimension, and — the honesty rule — no check may be
+ *      gap-gated without saying what the gap is).
+ */
+import { validatePack, type DomainPackManifest } from '../src/ai/domain-packs';
+import { ALL_CHECKS, CHECKS_AFTER_FORGET, CHECKS_BEFORE_FORGET } from './eval/evidence/checks';
+import { Findings, expectOneOf, expectStatus, knobOn, type Ctx } from './eval/evidence/context';
+import { denyPackManifest, eicarProbe, probePackManifest } from './eval/evidence/fixtures';
+import { DIMENSION_LABELS, type Dimension } from './eval/evidence/types';
+
+const ctxWith = (entries: Array<[string, string]>): Ctx =>
+  ({ gates: { config: new Map(entries) } }) as unknown as Ctx;
+
+describe('evidence battery — knob reading', () => {
+  it.each([
+    ['1', true],
+    ['true', true],
+    ['ON', true],
+    ['yes', true],
+    ['0', false],
+    ['', false],
+    ['off', false],
+  ])('reads %s as %s', (value, expected) => {
+    expect(knobOn(ctxWith([['EVIDENCE_QUARANTINE', value]]), 'EVIDENCE_QUARANTINE')).toBe(expected);
+  });
+
+  it('treats an absent knob as off rather than throwing', () => {
+    expect(knobOn(ctxWith([]), 'EVIDENCE_RAW_READ_ENABLED')).toBe(false);
+  });
+});
+
+describe('evidence battery — status assertions', () => {
+  it('passes on the expected status and names it', () => {
+    expect(expectStatus({ status: 404, text: '' }, 404, 'dark route')).toEqual({
+      status: 'pass',
+      detail: 'dark route: HTTP 404',
+    });
+  });
+
+  it('fails with the observed status AND the body', () => {
+    const verdict = expectStatus({ status: 500, text: 'boom' }, 400, 'empty part');
+    expect(verdict.status).toBe('fail');
+    expect(verdict.detail).toContain('got 500');
+    expect(verdict.detail).toContain('boom');
+  });
+
+  it('accepts any member of an allowed set', () => {
+    expect(expectOneOf({ status: 413, text: '' }, [400, 413], 'cap').status).toBe('pass');
+    expect(expectOneOf({ status: 201, text: '' }, [400, 413], 'cap').status).toBe('fail');
+  });
+});
+
+describe('evidence battery — multi-assertion collector', () => {
+  it('reports every confirmation when all hold', () => {
+    const f = new Findings();
+    f.ok(true, 'hash matched', 'hash drifted');
+    f.ok(true, 'nosniff set', 'nosniff missing');
+    expect(f.verdict()).toEqual({ status: 'pass', detail: 'hash matched; nosniff set' });
+  });
+
+  it('reports ONLY the problems when something breaks', () => {
+    const f = new Findings();
+    f.ok(true, 'hash matched', 'hash drifted');
+    f.ok(false, 'nosniff set', 'nosniff missing');
+    f.ok(false, 'no-store set', 'no-store missing');
+    expect(f.verdict()).toEqual({ status: 'fail', detail: 'nosniff missing; no-store missing' });
+  });
+});
+
+describe('evidence battery — fixture packs', () => {
+  it('the probe pack is a valid manifest that opens both gated surfaces', () => {
+    const manifest = probePackManifest('evunit1') as unknown as DomainPackManifest;
+    expect(() => validatePack(manifest)).not.toThrow();
+    // The two declarations the battery exists to reach: a processor need
+    // the platform's passthrough adapter serves, and the raw-evidence
+    // capability no INSTALLABLE pack supplies (the one builtin that
+    // declares it never writes the domain_pack row consent reads).
+    expect(manifest.memoryModel?.processors).toEqual([
+      { id: 'document_text', modality: 'document', produces: ['text'] },
+    ]);
+    expect(manifest.memoryModel?.rawEvidence).toEqual({ serve: true });
+  });
+
+  it('the deny pack is valid, declares an unservable need and NO raw evidence', () => {
+    const manifest = denyPackManifest('evunit1') as unknown as DomainPackManifest;
+    expect(() => validatePack(manifest)).not.toThrow();
+    expect(manifest.memoryModel?.processors?.[0]?.produces).toEqual(['caption']);
+    // Declaring rawEvidence here would silently satisfy the read-gateway
+    // consent fold and make the access checks measure the wrong pack.
+    expect(manifest.memoryModel?.rawEvidence).toBeUndefined();
+  });
+
+  it('the pack ids are run-scoped and snake_case', () => {
+    expect(probePackManifest('evmtsfj1io').id).toBe('evev_probe_evmtsfj1io');
+    expect(denyPackManifest('evmtsfj1io').id).toBe('evev_deny_evmtsfj1io');
+  });
+
+  it('the scanner probe carries the real EICAR body, run-salted in its padding', () => {
+    // Reassembled at runtime on purpose (see fixtures.ts). The body must
+    // be byte-exact or the probe proves nothing about whether a scanner
+    // is installed; the padding must vary or a second run on the same
+    // tenant collides with the first run's byteHash and gets a dedup 409
+    // instead of a scan verdict.
+    const body = [
+      'X5O!P%@AP[4\\PZX54(P^)7CC)7}',
+      '$EICAR-STANDARD-ANTIVIRUS-TEST-FILE!',
+      '$H+H*',
+    ].join('');
+    const probe = eicarProbe('evunit1').toString('utf8');
+    expect(body).toHaveLength(68);
+    expect(probe.slice(0, 68)).toBe(body);
+    // The EICAR spec allows only whitespace after the body, to 128 chars.
+    expect(probe.length).toBeLessThanOrEqual(128);
+    expect(probe.slice(68)).toMatch(/^[ \t\r\n]*$/);
+    expect(eicarProbe('evunit2').toString('utf8')).not.toBe(probe);
+    expect(eicarProbe('evunit1').toString('utf8')).toBe(probe);
+  });
+});
+
+describe('evidence battery — check table', () => {
+  it('has unique ids across both groups', () => {
+    const ids = ALL_CHECKS.map((c) => c.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('splits around the erasure phase without losing a check', () => {
+    expect(ALL_CHECKS).toHaveLength(CHECKS_BEFORE_FORGET.length + CHECKS_AFTER_FORGET.length);
+    // Every post-erasure check must be one that READS the aftermath —
+    // running any of them before the forget would measure nothing.
+    expect(CHECKS_AFTER_FORGET.map((c) => c.dimension).every((d) => d === 'E7' || d === 'E8')).toBe(
+      true,
+    );
+  });
+
+  it('covers every declared dimension', () => {
+    const covered = new Set(ALL_CHECKS.map((c) => c.dimension));
+    for (const dimension of Object.keys(DIMENSION_LABELS) as Dimension[]) {
+      expect(covered.has(dimension)).toBe(true);
+    }
+  });
+
+  it('states an intent, and a reason for every gap gate', () => {
+    for (const check of ALL_CHECKS) {
+      expect(check.intent.length).toBeGreaterThan(20);
+      if ('expectedUnknown' in check && check.expectedUnknown !== undefined) {
+        expect(check.expectedUnknown.length).toBeGreaterThan(20);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## What this is

`pnpm eval:evidence` — the fifth mechanical battery, sibling of
`eval:memory-fitness`, `eval:state-transitions`, `eval:domain-packs` and
`eval:code-memory`, and the first that measures **bytes** rather than beliefs.
29 checks drive the whole evidence plane over the wire, in order:

```
blob upload → quarantine scan → processing_run → fragment → citation
            → signed-URL gateway → grants → GC → GDPR erasure
```

across migrations 0114 (blob-GC outbox), 0121 (broker / processing_run /
quarantine), 0122 (grants), 0124 (fragment content search) and 0125 (access
audit + signed URLs).

Eight dimensions, one scorecard line each, mirroring memory-fitness's D1..D8:

| id | name | what a failure would mean |
|----|------|---------------------------|
| E1 | ingest & identity | bytes are not content-addressed, dedup forks a row, or a bad blob is stored instead of refused |
| E2 | quarantine | external bytes enter without the scan seam, or a flagged blob becomes evidence |
| E3 | processing | a declared processor need does not reach a terminal run, replays non-idempotently, or fails silently |
| E4 | fragments | a citation target cannot be attached over real bytes, or a bad locator writes rows |
| E5 | citations | **the north star** — a citation does not unroll to the exact fragment and blob it names |
| E6 | access | a signed URL outlives its TTL, crosses a tenant, survives revocation, or its signing key is readable |
| E7 | gc | a referenced blob is collected, or an orphan is not |
| E8 | gdpr | erasure leaves a user's evidence behind, or takes a co-owner's / co-tenant's with it |

## Real run against a purpose-booted stand

Own SurrealDB 3.2.4 container + own brain on port 3055 (the dogfood stand on
3033 and the `loco-321` container were left untouched). Two tenants, so the
cross-tenant checks measure rather than skip.

```
evidence scorecard — run evmtsfsatw (tenant evev-a)
────────────────────────────────────────────────────────────────────────
E1  ingest & identity    pass 6  fail 0
E2  quarantine           pass 1  fail 0  skipped 2
E3  processing           pass 3  fail 0  skipped 1
E4  fragments            pass 2  fail 0  skipped 1
E5  citations            pass 3  fail 0
E6  access               pass 3  fail 1
E7  gc                   pass 1  fail 0  skipped 2
E8  gdpr                 pass 3  fail 0
────────────────────────────────────────────────────────────────────────
overall: 22/23 scored (95.7%), 6 skipped of 29
```

Three consecutive runs against the **same** tenant produced the identical
scorecard — hermeticity by construction, not by a fresh database.

### The one failure is a real product bug

`e23-signing-secret-not-readable` — **`GET /v1/admin/config` returns
`EVIDENCE_SIGNED_URL_SECRET` verbatim.** Its catalog entry in
`src/admin/config-catalog.data.ts` omits `secret: true`, unlike
`OPENAI_API_KEY` (`"••• set"`) or `REGISTRY_UPSTREAM_TOKEN`. Any `brain:admin`
key can therefore read the HMAC key that signs raw-evidence URLs and forge a
redeemable token over any asset in reach — the redeem route is unauthenticated
by design, so the signature *is* the capability. Deliberately **not fixed
here**: this PR is a measuring instrument, and patching the catalog in the same
change would have turned the finding green before anyone saw it. One-line fix,
own PR.

### The five skips are gaps, each with the reason it observed

Gates are computed from live state — `GET /v1/admin/config`, a probe of the
orphan-GC route, the fixture-pack install result — never hardcoded.

* **e08 / e09 (quarantine)** — the battery uploads the EICAR test string and
  reports what came back. The stand cleared it, so the platform still ships
  only `AllowAllScanHook` and no upload can reach the `rejected` branch. A
  `rejected` verdict flips both checks to live assertions with no edit.
* **e13 (processing)** — 0121 ships the `processing_run` lifecycle but no read
  surface. The dispatch sweep returns counters
  (`assets/dispatched/runs/denied/failed`) in which a failed run is
  indistinguishable from a succeeded one, so *"recorded as failed, not silently
  dropped"* is unobservable over HTTP at all.
* **e16 (fragments)** — `RETRIEVAL_FRAGMENT_LANE` and
  `EVIDENCE_FRAGMENT_CITATIONS` are default-off, and the only reader is a
  generator call (opt-in behind `EVEV_ALLOW_SYNTHESIZE=1`).
* **e24 (GC)** — `POST /v1/admin/maintenance/evidence/orphan-blob-gc` answers
  404: the sweep is not in `main` (it lands with #481), so an unreferenced blob
  is not collected at all today.
* **e26 (GC)** — the shared-blob drainer defect from #481's own follow-up note
  (the 0114 drainer and the user-forget cascade delete a queued `storageRef`
  **unconditionally**, so a blob backing two rows loses its bytes when one row
  dies). Recorded as an open finding, because its precondition cannot be built
  over HTTP: `byteHash` is UNIQUE per tenant and the upload path derives the ref
  from the hash, so no sequence of API calls makes two rows share one ref.
  Closing it needs a test at the service seam. Its reachable half —
  `e25-shared-asset-survives-forget`, a co-owned asset keeping row, fragments
  and bytes through one owner's erasure — is **not** gap-gated and passes.

## Two things that differ from the four siblings

* **Zero model spend.** Nothing on the evidence plane calls a model, so the
  whole battery scores against a stand booted with a placeholder
  `OPENAI_API_KEY`. The single exception is E4's serving leg, opt-in.
* **It brings its own pack.** The plane gates on pack DECLARATIONS, not only on
  flags: the broker dispatches only capabilities a pack's
  `memoryModel.processors` asked for, and the raw-read gateway serves only for a
  tenant holding current consent to a pack declaring
  `memoryModel.rawEvidence.serve`. **No installable pack supplies that today** —
  five builtins omit `rawEvidence` deliberately (omission = deny), and the sixth
  (`real_estate`) declares it but, being builtin, never writes the `domain_pack`
  row the consent fold reads. So `fixtures.ts` installs a run-scoped probe pack,
  plus a deny twin whose declared `document → caption` need no adapter serves —
  which is how E3 measures that an unservable need is denied *with a reason*
  rather than silently skipped.

## Doctrine held

* **Run-scoped identity everywhere** — every user handle, pack id and byte
  payload carries the run salt. Including the EICAR probe: a fixed 68-byte body
  collided with the previous run's content address and answered the dedup 409
  instead of a scan verdict (observed on run 2 of the first stand), so the
  padding is now derived from the run id — the spec permits whitespace to 128
  characters, so it stays a conforming EICAR file that any real scanner flags.
* **Gap-gating from live state**, never a hardcoded assumption.
* Scorecard on stdout in the sibling table style; JSON report at
  `var/evidence/evidence-<runId>.json` carrying per-dimension tallies, the
  phase-0 setup trail (live knob values, pack install outcome, orphan-GC probe
  status, every minted asset id, dispatch counters, the erasure result) and
  every verdict with its detail. **Exit 0 even with failures.**

## Shape

`test/eval/evidence/` — `types.ts`, `wire.ts` (non-throwing HTTP, because every
check asserts a status), `fixtures.ts` (pack manifests + payloads),
`context.ts`, `checks-plane.ts` (E1–E4), `checks-access.ts` (E5–E8),
`checks.ts` (the ordered table, split around the one irreversible act),
`setup.ts`, `runner.ts`, `README.md`. Largest file 393 lines.

Zero production behaviour change — script, fixtures and one bullet in
`docs/eval-methodology.md`. `test/evidence-eval-gates.unit-spec.ts` (21 cases)
pins the pure parts, that both fixture manifests satisfy the real
`validatePack`, and that no check can be gap-gated without saying what the gap
is.

## Gates

| gate | exit |
|------|------|
| `npx tsc --noEmit -p tsconfig.json` | 0 |
| `npx tsc --noEmit -p tsconfig.spec.json` (the config that covers `test/`) | 0 |
| `npx jest --config ./test/jest-unit.json` | 0 — 387 suites, 4653 tests |
| `npx eslint "{src,test}/**/*.ts" --max-warnings 0` | 0 |
| `npx prettier --check "src/**/*.ts" "test/**/*.ts"` | 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB
