### PR TITLE
fix(admin): mask EVIDENCE_SIGNED_URL_SECRET in the config inspector

### DIFF
--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -1596,8 +1596,13 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
     defaultValue: '',
     runtimeMutable: true,
     isBooleanFlag: false,
+    // Masked, like OPENAI_API_KEY. This entry shipped without the flag, so
+    // GET /v1/admin/config returned the HMAC key verbatim to any brain:admin
+    // caller — and since redeem is unauthenticated by design, holding this
+    // signing key IS the capability to read any tenant's raw evidence.
+    secret: true,
     description:
-      'HMAC-SHA256 secret for minted raw-evidence URL tokens. NO default on purpose — a default would make every deployment mutually forgeable. Boot hard-errors when set shorter than 32 chars while EVIDENCE_RAW_READ_ENABLED is on, and warns when the flag is on without it (streaming works; mint answers 503, redeem 404 until the secret lands).',
+      'HMAC-SHA256 secret for minted raw-evidence URL tokens. NO default on purpose — a default would make every deployment mutually forgeable. Boot hard-errors when set shorter than 32 chars while EVIDENCE_RAW_READ_ENABLED is on, and warns when the flag is on without it (streaming works; mint answers 503, redeem 404 until the secret lands). Marked secret: the inspector masks it, because the signature it mints is itself the read capability.',
   },
   {
     key: 'EVIDENCE_SIGNED_URL_TTL_SECONDS',

--- a/test/config-catalog-truth.unit-spec.ts
+++ b/test/config-catalog-truth.unit-spec.ts
@@ -144,3 +144,34 @@ describe('source hygiene', () => {
     expect(offenders).toEqual([]);
   });
 });
+
+describe('credential masking', () => {
+  /**
+   * GET /v1/admin/config returned EVIDENCE_SIGNED_URL_SECRET verbatim: the
+   * entry simply omitted `secret: true`, so config-inspector handed the raw
+   * HMAC key to every brain:admin caller. That one is fixed; this gate is
+   * here so the NEXT credential cannot ship the same way, because the flag
+   * is opt-in and forgetting it fails open.
+   *
+   * The rule is deliberately name-shaped rather than a hand-kept allowlist:
+   * an allowlist has the same failure mode as the flag it guards.
+   */
+  const CREDENTIAL_NAME = /(SECRET|_API_KEY|_TOKEN|PASSWORD|PRIVATE_KEY)$/;
+
+  it('every credential-shaped catalogue key is masked', () => {
+    const unmasked = CONFIG_CATALOG.filter(
+      (e) => CREDENTIAL_NAME.test(e.key) && e.secret !== true,
+    ).map((e) => e.key);
+    expect(unmasked).toEqual([]);
+  });
+
+  it('nothing is masked that is not a credential (the regex still means something)', () => {
+    // Guards the other direction: if `secret: true` ever spreads to ordinary
+    // knobs, operators lose the ability to read their own configuration and
+    // the masking stops carrying information.
+    const surprising = CONFIG_CATALOG.filter(
+      (e) => e.secret === true && !CREDENTIAL_NAME.test(e.key),
+    ).map((e) => e.key);
+    expect(surprising).toEqual([]);
+  });
+});


### PR DESCRIPTION
`GET /v1/admin/config` returned the raw-evidence HMAC signing key **verbatim**. The catalogue entry omitted `secret: true`, so `config-inspector` echoed the live value instead of `"••• set"` the way `OPENAI_API_KEY` does.

## Why this is worse than an ordinary config leak

The redeem route is unauthenticated by design — a minted signature **is** the read capability. So any `brain:admin` key could read the signing secret and forge redeemable tokens for any tenant's raw evidence, never touching the asset's ownership fence that the rest of the evidence surface is built around.

## How it was found

The new `eval:evidence` battery (#499), check **e23** — "the signing secret is not readable back through the admin surface". It was left failing there on purpose so the fix could land as its own change.

## The one-line flag is not the whole fix

`secret` is opt-in, so forgetting it fails open, and the next credential would ship exactly the same way. Two gates in `config-catalog-truth` now hold the line from both sides:

- every credential-shaped key (`*SECRET`, `*_API_KEY`, `*_TOKEN`, `*PASSWORD`, `*PRIVATE_KEY`) must be masked;
- nothing that is *not* credential-shaped may be masked, so the marker keeps carrying information and operators do not lose the ability to read their own configuration.

The rule is name-shaped rather than a hand-kept allowlist on purpose: an allowlist has the same failure mode as the flag it is meant to guard. Both gates pass against the catalogue as it stands, so no other key is currently leaking.

## Operational note

Any deployment that has already served this value to an admin client should rotate `EVIDENCE_SIGNED_URL_SECRET`. Rotation invalidates outstanding minted URLs, which is the intended blast radius.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB