### PR TITLE
fix(db): renew scoped-pool sessions before the driver invalidates them

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,14 @@ SURREALDB_POOL_SIZE=8
 SURREALDB_SCOPED_POOL_SIZE=8
 # SURREALDB_SCOPED_USER=brain_caller
 # SURREALDB_SCOPED_PASS=brain-caller-password-must-be-overridden-via-env
+# Access-token lifetime brain declares for the scoped user (a SurrealDB
+# duration literal: 30m, 2h, 7d …). Leave unset to keep SurrealDB's own
+# default of 1h. Brain OVERWRITEs the user's definition on every boot, so
+# a DURATION set by hand on the server is discarded on the next deploy —
+# this is the knob that survives. It does NOT need tuning to stay up: the
+# scoped pool re-signs a connection before its token lapses either way
+# (src/db/session-keeper.ts). Raising it only trades signin frequency.
+# SURREALDB_SCOPED_TOKEN_DURATION=1h
 
 # ── Forget tombstones (GDPR erase) ───────────────────────────────────────
 # HMAC key that signs forget tombstones. REQUIRED when NODE_ENV=production

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -620,6 +620,44 @@ UI:
   is not fenced — the paywall guards the REGISTRY resolve path only; an
   operator who already has the manifest file can always install it.
 
+## Long-lived DB sessions (why reads used to die after an hour)
+
+`surrealdb-js` renews only the sessions it opened itself. When application
+code calls `db.signin()`, the driver records `authOverriden` and its renewal
+timer has nothing left to renew with — at `exp − 60s` it calls `invalidate()`
+and the connection is **anonymous for the rest of the process**. Its own type
+declarations say so: *"When this method is called, the `authentication`
+property passed to `connect()` will be ignored. You will be responsible for
+handling session invalidation."*
+
+`DEFINE USER` issues a 1-hour access token by default, so any connection that
+signs in once and lives forever goes anonymous about 59 minutes after boot.
+Nothing expires server-side; `DURATION FOR SESSION NONE` does **not** help,
+because the driver reads the JWT `exp` and never asks the server.
+
+Every long-lived connection in brain therefore re-signs before that timer
+fires:
+
+| Connection | Renewal |
+|---|---|
+| Root pool (`withCompany`, `withAdminDb`) | `signin` on every acquire (also its zombie-websocket liveness probe). |
+| Migrator connection | Same, via `ensureRootSession`. |
+| Scoped pool (`withScopedCompany` — every caller-facing read) | Re-signs when the access token enters a 5-minute margin. A signin runs the server-side password KDF (~16ms vs ~0.3ms for a `SELECT`), so paying it per read is not free; the margin comfortably clears the driver's 60s invalidate lead time. Fails **closed** if it cannot — a request errors rather than being served root-authorized. |
+| LIVE subscription channels | Renewed on the catch-up tick, same margin. |
+
+Symptoms to recognise if this ever regresses: reads answer
+`Anonymous access not allowed: Not enough permissions to perform this action`
+while writes, `/health` and MCP keep working. `/ready` now catches it —
+`pingScoped()` runs an authorization-gated statement on a scoped connection,
+because `version()` (what `ping()` uses) is answered for anonymous sessions
+too and reported "ok" throughout the original outage.
+
+`SURREALDB_SCOPED_TOKEN_DURATION` declares the scoped user's token lifetime
+(a SurrealDB duration literal; unset = the server's 1h default). It is a
+tuning knob, not the fix — brain OVERWRITEs the user definition on every
+boot, so it exists mainly so a duration set by hand on the server is not
+silently discarded on the next deploy.
+
 ## Boot-time validation
 
 The service runs `validateEnv()` before NestJS starts. Missing or

--- a/scripts/backfill-lang-attribution.ts
+++ b/scripts/backfill-lang-attribution.ts
@@ -42,6 +42,7 @@
 import { Surreal, StringRecordId } from 'surrealdb';
 import { detectLanguage, DETECTOR_VERSION } from '../src/ai/locale/language-detector';
 import { envFlagEnabled } from '../src/common/env-validation';
+import { SurrealSessionKeeper } from '../src/db/session-keeper';
 
 interface Args {
   url: string;
@@ -118,9 +119,22 @@ async function main(): Promise<void> {
   }
 
   const db = new Surreal();
+  const creds = { username: a.user, password: a.pass };
+  // A `signin()`-established session is NOT renewed by surrealdb-js — it is
+  // INVALIDATED when the access token lapses (1h by default), after which
+  // every statement fails with "Anonymous access not allowed". This loop is
+  // unbounded in the size of the tenant's corpus, so a large backfill will
+  // cross that line mid-run; `keepSession` re-signs before it happens.
+  // See src/db/session-keeper.ts.
+  const sessions = new SurrealSessionKeeper();
+  const keepSession = async () => {
+    if (!sessions.needsSignin(db)) return;
+    const tokens = await db.signin(creds);
+    sessions.record(db, tokens?.access);
+    await db.use({ namespace: a.ns, database: `co_${a.tenant}` });
+  };
   await db.connect(a.url);
-  await db.signin({ username: a.user, password: a.pass });
-  await db.use({ namespace: a.ns, database: `co_${a.tenant}` });
+  await keepSession();
 
   console.info(
     `backfill-lang-attribution: tenant=${a.tenant} detector=${DETECTOR_VERSION} ` +
@@ -131,6 +145,7 @@ async function main(): Promise<void> {
   let scanned = 0;
   let stamped = 0;
   for (;;) {
+    await keepSession();
     // Keyset pagination over the record id — stable under concurrent writes
     // and index-friendly (no OFFSET blow-up on large corpora).
     const [rows] = await db.query<[FactRow[]]>(

--- a/src/common/health.controller.ts
+++ b/src/common/health.controller.ts
@@ -47,19 +47,23 @@ export class HealthController {
   @Get('ready')
   @HttpCode(HttpStatus.OK)
   async ready() {
-    const { dbOk, embedderReady, ready } = await this.healthService.readiness();
+    const { dbOk, scopedOk, embedderReady, ready } = await this.healthService.readiness();
     if (!ready) {
       throw new ServiceUnavailableException({
         ready: false,
         checks: {
           surrealdb: dbOk ? 'ok' : 'unreachable',
+          // Distinct from `surrealdb`: the socket can be perfectly healthy
+          // while the scoped session has gone anonymous, which is exactly
+          // the failure /ready used to miss.
+          scopedPool: scopedOk ? 'ok' : 'unauthorized',
           embedder: embedderReady ? 'ok' : 'warming',
         },
       });
     }
     return {
       ready: true,
-      checks: { surrealdb: 'ok', embedder: 'ok' },
+      checks: { surrealdb: 'ok', scopedPool: 'ok', embedder: 'ok' },
     };
   }
 }

--- a/src/common/health.service.ts
+++ b/src/common/health.service.ts
@@ -8,6 +8,8 @@ export interface LivenessReport {
 
 export interface ReadinessReport {
   dbOk: boolean;
+  /** The caller-facing read path (scoped pool) can still authorize a query. */
+  scopedOk: boolean;
   embedderReady: boolean;
   ready: boolean;
 }
@@ -33,11 +35,20 @@ export class HealthService {
 
   /**
    * Readiness — request-path dependencies warm enough for production
-   * traffic: DB reachable AND the embedder finished its (ONNX) warmup.
+   * traffic: DB reachable, the CALLER-FACING read path still authorized,
+   * and the embedder finished its (ONNX) warmup.
+   *
+   * `ping()` alone is not enough: it calls `version()`, which SurrealDB
+   * answers for an anonymous session too. During the 2026-09-08
+   * scoped-session-expiry outage that made /ready green while every read
+   * failed with "Anonymous access not allowed". `pingScoped()` runs an
+   * authorization-gated statement on a scoped connection, so a read path
+   * that can no longer authorize takes the pod out of rotation.
    */
   async readiness(): Promise<ReadinessReport> {
     const dbOk = await this.surreal.ping().catch(() => false);
+    const scopedOk = dbOk ? await this.surreal.pingScoped().catch(() => false) : false;
     const embedderReady = this.embedder.isReady();
-    return { dbOk, embedderReady, ready: dbOk && embedderReady };
+    return { dbOk, scopedOk, embedderReady, ready: dbOk && scopedOk && embedderReady };
   }
 }

--- a/src/db/session-keeper.ts
+++ b/src/db/session-keeper.ts
@@ -1,0 +1,113 @@
+import type { Surreal } from 'surrealdb';
+
+/**
+ * Token-expiry bookkeeping for LONG-LIVED SurrealDB connections.
+ *
+ * ── The failure this exists to prevent ───────────────────────────────────
+ * surrealdb-js 2.0.8 owns session renewal, and it only owns it for sessions
+ * it opened itself. `ConnectionController` records `authOverriden = true` the
+ * moment `db.signin()` is called from application code (dist/surrealdb.mjs
+ * `signin(auth, session, skipOverride = false)`), and its own type
+ * declarations say so out loud:
+ *
+ *   "When this method is called, the `authentication` property passed to
+ *    `connect()` will be ignored. You will be responsible for handling
+ *    session invalidation by listening to the `auth` event."
+ *
+ * What "handling" means concretely: on signin the driver schedules a timer at
+ * `exp - expiryMargin` (margin defaults to 60s). When it fires,
+ * `#applyAuthentication` cannot reuse the near-dead access token, has no
+ * refresh token for a system user, and — because `authOverriden` is set —
+ * refuses to consult the connect-time auth provider. It falls through to
+ * `#abortAuthentication`, which calls `invalidate()`. The socket stays open,
+ * `version()` still answers, and every authorization-gated statement from
+ * that point on fails with:
+ *
+ *   "Anonymous access not allowed: Not enough permissions to perform this
+ *    action"
+ *
+ * …for the rest of the process. Nothing expired server-side: `DEFINE USER`
+ * defaults to `DURATION FOR TOKEN 1h`, and setting `DURATION FOR SESSION
+ * NONE` does NOT help, because the driver reads the JWT `exp` and never asks
+ * the server. Verified empirically against surrealdb/surrealdb:v3.2.4 — see
+ * test/scoped-session-expiry.e2e-spec.ts.
+ *
+ * ── The discipline ───────────────────────────────────────────────────────
+ * Any connection that outlives its access token must re-`signin()` BEFORE the
+ * driver's invalidation timer fires. The root pool already did this the
+ * expensive way (unconditionally, on every acquire — see
+ * `SurrealService.ensureRootSession`), which is why writes never showed the
+ * bug. Doing the same unconditionally on the READ path is not free: a Surreal
+ * `signin` runs the server-side password KDF and measures ~16ms against a
+ * local v3.2.4, versus ~0.3ms for a `SELECT` — a ~48x tax on every read.
+ *
+ * So this class tracks the access token's own expiry and re-signs only when
+ * the remaining life drops inside a margin. The margin MUST exceed the
+ * driver's own `expiryMargin` (60s) or we lose the race with its invalidate
+ * timer; 5 minutes leaves a 4-minute buffer on a default 1h token while
+ * costing one signin per connection per ~55 minutes.
+ */
+export const SESSION_REAUTH_MARGIN_MS = 5 * 60_000;
+
+/** The driver's own invalidate-on-expiry lead time (ConnectionController
+ *  `#expiryMargin`, seconds). Our margin has to be strictly larger. */
+export const DRIVER_EXPIRY_MARGIN_MS = 60_000;
+
+/**
+ * Epoch-ms at which a SurrealDB access token expires, or `undefined` when the
+ * token is missing or its `exp` claim is unreadable. Callers MUST treat
+ * `undefined` as "re-signin now" — guessing an expiry is how you end up
+ * anonymous.
+ */
+export function accessTokenExpiryMs(token: string | undefined): number | undefined {
+  if (!token) return undefined;
+  const parts = token.split('.');
+  if (parts.length !== 3) return undefined;
+  try {
+    const payload = JSON.parse(Buffer.from(parts[1]!, 'base64url').toString('utf8')) as {
+      exp?: unknown;
+    };
+    return typeof payload.exp === 'number' && Number.isFinite(payload.exp)
+      ? payload.exp * 1000
+      : undefined;
+  } catch {
+    // A non-JWT / malformed token is not an error here — it just means we
+    // cannot schedule, so every use re-signs. Correct, merely slower.
+    return undefined;
+  }
+}
+
+/**
+ * Remembers, per connection, when the session it holds stops being usable.
+ * Keyed weakly so a rebuilt/closed connection is collected with its entry.
+ */
+export class SurrealSessionKeeper {
+  private readonly expiry = new WeakMap<Surreal, number>();
+
+  constructor(private readonly marginMs: number = SESSION_REAUTH_MARGIN_MS) {
+    if (marginMs <= DRIVER_EXPIRY_MARGIN_MS) {
+      throw new Error(
+        `session re-auth margin must exceed the driver's ${DRIVER_EXPIRY_MARGIN_MS}ms ` +
+          `invalidate lead time, got ${marginMs}ms`,
+      );
+    }
+  }
+
+  /** True when this connection must be re-signed before it is handed out. */
+  needsSignin(conn: Surreal, now: number = Date.now()): boolean {
+    const exp = this.expiry.get(conn);
+    return exp === undefined || exp - now <= this.marginMs;
+  }
+
+  /** Record the token a fresh `signin()` handed back. */
+  record(conn: Surreal, accessToken: string | undefined): void {
+    const exp = accessTokenExpiryMs(accessToken);
+    if (exp === undefined) this.expiry.delete(conn);
+    else this.expiry.set(conn, exp);
+  }
+
+  /** Drop a connection's record — call when the connection is torn down. */
+  forget(conn: Surreal): void {
+    this.expiry.delete(conn);
+  }
+}

--- a/src/db/surreal.service.ts
+++ b/src/db/surreal.service.ts
@@ -4,6 +4,7 @@ import { Surreal } from 'surrealdb';
 import { join } from 'node:path';
 import { SchemaMigrator } from './migrator.service';
 import { enrichTransactionError } from './surreal-retry';
+import { SurrealSessionKeeper } from './session-keeper';
 import { envFlagEnabled } from '../common/env-validation';
 import { getPolicyContext } from '../common/request-context';
 import { compileDenyPushdown } from '../policy/db-fence';
@@ -16,6 +17,12 @@ export {
   enrichTransactionError,
   retryOnUniqueViolation,
 } from './surreal-retry';
+
+/**
+ * How long the readiness probe waits for a scoped connection before it gives
+ * the pool the benefit of the doubt. Short on purpose — see `pingScoped`.
+ */
+const SCOPED_PROBE_ACQUIRE_MS = 2000;
 
 /**
  * SurrealService — pooled connections with per-tenant database routing.
@@ -57,6 +64,18 @@ export class SurrealService implements OnModuleInit, OnApplicationShutdown {
    * never hands out a root-authorized conn silently.
    */
   private readonly rootFallbackConns = new Set<Surreal>();
+  /**
+   * Access-token expiry bookkeeping for the SCOPED pool. Audit 2026-09-08:
+   * scoped connections signed in exactly ONCE, at boot, and surrealdb-js
+   * 2.0.8 answers a `signin()`-established session's expiry by calling
+   * `invalidate()` — so ~59 minutes after boot every caller-facing read
+   * failed with "Anonymous access not allowed" while writes (root pool,
+   * re-signed per acquire) and /health kept answering. The keeper re-signs a
+   * scoped connection before the driver can invalidate it. See
+   * db/session-keeper.ts for the full mechanism.
+   */
+  private readonly scopedSessions = new SurrealSessionKeeper();
+  private scopedCreds?: { username: string; password: string; namespace: string };
   private readonly rootWaiters: Array<(c: Surreal) => void> = [];
   private readonly scopedWaiters: Array<(c: Surreal) => void> = [];
   private namespace!: string;
@@ -148,6 +167,65 @@ export class SurrealService implements OnModuleInit, OnApplicationShutdown {
     }
   }
 
+  /**
+   * Sign a connection in as the scoped (`brain_caller`) user and record the
+   * access token's expiry so the pool knows when it must re-sign.
+   */
+  private async signinScoped(conn: Surreal): Promise<void> {
+    if (!this.scopedCreds) throw new Error('scoped credentials not configured');
+    const tokens = await withTimeout(conn.signin(this.scopedCreds), 3000, 'scoped signin');
+    this.scopedSessions.record(conn, tokens?.access);
+    this.rootFallbackConns.delete(conn);
+  }
+
+  /**
+   * The scoped-pool counterpart of `ensureRootSession`: guarantee the
+   * connection about to serve a caller-facing read is still authorized as
+   * `brain_caller`.
+   *
+   * Unlike the root path this does NOT sign in unconditionally. A Surreal
+   * `signin` runs the server-side password KDF (~16ms locally, vs ~0.3ms for
+   * a SELECT), and reads are the hot path — paying it per request would be a
+   * ~48x tax on the cheapest queries. Instead we re-sign only when the access
+   * token is inside the re-auth margin, which is the condition that actually
+   * matters: past it, surrealdb-js invalidates the session and the connection
+   * goes anonymous (see db/session-keeper.ts).
+   *
+   * A signin failure means the socket is gone (zombie ws, gh#618) or the
+   * credentials no longer work. Rebuild once; if the rebuilt connection also
+   * cannot sign in scoped, throw — `acquireScoped` turns that into a
+   * fail-closed error rather than serving the request root-authorized.
+   *
+   * Returns the connection to use: the original, or a freshly built
+   * replacement. Callers MUST use the returned reference.
+   */
+  private async ensureScopedSession(conn: Surreal): Promise<Surreal> {
+    if (!this.rootFallbackConns.has(conn) && !this.scopedSessions.needsSignin(conn)) return conn;
+    try {
+      await this.signinScoped(conn);
+      return conn;
+    } catch (e) {
+      this.logger.warn(
+        `Scoped signin failed (${(e as Error).message?.slice(0, 120)}) — rebuilding conn`,
+      );
+      this.scopedSessions.forget(conn);
+      this.rootFallbackConns.delete(conn);
+      await withTimeout(conn.close(), 1000, 'close').catch(() => undefined);
+      const fresh = new Surreal();
+      await withTimeout(fresh.connect(this.surrealUrl), 5000, 'connect');
+      try {
+        await this.signinScoped(fresh);
+      } catch (rebuildErr) {
+        await fresh.close().catch(() => undefined);
+        throw rebuildErr;
+      }
+      const oldIdx = this.all.indexOf(conn);
+      if (oldIdx >= 0) this.all[oldIdx] = fresh;
+      else this.all.push(fresh);
+      return fresh;
+    }
+  }
+
   async onModuleInit() {
     const url = this.configService.getOrThrow<string>('SURREALDB_URL');
     const username = this.configService.getOrThrow<string>('SURREALDB_USERNAME');
@@ -209,15 +287,16 @@ export class SurrealService implements OnModuleInit, OnApplicationShutdown {
       // so any scoped pool signin failures with "user not found" are
       // contained to that tenant's first request and resolve on retry.
       this.scopedEnabled = true;
+      this.scopedCreds = {
+        username: scopedUser,
+        password: scopedPass,
+        namespace: this.namespace,
+      };
       for (let i = 0; i < this.scopedPoolSize; i++) {
         const conn = new Surreal();
         await conn.connect(url);
         try {
-          await conn.signin({
-            username: scopedUser,
-            password: scopedPass,
-            namespace: this.namespace,
-          });
+          await this.signinScoped(conn);
         } catch (e) {
           // brain_caller user not yet defined (first boot, no migrations
           // applied yet). Fall back to root signin so the conn is at
@@ -264,6 +343,69 @@ export class SurrealService implements OnModuleInit, OnApplicationShutdown {
       return true;
     } catch {
       return false;
+    }
+  }
+
+  /**
+   * Readiness probe for the CALLER-FACING read path.
+   *
+   * `ping()` cannot see this class of failure: `version()` is answered for an
+   * anonymous connection too (verified against surrealdb 3.2.4), so during
+   * the 2026-09-08 scoped-session-expiry outage /health and /ready both
+   * reported "ok" while every search, entity read and fact read 500'd. A
+   * readiness check that cannot observe the request path is not a readiness
+   * check — so this takes a real scoped connection and runs an
+   * authorization-gated statement on it.
+   *
+   * `RETURN 1` is the cheapest such statement: SurrealDB refuses it for an
+   * anonymous session with the same "Anonymous access not allowed" it refuses
+   * a SELECT with. Going through `acquireScoped` is deliberate — the probe
+   * exercises the same renew-or-fail-closed path a request takes, so a pool
+   * that can no longer authenticate at all (rotated secret, dropped user,
+   * unreachable DB) takes the pod out of rotation instead of serving errors.
+   *
+   * A BUSY pool is deliberately NOT a readiness failure. Saturation is a
+   * different signal — already visible as acquire-timeout 5xx and in
+   * /admin/now — and answering "not ready" for it would pull pods out of
+   * rotation exactly when the remaining pods are the most loaded. So the
+   * probe waits only briefly for a connection and reports ready if it does
+   * not get one; the question it answers is "can the read path authorize",
+   * not "is the read path idle".
+   *
+   * Returns true when the scoped pool is disabled: reads run on the root
+   * pool then, and `ping()` already covers it.
+   */
+  async pingScoped(): Promise<boolean> {
+    if (!this.scopedEnabled) return true;
+    const acquiring = this.acquireScoped();
+    let conn: Surreal | undefined;
+    let timer: NodeJS.Timeout | undefined;
+    try {
+      conn = await Promise.race([
+        acquiring,
+        new Promise<undefined>((resolve) => {
+          timer = setTimeout(() => resolve(undefined), SCOPED_PROBE_ACQUIRE_MS);
+        }),
+      ]);
+    } catch {
+      // The acquire itself failed closed — the pool cannot authorize.
+      return false;
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+    if (!conn) {
+      // Still queued. Hand the connection straight back whenever it lands,
+      // so an abandoned probe never leaks a pool slot.
+      void acquiring.then((c) => this.releaseScoped(c)).catch(() => undefined);
+      return true;
+    }
+    try {
+      await withTimeout(conn.query('RETURN 1'), 3000, 'scoped ping');
+      return true;
+    } catch {
+      return false;
+    } finally {
+      this.releaseScoped(conn);
     }
   }
 
@@ -455,35 +597,28 @@ export class SurrealService implements OnModuleInit, OnApplicationShutdown {
 
   private async acquireScoped(): Promise<Surreal> {
     const conn = await this.acquireWithTimeout(this.scopedIdle, this.scopedWaiters, 'scoped');
+    if (!this.scopedCreds) return conn;
     // Audit 2026-08-19 P1 / 2026-08-21 P1: a root-fallback conn
     // re-attempts the scoped signin on EVERY acquire — and FAILS CLOSED
     // when it can't. A deployment that configured the scoped pool asked
     // for a DB-level fence; silently serving the request root-authorized
     // widens privilege exactly when the caller believes it narrowed.
-    // The conn goes back to the pool (still flagged) for the next
-    // acquire's retry; this request errors instead of degrading.
-    if (this.rootFallbackConns.has(conn)) {
-      const scopedUser = this.configService.get<string>('SURREALDB_SCOPED_USER');
-      const scopedPass = this.configService.get<string>('SURREALDB_SCOPED_PASS');
-      if (scopedUser && scopedPass) {
-        try {
-          await conn.signin({
-            username: scopedUser,
-            password: scopedPass,
-            namespace: this.namespace,
-          });
-          this.rootFallbackConns.delete(conn);
-          this.logger.log('Root-fallback scoped conn re-signed as scoped');
-        } catch (e) {
-          this.releaseScoped(conn);
-          throw new Error(
-            `scoped DB signin unavailable — failing closed rather than ` +
-              `serving the request root-authorized: ${(e as Error).message}`,
-          );
-        }
-      }
+    // Audit 2026-09-08 P0: the SAME acquire now also renews a session whose
+    // access token is about to lapse. Without it, surrealdb-js invalidated
+    // the session ~59 minutes after boot and every caller-facing read
+    // answered "Anonymous access not allowed" until the process restarted,
+    // with writes and /health none the wiser.
+    // Either way the conn goes back to the pool for the next acquire's
+    // retry; this request errors instead of degrading.
+    try {
+      return await this.ensureScopedSession(conn);
+    } catch (e) {
+      this.releaseScoped(conn);
+      throw new Error(
+        `scoped DB signin unavailable — failing closed rather than ` +
+          `serving the request root-authorized: ${(e as Error).message}`,
+      );
     }
-    return conn;
   }
 
   private releaseScoped(conn: Surreal): void {
@@ -635,7 +770,8 @@ export class SurrealService implements OnModuleInit, OnApplicationShutdown {
     const escapedPass = scopedPass.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
     try {
       await this.migratorConn.query(
-        `DEFINE USER OVERWRITE ${scopedUser} ON NAMESPACE PASSWORD '${escapedPass}' ROLES EDITOR`,
+        `DEFINE USER OVERWRITE ${scopedUser} ON NAMESPACE PASSWORD '${escapedPass}' ` +
+          `ROLES EDITOR${this.scopedTokenDurationClause()}`,
       );
       this.logger.log(`Reset password for scoped user '${scopedUser}'`);
     } catch (err) {
@@ -649,6 +785,35 @@ export class SurrealService implements OnModuleInit, OnApplicationShutdown {
   }
 
   /**
+   * Optional `DURATION FOR TOKEN …` clause for the scoped user, from
+   * SURREALDB_SCOPED_TOKEN_DURATION. Empty by default, which leaves
+   * SurrealDB's own default (1h) in place.
+   *
+   * This exists because brain OVERWRITEs `brain_caller` on every boot, so
+   * a duration an operator sets by hand is silently discarded on the next
+   * deploy — the knob makes the token lifetime brain's declared property
+   * rather than an invisible server default. It is NOT the fix for session
+   * expiry (a longer token only moves the cliff; the pool re-signs before
+   * either lapses — see ensureScopedSession), but it makes the lifetime
+   * explicit and lets the expiry path be tested in seconds instead of an
+   * hour.
+   *
+   * Durations cannot be bound as parameters, so the value is spliced —
+   * hence the strict shape check. Anything else is refused, loudly.
+   */
+  private scopedTokenDurationClause(): string {
+    const raw = this.configService.get<string>('SURREALDB_SCOPED_TOKEN_DURATION')?.trim();
+    if (!raw) return '';
+    if (!/^\d+(ns|us|ms|s|m|h|d|w|y)$/.test(raw)) {
+      this.logger.error(
+        `Ignoring SURREALDB_SCOPED_TOKEN_DURATION='${raw}' — not a SurrealDB duration literal`,
+      );
+      return '';
+    }
+    return ` DURATION FOR TOKEN ${raw}`;
+  }
+
+  /**
    * Re-sign all idle scoped pool connections as `brain_caller` after
    * migration 0005 lands. Connections currently in flight will be
    * re-signed on their next acquire (we mark them via shadow Set).
@@ -656,24 +821,15 @@ export class SurrealService implements OnModuleInit, OnApplicationShutdown {
    * just no PERMISSIONS enforcement).
    */
   private async resignScopedConns(): Promise<void> {
-    const url = this.configService.getOrThrow<string>('SURREALDB_URL');
-    const scopedUser = this.configService.get<string>('SURREALDB_SCOPED_USER');
-    const scopedPass = this.configService.get<string>('SURREALDB_SCOPED_PASS');
-    if (!scopedUser || !scopedPass) return;
+    if (!this.scopedCreds) return;
     for (const conn of this.scopedIdle) {
       try {
-        await conn.signin({
-          username: scopedUser,
-          password: scopedPass,
-          namespace: this.namespace,
-        });
-        this.rootFallbackConns.delete(conn);
+        await this.signinScoped(conn);
       } catch (e) {
         this.rootFallbackConns.add(conn);
         this.logger.warn(`Re-signin to scoped failed for an idle conn: ${(e as Error).message}`);
       }
     }
-    void url; // silence unused
   }
 }
 

--- a/src/live/live-subscription.manager.ts
+++ b/src/live/live-subscription.manager.ts
@@ -4,6 +4,7 @@ import { Surreal, Table } from 'surrealdb';
 import type { LiveSubscription } from 'surrealdb';
 import { envFlagEnabled } from '../common/env-validation';
 import { queryRows } from '../db/surreal.service';
+import { SurrealSessionKeeper } from '../db/session-keeper';
 import { changefeedRow } from '../db/changefeed-row';
 import { makeRowPolicyFilter, type PredicatePolicyLookup } from '../policy/row-filter';
 
@@ -117,6 +118,16 @@ export class LiveSubscriptionManager implements OnApplicationShutdown {
   private readonly maxSubscribersPerTenant: number;
   private readonly maxQueuePerSubscriber: number;
   private readonly catchUpMs: number;
+  /**
+   * Subscription connections live OUTSIDE both pools and used to sign in
+   * exactly once, at channel open — the same shape that took the scoped pool
+   * anonymous ~59 minutes after boot (audit 2026-09-08, see
+   * db/session-keeper.ts). A standing subscription is the longest-lived
+   * connection in the process, so it is the most exposed: past the driver's
+   * invalidate timer the LIVE session dies and every catch-up tick fails with
+   * "Anonymous access not allowed". The keeper re-signs before that happens.
+   */
+  private readonly sessions = new SurrealSessionKeeper();
   private seq = 0;
 
   constructor(private readonly config: ConfigService) {
@@ -185,7 +196,7 @@ export class LiveSubscriptionManager implements OnApplicationShutdown {
 
     const conn = new Surreal();
     await conn.connect(this.url);
-    await conn.signin(this.creds);
+    await this.signin(conn);
     await conn.use({ namespace: this.namespace, database: dbNameFor(companyId) });
 
     // Anchor the changefeed cursor BEFORE the LIVE query starts. Anything
@@ -230,6 +241,12 @@ export class LiveSubscriptionManager implements OnApplicationShutdown {
   async catchUp(companyId: string): Promise<number> {
     const channel = this.channels.get(companyId);
     if (!channel) return 0;
+    // The catch-up tick is the only thing that touches this connection on a
+    // schedule, so it is where the session gets renewed. A re-signin does not
+    // disturb the selected namespace/database (verified against v3.2.4) and
+    // does not tear down the standing LIVE query — unlike the driver-side
+    // invalidate it is racing.
+    await this.signin(channel.conn);
     const changes = await queryRows<ChangefeedShowRow>(
       channel.conn,
       `SHOW CHANGES FOR TABLE ${TABLE} SINCE ${channel.versionstamp} LIMIT 1000`,
@@ -298,10 +315,22 @@ export class LiveSubscriptionManager implements OnApplicationShutdown {
     }
   }
 
+  /**
+   * Sign the subscription connection in, but only when its access token is
+   * close enough to expiry that the driver would otherwise invalidate the
+   * session. A no-op on the overwhelming majority of catch-up ticks.
+   */
+  private async signin(conn: Surreal): Promise<void> {
+    if (!this.sessions.needsSignin(conn)) return;
+    const tokens = await conn.signin(this.creds);
+    this.sessions.record(conn, tokens?.access);
+  }
+
   private async closeChannel(companyId: string): Promise<void> {
     const channel = this.channels.get(companyId);
     if (!channel) return;
     this.channels.delete(companyId);
+    this.sessions.forget(channel.conn);
     if (channel.timer) clearInterval(channel.timer);
     try {
       channel.unsubscribe();

--- a/test/health-ready.unit-spec.ts
+++ b/test/health-ready.unit-spec.ts
@@ -16,9 +16,12 @@ import { HealthService } from '../src/common/health.service';
 import { ServiceUnavailableException } from '@nestjs/common';
 
 describe('HealthController', () => {
-  function mk({ db, embedderReady }: { db: boolean; embedderReady: boolean }) {
-    const surreal = { ping: async () => db } as any;
-    const embedder = { isReady: () => embedderReady } as any;
+  function mk(opts: { db: boolean; embedderReady: boolean; scoped?: boolean }) {
+    const surreal = {
+      ping: async () => opts.db,
+      pingScoped: async () => opts.scoped ?? true,
+    } as any;
+    const embedder = { isReady: () => opts.embedderReady } as any;
     return new HealthController(new HealthService(surreal, embedder));
   }
 
@@ -49,7 +52,32 @@ describe('HealthController', () => {
       const res = await mk({ db: true, embedderReady: true }).ready();
       expect(res.ready).toBe(true);
       expect(res.checks.surrealdb).toBe('ok');
+      expect(res.checks.scopedPool).toBe('ok');
       expect(res.checks.embedder).toBe('ok');
+    });
+
+    /**
+     * Audit 2026-09-08: the scoped pool's session lapsed an hour after boot
+     * and every caller-facing read answered "Anonymous access not allowed" —
+     * while /ready stayed green, because `ping()` calls `version()`, which
+     * SurrealDB answers for an anonymous session too. A readiness probe that
+     * cannot see the request path is part of the outage, so /ready now runs
+     * an authorization-gated statement on a scoped connection.
+     */
+    it('throws 503 when the socket is fine but the scoped read path is unauthorized', async () => {
+      await expect(
+        mk({ db: true, embedderReady: true, scoped: false }).ready(),
+      ).rejects.toBeInstanceOf(ServiceUnavailableException);
+    });
+
+    it('names the scoped pool in the 503 body so the operator sees which leg failed', async () => {
+      const err = await mk({ db: true, embedderReady: true, scoped: false })
+        .ready()
+        .catch((e: ServiceUnavailableException) => e);
+      expect((err as ServiceUnavailableException).getResponse()).toMatchObject({
+        ready: false,
+        checks: { surrealdb: 'ok', scopedPool: 'unauthorized', embedder: 'ok' },
+      });
     });
 
     it('throws 503 when embedder is still warming', async () => {

--- a/test/live-subscription.unit-spec.ts
+++ b/test/live-subscription.unit-spec.ts
@@ -37,9 +37,17 @@ describe('LiveSubscriptionManager', () => {
     opts: { changes?: any[]; versionstamp?: number } = {},
   ) {
     const received: Array<{ sub: string; event: LiveEvent }> = [];
+    const signins: number[] = [];
     const channel = {
       conn: {
         query: async () => [opts.changes ?? []],
+        // A subscription connection outlives its access token, so the
+        // catch-up tick renews it. Hand back a token that is nowhere near
+        // expiring, so a second tick must NOT re-sign.
+        signin: async () => {
+          signins.push(Date.now());
+          return { access: farFutureJwt() };
+        },
       },
       sub: { kill: async () => {} },
       unsubscribe: () => {},
@@ -58,7 +66,13 @@ describe('LiveSubscriptionManager', () => {
         queued: 0,
       });
     };
-    return { channel, received, addSubscriber };
+    return { channel, received, addSubscriber, signins };
+  }
+
+  /** A syntactically real access token that expires in a year. */
+  function farFutureJwt(): string {
+    const b64 = (o: unknown) => Buffer.from(JSON.stringify(o)).toString('base64url');
+    return `${b64({ alg: 'HS512' })}.${b64({ exp: Math.floor(Date.now() / 1000) + 31_536_000 })}.s`;
   }
 
   const change = (versionstamp: number, id: string, predicate: string) => ({
@@ -224,6 +238,35 @@ describe('LiveSubscriptionManager', () => {
       addSubscriber('reader', ['brain:read'], lookup);
       await mgr.catchUp('co_x');
       expect(received.map((r) => r.sub)).toEqual(['privileged']);
+    });
+  });
+
+  describe('session renewal', () => {
+    /**
+     * A subscription connection is the longest-lived connection in the
+     * process, and surrealdb-js invalidates a `signin()`-established session
+     * when its access token lapses — after which the LIVE stream is dead and
+     * every catch-up tick fails with "Anonymous access not allowed" (audit
+     * 2026-09-08, see src/db/session-keeper.ts). The catch-up tick is where
+     * the session gets renewed.
+     */
+    it('signs the channel connection in on the first catch-up tick', async () => {
+      const mgr = makeManager();
+      const { signins } = installChannel(mgr, { versionstamp: 10, changes: [] });
+      await mgr.catchUp('co_x');
+      expect(signins).toHaveLength(1);
+    });
+
+    it('does not re-sign while the token still has life left', async () => {
+      const mgr = makeManager();
+      const { signins } = installChannel(mgr, { versionstamp: 10, changes: [] });
+      await mgr.catchUp('co_x');
+      await mgr.catchUp('co_x');
+      await mgr.catchUp('co_x');
+      // Renewal is driven by the token's own expiry, not by the tick — a
+      // signin runs the server-side password KDF and must not ride every
+      // catch-up interval.
+      expect(signins).toHaveLength(1);
     });
   });
 

--- a/test/scoped-session-expiry.e2e-spec.ts
+++ b/test/scoped-session-expiry.e2e-spec.ts
@@ -1,0 +1,170 @@
+/**
+ * Scoped-pool session expiry (audit 2026-09-08 P0) — against a REAL
+ * SurrealDB (testcontainers, v3.2.4, started by test/global-setup.ts).
+ *
+ * THE DEFECT. surrealdb-js 2.0.8 renews only the sessions it opened itself.
+ * `db.signin()` from application code sets `authOverriden`, and the driver's
+ * renewal timer then has nothing to renew with: at `exp - 60s` it calls
+ * `invalidate()` and the connection goes ANONYMOUS for the rest of the
+ * process. The root pool never showed this because it re-signs on every
+ * acquire; the scoped pool signed in exactly once, at boot, so ~59 minutes
+ * after start every caller-facing read — search, entity reads, fact reads,
+ * stats, artifacts — answered "Anonymous access not allowed" while writes,
+ * /health and /ready stayed green.
+ *
+ * HOW THIS TEST DRIVES IT IN SECONDS. Not by mocking `Date.now()` — that
+ * poisons the session state and produces a false positive (learned in #481).
+ * Instead the DB user is provisioned with a real, very short token lifetime
+ * (`SURREALDB_SCOPED_TOKEN_DURATION=5s`), so the identical code path runs on
+ * a compressed clock: the token really is issued with a 5-second `exp`, the
+ * driver really does fire its timer, and the wait is wall-clock.
+ */
+import { ConfigService } from '@nestjs/config';
+import { Surreal } from 'surrealdb';
+import { SurrealService } from '../src/db/surreal.service';
+
+const SCOPED_USER = 'brain_caller';
+const SCOPED_PASS = 'scoped-session-expiry-spec';
+/** Token lifetime brain provisions the scoped user with, for this spec. */
+const TOKEN_DURATION = '5s';
+/** Comfortably past `exp` (and past the driver's invalidate timer). */
+const PAST_EXPIRY_MS = 9_000;
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+/** The cheapest authorization-gated statement SurrealDB has. */
+const readOne = (db: Surreal) => db.query<[number]>('RETURN 1');
+const ANONYMOUS = /Anonymous access not allowed/i;
+
+describe('Scoped pool — session expiry', () => {
+  const tenant = `sesexp${Date.now().toString(36)}`;
+  const saved: Record<string, string | undefined> = {};
+  let url: string;
+  let namespace: string;
+  let root: Surreal;
+  let svc: SurrealService;
+
+  const setEnv = (key: string, value: string) => {
+    saved[key] = process.env[key];
+    process.env[key] = value;
+  };
+
+  beforeAll(async () => {
+    url = process.env.SURREALDB_URL!;
+    namespace = process.env.SURREALDB_NAMESPACE ?? 'brain';
+
+    root = new Surreal();
+    await root.connect(url);
+    await root.signin({
+      username: process.env.SURREALDB_USERNAME!,
+      password: process.env.SURREALDB_PASSWORD!,
+    });
+    await root.query(`DEFINE NAMESPACE IF NOT EXISTS \`${namespace}\``);
+    await root.use({ namespace });
+
+    setEnv('SURREALDB_SCOPED_USER', SCOPED_USER);
+    setEnv('SURREALDB_SCOPED_PASS', SCOPED_PASS);
+    setEnv('SURREALDB_SCOPED_TOKEN_DURATION', TOKEN_DURATION);
+    setEnv('SURREALDB_POOL_SIZE', '2');
+    setEnv('SURREALDB_SCOPED_POOL_SIZE', '2');
+
+    svc = new SurrealService(new ConfigService());
+    await svc.onModuleInit();
+    // Migrations run through a ROOT path first — same as app bootstrap. This
+    // is where migration 0005 defines `brain_caller`, where brain then
+    // (re)provisions it with the declared short token lifetime, and where the
+    // idle scoped connections are re-signed. From here the pool holds
+    // 5-second tokens.
+    await svc.withCompany(tenant, (db) => readOne(db));
+    await svc.withScopedCompany(tenant, ['brain:read'], (db) => readOne(db));
+  }, 180_000);
+
+  afterAll(async () => {
+    await svc?.onApplicationShutdown();
+    // Put the shared container's scoped user back on the server default so
+    // later specs in this worker are not left signing in every read.
+    await root
+      ?.query(
+        `DEFINE USER OVERWRITE ${SCOPED_USER} ON NAMESPACE PASSWORD '${SCOPED_PASS}' ROLES EDITOR`,
+      )
+      .catch(() => undefined);
+    await root?.close().catch(() => undefined);
+    for (const [key, value] of Object.entries(saved)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+
+  it('provisions the scoped user with the declared token lifetime', async () => {
+    const probe = new Surreal();
+    await probe.connect(url);
+    const tokens = await probe.signin({
+      username: SCOPED_USER,
+      password: SCOPED_PASS,
+      namespace,
+    });
+    const claims = JSON.parse(
+      Buffer.from(tokens.access.split('.')[1]!, 'base64url').toString('utf8'),
+    ) as { iat: number; exp: number };
+    expect(claims.exp - claims.iat).toBe(5);
+    await probe.close();
+  });
+
+  it('DEFECT: a connection signed in ONCE goes anonymous when its token lapses', async () => {
+    // This is the pre-fix scoped pool, reproduced verbatim: connect, signin,
+    // use, then serve reads from it forever.
+    const stuck = new Surreal();
+    await stuck.connect(url);
+    await stuck.signin({ username: SCOPED_USER, password: SCOPED_PASS, namespace });
+    await stuck.use({ namespace, database: `co_${tenant}` });
+    await expect(stuck.query('RETURN 1')).resolves.toBeDefined();
+
+    await sleep(PAST_EXPIRY_MS);
+
+    // The socket is still open and the server never dropped the connection —
+    // the driver invalidated the session on its own.
+    await expect(stuck.query('RETURN 1')).rejects.toThrow(ANONYMOUS);
+    // …and it stays broken. No retry heals it; only a new signin does.
+    await expect(stuck.query('RETURN 1')).rejects.toThrow(ANONYMOUS);
+
+    // The health probe brain used to rely on is BLIND to this: `version()`
+    // is answered for an anonymous session too, which is why /health and
+    // /ready reported "ok" throughout the outage.
+    await expect(stuck.version()).resolves.toBeDefined();
+
+    await stuck.close();
+  }, 60_000);
+
+  it('FIX: the scoped pool keeps serving reads across the same lapse', async () => {
+    await sleep(PAST_EXPIRY_MS);
+    const first = await svc.withScopedCompany(tenant, ['brain:read'], (db) => readOne(db));
+    expect(first).toEqual([1]);
+
+    // Not a one-shot heal — the pool must survive every subsequent lapse.
+    await sleep(PAST_EXPIRY_MS);
+    const second = await svc.withScopedCompany(tenant, ['brain:read'], (db) => readOne(db));
+    expect(second).toEqual([1]);
+  }, 90_000);
+
+  it('FIX: readiness exercises the scoped read path, not just the socket', async () => {
+    await sleep(PAST_EXPIRY_MS);
+    // `ping()` only proves the socket answers — it did so throughout the
+    // outage. `pingScoped()` runs an authorization-gated statement on a
+    // scoped connection, so it can actually observe the read path.
+    await expect(svc.ping()).resolves.toBe(true);
+    await expect(svc.pingScoped()).resolves.toBe(true);
+  }, 60_000);
+
+  it('FIX: the pool returns connections that are still scoped, not root', async () => {
+    // Renewal must not quietly widen privilege. `$auth` is NONE for a system
+    // user, so identity is checked the way the DB reports it: a root session
+    // can read the namespace user list, brain_caller (NS EDITOR) can too, but
+    // neither may be silently swapped — assert the session is the scoped one
+    // by its inability to reach ROOT-only metadata.
+    await sleep(PAST_EXPIRY_MS);
+    await expect(
+      svc.withScopedCompany(tenant, ['brain:read'], (db) => db.query('INFO FOR ROOT')),
+    ).rejects.toThrow();
+    // …while the root pool, which may reach it, still can.
+    await expect(svc.withCompany(tenant, (db) => db.query('INFO FOR ROOT'))).resolves.toBeDefined();
+  }, 60_000);
+});

--- a/test/session-keeper.unit-spec.ts
+++ b/test/session-keeper.unit-spec.ts
@@ -1,0 +1,114 @@
+/**
+ * SurrealSessionKeeper — the freshness arithmetic that keeps long-lived
+ * SurrealDB connections out of the driver's invalidate-on-expiry path.
+ *
+ * The behavioural proof (a real connection actually going anonymous, and the
+ * pool surviving it) lives in test/scoped-session-expiry.e2e-spec.ts; this
+ * pins the decision rule itself, including the two ways it must fail safe.
+ */
+import type { Surreal } from 'surrealdb';
+import {
+  DRIVER_EXPIRY_MARGIN_MS,
+  SESSION_REAUTH_MARGIN_MS,
+  SurrealSessionKeeper,
+  accessTokenExpiryMs,
+} from '../src/db/session-keeper';
+
+/** A syntactically real JWT with the given `exp` (seconds). */
+function jwt(claims: Record<string, unknown>): string {
+  const b64 = (o: unknown) => Buffer.from(JSON.stringify(o)).toString('base64url');
+  return `${b64({ alg: 'HS512', typ: 'JWT' })}.${b64(claims)}.c2ln`;
+}
+
+/** The keeper only ever uses connections as WeakMap keys. */
+const conn = () => ({}) as unknown as Surreal;
+
+describe('accessTokenExpiryMs', () => {
+  it('reads the exp claim as epoch-ms', () => {
+    expect(accessTokenExpiryMs(jwt({ exp: 1788883374 }))).toBe(1788883374000);
+  });
+
+  it('returns undefined for anything it cannot read', () => {
+    expect(accessTokenExpiryMs(undefined)).toBeUndefined();
+    expect(accessTokenExpiryMs('')).toBeUndefined();
+    expect(accessTokenExpiryMs('not-a-jwt')).toBeUndefined();
+    expect(accessTokenExpiryMs('a.b.c')).toBeUndefined();
+    // A token with no exp claim (SurrealDB bearer keys) must not be
+    // mistaken for one that never expires.
+    expect(accessTokenExpiryMs(jwt({ ID: 'brain_caller' }))).toBeUndefined();
+    expect(accessTokenExpiryMs(jwt({ exp: 'soon' }))).toBeUndefined();
+  });
+});
+
+describe('SurrealSessionKeeper', () => {
+  const NOW = 1_800_000_000_000;
+  const tokenExpiringIn = (ms: number) => jwt({ exp: Math.floor((NOW + ms) / 1000) });
+
+  it('refuses a margin the driver would beat it to', () => {
+    // surrealdb-js invalidates at exp-60s. A margin at or below that loses
+    // the race, which is the whole failure this class exists to prevent.
+    expect(() => new SurrealSessionKeeper(DRIVER_EXPIRY_MARGIN_MS)).toThrow(/must exceed/);
+    expect(() => new SurrealSessionKeeper(30_000)).toThrow(/must exceed/);
+    expect(() => new SurrealSessionKeeper(DRIVER_EXPIRY_MARGIN_MS + 1)).not.toThrow();
+  });
+
+  it('demands a signin for a connection it has never seen', () => {
+    expect(new SurrealSessionKeeper().needsSignin(conn(), NOW)).toBe(true);
+  });
+
+  it('holds off while the token has more life than the margin', () => {
+    const keeper = new SurrealSessionKeeper();
+    const c = conn();
+    keeper.record(c, tokenExpiringIn(3_600_000)); // a default 1h token
+    expect(keeper.needsSignin(c, NOW)).toBe(false);
+    // …and keeps holding off right up to the margin.
+    expect(keeper.needsSignin(c, NOW + 3_600_000 - SESSION_REAUTH_MARGIN_MS - 1000)).toBe(false);
+  });
+
+  it('demands a signin once the token enters the margin — before the driver acts', () => {
+    const keeper = new SurrealSessionKeeper();
+    const c = conn();
+    keeper.record(c, tokenExpiringIn(3_600_000));
+    const atMargin = NOW + 3_600_000 - SESSION_REAUTH_MARGIN_MS;
+    expect(keeper.needsSignin(c, atMargin)).toBe(true);
+    // The driver would not have invalidated yet at that point: our margin
+    // has to leave real headroom over its 60s lead time.
+    expect(SESSION_REAUTH_MARGIN_MS).toBeGreaterThan(DRIVER_EXPIRY_MARGIN_MS);
+  });
+
+  it('demands a signin for an already-lapsed token', () => {
+    const keeper = new SurrealSessionKeeper();
+    const c = conn();
+    keeper.record(c, tokenExpiringIn(-1));
+    expect(keeper.needsSignin(c, NOW)).toBe(true);
+  });
+
+  it('fails safe when the token is unreadable — re-signs every time', () => {
+    const keeper = new SurrealSessionKeeper();
+    const c = conn();
+    keeper.record(c, tokenExpiringIn(3_600_000));
+    expect(keeper.needsSignin(c, NOW)).toBe(false);
+    // A driver/server that stops handing back a parseable JWT must degrade
+    // to "sign in on every use", never to "assume it is still valid".
+    keeper.record(c, 'opaque-token');
+    expect(keeper.needsSignin(c, NOW)).toBe(true);
+  });
+
+  it('forgets a torn-down connection', () => {
+    const keeper = new SurrealSessionKeeper();
+    const c = conn();
+    keeper.record(c, tokenExpiringIn(3_600_000));
+    keeper.forget(c);
+    expect(keeper.needsSignin(c, NOW)).toBe(true);
+  });
+
+  it('tracks connections independently', () => {
+    const keeper = new SurrealSessionKeeper();
+    const fresh = conn();
+    const stale = conn();
+    keeper.record(fresh, tokenExpiringIn(3_600_000));
+    keeper.record(stale, tokenExpiringIn(10_000));
+    expect(keeper.needsSignin(fresh, NOW)).toBe(false);
+    expect(keeper.needsSignin(stale, NOW)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Verdict: CONFIRMED

An externally reported defect — "every read starts answering `Anonymous access not allowed` about an hour after boot, while writes and health checks keep working" — reproduces from the code, and the mechanism is now pinned by a test that drives the real expiry path against a testcontainer.

The reporter's **symptom, blast radius and root cause are correct**. One part of their diagnosis is **wrong**: it is not the DB user's *session* duration. `DURATION FOR SESSION NONE` does not help — nothing expires server-side at all. The driver reads the JWT `exp` (from the *token* duration, 1h by default) and invalidates the session client-side without ever asking the server. Details under "Where the report is wrong" below.

## The mechanism

`surrealdb-js` 2.0.8 renews only the sessions it opened itself. Calling `db.signin()` from application code sets `authOverriden` on the session, and the renewal timer then has nothing to renew with:

1. reuse the current access token — skipped, it is inside the expiry margin;
2. use a refresh token — system users have none;
3. invoke the connect-time auth provider — **skipped, because `authOverriden` is set**;
4. → `#abortAuthentication()` → `invalidate()`.

The driver's own type declarations state the contract: *"When this method is called, the `authentication` property passed to `connect()` will be ignored. You will be responsible for handling session invalidation."*

After that the socket is still open, `version()` still answers, and every authorization-gated statement fails with `Anonymous access not allowed: Not enough permissions to perform this action` — for the rest of the process.

`DEFINE USER … ROLES EDITOR` (migration 0005) issues a **1-hour** token, so the timer fires at ~59 minutes.

## Blast radius

**Dead** — everything routed through `withScopedCompany`, i.e. the whole caller-facing read surface: search, entity reads/profiles, fact reads, beliefs, stats, artifacts, communities, memory-diff, user profile, answer cache, code-memory search/anchors, procedural memory, ingest predictor.

**Alive** — writes and admin paths (`withCompany` / `withAdminDb`: the root pool re-signs on every acquire, so it self-heals), `/health`, `/ready`, the MCP transport, migrations.

The service looks healthy and serves errors — including to its own readiness probe.

## Why this fix

Three candidate fixes; only one removes the failure mode without a new one.

| Option | Verdict |
|---|---|
| **Re-auth before use, driven by token expiry** (chosen) | Symmetric with the discipline the root pool already has, self-heals every variant (expiry, zombie socket, rotated secret, boot-time root fallback), fails closed, and keeps the read path cheap. |
| Hand the credentials to `connect({ authentication })` | Works *only* if `signin()` is never called on that connection — `authOverriden` is sticky and one manual signin kills renewal permanently. Verified: connect-auth alone survives the lapse; connect-auth followed by one `signin()` goes anonymous again. The existing root-fallback and password-sync paths both call `signin()`, so this would leave a latent hole exactly where the previous audits added one. It also fails boot hard when `brain_caller` does not exist yet. |
| Set a session/token duration on the user | Does not fix anything. `FOR SESSION NONE` is irrelevant (client-side invalidation), and a longer token only moves the cliff — the driver still invalidates at `exp − 60s`. Brain also OVERWRITEs the user on every boot, silently discarding any duration set by hand. |

Renewal is **expiry-driven rather than unconditional** on purpose: a Surreal `signin` runs the server-side password KDF, measured at **~16 ms** against a local v3.2.4 versus **~0.3 ms** for a `SELECT`. Paying it on every read would be a ~48x tax on the hot path. The margin is 5 minutes, comfortably clear of the driver's 60 s invalidate lead time; a connection re-signs roughly once an hour.

## Changes

- **`src/db/session-keeper.ts`** (new) — records each connection's access-token expiry and answers whether it must be re-signed. Fails safe: an unreadable token means "re-sign every use", never "assume valid". Refuses a margin that would lose the race with the driver.
- **`src/db/surreal.service.ts`** — `ensureScopedSession` renews inside `acquireScoped`, rebuilding the connection when the socket is gone, and still failing **closed** rather than serving a request root-authorized. `pingScoped()` added.
- **`src/live/live-subscription.manager.ts`** — subscription channels are the longest-lived connections in the process and had the identical defect (`LIVE_SUBSCRIPTIONS_ENABLED=1` in the deploy workflow). They renew on the catch-up tick; re-signin does not disturb the selected namespace/database or the standing LIVE query.
- **`scripts/backfill-lang-attribution.ts`** — renews per batch; its loop is unbounded in corpus size and will cross an hour on a large tenant. (`scan-hnsw-parity.ts` has the same shape but a fixed, bounded sweep — left alone deliberately.)
- **Readiness** — `/ready` now runs an authorization-gated statement on a scoped connection and reports a distinct `scopedPool` check. `ping()` could not see any of this: `version()` is answered for anonymous sessions too, which is exactly why the probes stayed green. A **busy** pool is deliberately *not* a readiness failure — that would pull pods from rotation when the remaining ones are the most loaded — so the probe waits briefly, hands the slot back if it lands late, and reports ready.
- **`SURREALDB_SCOPED_TOKEN_DURATION`** — declares the scoped user's token lifetime. Not the fix; it exists so a duration set by hand on the server is not silently discarded on the next deploy, and so the expiry path can be tested in seconds.

## Where the report is wrong

- *"the DB user is defined with no session duration, so the default 1 hour applies"* — the user is indeed defined without any `DURATION`, but the session duration is not what bites. Measured: with `DURATION FOR TOKEN 5s, FOR SESSION NONE` the connection still goes anonymous. The invalidation is entirely client-side, driven by the **token** `exp`.
- *"the driver … on expiry just cuts the session"* — accurate, with one correction: it cuts it 60 seconds **before** `exp`, so the cliff is at ~59 minutes, not exactly 60.
- The reporter's workaround (reading through the root pool) is genuinely blocked in production, as they said — `validateEnv` hard-fails without the scoped credentials. That guard is deliberate and untouched here.

## Proof

`test/scoped-session-expiry.e2e-spec.ts` drives the real expiry against a testcontainer by provisioning a 5-second token lifetime — **no `Date.now()` mocking**, which poisons the SurrealDB session and produces a false positive (learned in #481). It pins both sides:

- **the defect** — a once-signed-in connection goes anonymous and stays that way, while `version()` keeps answering (the health-check blindness, demonstrated rather than asserted);
- **the fix** — the pool serves reads across repeated lapses, readiness observes the read path, and renewal does not silently widen privilege to root.

Negative control: with the renewal disabled, the two "FIX" legs fail with the exact production error, `NotAllowedError: Anonymous access not allowed: Not enough permissions to perform this action`.

`test/session-keeper.unit-spec.ts` pins the decision rule itself, including both fail-safe directions.

## Gates

`tsc -p tsconfig.json`, `tsc -p tsconfig.spec.json`, `lint:ci`, `prettier --check`, full unit suite (392 suites / 4791 tests), full e2e suite.

## Residual, not fixed here

The root pool signs in unconditionally on **every** acquire, so every write and admin query pays that ~16 ms KDF. That is a pre-existing performance cost, not a correctness bug, and the unconditional signin doubles as the root pool's zombie-websocket liveness probe — changing it deserves its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB
