### PR TITLE
docs(embedder): stop the space state machine claiming a wiring it does not have

### DIFF
--- a/src/admin/admin-embedding-space.controller.ts
+++ b/src/admin/admin-embedding-space.controller.ts
@@ -26,8 +26,31 @@ import {
  * endpoints refuse (400) rather than mutate — so the surface is inert by
  * default and cannot shift serving behaviour.
  *
- * Recommended order: begin → reindex (POST /v1/admin/reindex/embeddings
- * ?allTables=true) → cutover.
+ * ── READ THIS BEFORE RUNNING THE PROTOCOL ─────────────────────────────
+ *
+ * The state machine below is REAL and ATOMIC; what it drives is not yet
+ * connected. `activeSpaceFor` / `targetSpaceFor`
+ * (embedding-space.service.ts:88, :100) have no callers outside their own
+ * class: no read path selects a space, no write path produces a
+ * target-space vector, and no table has a second vector column for one to
+ * land in. So with the flags ON an operator can run
+ * begin → reindex → cutover to completion and change NOTHING about what is
+ * served — the cutover flips a field nothing reads.
+ *
+ * That is deliberate scope, not an oversight (the service's own SCOPE NOTE
+ * has said so since Tier 2), and the missing half is programme items E7-E9
+ * of docs/roadmap/embedding-spaces-2026-09.md — a second vector column per
+ * space, dual-write at every write site, and the resolver threaded through
+ * the 13 cosine sites, the 4 KNN sites and the resolve_fact dedup gate.
+ * Until those land, treat this surface as state-keeping only. The flags'
+ * catalogue entries say the same thing, because the operator meets those
+ * first.
+ *
+ * Recommended order once E7-E9 exist: begin → reindex
+ * (POST /v1/admin/reindex/embeddings?allTables=true) → cutover. Arming
+ * dual-write BEFORE the backfill is load-bearing, not stylistic: the other
+ * order leaves the target space permanently missing every row written
+ * during the backfill.
  */
 @Controller('v1/admin/embedding-space')
 @UseGuards(ApiKeyGuard)

--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -1095,7 +1095,7 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
     runtimeMutable: true,
     isBooleanFlag: true,
     description:
-      'Zero-downtime migration phase 1: arm shadow dual-write so a begun migration keeps the target space warm (new writes produced in BOTH the active and target space) while the reindex backfills history. Off (default) → no target-space write is armed and beginMigration refuses.',
+      'Zero-downtime migration phase 1: unlock POST /v1/admin/embedding-space/begin, which records dual-write arming in embedding_space_state. NOT YET WIRED: no write site consults targetSpaceFor(), and no table has a second vector column for a target-space vector to land in, so arming this records state and produces NO second vector — turning it on changes no behaviour at all. Off (default) → beginMigration refuses (400). The per-write-site wiring is programme item E7/E8 in docs/roadmap/embedding-spaces-2026-09.md; do not run the documented migration against a corpus until it lands.',
   },
   {
     key: 'EMBEDDING_SPACE_ACTIVE',
@@ -1105,7 +1105,7 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
     runtimeMutable: true,
     isBooleanFlag: true,
     description:
-      'Zero-downtime migration phase 3: per-tenant active-space selection + ATOMIC cutover. When on, reads resolve the tenant’s active space from embedding_space_state and the admin cutover flips it all-or-nothing after reindex. Off (default) → reads use the current provider space and the cutover surface refuses — byte-identical serving.',
+      'Zero-downtime migration phase 3: unlock POST /v1/admin/embedding-space/cutover, which atomically flips activeSpace in embedding_space_state. NOT YET WIRED: no read path consults activeSpaceFor(), so the cutover flips a field nothing reads — an operator can run begin → reindex → cutover to completion and change NOTHING about what is served. Off (default) → the cutover surface refuses (400), which is the honest state. Wiring the resolver into the 13 cosine sites, the 4 KNN sites and the resolve_fact dedup gate is programme item E9 in docs/roadmap/embedding-spaces-2026-09.md.',
   },
   // ── Cost ────────────────────────────────────────────
   {

--- a/test/embedding-space-wiring-truth.unit-spec.ts
+++ b/test/embedding-space-wiring-truth.unit-spec.ts
@@ -1,0 +1,98 @@
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { CONFIG_CATALOG } from '../src/admin/config-catalog.data';
+
+/**
+ * The space state machine says what it does — in BOTH directions.
+ *
+ * The finding (embedding-spaces-2026-09 §2 D2/D3): `activeSpaceFor` and
+ * `targetSpaceFor` have zero callers outside their own class, so the
+ * per-tenant cutover atomically flips a field nothing reads. An operator
+ * could run the documented three-step migration to completion and change
+ * nothing — while the two flags' catalogue entries, which are the
+ * operator's contract and what GET /v1/admin/config serves, claimed that
+ * "reads resolve the tenant's active space" and that dual-write produces
+ * "new writes in BOTH the active and target space".
+ *
+ * The machinery is deliberately kept: it is exactly what programme items
+ * E7-E9 reuse, and deleting it would throw away the state row, the atomic
+ * cutover statement and the resolver that the migration path needs. What
+ * is not kept is the pretence.
+ *
+ * This gate is two-way on purpose:
+ *   - while the resolvers are unwired, the catalogue MUST warn;
+ *   - the moment E9 wires them, the first assertion fails and forces the
+ *     warning to be removed rather than left to rot into the opposite lie.
+ */
+const SRC = join(__dirname, '..', 'src');
+const SERVICE = join(SRC, 'ai', 'embedder', 'embedding-space.service.ts');
+
+function walk(dir: string): string[] {
+  const out: string[] = [];
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    if (statSync(p).isDirectory()) out.push(...walk(p));
+    else if (p.endsWith('.ts')) out.push(p);
+  }
+  return out;
+}
+
+/**
+ * Prose about a resolver must not count as a call to it — neither in a
+ * comment nor inside a description string (the catalogue entry this gate
+ * checks names `targetSpaceFor()` in its own text, and the config-catalog
+ * truth spec excludes that file for the same reason).
+ */
+const stripProse = (text: string): string =>
+  text
+    .replace(/\/\*[\s\S]*?\*\/|\/\/[^\n]*/g, '')
+    .replace(/'(?:[^'\\\n]|\\.)*'|"(?:[^"\\\n]|\\.)*"|`(?:[^`\\]|\\.)*`/g, "''");
+
+/** Files that CALL `resolver(` outside the class that defines it. */
+function callersOf(resolver: string): string[] {
+  const call = new RegExp(`\\b${resolver}\\s*\\(`);
+  return walk(SRC)
+    .filter((f) => f !== SERVICE && !f.endsWith('config-catalog.data.ts'))
+    .filter((f) => call.test(stripProse(readFileSync(f, 'utf8'))))
+    .map((f) => f.slice(SRC.length + 1));
+}
+
+const entry = (key: string) => CONFIG_CATALOG.find((e) => e.key === key)!;
+
+describe('embedding-space wiring truth', () => {
+  it('activeSpaceFor is still unwired, and EMBEDDING_SPACE_ACTIVE says so', () => {
+    const callers = callersOf('activeSpaceFor');
+    if (callers.length === 0) {
+      // Unwired ⇒ the flag must not promise serving behaviour.
+      expect(entry('EMBEDDING_SPACE_ACTIVE').description).toMatch(/NOT YET WIRED/);
+    } else {
+      // Wired (E9 landed) ⇒ the warning is now the lie. Remove it, and say
+      // what the flag really does.
+      expect(entry('EMBEDDING_SPACE_ACTIVE').description).not.toMatch(/NOT YET WIRED/);
+    }
+  });
+
+  it('targetSpaceFor is still unwired, and EMBEDDING_SPACE_DUAL_WRITE says so', () => {
+    const callers = callersOf('targetSpaceFor');
+    if (callers.length === 0) {
+      expect(entry('EMBEDDING_SPACE_DUAL_WRITE').description).toMatch(/NOT YET WIRED/);
+    } else {
+      expect(entry('EMBEDDING_SPACE_DUAL_WRITE').description).not.toMatch(/NOT YET WIRED/);
+    }
+  });
+
+  it('the admin controller carries the same warning as the flags', () => {
+    // The operator meets the flag description first and the route second;
+    // they must not disagree.
+    // Collapse the JSDoc leader + wrapping so the phrase is matched as
+    // prose rather than as a particular line break.
+    const controller = readFileSync(
+      join(SRC, 'admin', 'admin-embedding-space.controller.ts'),
+      'utf8',
+    )
+      .replace(/^\s*\*/gm, ' ')
+      .replace(/\s+/g, ' ');
+    const unwired = callersOf('activeSpaceFor').length === 0;
+    expect(/have no callers outside their own class/.test(controller)).toBe(unwired);
+  });
+});


### PR DESCRIPTION
The "also worth a decision" item beside E1/E2/E6 — diagnosis **D2/D3** of [#505](https://github.com/inite-ai/inite-brain-service/pull/505). **The decision is: keep the machinery, kill the pretence.** No behaviour change — two description strings, one docstring, one test.

## The finding

`activeSpaceFor` / `targetSpaceFor` (`embedding-space.service.ts:88`, `:100`) have **no callers outside their own class**. No read path selects a space, no write path produces a target-space vector, and no table has a second vector column for one to land in. The state machine is real and its cutover is genuinely atomic — but with the flags **on** an operator can run `begin → reindex → cutover` to completion and change **nothing** about what is served, because the cutover flips a field nothing reads.

The default state was never dishonest: both mutating routes 400 with the flags off, and the service's own SCOPE NOTE (`:32-38`) has stated the bound since Tier 2. The dishonesty was reachable by enabling exactly the two flags whose descriptions promised the behaviour — and those descriptions are the operator's contract, served by `GET /v1/admin/config` and shown in the config UI:

| flag | it claimed | reality |
|---|---|---|
| `EMBEDDING_SPACE_ACTIVE` | *"When on, **reads resolve** the tenant's active space from `embedding_space_state`"* | no read site calls `activeSpaceFor` |
| `EMBEDDING_SPACE_DUAL_WRITE` | *"**new writes produced in BOTH** the active and target space"* | no write site calls `targetSpaceFor`, and there is no second column to write to |

That is the shape of control that is worse than an absent one: it fails silently, and only for the operator who trusted it enough to turn it on.

## Why keep it rather than delete it

Deleting would throw away precisely what the migration path is built from — the per-tenant state row (0101), the single-statement atomic cutover, and the resolver itself. #505's recommendation is *"keep single-space serving, **build the migration path**, do not build multi-space retrieval"*; this machinery **is** that path's first half, and E7–E10 are written to reuse it as-is.

Wiring it is programme item **E9**: the resolver threaded through 13 cosine sites, 4 KNN sites, and a new revision of the `resolve_fact` DB function, which is copied across 19 migrations. That is a migration-bearing change to every dense read in the system and does not belong in a defect-fix wave. So: **it belongs with E7–E9, and it is left there** — but it no longer advertises itself as finished.

## What changed

- both catalogue descriptions now say plainly what turning the flag on does and does not do, and name the programme item that would make it real;
- `admin-embedding-space.controller.ts` carries the same warning **above** the runbook it documents (an operator reads the route after the flag), and the "recommended order" line now says *once E7–E9 exist* — with the note that arming dual-write **before** the backfill is load-bearing, not stylistic, since the other order leaves the target space permanently missing every row written during the backfill.

## The gate

`test/embedding-space-wiring-truth.unit-spec.ts` keeps this from rotting **in either direction**:

- while the resolvers have no callers, the catalogue **must** carry the warning;
- the moment E9 wires them, the assertion **inverts** and fails, forcing the warning to be removed rather than left standing as the opposite lie.

Callers are counted with comments *and string literals* stripped, so the descriptions naming `targetSpaceFor()` in their own text cannot be mistaken for call sites.

## Note

The descriptions reference `docs/roadmap/embedding-spaces-2026-09.md`, which lands with #505. Independent of #506 / #507 / #508; branches off `main`.

## Gates

Run un-piped, real exit codes:

| Gate | Exit |
|---|---|
| `npx tsc --noEmit -p tsconfig.json` | 0 |
| `npx tsc --noEmit -p tsconfig.spec.json` | 0 |
| `npx eslint "{src,test}/**/*.ts" --max-warnings 0` | 0 |
| `npx prettier --check "src/**/*.ts" "test/**/*.ts"` | 0 |
| `jest --config ./test/jest-unit.json` | 0 — 396 suites, 4841 tests |

One unrelated flake surfaced on the first full run and is worth its own fix: `test/evidence-fs-adapter.unit-spec.ts` › *"ignores files the content-addressed layout could not have produced"* writes a stray `'b'.repeat(64)` into the shard `hash.slice(0, 2)` intending it to be in the **wrong** fan-out shard — but when the random blob's hash happens to start with `bb` (1 in 256 runs) the stray lands in the **right** shard with a well-formed name and is correctly enumerated. Green on re-run; not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB
