### PR TITLE
fix(search): detect a missing HNSW index instead of waiting for an error that never comes

### DIFF
--- a/src/db/knn-index.ts
+++ b/src/db/knn-index.ts
@@ -1,0 +1,123 @@
+import type { Surreal } from 'surrealdb';
+
+/**
+ * Missing-HNSW-index detection for the `<|k,ef|>` KNN legs.
+ *
+ * THE DEFECT. SurrealDB does not error when the `<|K,EF|>` operator has no
+ * index to ride. It drops the operator from the plan and answers the rest
+ * of the statement — `EXPLAIN` shows a bare `TableScan` — so the query
+ * returns the first k rows in TABLE ORDER with `vector::distance::knn()`
+ * projecting NULL. Measured on `surrealdb/surrealdb:v3.2.4` (3 000 × 1024-d,
+ * scratch container):
+ *
+ *   no index   → [{"knnDist":null,"n":1144},{"knnDist":null,"n":2781}, …]
+ *                EXPLAIN → SelectProject → TableScan (no KnnScan node)
+ *   index ready→ [{"knnDist":0.8998…,"n":1802},{"knnDist":0.8999…,"n":2007}, …]
+ *
+ * Every KNN leg in this repo was written against the OPPOSITE assumption —
+ * "throws when the tenant has no index — the caller falls back to the scan"
+ * — so the `catch` that implements the fallback never fires and the leg
+ * hands its caller k arbitrary rows with no similarity score. Production
+ * runs `SEARCH_HNSW_ENABLED=1` while index creation is a manual per-tenant
+ * admin call, so any tenant whose index was never built is served unranked
+ * rows that look exactly like ranked ones.
+ *
+ * THE SIGNAL. `knnDist === null` on every returned row is a DIRECT
+ * observation that the operator was not applied — not an inference from an
+ * error that never arrives. It costs nothing (the rows are already in hand)
+ * and it is exact: when the index rides, SurrealDB projects a number on
+ * every row; when it is dropped, it projects NULL on every row.
+ *
+ * It also covers a second state that `INFO FOR TABLE` alone cannot see.
+ * A `DEFINE INDEX … CONCURRENTLY` build EXISTS from the moment the DDL
+ * returns but is not usable until it reports `ready`, and during the build
+ * the KNN operator is dropped exactly as if no index existed (measured: at
+ * `t+0.1s`, `{"initial":16,"pending":0,"status":"indexing"}` returned the
+ * same three null-distance rows as the un-indexed table; at `t+1.2s`,
+ * `status:"ready"` returned real distances). So "the index exists" is not
+ * the property a KNN leg needs — "the operator was applied" is, and that is
+ * what this module tests.
+ */
+
+/**
+ * True when SurrealDB answered a `<|k,ef|>` statement WITHOUT applying the
+ * KNN operator — the rows are the table's first k in storage order and the
+ * distance projection is NULL on all of them.
+ *
+ * Conservative on purpose: an empty result is NOT reported as dropped (an
+ * empty tenant, or gates that ate every approximate neighbour, look the
+ * same from here and the callers already have their own empty-pool
+ * doctrine), and a single ranked row is enough to say the operator ran.
+ */
+export function knnOperatorDropped(
+  rows: readonly unknown[] | null | undefined,
+  distanceField: string,
+): boolean {
+  if (!Array.isArray(rows) || rows.length === 0) return false;
+  return rows.every((row) => typeof (row as Record<string, unknown>)?.[distanceField] !== 'number');
+}
+
+/** What an HNSW index is doing on a tenant, for the diagnostic log. */
+export type HnswIndexState = 'ready' | 'building' | 'absent' | 'unknown';
+
+/**
+ * Why the KNN operator was dropped, for the operator-facing log line.
+ *
+ * Read-only and best-effort: it runs ONLY on the failure path (never on the
+ * hot path), and any error answers `'unknown'` rather than escalating — a
+ * diagnostic must not turn a recovered query into a failed one.
+ *
+ * `INFO FOR TABLE` is the existence probe because `INFO FOR INDEX` THROWS
+ * on an absent index ("The index 'x' does not exist"); `INFO FOR INDEX` is
+ * then consulted only when the index does exist, to separate a finished
+ * index from one still building (`{building:{status:'indexing'|'ready',…}}`).
+ */
+export async function hnswIndexState(
+  db: Pick<Surreal, 'query'>,
+  spec: { table: string; index: string },
+): Promise<HnswIndexState> {
+  try {
+    const [info] = await db.query<[{ indexes?: Record<string, string> }]>(
+      `INFO FOR TABLE ${spec.table};`,
+    );
+    const indexes = (info as { indexes?: Record<string, string> } | undefined)?.indexes;
+    if (!indexes || typeof indexes[spec.index] !== 'string') return 'absent';
+  } catch {
+    return 'unknown';
+  }
+  try {
+    const [detail] = await db.query<[{ building?: { status?: string } }]>(
+      `INFO FOR INDEX ${spec.index} ON ${spec.table};`,
+    );
+    const status = (detail as { building?: { status?: string } } | undefined)?.building?.status;
+    if (status === undefined) return 'ready';
+    return status === 'ready' ? 'ready' : 'building';
+  } catch {
+    return 'unknown';
+  }
+}
+
+/**
+ * The single operator-facing sentence for a dropped KNN operator. ERROR,
+ * not WARN: with `SEARCH_HNSW_ENABLED=1` this is a live misconfiguration
+ * that has been answering searches with unranked rows, and the remedy is
+ * one admin call. The exact scan the caller falls back to is the same query
+ * every tenant runs with the flag off, so the request is still answered
+ * correctly — the shout is about the tenant being un-indexed, not about the
+ * request failing.
+ */
+export function knnDroppedMessage(
+  spec: { table: string; index: string },
+  state: HnswIndexState,
+): string {
+  const why =
+    state === 'absent'
+      ? `index '${spec.index}' does not exist on this tenant — build it with POST /v1/admin/maintenance/hnsw`
+      : state === 'building'
+        ? `index '${spec.index}' exists but is still building — it is not usable until it reports ready`
+        : `index '${spec.index}' state could not be determined`;
+  return (
+    `hnsw KNN operator was DROPPED on ${spec.table} (every row came back with a null ` +
+    `distance, i.e. unranked table-order rows): ${why}. Falling back to the exact scan.`
+  );
+}

--- a/src/dreams/dedup.service.ts
+++ b/src/dreams/dedup.service.ts
@@ -5,6 +5,7 @@ import { EntityJudgeService } from '../ai/entity-judge.service';
 import { withSpan } from '../common/tracing';
 import { envFlagEnabled } from '../common/env-validation';
 import { derivedVersionFence } from '../episodes/read-pin.service';
+import { hnswIndexState, knnDroppedMessage, knnOperatorDropped } from '../db/knn-index';
 
 /**
  * DreamsDedupService — find near-duplicate ENTITIES inside a tenant
@@ -200,9 +201,15 @@ export class DreamsDedupService {
    * K nearest name facts to a seed name fact, seed vector resolved
    * DB-side by fact id. With SEARCH_HNSW_ENABLED the KNN operator rides
    * the HNSW index (same literal-K idiom + overfetch as the search
-   * vector leg; the operator throws when the tenant has no index, and
-   * we fall back to the scan). Without it, a scan ordered by cosine —
-   * still zero vectors shipped to JS in both directions.
+   * vector leg). Without it, a scan ordered by cosine — still zero
+   * vectors shipped to JS in both directions.
+   *
+   * The KNN statement does NOT throw when the tenant has no (or a
+   * still-building) index: SurrealDB drops the operator and answers with
+   * table-order rows carrying a NULL distance, which this pass then read
+   * as `sim = 0` — below every threshold, so the whole dedup sweep went
+   * silently inert on un-indexed tenants. Detected from the rows
+   * (src/db/knn-index.ts) and routed to the exact scan below.
    */
   private async nearestNames(
     db: Surreal,
@@ -237,12 +244,18 @@ export class DreamsDedupService {
             LIMIT 5;`,
           { fid: seedFactId, ...fence.params },
         );
-        return ((res[1] as Array<{ entityId: unknown; dist: number }>) ?? []).map(
-          ({ entityId, dist }) => ({
+        const knnRows = (res[1] as Array<{ entityId: unknown; dist: number }>) ?? [];
+        if (knnOperatorDropped(knnRows, 'dist')) {
+          const spec = { table: 'knowledge_fact', index: 'fact_embedding_hnsw' };
+          this.logger.error(
+            `[dreams.dedup] ${knnDroppedMessage(spec, await hnswIndexState(db, spec))}`,
+          );
+        } else {
+          return knnRows.map(({ entityId, dist }) => ({
             entityId,
             sim: typeof dist === 'number' ? 1 - dist : 0,
-          }),
-        );
+          }));
+        }
       } catch (e) {
         this.logger.warn(
           `[dreams.dedup] KNN leg failed (${(e as Error).message}); falling back to scan`,

--- a/src/ingest/entity-resolver.service.ts
+++ b/src/ingest/entity-resolver.service.ts
@@ -5,6 +5,10 @@ import { EmbedderService } from '../ai/embedder.service';
 import { EntityJudgeService, EntityVerdict } from '../ai/entity-judge.service';
 import { envFlagEnabled } from '../common/env-validation';
 import { dbCreate } from '../db/surreal.service';
+import { hnswIndexState, knnDroppedMessage, knnOperatorDropped } from '../db/knn-index';
+
+/** The index the name-candidate KNN scan rides — for the diagnostic. */
+const NAME_HNSW = { table: 'knowledge_fact', index: 'fact_embedding_hnsw' } as const;
 
 /** One auditable reuse/candidate decision (migration 0102 entity_merge_log). */
 export interface MergeLogEntry {
@@ -209,6 +213,13 @@ export class EntityResolverService {
    * native HNSW index (`<|k,ef|>`); any failure — most commonly "no index
    * on this tenant yet" — falls back to the exact full scan, so the flag
    * can be flipped globally while tenants are indexed one by one.
+   *
+   * "No index on this tenant yet" is NOT a failure the statement reports:
+   * SurrealDB drops the KNN operator and answers with table-order rows
+   * carrying a NULL distance, which this path read as `sim = 0`. Since the
+   * rows are sorted DESC and the loop `break`s below `cosineFloor`, an
+   * un-indexed tenant resolved nothing at all. Detected from the rows
+   * (src/db/knn-index.ts), which returns null and falls through.
    */
   private async findBestNameCandidate(
     db: Surreal,
@@ -264,13 +275,13 @@ export class EntityResolverService {
    * The `<|kOver,ef|>` operator picks candidates before the WHERE filters,
    * so we over-fetch (kOver = candidateK × overfetch, capped 1000) and let
    * the same predicate/status/type fences narrow the result, then LIMIT to
-   * candidateK. Throws when the tenant has no HNSW index — the caller falls
-   * back to the exact scan.
+   * candidateK. Returns NULL — not a throw — when the tenant has no usable
+   * HNSW index, so the caller falls back to the exact scan.
    */
   private async queryNameCandidatesKnn(
     db: Surreal,
     q: number[],
-  ): Promise<Array<{ entityId: unknown; etype: string; sim: number }>> {
+  ): Promise<Array<{ entityId: unknown; etype: string; sim: number }> | null> {
     const kOver = Math.min(this.candidateK * this.hnswOverfetch, 1000);
     // `<|K,EF|>` takes literals, not params — kOver/ef are validated ints.
     // vector::distance::knn() reuses the walk's distance — projecting a
@@ -291,12 +302,17 @@ export class EntityResolverService {
          LIMIT $k`,
       { q, k: this.candidateK },
     );
-    return ((rows as Array<{ entityId: unknown; etype: string; dist: number }>) ?? []).map(
-      ({ dist, ...rest }) => ({
-        ...rest,
-        sim: typeof dist === 'number' ? 1 - dist : 0,
-      }),
-    );
+    const knnRows = (rows as Array<{ entityId: unknown; etype: string; dist: number }>) ?? [];
+    if (knnOperatorDropped(knnRows, 'dist')) {
+      this.logger.error(
+        `[ingest.inline_resolution] ${knnDroppedMessage(NAME_HNSW, await hnswIndexState(db, NAME_HNSW))}`,
+      );
+      return null;
+    }
+    return knnRows.map(({ dist, ...rest }) => ({
+      ...rest,
+      sim: typeof dist === 'number' ? 1 - dist : 0,
+    }));
   }
 }
 

--- a/src/search/internals/legs.ts
+++ b/src/search/internals/legs.ts
@@ -3,6 +3,10 @@ import type { EmbedderService } from '../../ai/embedder.service';
 import type { FactRow } from './types';
 import type { SearchTuning } from '../retrieval-profile';
 import { buildEdgeFence, type EdgeFence } from './edge-fence';
+import { hnswIndexState, knnDroppedMessage, knnOperatorDropped } from '../../db/knn-index';
+
+/** The index the fact vector leg rides; named here for the diagnostic. */
+const FACT_HNSW = { table: 'knowledge_fact', index: 'fact_embedding_hnsw' } as const;
 
 /** The slice of SearchTuning the legs consume (kept narrow for tests). */
 export type LegTuning = Pick<
@@ -46,8 +50,11 @@ export interface RunVectorLegOptions {
   query: string;
   k: number;
   baseWhere: { sql: string; params: Record<string, unknown> };
-  /** For the HNSW-fallback warning; the leg stays silent without it. */
-  logger?: { warn: (msg: string) => void };
+  /** For the HNSW-fallback warning; the leg stays silent without it.
+   *  `error` carries the dropped-KNN-operator shout (a live tenant
+   *  misconfiguration, not a transient); `warn` keeps the legacy
+   *  throw-path message. */
+  logger?: { warn: (msg: string) => void; error?: (msg: string) => void };
   /** Resolved by the retrieval-profile bootstrap (S5.2). */
   tuning?: LegTuning;
   /** Edge policy fence for the combined vector+graph projection; the
@@ -67,13 +74,29 @@ export async function runVectorLeg({
 }: RunVectorLegOptions): Promise<FactRow[]> {
   const queryEmbedding = await embedder.embed(query);
   // HNSW path (opt-in): approximate KNN over the per-tenant indexes
-  // created by POST /v1/admin/maintenance/hnsw. Any failure — most
-  // commonly "no index on this tenant yet" — falls back to the exact
-  // full scan below, so the flag can be flipped globally while tenants
-  // are indexed one by one.
+  // created by POST /v1/admin/maintenance/hnsw. Two ways it can miss, and
+  // only one of them is an exception:
+  //
+  //   - the statement throws → the legacy catch below;
+  //   - the statement SUCCEEDS with the KNN operator silently dropped from
+  //     the plan, because the tenant has no (or a still-building) index.
+  //     SurrealDB then answers with the table's first k rows and a NULL
+  //     distance on each — unranked rows that are indistinguishable from
+  //     ranked ones downstream. See src/db/knn-index.ts for the 3.2.4
+  //     measurement.
+  //
+  // The second case is the one production is in: SEARCH_HNSW_ENABLED=1 is
+  // set globally while index creation is a manual per-tenant admin call.
+  // Both now fall back to the exact scan below, which is byte-identical to
+  // what the tenant is served with the flag off.
   if (tuning.hnswEnabled) {
     try {
-      return await runVectorLegKnn({ db, queryEmbedding, k, baseWhere, tuning });
+      const knnRows = await runVectorLegKnn({ db, queryEmbedding, k, baseWhere, tuning });
+      if (knnRows !== null) return knnRows;
+      const state = await hnswIndexState(db, FACT_HNSW);
+      const message = knnDroppedMessage(FACT_HNSW, state);
+      if (logger?.error) logger.error(message);
+      else logger?.warn(message);
     } catch (e) {
       logger?.warn(`hnsw vector leg fell back to full scan: ${(e as Error).message}`);
     }
@@ -105,8 +128,13 @@ export async function runVectorLeg({
  * HNSW KNN variant of the vector leg. The KNN operator picks candidates
  * BEFORE the WHERE filters apply, so the query over-fetches
  * (`SEARCH_HNSW_OVERFETCH × k`, capped 1000) to keep filtered recall
- * up; `SEARCH_HNSW_EF` is the HNSW search width. Throws when the tenant
- * has no index — the caller falls back to the scan.
+ * up; `SEARCH_HNSW_EF` is the HNSW search width.
+ *
+ * Returns NULL — not rows, and not a throw — when the tenant has no usable
+ * index. SurrealDB answers such a statement successfully with the KNN
+ * operator dropped and a null distance on every row, so "no index" is
+ * detected from the result rather than from an exception that never
+ * arrives; the caller falls back to the exact scan.
  */
 async function runVectorLegKnn({
   db,
@@ -120,7 +148,7 @@ async function runVectorLegKnn({
   k: number;
   baseWhere: { sql: string; params: Record<string, unknown> };
   tuning: LegTuning;
-}): Promise<FactRow[]> {
+}): Promise<FactRow[] | null> {
   const ef = tuning.hnswEf;
   const kOver = Math.min(k * tuning.hnswOverfetch, 1000);
   const projection = `
@@ -147,6 +175,7 @@ async function runVectorLegKnn({
        LIMIT $k`,
     { ...baseWhere.params, q: queryEmbedding, k },
   );
+  if (knnOperatorDropped(rows, 'knnDist')) return null;
   return (rows ?? []).map(({ knnDist, ...rest }) => ({
     ...rest,
     simScore: typeof knnDist === 'number' ? 1 - knnDist : undefined,

--- a/src/synthesize/scan-leg.ts
+++ b/src/synthesize/scan-leg.ts
@@ -1,5 +1,12 @@
 import type { Surreal } from 'surrealdb';
 import type { CoverageScanMode } from '../search/retrieval-profile';
+import { hnswIndexState, knnDroppedMessage, knnOperatorDropped } from '../db/knn-index';
+
+/** The HNSW index each coverage-scan table rides — for the diagnostic. */
+const SCAN_HNSW: Record<DenseScanLegRequest['table'], string> = {
+  episode_segment: 'segment_embedding_hnsw',
+  knowledge_fact: 'fact_embedding_hnsw',
+};
 
 /**
  * Shared dense leg of the two coverage-first scan lanes (mention-scan
@@ -14,6 +21,14 @@ import type { CoverageScanMode } from '../search/retrieval-profile';
  * post-filter pool — an empty pool under KNN is most likely gate
  * starvation (every approximate neighbor eaten by the pii/user/world
  * gates), which the exact scan recovers in exactly the rare thin case.
+ *
+ * The third way it misses is the one no error reports: with no (or a
+ * still-building) index SurrealDB drops the KNN operator from the plan and
+ * answers the statement successfully with the table's first k rows and a
+ * NULL distance on each. That is a NON-empty, unranked result — it passed
+ * the `rows.length > 0` check above and was returned as if it were ranked.
+ * Detected from the rows themselves (src/db/knn-index.ts) and routed to the
+ * same brute fallback.
  *
  * Pure query composition + execution — no DI, no env; the tuning
  * arrives from the resolved profile via the lane services.
@@ -51,7 +66,9 @@ export interface DenseScanLegRequest {
   params: Record<string, unknown>;
   k: number;
   tuning: CoverageScanTuning;
-  logger?: { warn(message: string): void };
+  /** `error` carries the dropped-KNN-operator shout (a live tenant
+   *  misconfiguration); `warn` keeps the empty-pool / throw messages. */
+  logger?: { warn(message: string): void; error?(message: string): void };
 }
 
 /**
@@ -89,6 +106,13 @@ export async function runDenseScanLeg<Row>(req: DenseScanLegRequest): Promise<Ro
   LIMIT $k`,
       params,
     );
+    if (knnOperatorDropped(rows, 'knnDist')) {
+      const spec = { table: req.table, index: SCAN_HNSW[req.table] };
+      const message = knnDroppedMessage(spec, await hnswIndexState(db, spec));
+      if (logger?.error) logger.error(message);
+      else logger?.warn(message);
+      return runBrute(req);
+    }
     if (rows && rows.length > 0) {
       return rows.map(({ knnDist, ...rest }) => {
         const row = {

--- a/test/coverage-scan-leg.unit-spec.ts
+++ b/test/coverage-scan-leg.unit-spec.ts
@@ -73,14 +73,19 @@ describe('runDenseScanLeg', () => {
     expect(db.calls[0]).not.toContain('vector::similarity::cosine');
   });
 
+  // knnDist is present on these fixtures on purpose: a row with NO
+  // distance is how SurrealDB reports "the KNN operator was dropped"
+  // (see knn-missing-index.unit-spec.ts), which now routes to the brute
+  // fallback — these two cases are about the ef/overfetch arithmetic and
+  // must exercise the ridden-index path.
   it('ef above the overfetched k survives the clamp', async () => {
-    const db = fakeDb([[[{ id: 's1' }]]]);
+    const db = fakeDb([[[{ id: 's1', knnDist: 0.3 }]]]);
     await runDenseScanLeg(legRequest(db, { mode: 'hnsw', ef: 5000, overfetch: 4 }));
     expect(db.calls[0]).toContain('<|1600,5000|>');
   });
 
   it('caps the KNN candidate walk at 4000', async () => {
-    const db = fakeDb([[[{ id: 's1' }]]]);
+    const db = fakeDb([[[{ id: 's1', knnDist: 0.3 }]]]);
     await runDenseScanLeg(legRequest(db, { mode: 'hnsw', ef: 400, overfetch: 100 }));
     expect(db.calls[0]).toContain('<|4000,4000|>');
   });

--- a/test/hnsw.e2e-spec.ts
+++ b/test/hnsw.e2e-spec.ts
@@ -49,6 +49,45 @@ describe('HNSW vector leg (real SurrealDB)', () => {
     expect(results[0]!.canonicalName).toBe('hnsw_subject');
   });
 
+  /**
+   * The behaviour the whole fallback rests on, asserted against the real
+   * engine rather than assumed. Before this was pinned, the leg's catch
+   * clause waited for an exception that never arrives and the search was
+   * answered from unranked table-order rows.
+   */
+  it('a missing index does not error — the KNN operator is dropped and every distance is null', async () => {
+    const surreal = f.app.get(SurrealService);
+    await surreal.withCompany(f.companyId, async (db) => {
+      const [info] = await db.query<[{ indexes?: Record<string, string> }]>(
+        `INFO FOR TABLE knowledge_fact;`,
+      );
+      // Precondition: this tenant genuinely has no HNSW index.
+      expect((info as { indexes?: Record<string, string> })?.indexes?.fact_embedding_hnsw).toBe(
+        undefined,
+      );
+
+      const [rows] = await db.query<[Array<{ id: unknown; knnDist: number | null }>]>(
+        `SELECT id, vector::distance::knn() AS knnDist
+           FROM knowledge_fact
+          WHERE embedding <|8,100|> $q
+          LIMIT 8`,
+        { q: new Array(1536).fill(0.01) },
+      );
+      // Not an error, not empty — rows with NO similarity information.
+      expect(Array.isArray(rows)).toBe(true);
+      expect((rows ?? []).length).toBeGreaterThan(0);
+      for (const r of rows ?? []) expect(typeof r.knnDist).not.toBe('number');
+
+      // EXPLAIN confirms the operator left the plan entirely.
+      const [plan] = await db.query<[unknown]>(
+        `SELECT id FROM knowledge_fact WHERE embedding <|8,100|> $q EXPLAIN`,
+        { q: new Array(1536).fill(0.01) },
+      );
+      expect(JSON.stringify(plan)).toContain('TableScan');
+      expect(JSON.stringify(plan)).not.toContain('KnnScan');
+    });
+  });
+
   it('creates indexes with the live dimension and matches the exact scan', async () => {
     // A second entity so ranking has something to order.
     await f.http

--- a/test/knn-missing-index.unit-spec.ts
+++ b/test/knn-missing-index.unit-spec.ts
@@ -1,0 +1,289 @@
+import { runVectorLeg } from '../src/search/internals/legs';
+import { runDenseScanLeg } from '../src/synthesize/scan-leg';
+import { hnswIndexState, knnDroppedMessage, knnOperatorDropped } from '../src/db/knn-index';
+
+/**
+ * The missing-HNSW-index defect (roadmap embedding-spaces-2026-09 §6 E1).
+ *
+ * SurrealDB 3.2.4 does not error when `<|K,EF|>` has no index to ride: it
+ * drops the operator from the plan and answers with the table's first k
+ * rows and `vector::distance::knn()` projecting NULL on each. Measured on a
+ * scratch v3.2.4 container (3 000 × 1024-d):
+ *
+ *   no index          → [{"knnDist":null,"n":1144},{"knnDist":null,"n":2781},…]
+ *   CONCURRENTLY, mid-build ({"status":"indexing"})
+ *                     → the SAME null-distance rows
+ *   index ready       → [{"knnDist":0.8998…,"n":1802},…]
+ *
+ * So every leg's documented "throws when the tenant has no index — the
+ * caller falls back to the scan" was dead code, and production
+ * (`SEARCH_HNSW_ENABLED=1`, per-tenant manual index creation) served
+ * unranked table-order rows to any un-indexed tenant. These tests pin the
+ * detection and the fallback, using the exact row shape the driver returns.
+ */
+
+interface FakeDb {
+  query: jest.Mock;
+  calls: string[];
+}
+
+/** A db whose successive `query` calls answer from `results` in order; the
+ *  last entry repeats. Mirrors the driver's `[resultOfStatement1, …]` shape. */
+function fakeDb(results: unknown[][]): FakeDb {
+  const calls: string[] = [];
+  let i = 0;
+  const query = jest.fn(async (sql: string) => {
+    calls.push(sql);
+    const r = results[Math.min(i, results.length - 1)];
+    i += 1;
+    return r;
+  });
+  return { query, calls };
+}
+
+/** What SurrealDB returns for `INFO FOR TABLE t` with no index defined. */
+const INFO_TABLE_NO_INDEX = [{ events: {}, fields: {}, indexes: {}, lives: {}, tables: {} }];
+const INFO_TABLE_WITH_INDEX = [
+  {
+    events: {},
+    fields: {},
+    indexes: {
+      fact_embedding_hnsw:
+        'DEFINE INDEX fact_embedding_hnsw ON knowledge_fact FIELDS embedding HNSW DIMENSION 1024 DIST COSINE TYPE F32 EFC 200 M 16',
+    },
+    lives: {},
+    tables: {},
+  },
+];
+
+describe('knnOperatorDropped — the signal is the null distance, not an exception', () => {
+  it('is true when every row of a non-empty result has a null distance', () => {
+    // Verbatim from the 3.2.4 measurement with no index.
+    const rows = [
+      { knnDist: null, n: 1144 },
+      { knnDist: null, n: 2781 },
+      { knnDist: null, n: 2778 },
+    ];
+    expect(knnOperatorDropped(rows, 'knnDist')).toBe(true);
+  });
+
+  it('is false when the operator rode the index (numeric distances)', () => {
+    const rows = [
+      { knnDist: 0.8998647510844109, n: 1802 },
+      { knnDist: 0.8999069422705311, n: 2007 },
+    ];
+    expect(knnOperatorDropped(rows, 'knnDist')).toBe(false);
+  });
+
+  it('is false for an empty result — that is gate starvation, not a missing index', () => {
+    expect(knnOperatorDropped([], 'knnDist')).toBe(false);
+    expect(knnOperatorDropped(null, 'knnDist')).toBe(false);
+    expect(knnOperatorDropped(undefined, 'knnDist')).toBe(false);
+  });
+
+  it('one ranked row is enough to say the operator ran', () => {
+    expect(knnOperatorDropped([{ knnDist: null }, { knnDist: 0.2 }], 'knnDist')).toBe(false);
+  });
+
+  it('reads whichever distance alias the caller projected', () => {
+    expect(knnOperatorDropped([{ dist: null }], 'dist')).toBe(true);
+    expect(knnOperatorDropped([{ dist: 0.4 }], 'dist')).toBe(false);
+  });
+});
+
+describe('hnswIndexState — why the operator was dropped', () => {
+  const SPEC = { table: 'knowledge_fact', index: 'fact_embedding_hnsw' };
+
+  it('reports absent from INFO FOR TABLE without consulting INFO FOR INDEX', async () => {
+    // INFO FOR INDEX THROWS on a missing index ("The index 'x' does not
+    // exist"), so existence must be probed on the table.
+    const db = fakeDb([INFO_TABLE_NO_INDEX]);
+    expect(await hnswIndexState(db as never, SPEC)).toBe('absent');
+    expect(db.calls).toEqual(['INFO FOR TABLE knowledge_fact;']);
+  });
+
+  it('reports building for an index that exists but is still indexing', async () => {
+    const db = fakeDb([
+      INFO_TABLE_WITH_INDEX,
+      [{ building: { initial: 16, pending: 0, status: 'indexing' } }],
+    ]);
+    expect(await hnswIndexState(db as never, SPEC)).toBe('building');
+  });
+
+  it('reports ready once the build completes', async () => {
+    const db = fakeDb([
+      INFO_TABLE_WITH_INDEX,
+      [{ building: { initial: 3000, pending: 0, status: 'ready', updated: 0 } }],
+    ]);
+    expect(await hnswIndexState(db as never, SPEC)).toBe('ready');
+  });
+
+  it('never escalates a diagnostic failure into a query failure', async () => {
+    const db = {
+      query: jest.fn(async () => {
+        throw new Error('connection reset');
+      }),
+    };
+    await expect(hnswIndexState(db as never, SPEC)).resolves.toBe('unknown');
+  });
+
+  it('names the remedy for each state', () => {
+    const spec = { table: 'knowledge_fact', index: 'fact_embedding_hnsw' };
+    expect(knnDroppedMessage(spec, 'absent')).toContain('/v1/admin/maintenance/hnsw');
+    expect(knnDroppedMessage(spec, 'building')).toContain('still building');
+    expect(knnDroppedMessage(spec, 'unknown')).toContain('could not be determined');
+  });
+});
+
+describe('search vector leg — a dropped KNN operator falls back to the exact scan', () => {
+  const embedder = { embed: async () => [0.1, 0.2, 0.3] };
+  const tuning = {
+    combinedVectorGraph: false,
+    hnswEnabled: true,
+    hnswEf: 100,
+    hnswOverfetch: 4,
+    highlightEnabled: false,
+  };
+  const legArgs = (db: FakeDb, logger?: object) => ({
+    db: db as never,
+    embedder: embedder as never,
+    query: 'who is ada',
+    k: 5,
+    baseWhere: { sql: 'AND status = "active"', params: {} },
+    tuning,
+    ...(logger ? { logger: logger as never } : {}),
+  });
+
+  it('never returns unranked table-order rows as if they were ranked', async () => {
+    const db = fakeDb([
+      // 1. the KNN statement — succeeds, operator dropped
+      [
+        [
+          { id: 'f1', knnDist: null },
+          { id: 'f2', knnDist: null },
+        ],
+      ],
+      // 2. the diagnostic probe
+      INFO_TABLE_NO_INDEX,
+      // 3. the exact scan
+      [[{ id: 'f9', simScore: 0.91 }]],
+    ]);
+    const errors: string[] = [];
+    const rows = await runVectorLeg(
+      legArgs(db, { warn: () => {}, error: (m: string) => errors.push(m) }),
+    );
+
+    // The garbage is discarded, not scored.
+    expect(rows).toEqual([{ id: 'f9', simScore: 0.91 }]);
+    expect(rows.map((r) => r.id)).not.toContain('f1');
+    // KNN → INFO FOR TABLE → exact scan.
+    expect(db.calls).toHaveLength(3);
+    expect(db.calls[0]).toContain('<|20,100|>');
+    expect(db.calls[1]).toContain('INFO FOR TABLE knowledge_fact');
+    expect(db.calls[2]).toContain('vector::similarity::cosine(embedding, $q) AS simScore');
+    // Loud: ERROR, not a debug crumb, and it names the fix.
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('DROPPED');
+    expect(errors[0]).toContain('/v1/admin/maintenance/hnsw');
+  });
+
+  it('says "still building" when the index exists but is not ready', async () => {
+    const db = fakeDb([
+      [[{ id: 'f1', knnDist: null }]],
+      INFO_TABLE_WITH_INDEX,
+      [{ building: { initial: 16, pending: 0, status: 'indexing' } }],
+      [[{ id: 'f9', simScore: 0.5 }]],
+    ]);
+    const errors: string[] = [];
+    await runVectorLeg(legArgs(db, { warn: () => {}, error: (m: string) => errors.push(m) }));
+    expect(errors[0]).toContain('still building');
+  });
+
+  it('keeps the KNN result when the operator rode the index (one round trip)', async () => {
+    const db = fakeDb([[[{ id: 'f1', knnDist: 0.25 }]]]);
+    const rows = await runVectorLeg(legArgs(db));
+    // COSINE distance → similarity.
+    expect(rows).toEqual([{ id: 'f1', simScore: 0.75 }]);
+    expect(db.calls).toHaveLength(1);
+    expect(db.calls[0]).toContain('<|');
+  });
+
+  it('leaves an empty KNN result empty — that is not a missing index', async () => {
+    const db = fakeDb([[[]]]);
+    const rows = await runVectorLeg(legArgs(db));
+    expect(rows).toEqual([]);
+    // No probe, no scan: an empty tenant must not trigger a full-table
+    // cosine walk (a brute scan over 20k × 1024-d OOM-killed the server at
+    // 6 GB and 8 GB — roadmap §3 S11).
+    expect(db.calls).toHaveLength(1);
+  });
+
+  it('is inert when the HNSW flag is off (byte-identical legacy scan)', async () => {
+    const db = fakeDb([[[{ id: 'f9', simScore: 0.4 }]]]);
+    const rows = await runVectorLeg({
+      ...legArgs(db),
+      tuning: { ...tuning, hnswEnabled: false },
+    });
+    expect(rows).toEqual([{ id: 'f9', simScore: 0.4 }]);
+    expect(db.calls).toHaveLength(1);
+    expect(db.calls[0]).not.toContain('<|');
+  });
+
+  it('still falls back when the KNN statement throws (the legacy path)', async () => {
+    const calls: string[] = [];
+    let first = true;
+    const db = {
+      calls,
+      query: jest.fn(async (sql: string) => {
+        calls.push(sql);
+        if (first) {
+          first = false;
+          throw new Error('boom');
+        }
+        return [[{ id: 'f9', simScore: 0.3 }]];
+      }),
+    };
+    const warns: string[] = [];
+    const rows = await runVectorLeg(
+      legArgs(db as unknown as FakeDb, { warn: (m: string) => warns.push(m) }),
+    );
+    expect(rows).toEqual([{ id: 'f9', simScore: 0.3 }]);
+    expect(warns.join(' ')).toContain('fell back to full scan');
+  });
+});
+
+describe('coverage dense scan leg — the same defect, the same fallback', () => {
+  const request = (db: FakeDb, logger?: object) => ({
+    db: db as never,
+    table: 'episode_segment' as const,
+    projection: 'id, text',
+    gates: 'AND userId IS NONE',
+    params: { q: [0.1], k: 400 },
+    k: 400,
+    tuning: { mode: 'hnsw' as const, ef: 400, overfetch: 4 },
+    ...(logger ? { logger: logger as never } : {}),
+  });
+
+  it('discards the unranked rows and re-runs the brute scan', async () => {
+    const db = fakeDb([
+      // The bug: a NON-empty result, so the existing `rows.length > 0`
+      // guard passed it through with `score: undefined`.
+      [
+        [
+          { id: 's1', knnDist: null },
+          { id: 's2', knnDist: null },
+        ],
+      ],
+      [{ events: {}, fields: {}, indexes: {}, lives: {}, tables: {} }],
+      [[{ id: 's9', score: 0.8 }]],
+    ]);
+    const errors: string[] = [];
+    const rows = await runDenseScanLeg(
+      request(db, { warn: () => {}, error: (m: string) => errors.push(m) }),
+    );
+    expect(rows).toEqual([{ id: 's9', score: 0.8 }]);
+    expect(db.calls[0]).toContain('<|');
+    expect(db.calls[2]).toContain('embedding != NONE');
+    expect(errors[0]).toContain('segment_embedding_hnsw');
+  });
+});


### PR DESCRIPTION
Item **E1** of the programme in [#505](https://github.com/inite-ai/inite-brain-service/pull/505) §6 — the one defect on that list that produces **wrong answers shaped like answers**. Independent of E2 and E6; branches off `main`.

## The defect

SurrealDB 3.2.4 does **not** fail a `<|K,EF|>` query when there is no index to ride. It drops the KNN operator from the plan and answers the rest of the statement — `EXPLAIN` shows a bare `TableScan` — returning the table's first *k* rows **in storage order** with `vector::distance::knn()` projecting `NULL` on every one.

Measured here on a scratch `surrealdb/surrealdb:v3.2.4` container (3 000 × 1024-d, rocksdb, port 3058):

| state | result |
|---|---|
| no index | `[{"knnDist":null,"n":1144},{"knnDist":null,"n":2781},{"knnDist":null,"n":2778}]`, `EXPLAIN` → `SelectProject → TableScan` |
| `CONCURRENTLY`, mid-build (`{"initial":16,"pending":0,"status":"indexing"}`) | **the same three null-distance rows** |
| index `ready` (`{"initial":3000,"pending":0,"status":"ready"}`) | `[{"knnDist":0.8998…,"n":1802},{"knnDist":0.8999…,"n":2007}]` |

Every KNN leg in the repo was written against the opposite assumption — *"Throws when the tenant has no index — the caller falls back to the scan"* (`legs.ts:109`) — so the `catch` clauses that implement the fallback are dead code. `SEARCH_HNSW_ENABLED=1` is set globally in `deploy-brain.yml:178` while index creation is a manual per-tenant admin call (`hnsw-maintenance.service.ts:15`), so an un-indexed tenant has been served *k* arbitrary facts with **no similarity score at all**.

The third row of that table is the part that was not previously known: **"the index exists" is not the property a KNN leg needs.** A `CONCURRENTLY` build exists from the moment the DDL returns and is unusable until it reports `ready`, and during the build the operator is dropped exactly as if no index existed. That makes this fix a prerequisite for E2, not merely adjacent to it.

## The fix

The signal is `knnDist === null` on **every** row of a **non-empty** result. It is a direct observation that the operator was not applied — not an inference from an exception that never arrives — it costs nothing (the rows are already in hand), and it covers the still-building state that an `INFO FOR TABLE` probe cannot see.

`src/db/knn-index.ts` (new) owns three small pure/read-only pieces: `knnOperatorDropped(rows, distanceField)`, `hnswIndexState(db, spec)` → `ready | building | absent | unknown` for the diagnostic, and `knnDroppedMessage(spec, state)`.

### Fallback, not failure — and why

The exact scan is the **same statement every tenant is served with the flag off**, so falling back is a return to the documented baseline rather than a new risk. Three things make it the right call over a loud 503:

1. **The OOM measurement does not apply to this query.** §3 S11's kill was an unfenced full walk of a 20k-row table; the search leg's scan carries the tenant's `status` / `retractedAt` / ABAC / user-scope gates and a `LIMIT $k`, and it is what production runs today for every tenant whenever `SEARCH_HNSW_ENABLED=0`.
2. **A hard failure moves the outage onto the least-watched tenants.** "Un-indexed" correlates almost perfectly with "newly onboarded". Turning a wrong answer into no answer at all is not obviously the better trade for them; turning it into a *right* answer plus a screaming log is.
3. **The empty-pool case is deliberately excluded.** An empty KNN result is gate starvation, not a missing index. Treating it as one would trigger a full-table cosine walk on exactly the pathological input — that *is* the OOM shape, and it is the one thing this PR is careful not to do.

What is new is that the state is **loud**: `ERROR`, not a debug crumb, naming the tenant's missing (or still-building) index and the single admin call that fixes it. Verified firing against a real container in the e2e run:

```
ERROR [SearchRetrievalService] hnsw KNN operator was DROPPED on knowledge_fact
(every row came back with a null distance, i.e. unranked table-order rows):
index 'fact_embedding_hnsw' does not exist on this tenant — build it with
POST /v1/admin/maintenance/hnsw. Falling back to the exact scan.
```

### The four KNN sites, all fixed the same way

| site | what the null distances did before |
|---|---|
| `src/search/internals/legs.ts` | **the live one** — unranked table-order facts returned with `simScore: undefined`, into fusion and ranking |
| `src/synthesize/scan-leg.ts` | the dropped result is **non-empty**, so it passed the existing `rows.length > 0` guard and was returned with `score: undefined` |
| `src/dreams/dedup.service.ts` | read as `sim = 0` → below every threshold → the whole dedup sweep went **silently inert** on un-indexed tenants |
| `src/ingest/entity-resolver.service.ts` | same, and the loop `break`s below `cosineFloor` → inline resolution resolved **nothing** |

## Blast radius

No flag — this is a bug fix whose "off" state is broken (as #505 §6 notes for E1 specifically). Behaviour is unchanged wherever the index rides (one round trip, identical rows) and wherever the HNSW flag is off (byte-identical legacy scan). The probe query runs **only** on the failure path, never on the hot path, and any error inside it answers `unknown` rather than escalating — a diagnostic must not turn a recovered query into a failed one.

## What proves it

- `test/knn-missing-index.unit-spec.ts` (new, 17 tests) — the detector against the **verbatim row shape** from the container measurement; the leg discards the unranked rows, probes, and returns the *scan's* rows; the `still building` variant; one ranked row is enough to keep the KNN result; an empty result stays empty with **no** second query; flag-off is byte-identical; the legacy throw path still falls back.
- `test/hnsw.e2e-spec.ts` — a new case asserts the engine behaviour directly rather than assuming it: on a tenant with no index, `INFO FOR TABLE` shows no `fact_embedding_hnsw`, the KNN statement returns non-empty rows with **no numeric** `knnDist`, and `EXPLAIN` contains `TableScan` and **not** `KnnScan`.
- `test/coverage-scan-leg.unit-spec.ts` — two fixtures that omitted `knnDist` now carry one, so the ef/overfetch arithmetic cases exercise the ridden-index path they were written for.

## Gates

Run un-piped, real exit codes:

| Gate | Exit |
|---|---|
| `npx tsc --noEmit -p tsconfig.json` | 0 |
| `npx tsc --noEmit -p tsconfig.spec.json` | 0 |
| `npx eslint "{src,test}/**/*.ts" --max-warnings 0` | 0 |
| `npx prettier --check "src/**/*.ts" "test/**/*.ts"` | 0 |
| `jest --config ./test/jest-unit.json` | 0 — 396 suites, 4855 tests |
| `jest --config ./test/jest-e2e.json --testPathPatterns hnsw` | 0 — 2 suites, 8 tests, real SurrealDB 3.2.4 |

Running the suites from a worktree needs both `testPathIgnorePatterns` and `modulePathIgnorePatterns` overridden (`test/jest-unit.json` excludes `/.claude/worktrees/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB
