### PR TITLE
fix(fovea): close the lens-suppression centroid bypass — width and space checked at the write

### DIFF
--- a/src/db/migrations/0132_lens_centroid_space.surql
+++ b/src/db/migrations/0132_lens_centroid_space.surql
@@ -1,0 +1,61 @@
+-- 0132: embedding-space stamps for the two vector columns 0101 missed —
+-- lens_suppression.centroid and semantic_belief.embedding.
+--
+-- WHY. 0101 gave every embedding-bearing table an `embeddingSpaceId`
+-- describing the (model, dimensionality, normalization) triple its vectors
+-- were produced under, so a cross-space compare can be refused instead of
+-- silently returning meaningless numbers. Two vector columns were left out,
+-- and one of them is the only vector in the system that arrives from
+-- OUTSIDE the embedder.
+--
+-- lens_suppression.centroid (0096) is cosine-compared against a live query
+-- embedding on the serving path (decideSuppression, nearest-centroid match)
+-- and is written by a THIN ADMIN INGEST — the training data is offline
+-- ablation-mined, so the operator POSTs the centroid rather than the
+-- service computing it. The write guard added in #503 (`0cd331c`) is a
+-- guard on EmbedderService: it fails closed when the provider that would
+-- serve is not in the primary's space, and it re-checks the produced
+-- width. A vector that never touches the embedder cannot be reached by it.
+-- Until now the only validation on an ingested centroid was that its
+-- numbers are finite — not its width, not its space — so a 1536-wide
+-- centroid could be persisted into a 1024-wide tenant and would sit there
+-- until the serving cosine failed on it.
+--
+-- semantic_belief.embedding (0126) is write-dead by design (no producer
+-- yet) but is declared in VECTOR_COLUMNS and will be cosine-compared the
+-- moment a producer exists. It gets the same stamp now so the column
+-- cannot acquire a writer without a space.
+--
+-- ADDITIVE + OPTIONAL, the 0101 posture exactly: `option<string>`, so every
+-- existing row reads NONE and NO backfill runs at migrate time. NONE is
+-- interpreted as "the current provider's space" (the legacy / implicit
+-- space), which is what those rows are in — the ingest that wrote them
+-- could only produce the deployed embedder's width without failing at read
+-- time. Nothing is rewritten here.
+--
+-- GDPR. Neither column is new personal data and neither needs new forget
+-- reach. `embeddingSpaceId` holds a deployment descriptor
+-- (`provider:model:dim:norm`), not user content. `lens_suppression` is
+-- tenant-scoped aggregate state (companyId, no userId) that no user- or
+-- entity-forget path touches. `semantic_belief` IS reached by both forget
+-- paths, and both DELETE the whole row through the mandatory two-step
+-- `LET $ids = (SELECT VALUE id …); DELETE $ids;` idiom
+-- (user-forget.service.ts, entity-forget.service.ts) — a column on a row
+-- that is deleted entirely needs no separate sweep.
+--
+-- No index, no changefeed, no event: this column is read by the admin
+-- surface and by nothing on the hot path, and a single-field index over it
+-- would only invite the `UPDATE … WHERE <indexed field>` shape 3.2.4's
+-- planner mishandles.
+
+-- lens_suppression — the externally-supplied class centroid (0096). The
+-- admin `fit` ingest now refuses a centroid whose width does not match the
+-- tenant's primary embedder and stamps the space it validated against.
+DEFINE FIELD IF NOT EXISTS embeddingSpaceId ON lens_suppression TYPE option<string>
+    ASSERT $value IS NONE OR string::len($value) >= 3;
+
+-- semantic_belief — the belief lane's dense leg (0126), write-dead until a
+-- promotion-side producer exists. Stamped now so it cannot gain one
+-- without declaring a space.
+DEFINE FIELD IF NOT EXISTS embeddingSpaceId ON semantic_belief TYPE option<string>
+    ASSERT $value IS NONE OR string::len($value) >= 3;

--- a/src/synthesize/lens-admin.controller.ts
+++ b/src/synthesize/lens-admin.controller.ts
@@ -22,6 +22,13 @@ import { LensSuppressionService, type LensSuppressionFitClass } from './lens-sup
  * idiom). The `fit` is a THIN INGEST of externally-mined (class, centroid,
  * suppressLanes) rows — the training data is offline/parked, so this surface
  * persists provided rows rather than learning at serving time.
+ *
+ * Because the centroid arrives from outside, it is the one vector in the
+ * system that never passes EmbedderService and therefore never met #503's
+ * cross-space write guard. The width/space check now lives in the service
+ * (LensSuppressionService.assertCentroidSpace) rather than here, so it
+ * covers every caller of `fitAndPersist` and not merely this route; the
+ * shape validation below stays where it is.
  */
 @Controller('v1/admin/lens-suppression')
 @UseGuards(ApiKeyGuard)
@@ -42,6 +49,8 @@ export class LensAdminController {
       sampleCount: number;
       version: number;
       centroidDim: number;
+      /** The space stamp (0132). NULL = written before the guard existed. */
+      embeddingSpaceId: string | null;
     }>;
   }> {
     this.assertEnabled();
@@ -61,6 +70,7 @@ export class LensAdminController {
         centroid?: unknown;
         suppressLanes?: unknown;
         sampleCount?: unknown;
+        embeddingSpaceId?: unknown;
       }>;
     },
   ): Promise<{ persisted: number; classes: string[] }> {
@@ -86,11 +96,17 @@ export class LensAdminController {
           'each class needs a classId, a numeric centroid[], a string suppressLanes[], and a non-negative sampleCount',
         );
       }
+      // Optional, but not free-form: a declared space is an assertion the
+      // service checks against the tenant's primary space.
+      if (c.embeddingSpaceId !== undefined && typeof c.embeddingSpaceId !== 'string') {
+        throw new BadRequestException('embeddingSpaceId must be a string when supplied');
+      }
       return {
         classId: c.classId,
         centroid: c.centroid as number[],
         suppressLanes: c.suppressLanes as string[],
         sampleCount: c.sampleCount,
+        ...(typeof c.embeddingSpaceId === 'string' ? { embeddingSpaceId: c.embeddingSpaceId } : {}),
       };
     });
     return this.lens.fitAndPersist(req.brainAuth.companyId, classes);

--- a/src/synthesize/lens-suppression.service.ts
+++ b/src/synthesize/lens-suppression.service.ts
@@ -1,7 +1,14 @@
-import { Injectable, Logger, Optional } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  Logger,
+  Optional,
+  ServiceUnavailableException,
+} from '@nestjs/common';
 import { lensSuppressEnabled, lensSuppressMinCosine } from '../common/fovea-flags';
 import { SurrealService } from '../db/surreal.service';
 import { EmbedderService } from '../ai/embedder.service';
+import { describeSpaceIncompatibility } from '../ai/embedder/embedding-space';
 import { MetricsService } from '../metrics/metrics.service';
 import type { RetrievalProfile } from '../search/retrieval-profile';
 import {
@@ -18,6 +25,14 @@ export interface LensSuppressionFitClass {
   centroid: number[];
   suppressLanes: string[];
   sampleCount: number;
+  /**
+   * The embedding space the centroid was mined in
+   * (`provider:model:dim:norm`). Optional: omitted means "the tenant's
+   * primary space", which is the only space a centroid may be stored in.
+   * Supplied and incompatible is a 400 — an operator who names a space is
+   * asserting something checkable, and a wrong assertion here is durable.
+   */
+  embeddingSpaceId?: string;
 }
 
 /**
@@ -148,18 +163,87 @@ export class LensSuppressionService {
   }
 
   /**
+   * The write guard #503 could not reach.
+   *
+   * `lens_suppression.centroid` is the one vector in the system that never
+   * touches the embedder: the training data is offline ablation-mined, so
+   * the operator POSTs the centroid. EmbedderService's guard is a guard on
+   * the embedder — it fails closed when the serving provider is in a
+   * foreign space and re-checks the produced width — and a vector produced
+   * elsewhere simply walks past it. Until this, the only validation was
+   * that the numbers are finite.
+   *
+   * The invariant is the same one #503 argued and the reason is the same:
+   * a cross-space READ is transient and self-healing, a cross-space WRITE
+   * is durable damage. A 1536-wide centroid in a 1024-wide tenant makes
+   * `vector::similarity::cosine` raise for the whole query the moment the
+   * governor is switched on, and it cannot be repaired by re-embedding —
+   * there is no stored source text for it (it arrives from outside), so
+   * the only fix is to re-fit the model offline.
+   *
+   * Validated against the PRIMARY space, never the serving one: the
+   * centroid did not come from whoever happens to be serving, and the
+   * corpus it will be compared against is the primary's. That also keeps
+   * the ingest usable during the bge-m3 warmup window instead of 503-ing
+   * for no reason.
+   *
+   * Unconditional, not flag-gated — exactly as #503's guard is. There is no
+   * configuration in which persisting a wrong-width centroid is the desired
+   * outcome, and the whole surface is already behind FOVEA_LENS_SUPPRESS
+   * (the routes 404 when it is off).
+   */
+  private assertCentroidSpace(c: LensSuppressionFitClass): string {
+    if (!this.embedder) {
+      // Width unknowable ⇒ refuse. Fail closed: an unvalidated centroid is
+      // durable and unrepairable, a 503 is retryable.
+      throw new ServiceUnavailableException(
+        `lens-suppression fit: no embedder is wired, so the centroid width for ` +
+          `class '${c.classId}' cannot be validated. Refusing to persist an ` +
+          `unvalidated vector.`,
+      );
+    }
+    const expected = this.embedder.primaryDimensions();
+    if (c.centroid.length !== expected) {
+      throw new BadRequestException(
+        `lens-suppression fit: class '${c.classId}' has a ${c.centroid.length}-wide ` +
+          `centroid but this tenant's corpus is ${expected}-wide ` +
+          `(${this.embedder.primarySpaceId()}). A cross-space centroid is ` +
+          `cosine-compared against query vectors and is meaningless.`,
+      );
+    }
+    const primary = this.embedder.primarySpaceId();
+    if (c.embeddingSpaceId !== undefined) {
+      const reason = describeSpaceIncompatibility(c.embeddingSpaceId, primary);
+      if (reason !== null) {
+        throw new BadRequestException(
+          `lens-suppression fit: class '${c.classId}' declares embedding space ` +
+            `'${c.embeddingSpaceId}' but this tenant serves '${primary}' (${reason}).`,
+        );
+      }
+    }
+    // Stamp the space that was actually validated, so a later width change
+    // can tell an old centroid from a current one (0101/0132).
+    return primary;
+  }
+
+  /**
    * THIN INGEST of externally-mined suppression rows (the training data is
    * offline/parked). Each class is persisted as a NEW versioned row
    * (calibration_table idiom); the reader picks max(version) per class.
    * Unknown lane ids are dropped. Returns the persisted class ids.
+   *
+   * Every class is width- and space-checked BEFORE anything is written, so
+   * a batch with one bad centroid persists nothing rather than half of
+   * itself.
    */
   async fitAndPersist(
     companyId: string,
     classes: readonly LensSuppressionFitClass[],
   ): Promise<{ persisted: number; classes: string[] }> {
+    const spaces = classes.map((c) => this.assertCentroidSpace(c));
     return this.surreal.withCompany(companyId, async (db) => {
       const out: string[] = [];
-      for (const c of classes) {
+      for (const [i, c] of classes.entries()) {
         const suppressLanes = c.suppressLanes
           .map(toLaneId)
           .filter((l): l is NonNullable<typeof l> => l !== null);
@@ -176,7 +260,8 @@ export class LensSuppressionService {
               centroid: $centroid,
               suppressLanes: $suppressLanes,
               sampleCount: $sampleCount,
-              version: $version
+              version: $version,
+              embeddingSpaceId: $embeddingSpaceId
            }`,
           {
             companyId,
@@ -185,6 +270,7 @@ export class LensSuppressionService {
             suppressLanes,
             sampleCount: c.sampleCount,
             version: next,
+            embeddingSpaceId: spaces[i],
           },
         );
         out.push(c.classId);
@@ -194,7 +280,10 @@ export class LensSuppressionService {
   }
 
   /** List the latest suppression class per classId (max version) — the admin
-   *  read surface. Centroid vectors are omitted (bulky, not operator-useful). */
+   *  read surface. Centroid vectors are omitted (bulky, not operator-useful);
+   *  the width and the space stamp are exactly what an operator checking a
+   *  fit needs, so both are reported (0132). A NONE stamp is a row written
+   *  before the guard existed and reads as the legacy/implicit space. */
   async listClasses(companyId: string): Promise<
     Array<{
       classId: string;
@@ -202,6 +291,7 @@ export class LensSuppressionService {
       sampleCount: number;
       version: number;
       centroidDim: number;
+      embeddingSpaceId: string | null;
     }>
   > {
     return this.surreal.withCompany(companyId, async (db) => {
@@ -213,10 +303,11 @@ export class LensSuppressionService {
             suppressLanes: string[];
             sampleCount: number;
             version: number;
+            embeddingSpaceId?: string | null;
           }>,
         ]
       >(
-        `SELECT classId, centroid, suppressLanes, sampleCount, version
+        `SELECT classId, centroid, suppressLanes, sampleCount, version, embeddingSpaceId
             FROM lens_suppression
             ORDER BY version DESC`,
       );
@@ -227,6 +318,7 @@ export class LensSuppressionService {
         sampleCount: number;
         version: number;
         centroidDim: number;
+        embeddingSpaceId: string | null;
       }> = [];
       for (const r of rows ?? []) {
         if (seen.has(r.classId)) continue;
@@ -239,6 +331,7 @@ export class LensSuppressionService {
           sampleCount: typeof r.sampleCount === 'number' ? r.sampleCount : 0,
           version: r.version,
           centroidDim: Array.isArray(r.centroid) ? r.centroid.length : 0,
+          embeddingSpaceId: typeof r.embeddingSpaceId === 'string' ? r.embeddingSpaceId : null,
         });
       }
       return out;

--- a/test/fovea-lens-suppress.e2e-spec.ts
+++ b/test/fovea-lens-suppress.e2e-spec.ts
@@ -162,4 +162,76 @@ describe('Fovea Optics §4.3 lens-suppression governor e2e', () => {
     expect(prompt).not.toContain(INSTRUCTION_MARKER);
     expect(await suppressCount(fSuppress, 'suppressed')).toBe(before + 1);
   });
+
+  /**
+   * The centroid write guard (0132). The `fit` ingest is the only way a
+   * vector enters this store, and it never passes EmbedderService — so
+   * #503's cross-space write guard cannot see it. A wrong-width centroid
+   * here is durable and unrepairable (no stored source text to re-embed
+   * from), which is why the refusal is unconditional rather than flagged.
+   */
+  describe('POST /v1/admin/lens-suppression/fit — centroid space guard', () => {
+    const fit = (body: object) =>
+      fControl.http.post('/v1/admin/lens-suppression/fit').set(authControl()).send(body);
+
+    const cls = (centroid: number[], extra: Record<string, unknown> = {}) => ({
+      classes: [
+        {
+          classId: 'guard_probe',
+          centroid,
+          suppressLanes: ['instruction'],
+          sampleCount: 10,
+          ...extra,
+        },
+      ],
+    });
+
+    beforeEach(() => {
+      process.env.FOVEA_LENS_SUPPRESS = '1';
+    });
+
+    it('refuses a wrong-width centroid with a 400', async () => {
+      const width = fControl.app.get(EmbedderService).primaryDimensions();
+      const wrong = width === 1024 ? 1536 : 1024;
+      const r = await fit(cls(new Array(wrong).fill(0.01)));
+      expect(r.status).toBe(400);
+      expect(String(r.body.message)).toContain(`${wrong}-wide centroid`);
+
+      // Nothing was written: the class never appears in the listing.
+      const list = await fControl.http.get('/v1/admin/lens-suppression/classes').set(authControl());
+      expect(list.status).toBe(200);
+      expect(
+        (list.body.classes as Array<{ classId: string }>).some((c) => c.classId === 'guard_probe'),
+      ).toBe(false);
+    });
+
+    it('refuses a centroid that declares a foreign space with a 400', async () => {
+      const width = fControl.app.get(EmbedderService).primaryDimensions();
+      const r = await fit(
+        cls(new Array(width).fill(0.01), { embeddingSpaceId: 'openai:some-other-model:1536:l2' }),
+      );
+      expect(r.status).toBe(400);
+    });
+
+    it('accepts a right-width centroid and stamps the tenant space', async () => {
+      const embedder = fControl.app.get(EmbedderService);
+      const r = await fit(cls(new Array(embedder.primaryDimensions()).fill(0.01)));
+      expect([200, 201]).toContain(r.status);
+      expect(r.body.persisted).toBe(1);
+
+      const list = await fControl.http.get('/v1/admin/lens-suppression/classes').set(authControl());
+      const row = (
+        list.body.classes as Array<{
+          classId: string;
+          centroidDim: number;
+          embeddingSpaceId: string | null;
+        }>
+      ).find((c) => c.classId === 'guard_probe');
+      expect(row).toBeDefined();
+      expect(row!.centroidDim).toBe(embedder.primaryDimensions());
+      // The stamp is the space the guard validated against — 0101's
+      // descriptor, now reaching the column 0101 missed.
+      expect(row!.embeddingSpaceId).toBe(embedder.primarySpaceId());
+    });
+  });
 });

--- a/test/lens-centroid-space-guard.unit-spec.ts
+++ b/test/lens-centroid-space-guard.unit-spec.ts
@@ -1,0 +1,173 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { LensSuppressionService } from '../src/synthesize/lens-suppression.service';
+
+/**
+ * The centroid bypass (roadmap embedding-spaces-2026-09 §2 D7 / §6 E6).
+ *
+ * #503 (`0cd331c`) made a cross-space vector write unrepresentable — for
+ * every vector that passes EmbedderService. `lens_suppression.centroid` is
+ * the one that does not: the training data is offline ablation-mined, so
+ * an operator POSTs the centroid to /v1/admin/lens-suppression/fit and it
+ * reaches the vector store having met exactly one check, that its numbers
+ * are finite. Not the width. Not the space.
+ *
+ * A 1536-wide centroid in a 1024-wide tenant is durable damage: the
+ * governor cosine-compares it against a live query embedding, so the first
+ * suppressed query raises "The two vectors must be of the same dimension".
+ * And unlike every other vector column it cannot be repaired by
+ * re-embedding — there is no stored source text for a centroid, so the
+ * only fix is an offline re-fit.
+ */
+
+const DIM = 1024;
+const SPACE = 'bge-m3:Xenova/bge-m3:1024:l2';
+
+function embedder(dim = DIM, space = SPACE) {
+  return {
+    primaryDimensions: () => dim,
+    primarySpaceId: () => space,
+  };
+}
+
+/** Records what actually reached the DB, so "refused" can be distinguished
+ *  from "written and then complained about". */
+function recordingSurreal() {
+  const created: Array<Record<string, unknown>> = [];
+  const surreal = {
+    withCompany: async <T>(_c: string, fn: (db: unknown) => Promise<T>): Promise<T> =>
+      fn({
+        query: async (sql: string, params?: Record<string, unknown>) => {
+          if (sql.includes('CREATE lens_suppression')) {
+            created.push(params ?? {});
+            return [null];
+          }
+          // The max(version) lookup.
+          return [[]];
+        },
+      }),
+  };
+  return { surreal, created };
+}
+
+/** `emb` is passed positionally on purpose — a default would swallow the
+ *  "no embedder wired" case this suite has to exercise. */
+function service(...args: [] | [ReturnType<typeof embedder> | undefined]) {
+  const emb = args.length === 0 ? embedder() : args[0];
+  const { surreal, created } = recordingSurreal();
+  return {
+    svc: new LensSuppressionService(surreal as never, emb as never),
+    created,
+  };
+}
+
+const cls = (over: Partial<Record<string, unknown>> = {}) => ({
+  classId: 'default',
+  centroid: new Array(DIM).fill(0.01),
+  suppressLanes: ['instruction'],
+  sampleCount: 42,
+  ...over,
+});
+
+describe('lens-suppression fit — the centroid write guard', () => {
+  it('a 1536-wide centroid into a 1024 tenant is a 400, and nothing is written', async () => {
+    const { svc, created } = service();
+    await expect(
+      svc.fitAndPersist('co1', [cls({ centroid: new Array(1536).fill(0.01) }) as never]),
+    ).rejects.toMatchObject({ status: 400 });
+    expect(created).toEqual([]);
+  });
+
+  it('the message names both widths and the tenant space', async () => {
+    const { svc } = service();
+    await expect(
+      svc.fitAndPersist('co1', [cls({ centroid: [0.1, 0.2, 0.3] }) as never]),
+    ).rejects.toThrow(/3-wide centroid but this tenant's corpus is 1024-wide/);
+  });
+
+  it('a declared space that is not the tenant space is a 400', async () => {
+    const { svc, created } = service();
+    await expect(
+      svc.fitAndPersist('co1', [
+        cls({ embeddingSpaceId: 'openai:text-embedding-3-small:1536:l2' }) as never,
+      ]),
+    ).rejects.toMatchObject({ status: 400 });
+    expect(created).toEqual([]);
+  });
+
+  it('a right-width centroid persists and is stamped with the tenant space', async () => {
+    const { svc, created } = service();
+    const res = await svc.fitAndPersist('co1', [cls() as never]);
+    expect(res).toEqual({ persisted: 1, classes: ['default'] });
+    expect(created).toHaveLength(1);
+    expect(created[0]!.embeddingSpaceId).toBe(SPACE);
+  });
+
+  it('a matching declared space is accepted and stamped', async () => {
+    const { svc, created } = service();
+    await svc.fitAndPersist('co1', [cls({ embeddingSpaceId: SPACE }) as never]);
+    expect(created[0]!.embeddingSpaceId).toBe(SPACE);
+  });
+
+  it('one bad centroid in a batch persists NOTHING — the check runs before any write', async () => {
+    const { svc, created } = service();
+    await expect(
+      svc.fitAndPersist('co1', [
+        cls({ classId: 'good' }) as never,
+        cls({ classId: 'bad', centroid: new Array(1536).fill(0.01) }) as never,
+      ]),
+    ).rejects.toMatchObject({ status: 400 });
+    expect(created).toEqual([]);
+  });
+
+  it('no embedder ⇒ the width is unknowable ⇒ 503, not a write', async () => {
+    // Fail closed. An unvalidated centroid is durable and unrepairable; a
+    // 503 is retryable.
+    const { svc, created } = service(undefined);
+    await expect(svc.fitAndPersist('co1', [cls() as never])).rejects.toMatchObject({
+      status: 503,
+    });
+    expect(created).toEqual([]);
+  });
+
+  it('the guard follows the PRIMARY space, so a warmup failover cannot widen it', async () => {
+    // primaryDimensions()/primarySpaceId() are stable across the bge-m3
+    // warmup window, unlike getDimensions()/activeSpaceId(). The ingest
+    // therefore neither accepts a 1536 centroid during warmup nor 503s for
+    // a correct one.
+    const { svc, created } = service(embedder(1024, SPACE));
+    await svc.fitAndPersist('co1', [cls() as never]);
+    expect(created[0]!.embeddingSpaceId).toBe(SPACE);
+  });
+});
+
+describe('migration 0132 — the stamp columns', () => {
+  const DIR = join(__dirname, '..', 'src', 'db', 'migrations');
+  const sql = readFileSync(join(DIR, '0132_lens_centroid_space.surql'), 'utf8');
+  /** Prose explaining a rule must not trip the rule (the truth-gate idiom). */
+  const ddl = sql.replace(/^\s*--.*$/gm, '');
+
+  it('takes a migration number nothing else on main uses', () => {
+    // migrationId is UNIQUE in schema_migrations: two branches shipping the
+    // same number means one of them silently never applies.
+    const numbers = readdirSync(DIR)
+      .filter((f) => f.endsWith('.surql'))
+      .map((f) => f.slice(0, 4));
+    expect(numbers.filter((n) => n === '0132')).toHaveLength(1);
+  });
+
+  it('stamps both columns 0101 missed, additively', () => {
+    for (const table of ['lens_suppression', 'semantic_belief']) {
+      expect(ddl).toContain(
+        `DEFINE FIELD IF NOT EXISTS embeddingSpaceId ON ${table} TYPE option<string>`,
+      );
+    }
+    // option<> so existing rows read NONE and no backfill runs at migrate
+    // time (the 0101 posture).
+    expect(ddl).not.toMatch(/TYPE string/);
+    // No data mutation and no index: 3.2.4's planner mishandles
+    // UPDATE/DELETE … WHERE over an indexed field.
+    expect(ddl).not.toMatch(/\b(UPDATE|DELETE|CREATE|UPSERT)\b/);
+    expect(ddl).not.toMatch(/DEFINE INDEX/);
+  });
+});


### PR DESCRIPTION
Item **E6** of the programme in [#505](https://github.com/inite-ai/inite-brain-service/pull/505) §6 (diagnosis **D7**). Independent of E1 and E2; branches off `main`.

## The defect

[#503](https://github.com/inite-ai/inite-brain-service/pull/503) (`0cd331c`) made a cross-space vector write unrepresentable — **for every vector that passes `EmbedderService`**. `lens_suppression.centroid` is the one that does not.

The lens-suppression training data is offline ablation-mined, so the operator **POSTs** the centroid to `/v1/admin/lens-suppression/fit` and it reaches the vector store having met exactly one check — that its numbers are finite (`lens-admin.controller.ts:77-78`). Not the width. Not the space. #503's guard is a guard *on the embedder*: it fails closed when the serving provider is in a foreign space and re-checks the produced width. A vector produced elsewhere walks straight past it.

The damage is durable and — uniquely among the thirteen vector columns — **unrepairable**. The governor cosine-compares the centroid against a live query embedding, so a 1536-wide centroid in a 1024-wide tenant makes `vector::similarity::cosine` raise for the whole query the moment `FOVEA_LENS_SUPPRESS` goes on. Every other vector column can be fixed by re-embedding its stored text; a centroid has **no source text** (Qdrant's unwritten precondition, quoted in #505 §4.6: *"re-embedding requires access to the original data used to create the embeddings"*), so the only remedy is an offline re-fit.

## The fix

The guard lives in `LensSuppressionService.assertCentroidSpace`, **not** in the controller, so it covers every caller of `fitAndPersist` rather than one route.

| condition | result |
|---|---|
| centroid width ≠ the tenant's primary width | **400**, naming both widths and the tenant space |
| class declares an `embeddingSpaceId` incompatible with the tenant's primary space | **400** |
| no embedder wired ⇒ width unknowable | **503** — fail closed; an unvalidated centroid is permanent, a 503 is retryable |
| accepted | persisted **and stamped** with the space that was validated; `GET /classes` reports it beside `centroidDim` |

Every class is checked **before anything is written**, so a batch with one bad centroid persists nothing rather than half of itself.

Validated against the **primary** space, never the serving one. The centroid did not come from whoever happens to be serving, and the corpus it will be compared against is the primary's — which also keeps the ingest usable during the bge-m3 warmup window instead of 503-ing for no reason.

**Unconditional rather than flag-gated**, exactly as #503's write guard is: there is no configuration in which persisting a wrong-width centroid is the desired outcome, and the whole surface already 404s when `FOVEA_LENS_SUPPRESS` is off.

## Migration 0132, not 0133

The programme numbered this one after E4's `0132`, and **E4 is not in this wave**. `0131_indexer_run_pack_idx.surql` is the highest on `main` and no branch in flight ships a `0132` (checked across every remote branch, including #504 and #505), so `0132` is the next genuinely free number. This matters: `migrationId` is UNIQUE in `schema_migrations`, so a collision means one of the two migrations **silently never applies** (`migrator.service.ts:51`, `:105-116`). A unit test pins that exactly one migration file claims `0132`.

`0132` adds `embeddingSpaceId` to `lens_suppression` **and** to `semantic_belief` — 0126's write-dead dense column, the second half of D12 — both `option<string>` in the 0101 posture, so existing rows read NONE and no backfill runs at migrate time. NONE reads as the legacy/implicit space, which is what those rows are in.

## GDPR

Neither column is new personal data and neither needs new forget reach.

- `embeddingSpaceId` holds a deployment descriptor (`provider:model:dim:norm`), not user content.
- `lens_suppression` is tenant-scoped aggregate state (`companyId`, no `userId`) that no user- or entity-forget path touches.
- `semantic_belief` **is** reached by both forget paths, and both `DELETE` the whole row through the mandatory two-step `LET $ids = (SELECT VALUE id …); DELETE $ids;` idiom (`user-forget.service.ts:427`, `entity-forget.service.ts:299`) — a column on a row that is deleted entirely needs no separate sweep.

No index is added: a single-field index here would only invite the `UPDATE`/`DELETE … WHERE <indexed field>` shape 3.2.4's planner mishandles, and nothing reads this column on the hot path.

## Blast radius

The lens-suppression admin route only. Existing centroids read `embeddingSpaceId` as NONE = the active space, so the serving path (`decideSuppression`) is unchanged. `GET /classes` gains one additive field.

## What proves it

- `test/lens-centroid-space-guard.unit-spec.ts` (new, 10 tests) — a 1536-wide centroid into a 1024 tenant is a **400 with nothing written**; the message names both widths and the tenant space; a foreign declared space is a 400; a right-width centroid persists **and carries the stamp**; one bad centroid in a batch persists **nothing**; no embedder is a 503 and not a write; the guard follows the primary space so a warmup failover cannot widen it. Plus migration gates: exactly one file claims `0132`, both columns are `option<string>`, and the DDL contains no data mutation and no index.
- `test/fovea-lens-suppress.e2e-spec.ts` — against a real SurrealDB 3.2.4: the wrong-width POST returns 400 and the class **never appears in the listing**; a declared foreign space returns 400; a right-width POST persists and `GET /classes` reports `centroidDim` and `embeddingSpaceId` equal to the tenant's primary space — i.e. 0132 applies and the stamp round-trips.

## Gates

Run un-piped, real exit codes:

| Gate | Exit |
|---|---|
| `npx tsc --noEmit -p tsconfig.json` | 0 |
| `npx tsc --noEmit -p tsconfig.spec.json` | 0 |
| `npx eslint "{src,test}/**/*.ts" --max-warnings 0` | 0 |
| `npx prettier --check "src/**/*.ts" "test/**/*.ts"` | 0 |
| `jest --config ./test/jest-unit.json` | 0 — 396 suites, 4848 tests |
| `jest --config ./test/jest-e2e.json --testPathPatterns fovea-lens-suppress` | 0 — 1 suite, 6 tests, real SurrealDB 3.2.4 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB
