### PR TITLE
feat(monitoring): capability probes — an active signal for the capability that dies while /health stays green

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,24 @@ SURREALDB_SCOPED_POOL_SIZE=8
 # (src/db/session-keeper.ts). Raising it only trades signin frequency.
 # SURREALDB_SCOPED_TOKEN_DURATION=1h
 
+# ── Capability probes (active monitoring) ────────────────────────────────
+# Periodically RUN each capability instead of asking a component whether it
+# thinks it is fine. Exists because the service twice reported healthy while
+# a whole capability was dead — the scoped pool going anonymous ~59 minutes
+# after boot with /health green (#502), and the embedder answering outside
+# the configured space with /ready green (#503). Both fixes landed in
+# /ready, which a deploy polls once and never again; this is the continuous
+# half. Emits brain_capability_probe_{total,ok,last_success_timestamp_seconds}.
+# Every pod probes itself — no leader lease, because the failure is
+# per-process. Off = no timer and no series at all.
+CAPABILITY_PROBE_ENABLED=0
+# Cadence, and therefore the detection-latency floor (minimum 5000).
+# CAPABILITY_PROBE_INTERVAL_MS=60000
+# Canary tenant for the scoped-read probe; unset = first id of the roster.
+# One tenant is enough: the scoped session is shared by every tenant on the
+# pod, so probing all of them re-answers the same question N times.
+# CAPABILITY_PROBE_TENANT=
+
 # ── Forget tombstones (GDPR erase) ───────────────────────────────────────
 # HMAC key that signs forget tombstones. REQUIRED when NODE_ENV=production
 # (boot refuses to start without it — the default would let anyone forge

--- a/.github/workflows/deploy-brain.yml
+++ b/.github/workflows/deploy-brain.yml
@@ -288,6 +288,14 @@ jobs:
           POLICY_META_UNION_ENABLED=1
           PRIVACY_SEGMENT_USER_FENCE=1
           PRIVACY_COMPOSER_USER_SCOPE=1
+          # ── Capability probes (active monitoring) ──
+          # ON deliberately, and this is the one line that makes the monitor
+          # real: a probe nobody enables repeats the bug it was written for.
+          # Both incidents it covers (#502 scoped pool anonymous, #503
+          # embedder answering cross-space) reached production while /health
+          # and /ready were green. Cost: one LIMIT 1 read + one short embed
+          # per pod per minute. Kill switch: set to 0 and restart.
+          CAPABILITY_PROBE_ENABLED=1
           # ── Packs / MCP / QA ──
           MCP_PACK_EXTERNAL_TOOLS_ENABLED=1
           AGENT_QA_TOOLS_V2=1

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -649,13 +649,86 @@ Symptoms to recognise if this ever regresses: reads answer
 while writes, `/health` and MCP keep working. `/ready` now catches it —
 `pingScoped()` runs an authorization-gated statement on a scoped connection,
 because `version()` (what `ping()` uses) is answered for anonymous sessions
-too and reported "ok" throughout the original outage.
+too and reported "ok" throughout the original outage. `/ready` is only
+polled at deploy time, though — the **continuous** signal is the
+`scoped_read` capability probe (§ Capability probes), which runs the same
+read path on a timer and alerts when it stops authorizing.
 
 `SURREALDB_SCOPED_TOKEN_DURATION` declares the scoped user's token lifetime
 (a SurrealDB duration literal; unset = the server's 1h default). It is a
 tuning knob, not the fix — brain OVERWRITEs the user definition on every
 boot, so it exists mainly so a duration set by hand on the server is not
 silently discarded on the next deploy.
+
+## Capability probes
+
+The failure class: **the service reports healthy while a whole capability is
+dead.** Three instances in one week — the scoped pool going anonymous ~59
+minutes after boot with `/health` green (#502), `/ready` green through
+embedder warmup because it ORed in an always-ready fallback (#503), and
+`POST /v1/ingest/mention` 400ing for six days from a two-flag interaction
+(#510). The common property is a green signal that does not exercise the
+thing it claims to cover.
+
+`/ready` gained real checks in the first two fixes, but **readiness is polled
+at deploy time**: a pool that lapses an hour after a successful deploy is
+invisible to it by construction. `CAPABILITY_PROBE_ENABLED=1` arms a timer
+(default 60s, every pod, no leader lease — the failure is per-process) that
+RUNS each capability and publishes what happened.
+
+| Capability | What the probe actually does | Covers `/ready` check |
+|---|---|---|
+| `scoped_read` | `withScopedCompany(canary tenant, ['brain:read'], SELECT VALUE id FROM knowledge_fact LIMIT 1)` — acquire → renew-or-fail-closed → `use(co_<tenant>)` → schema check → scope binding → an authorization-gated read of a real table. An empty result is a pass: the question is "was this authorized", not "is there data". | `dbOk`, `scopedOk` |
+| `embed` | Embeds a short string **uncached** and compares the width of the returned vector against the configured (primary) space. Not `isReady()` — that is the component's opinion of itself, and in #503 the opinion was green while every vector came back 1536 wide for a 1024-wide corpus. | `embedderReady` |
+
+Outcomes, and why `busy` is not a failure:
+
+| Outcome | Meaning | Moves the up-gauge? |
+|---|---|---|
+| `serving` | Exercised end to end, produced the expected result. | yes → 1 |
+| `unauthorized` | Alive but refusing — the session can no longer authorize. **This is #502's exact state.** | yes → 0 |
+| `degraded` | Answered, wrong property — a vector outside the configured space. **#503's exact state.** | yes → 0 |
+| `busy` | Pool acquire timed out. The pool is answering, just not us. | **no** — the previous value stands |
+| `error` | Anything else (unreachable, statement threw, probe deadline). | yes → 0 |
+| `skipped` | Nothing to exercise (no tenant in the roster, no embedder in this process). | no |
+
+A saturated pool must not page anyone — the same call `pingScoped()` makes
+in readiness (#502) — so that distinction lives in the metric itself, not in
+an alert threshold: `brain_capability_probe_ok` is written **only** on a
+conclusive outcome.
+
+### Metrics and alerts
+
+| Series | Use |
+|---|---|
+| `brain_capability_probe_ok{capability}` | 1/0 up-signal. Absent until the first conclusive probe, so a booting pod is *absent*, not *down*. |
+| `brain_capability_probe_total{capability,outcome}` | Rates per outcome. A steady `busy` rate is a capacity signal, not a health one. |
+| `brain_capability_probe_last_success_timestamp_seconds{capability}` | Catches what the up-gauge cannot: a wedged prober, or a pool that has been nothing but busy. |
+
+No `companyId` label anywhere (the standing cardinality rule): one scoped
+session serves every tenant on the pod, so the canary tenant proves the
+property for all of them and the scraper's `instance` label already pins
+*which pod*. The tenant is named in the log line.
+
+Rules in `monitoring/grafana/provisioning/alerting/rules.yaml`:
+
+- **ScopedReadCapabilityDead** (critical, `for: 5m`) — `min(brain_capability_probe_ok{capability="scoped_read"}) < 1`. Five consecutive conclusive failures at the default cadence. The failure is sticky (a lapsed session stays lapsed until restart), so the wait costs almost nothing and buys immunity from a single-tick blip.
+- **CapabilityProbeFailing** (warning, `for: 20m`) — the same check for every *other* capability, so a newly added one is alerted on without anyone remembering to write a rule. Long window because `embed` is legitimately 0 during a cold bge-m3 warmup.
+- **CapabilityProbeStale** (warning) — no confirmed serve for 30m.
+
+### When ScopedReadCapabilityDead fires
+
+1. The `instance` label names the pod. Reads are failing **there** while
+   writes, `/health` and MCP may still answer — see § Long-lived DB sessions
+   for why.
+2. Restart that pod: a fresh process re-establishes the scoped session.
+3. If it recurs across restarts, the pool cannot authenticate at all —
+   check `SURREALDB_SCOPED_USER` / `SURREALDB_SCOPED_PASS` against the server
+   and that migration 0005's `brain_caller` still exists. The probe's error
+   log carries the DB's own message.
+4. `brain_capability_probe_total{outcome="busy"}` climbing instead means
+   saturation, not authorization — that is a pool-size / slow-query problem
+   and never fires this alert.
 
 ## Boot-time validation
 

--- a/monitoring/grafana/dashboards/brain-overview.json
+++ b/monitoring/grafana/dashboards/brain-overview.json
@@ -467,6 +467,197 @@
       }
     },
     {
+      "id": 35,
+      "type": "row",
+      "title": "Capability probes",
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 25
+      },
+      "panels": []
+    },
+    {
+      "type": "stat",
+      "title": "Capability up (last conclusive probe)",
+      "description": "1 = a probe actually ran the capability end to end and it served. 0 = alive but refusing (unauthorized) or answering wrongly (degraded). A BUSY probe leaves the previous value standing - saturation is not a failure.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "vm"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "textMode": "value_and_name"
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "expr": "min by (capability) (brain_capability_probe_ok)",
+          "legendFormat": "{{capability}}",
+          "instant": true
+        }
+      ],
+      "id": 36,
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 26
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Probe outcomes (/min)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "vm"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "expr": "sum by (capability, outcome) (rate(brain_capability_probe_total[5m])) * 60",
+          "legendFormat": "{{capability}} {{outcome}}"
+        }
+      ],
+      "id": 37,
+      "gridPos": {
+        "h": 8,
+        "w": 9,
+        "x": 6,
+        "y": 26
+      },
+      "description": "Every tick lands on exactly one outcome. A steady 'busy' rate means the pool is saturated, not broken; 'unauthorized' or 'degraded' is the capability itself."
+    },
+    {
+      "type": "timeseries",
+      "title": "Time since capability last served (s)",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "vm"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "vm"
+          },
+          "expr": "time() - min by (capability) (brain_capability_probe_last_success_timestamp_seconds)",
+          "legendFormat": "{{capability}}"
+        }
+      ],
+      "id": 38,
+      "gridPos": {
+        "h": 8,
+        "w": 9,
+        "x": 15,
+        "y": 26
+      },
+      "description": "Catches what the up-gauge cannot: a wedged prober (the gauge would sit at 1 forever) and a pool that has been nothing but busy."
+    },
+    {
       "id": 9,
       "type": "row",
       "title": "LLM cost",
@@ -475,7 +666,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 25
+        "y": 34
       },
       "panels": []
     },
@@ -537,7 +728,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 26
+        "y": 35
       }
     },
     {
@@ -595,7 +786,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 26
+        "y": 35
       }
     },
     {
@@ -649,7 +840,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 34
+        "y": 43
       }
     },
     {
@@ -712,7 +903,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 34
+        "y": 43
       }
     },
     {
@@ -770,7 +961,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 34
+        "y": 43
       }
     },
     {
@@ -782,7 +973,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 42
+        "y": 51
       },
       "panels": []
     },
@@ -844,7 +1035,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 43
+        "y": 52
       }
     },
     {
@@ -902,7 +1093,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 43
+        "y": 52
       }
     },
     {
@@ -964,7 +1155,7 @@
         "h": 8,
         "w": 6,
         "x": 0,
-        "y": 51
+        "y": 60
       }
     },
     {
@@ -1022,7 +1213,7 @@
         "h": 8,
         "w": 9,
         "x": 6,
-        "y": 51
+        "y": 60
       }
     },
     {
@@ -1083,7 +1274,7 @@
         "h": 8,
         "w": 9,
         "x": 15,
-        "y": 51
+        "y": 60
       }
     },
     {
@@ -1095,7 +1286,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 59
+        "y": 68
       },
       "panels": []
     },
@@ -1154,7 +1345,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 60
+        "y": 69
       }
     },
     {
@@ -1212,7 +1403,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 60
+        "y": 69
       }
     },
     {
@@ -1273,7 +1464,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 68
+        "y": 77
       }
     },
     {
@@ -1331,7 +1522,7 @@
         "h": 8,
         "w": 4,
         "x": 8,
-        "y": 68
+        "y": 77
       }
     },
     {
@@ -1385,7 +1576,7 @@
         "h": 8,
         "w": 4,
         "x": 12,
-        "y": 68
+        "y": 77
       }
     },
     {
@@ -1443,7 +1634,7 @@
         "h": 8,
         "w": 4,
         "x": 16,
-        "y": 68
+        "y": 77
       }
     },
     {
@@ -1497,7 +1688,7 @@
         "h": 8,
         "w": 4,
         "x": 20,
-        "y": 68
+        "y": 77
       }
     },
     {
@@ -1509,7 +1700,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 76
+        "y": 85
       },
       "panels": []
     },
@@ -1578,7 +1769,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 77
+        "y": 86
       }
     },
     {
@@ -1641,7 +1832,7 @@
         "h": 8,
         "w": 4,
         "x": 8,
-        "y": 77
+        "y": 86
       }
     },
     {
@@ -1699,7 +1890,7 @@
         "h": 8,
         "w": 6,
         "x": 12,
-        "y": 77
+        "y": 86
       }
     },
     {
@@ -1757,7 +1948,7 @@
         "h": 8,
         "w": 6,
         "x": 18,
-        "y": 77
+        "y": 86
       }
     },
     {
@@ -1793,7 +1984,7 @@
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 85
+        "y": 94
       }
     }
   ]

--- a/monitoring/grafana/provisioning/alerting/rules.yaml
+++ b/monitoring/grafana/provisioning/alerting/rules.yaml
@@ -183,6 +183,132 @@ groups:
               conditions:
                 - evaluator: { type: gt, params: [0.15] }
 
+      # ── Capability probes ────────────────────────────────────────────
+      # The active counterpart to /ready. Readiness is polled at DEPLOY
+      # time; the scoped pool that went anonymous ~59 minutes after boot
+      # (#502) was invisible to it by construction. These three rules read
+      # the series a timer writes by actually RUNNING each capability.
+      #
+      # A busy pool never reaches any of them: `brain_capability_probe_ok`
+      # is written only on a CONCLUSIVE outcome, so saturation leaves the
+      # gauge where it was — the same call #502 made in readiness.
+      - uid: brain-capability-scoped-read-dead
+        title: ScopedReadCapabilityDead
+        condition: C
+        # 5m = five consecutive conclusive failures at the 60s default
+        # cadence. This failure is STICKY (a lapsed session stays lapsed
+        # until the process restarts), so waiting costs almost nothing and
+        # buys immunity from a single-tick blip — a DB restart, a rolling
+        # deploy, one dropped websocket. The alternative baseline is not
+        # "faster", it is the 6-day and forever-until-a-user-reported-it
+        # detection the last two incidents actually got.
+        for: 5m
+        # No series = the probe is off or the pod is still booting; a dead
+        # target is BrainScrapeDown's job, not this rule's.
+        noDataState: OK
+        execErrState: Alerting
+        labels:
+          severity: critical
+        annotations:
+          summary: >-
+            a pod's caller-facing read path cannot authorize — every search / entity / fact read is
+            failing there while /health stays green. Which pod: the `instance` label. Which tenant:
+            all of them (one scoped session serves the whole pod). Runbook: docs/operations.md §
+            Capability probes
+        data:
+          - refId: A
+            relativeTimeRange: { from: 600, to: 0 }
+            datasourceUid: vm
+            model:
+              refId: A
+              # min across pods: ONE bad pod is a real outage for the share
+              # of traffic it serves, and the session lapses per-process.
+              expr: min(brain_capability_probe_ok{capability="scoped_read"})
+              instant: true
+          - refId: C
+            relativeTimeRange: { from: 0, to: 0 }
+            datasourceUid: __expr__
+            model:
+              refId: C
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator: { type: lt, params: [1] }
+
+      # Catch-all for every OTHER capability, so the next one added gets an
+      # alert without anyone remembering to write one. Deliberately excludes
+      # scoped_read (covered above at 5m) to avoid double-paging, and runs a
+      # long window because the capability it covers today — embed — is 0
+      # during a legitimate cold bge-m3 warmup (~340MB ONNX pull). 20m is
+      # comfortably past a slow warmup and far short of a shift.
+      - uid: brain-capability-probe-failing
+        title: CapabilityProbeFailing
+        condition: C
+        for: 20m
+        noDataState: OK
+        execErrState: Alerting
+        labels:
+          severity: warning
+        annotations:
+          summary: >-
+            capability {{ $labels.capability }} has been failing its probe for 20m — it is alive
+            but not serving correctly (unauthorized, or answering outside the configured embedding
+            space). Runbook: docs/operations.md § Capability probes
+        data:
+          - refId: A
+            relativeTimeRange: { from: 1800, to: 0 }
+            datasourceUid: vm
+            model:
+              refId: A
+              expr: min by (capability) (brain_capability_probe_ok{capability!="scoped_read"})
+              instant: true
+          - refId: C
+            relativeTimeRange: { from: 0, to: 0 }
+            datasourceUid: __expr__
+            model:
+              refId: C
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator: { type: lt, params: [1] }
+
+      # The up-gauge cannot see a prober that is itself wedged (it would sit
+      # at its last value forever) or a pool that has been nothing but BUSY
+      # — the two states where "green" means "unmeasured". 30m of no
+      # confirmed serve is a warning, never a page: sustained saturation is
+      # a capacity problem, and paging on it would punish the pods that are
+      # still taking traffic.
+      - uid: brain-capability-probe-stale
+        title: CapabilityProbeStale
+        condition: C
+        for: 5m
+        noDataState: OK
+        execErrState: Alerting
+        labels:
+          severity: warning
+        annotations:
+          summary: >-
+            capability {{ $labels.capability }} has not been confirmed serving for 30m — the probe
+            is wedged, or the pool has been saturated that whole time. Check
+            brain_capability_probe_total{outcome="busy"} to tell the two apart
+        data:
+          - refId: A
+            relativeTimeRange: { from: 3600, to: 0 }
+            datasourceUid: vm
+            model:
+              refId: A
+              expr: time() - min by (capability) (brain_capability_probe_last_success_timestamp_seconds)
+              instant: true
+          - refId: C
+            relativeTimeRange: { from: 0, to: 0 }
+            datasourceUid: __expr__
+            model:
+              refId: C
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator: { type: gt, params: [1800] }
+
       - uid: host-disk-low
         title: HostDiskLow
         condition: C

--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -3221,4 +3221,32 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
     description:
       'Boot-only role split: all (default, single do-everything process), api (applies WORKER_LOOP_ENABLED=0 + JOB_WORKER_POOL_SIZE=0 unless set explicitly), worker (applies CHAT_ROUTE_NLI_ENABLED=false unless set). api/worker require JOBS_QUEUE_MODE=enqueue — validated at boot. See docs/operations.md "Splitting API and worker roles".',
   },
+  // ── Capability probes (active monitoring) ─────────────────
+  {
+    key: 'CAPABILITY_PROBE_ENABLED',
+    category: 'misc',
+    defaultValue: '0',
+    runtimeMutable: false,
+    isBooleanFlag: true,
+    description:
+      'Periodically RUN each capability the service claims and publish the result (brain_capability_probe_*). Covers the class where the service reports healthy while a capability is dead: the scoped pool that went anonymous ~59 min after boot with /health green (#502), and the embedder answering outside the configured space while /ready was green (#503). Both fixes landed in /ready, which is only polled at deploy time — this is the continuous counterpart. Per pod, no leader lease (the failure is per-process). Off = no timer, no series.',
+  },
+  {
+    key: 'CAPABILITY_PROBE_INTERVAL_MS',
+    category: 'misc',
+    defaultValue: '60000',
+    runtimeMutable: false,
+    isBooleanFlag: false,
+    description:
+      'Probe cadence, and therefore the detection-latency floor. Minimum 5000. Each tick costs one indexless LIMIT 1 read plus one embed of a four-word string — on EMBEDDER_PROVIDER=openai that embed is a real (tiny) API call, so raise this if probe traffic matters more than a 60s floor.',
+  },
+  {
+    key: 'CAPABILITY_PROBE_TENANT',
+    category: 'misc',
+    defaultValue: null,
+    runtimeMutable: false,
+    isBooleanFlag: false,
+    description:
+      'Canary tenant for the scoped-read probe. Unset = the first id of the known roster. One tenant, not all: the scoped session is shared by every tenant on the pod, so a per-tenant sweep would multiply series and DB load by the roster size to re-answer the same question.',
+  },
 ];

--- a/src/ai/embedder.service.ts
+++ b/src/ai/embedder.service.ts
@@ -185,6 +185,30 @@ export class EmbedderService implements OnModuleInit, OnModuleDestroy {
     const key = this.cacheKey(provider.providerId, trimmed);
     const hit = this.cache.get(key);
     if (hit) return hit;
+    const vector = await this.embedThrough(provider, trimmed);
+    this.cache.set(key, vector);
+    return vector;
+  }
+
+  /**
+   * Embed WITHOUT reading or writing the cache.
+   *
+   * For the capability probe (src/metrics/capability-probe.service.ts),
+   * which measures the width of a vector the embedder actually produced.
+   * Through `embed()` a fixed probe string would be a cache hit from the
+   * second tick onwards, and the probe would then be measuring the LRU —
+   * a green signal that proves nothing, which is the exact class of bug
+   * it exists to catch. Nothing on the request path should use this: the
+   * cache is there for a reason.
+   */
+  async embedUncached(text: string): Promise<number[]> {
+    const trimmed = text.trim();
+    if (!trimmed) return new Array(this.getDimensions()).fill(0);
+    return this.embedThrough(this.serveProvider(), trimmed);
+  }
+
+  /** The provider call itself, with its gen_ai span + token accounting. */
+  private async embedThrough(provider: EmbedderProvider, trimmed: string): Promise<number[]> {
     // Provider IDs encode `${vendor}:${model}:${dim}` (see
     // OpenAIEmbedderProvider / BgeM3EmbedderProvider). We split for
     // gen_ai.system + gen_ai.request.model; OpenAI is the only vendor
@@ -213,7 +237,6 @@ export class EmbedderService implements OnModuleInit, OnModuleDestroy {
           ? provider.embedWithUsage(trimmed)
           : { vector: await provider.embed(trimmed) },
     );
-    this.cache.set(key, vector);
     return vector;
   }
 

--- a/src/metrics/capability-probe.service.ts
+++ b/src/metrics/capability-probe.service.ts
@@ -1,0 +1,266 @@
+import {
+  Injectable,
+  Logger,
+  OnApplicationBootstrap,
+  OnApplicationShutdown,
+  Optional,
+} from '@nestjs/common';
+import { SurrealService } from '../db/surreal.service';
+import { ApiKeyService } from '../auth/api-key.service';
+import { EmbedderService } from '../ai/embedder.service';
+import { MetricsService } from './metrics.service';
+import { envFlagEnabled } from '../common/env-validation';
+import {
+  CAPABILITY_NAMES,
+  classifyProbeFailure,
+  isConclusive,
+  probeErrorDetail,
+  type ProbeReport,
+} from './capability-probe';
+
+/** Default probe cadence. One minute is the detection latency floor. */
+const DEFAULT_INTERVAL_MS = 60_000;
+/** Below this the probe becomes load rather than measurement. */
+const MIN_INTERVAL_MS = 5_000;
+/**
+ * Per-probe deadline. Longer than the pool's own 10s acquire timeout (so a
+ * saturated pool still classifies as `busy` rather than as this deadline),
+ * short enough that a wedged capability cannot hold the tick past the next.
+ */
+const PROBE_DEADLINE_MS = 15_000;
+
+/**
+ * The cheapest statement that exercises the WHOLE scoped read path:
+ * acquire → renew-or-fail-closed → `use(co_<tenant>)` → schema check →
+ * `LET $caller_scopes` → an authorization-gated read of a real table.
+ *
+ * `LIMIT 1` with no WHERE, and the result is deliberately NOT asserted to
+ * be non-empty — a tenant with zero facts is a healthy tenant, and a probe
+ * that pages on an empty table is a probe that gets switched off. The
+ * question is "was this authorized", not "is there data".
+ */
+const SCOPED_READ_STATEMENT = 'SELECT VALUE id FROM knowledge_fact LIMIT 1';
+
+/** Scope set bound for the probe read — what an ordinary reader carries. */
+const PROBE_SCOPES = ['brain:read'] as const;
+
+/** Short and stable: the embedder is measured on the width it returns. */
+const EMBED_PROBE_TEXT = 'brain capability probe';
+
+const RUNBOOK = 'runbook: docs/operations.md § Capability probes';
+
+/** What an operator should do about a scoped read path that cannot authorize. */
+const REMEDY =
+  'Reads are failing on THIS pod while writes and /health may still answer; ' +
+  'restart it to re-establish the session, then check SURREALDB_SCOPED_USER/PASS ' +
+  "and that migration 0005's brain_caller still exists";
+
+/**
+ * CapabilityProbeService — periodically RUNS each capability the service
+ * claims and publishes what happened (see capability-probe.ts for the
+ * failure class and the design rules).
+ *
+ * ── Why every pod, with no leader lease ──────────────────────────────────
+ * The failure this exists for is per-PROCESS: a scoped pool's session
+ * lapses inside one node process, and its neighbours are unaffected. A
+ * leader-elected probe would prove one pod healthy and say nothing about
+ * the other four. So every pod probes itself (the MemoryQualityService
+ * precedent, for a different reason) and the alert aggregates with
+ * `min by (capability)` — one bad pod is enough to page.
+ *
+ * ── Cost ─────────────────────────────────────────────────────────────────
+ * Per pod per minute: one indexless `LIMIT 1` read, and one embed of a
+ * four-word string. On `EMBEDDER_PROVIDER=bge-m3` the embed is local CPU;
+ * on `openai` it is a real (tiny) API call that shows up in
+ * `brain_openai_calls_total` — raise `CAPABILITY_PROBE_INTERVAL_MS` if that
+ * matters more than a 60s detection floor.
+ */
+@Injectable()
+export class CapabilityProbeService implements OnApplicationBootstrap, OnApplicationShutdown {
+  private readonly logger = new Logger(CapabilityProbeService.name);
+  private readonly enabled = envFlagEnabled(process.env.CAPABILITY_PROBE_ENABLED);
+  private readonly intervalMs = Math.max(
+    MIN_INTERVAL_MS,
+    parseInt(process.env.CAPABILITY_PROBE_INTERVAL_MS ?? String(DEFAULT_INTERVAL_MS), 10) ||
+      DEFAULT_INTERVAL_MS,
+  );
+  private readonly tenantOverride = process.env.CAPABILITY_PROBE_TENANT?.trim() || undefined;
+  private timer: NodeJS.Timeout | undefined;
+  private running = false;
+
+  // eslint-disable-next-line max-params -- Nest DI constructor; each param is an injection token and cannot be folded into an options object without breaking DI
+  constructor(
+    private readonly surreal: SurrealService,
+    private readonly apiKeys: ApiKeyService,
+    private readonly metrics: MetricsService,
+    // Optional so a process that does not wire the AI module (and every
+    // unit fixture) still gets the scoped-read probe; the embed probe then
+    // reports `skipped` rather than pretending to have run.
+    @Optional() private readonly embedder?: EmbedderService,
+  ) {}
+
+  onApplicationBootstrap(): void {
+    if (!this.enabled) return;
+    // unref: a monitoring timer must never be the reason a process (or a
+    // jest worker) refuses to exit.
+    this.timer = setInterval(() => void this.tick(), this.intervalMs);
+    this.timer.unref();
+    this.logger.log(
+      `capability probe armed: [${CAPABILITY_NAMES.join(', ')}] every ${this.intervalMs}ms ` +
+        `(tenant=${this.probeTenant() ?? 'none yet'})`,
+    );
+  }
+
+  onApplicationShutdown(): void {
+    if (this.timer) clearInterval(this.timer);
+    this.timer = undefined;
+  }
+
+  /**
+   * One pass over every capability. Public so tests and an operator-driven
+   * check can run exactly what the timer runs — no second code path that
+   * could disagree with the one being monitored.
+   */
+  async runOnce(): Promise<ProbeReport[]> {
+    const reports = [await this.probeScopedRead(), await this.probeEmbed()];
+    for (const report of reports) this.publish(report);
+    return reports;
+  }
+
+  private async tick(): Promise<void> {
+    if (this.running) {
+      // A tick that overruns its interval means a capability is hanging.
+      // Stacking probes would make that worse; the last-success gauge is
+      // what surfaces it (the up-gauge would otherwise sit at its last
+      // value forever, which is the exact blindness this service exists
+      // to remove).
+      this.logger.warn(`capability probe still running after ${this.intervalMs}ms — tick skipped`);
+      return;
+    }
+    this.running = true;
+    try {
+      await this.runOnce();
+    } catch (e) {
+      // runOnce swallows per-capability failures; reaching here means the
+      // prober itself broke, which must not kill the timer.
+      this.logger.error(`capability probe tick failed: ${probeErrorDetail(e)}`);
+    } finally {
+      this.running = false;
+    }
+  }
+
+  private publish(report: ProbeReport): void {
+    this.metrics.recordCapabilityProbe(report.capability, report.outcome);
+    if (report.outcome === 'serving') return;
+    const line = `capability '${report.capability}' is ${report.outcome}: ${report.detail ?? '—'}`;
+    if (isConclusive(report.outcome)) this.logger.error(`${line} — ${RUNBOOK}`);
+    else this.logger.debug(line);
+  }
+
+  /**
+   * The canary tenant. Explicit override first, else the first id of the
+   * known roster (static keys before registry ids — a stable ordering, so
+   * the probe hits the same database every tick and its cost is bounded).
+   *
+   * One tenant, not all of them: the scoped session is shared by every
+   * tenant on the pod, so a per-tenant sweep would multiply series and DB
+   * load by the roster size to re-answer the same question.
+   */
+  private probeTenant(): string | undefined {
+    if (this.tenantOverride) return this.tenantOverride;
+    return this.apiKeys.knownCompanyIds()[0];
+  }
+
+  private async probeScopedRead(): Promise<ProbeReport> {
+    const tenant = this.probeTenant();
+    if (!tenant) {
+      return {
+        capability: 'scoped_read',
+        outcome: 'skipped',
+        detail: 'no tenant in the roster to probe (set CAPABILITY_PROBE_TENANT to pin one)',
+      };
+    }
+    try {
+      await withDeadline(
+        this.surreal.withScopedCompany(tenant, PROBE_SCOPES, (db) =>
+          db.query(SCOPED_READ_STATEMENT),
+        ),
+        PROBE_DEADLINE_MS,
+      );
+      return { capability: 'scoped_read', outcome: 'serving' };
+    } catch (e) {
+      const outcome = classifyProbeFailure(e);
+      const where = `scoped pool, tenant=${tenant} (db=co_${tenant}): ${probeErrorDetail(e)}`;
+      // The remedy belongs only on a CONCLUSIVE outcome. Telling an
+      // operator to restart a pod because its pool was briefly saturated
+      // is how a monitor teaches people to ignore it.
+      return {
+        capability: 'scoped_read',
+        outcome,
+        detail: outcome === 'busy' ? `${where} (saturation, not a failure)` : `${where}. ${REMEDY}`,
+      };
+    }
+  }
+
+  /**
+   * Exercise the embedder and measure the WIDTH of what came back against
+   * the configured (primary) space.
+   *
+   * Not `isReady()`: that is the component's opinion of itself, and in
+   * #503 the opinion was green from the first millisecond of boot while
+   * every vector came back 1536 wide for a 1024-wide corpus. A probe that
+   * asks the same question as the thing it monitors inherits its bugs.
+   * `embedUncached` for the same reason — a cached answer proves only that
+   * the cache works.
+   */
+  private async probeEmbed(): Promise<ProbeReport> {
+    const embedder = this.embedder;
+    if (!embedder) {
+      return {
+        capability: 'embed',
+        outcome: 'skipped',
+        detail: 'no embedder in this process',
+      };
+    }
+    try {
+      const expected = embedder.primaryDimensions();
+      const vector = await withDeadline(
+        embedder.embedUncached(EMBED_PROBE_TEXT),
+        PROBE_DEADLINE_MS,
+      );
+      if (vector.length !== expected) {
+        return {
+          capability: 'embed',
+          outcome: 'degraded',
+          detail:
+            `embedder answered ${vector.length}-wide, configured space is ${expected}-wide ` +
+            `(serving '${embedder.activeSpaceId()}'). Vector WRITES are refused until the ` +
+            `primary warms up; if this persists the warmup failed — check the boot log for ` +
+            `the bge-m3 model pull and consider EMBEDDER_PROVIDER=openai to roll back`,
+        };
+      }
+      return { capability: 'embed', outcome: 'serving' };
+    } catch (e) {
+      return {
+        capability: 'embed',
+        outcome: classifyProbeFailure(e),
+        detail: `embedder: ${probeErrorDetail(e)}`,
+      };
+    }
+  }
+}
+
+/**
+ * Bound a probe's wall-clock. `Promise.race` attaches a handler to `p`
+ * immediately, so a rejection arriving after the deadline is still handled
+ * and cannot surface as an unhandled rejection.
+ */
+function withDeadline<T>(p: Promise<T>, ms: number): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  const deadline = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => reject(new Error(`capability probe timed out after ${ms}ms`)), ms);
+  });
+  return Promise.race([p, deadline]).finally(() => {
+    if (timer) clearTimeout(timer);
+  });
+}

--- a/src/metrics/capability-probe.ts
+++ b/src/metrics/capability-probe.ts
@@ -1,0 +1,146 @@
+import type { ReadinessReport } from '../common/health.service';
+
+/**
+ * Capability probes — the ACTIVE half of "is this capability alive".
+ *
+ * ── The failure class ────────────────────────────────────────────────────
+ * Three incidents in one week shared one shape: **the service reported
+ * healthy while a whole capability was dead.**
+ *
+ *   1. The scoped pool went anonymous ~59 minutes after boot (#502). Every
+ *      caller-facing read failed; `/health` stayed green because `version()`
+ *      — what `ping()` calls — is answered for anonymous sessions too.
+ *   2. `/ready` reported ready during embedder warmup (#503) because it
+ *      ORed in an always-ready fallback provider, so the rollout playbook's
+ *      "reindex once /ready is 200" gate never held.
+ *   3. `POST /v1/ingest/mention` 400'd for six days from a two-flag
+ *      interaction (#510) and nothing noticed.
+ *
+ * The common property is a **green signal that does not exercise the thing
+ * it claims to cover.** #502 and #503 fixed the signals; both fixes landed
+ * in `/ready`, which is polled at DEPLOY time and then never again. A pool
+ * that lapses 59 minutes after a successful deploy is invisible to a
+ * deploy-time gate by construction.
+ *
+ * So these probes RUN the capability on a timer and publish what happened.
+ * Two rules follow from the incidents and are load-bearing:
+ *
+ *   - **A probe asserts an observable property of the OUTPUT, never the
+ *     component's own opinion of itself.** #503's `/ready` was wrong
+ *     precisely because it asked "does something think it can answer".
+ *     The embed probe therefore measures the WIDTH of a vector the
+ *     embedder actually produced, not `isReady()`.
+ *   - **A probe must not be answerable from cache**, or it decays into the
+ *     same green-that-proves-nothing (hence `embedUncached`).
+ *
+ * ── How far this generalises (deliberately not a framework) ──────────────
+ * `CAPABILITY_COVERAGE` below ties each probe to the readiness checks it
+ * continuously exercises, and `keyof ReadinessReport` makes that link a
+ * COMPILE error if a check is renamed (test/capability-probe.unit-spec.ts
+ * fails if one is ADDED without a probe). That is the whole generalisation:
+ * the service's own readiness contract — three checks — must have a
+ * continuous counterpart. Enumerating every "capability" brain claims (145
+ * flags, every route) and asserting each is exercised by something is NOT
+ * built here: that inventory is what per-surface flag-set specs (#510) and
+ * the e2e suite are for, and a registry nobody can keep honest is another
+ * green signal that proves nothing.
+ */
+
+/** The checks `/ready` reports, minus its own roll-up field. */
+export type ReadinessCheck = Exclude<keyof ReadinessReport, 'ready'>;
+
+export const CAPABILITY_NAMES = ['scoped_read', 'embed'] as const;
+export type CapabilityName = (typeof CAPABILITY_NAMES)[number];
+
+/**
+ * Probe outcomes. Bounded on purpose — this is a metric label, and the
+ * whole series set is (capabilities × outcomes), not (× tenants).
+ *
+ *   serving      — exercised end to end and produced the expected result.
+ *   unauthorized — ALIVE but refused: the session can no longer authorize
+ *                  (incident 1's exact state).
+ *   degraded     — answered, but with the wrong property: a vector in a
+ *                  space the corpus is not in (incident 2's exact state).
+ *   busy         — could not be exercised because the resource was
+ *                  saturated. NOT A FAILURE — see `isConclusive`.
+ *   error        — anything else: DB unreachable, statement threw, the
+ *                  probe's own deadline expired.
+ *   skipped      — nothing to exercise (no tenant in the roster, no
+ *                  embedder in this process). Also not a failure.
+ */
+export const PROBE_OUTCOMES = [
+  'serving',
+  'unauthorized',
+  'degraded',
+  'busy',
+  'error',
+  'skipped',
+] as const;
+export type ProbeOutcome = (typeof PROBE_OUTCOMES)[number];
+
+export interface ProbeReport {
+  capability: CapabilityName;
+  outcome: ProbeOutcome;
+  /** Operator-facing specifics: which pool, which tenant, what the DB said. */
+  detail?: string;
+}
+
+/**
+ * Which readiness checks each probe continuously exercises.
+ *
+ * `scoped_read` covers `dbOk` as well as `scopedOk` because it cannot pass
+ * without a reachable database — deliberately NOT a separate root-`ping()`
+ * probe, which would be exactly the version()-answers-anonymously signal
+ * that started all this.
+ */
+export const CAPABILITY_COVERAGE: Record<CapabilityName, readonly ReadinessCheck[]> = {
+  scoped_read: ['dbOk', 'scopedOk'],
+  embed: ['embedderReady'],
+};
+
+/**
+ * A CONCLUSIVE outcome carries information about the capability's health;
+ * an inconclusive one carries information about the probe. Only conclusive
+ * outcomes move the up/down gauge — which is how "a saturated pool must not
+ * page anyone" is enforced in the metric itself rather than in the alert
+ * threshold, matching the same distinction `pingScoped()` makes in
+ * readiness (#502): a busy pool is answering, it is just not answering US.
+ */
+export function isConclusive(outcome: ProbeOutcome): boolean {
+  return outcome !== 'busy' && outcome !== 'skipped';
+}
+
+/**
+ * Pool saturation, verbatim from `SurrealService.acquireWithTimeout`:
+ * "Surreal scoped pool acquire timed out after 10000ms (pool=…, waiters=…)".
+ */
+const BUSY = /pool acquire timed out/i;
+
+/**
+ * Authorization refusals. The first two are what SurrealDB answers an
+ * anonymous session (incident 1); the third is brain's own fail-closed
+ * wrapper when the scoped signin cannot be renewed at all — a rotated
+ * secret or a dropped `brain_caller` — which is the same operator problem
+ * with a different first line.
+ */
+const UNAUTHORIZED =
+  /Anonymous access not allowed|Not enough permissions|IAM error|scoped DB signin unavailable|Invalid credentials|There was a problem with authentication/i;
+
+/**
+ * Classify a thrown probe failure. Order matters: saturation is checked
+ * FIRST, because an acquire timeout says nothing about whether the pool
+ * could have authorized — reporting it as a failure is how a load spike
+ * turns into a page.
+ */
+export function classifyProbeFailure(error: unknown): 'unauthorized' | 'busy' | 'error' {
+  const message = error instanceof Error ? error.message : String(error);
+  if (BUSY.test(message)) return 'busy';
+  if (UNAUTHORIZED.test(message)) return 'unauthorized';
+  return 'error';
+}
+
+/** Short, greppable text for the operator; the runbook carries the rest. */
+export function probeErrorDetail(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.length > 300 ? `${message.slice(0, 300)}…` : message;
+}

--- a/src/metrics/metrics.module.ts
+++ b/src/metrics/metrics.module.ts
@@ -1,6 +1,7 @@
 import { Global, Module } from '@nestjs/common';
 import { MetricsService } from './metrics.service';
 import { MemoryQualityService } from './memory-quality.service';
+import { CapabilityProbeService } from './capability-probe.service';
 import { MetricsController } from './metrics.controller';
 
 @Global()
@@ -8,7 +9,9 @@ import { MetricsController } from './metrics.controller';
   controllers: [MetricsController],
   // MemoryQualityService's deps (SurrealService, ApiKeyService) come from
   // the global SurrealModule / AuthModule — no imports needed here.
-  providers: [MetricsService, MemoryQualityService],
-  exports: [MetricsService],
+  // CapabilityProbeService adds EmbedderService (global AiModule), injected
+  // @Optional() so a process without it still probes the read path.
+  providers: [MetricsService, MemoryQualityService, CapabilityProbeService],
+  exports: [MetricsService, CapabilityProbeService],
 })
 export class MetricsModule {}

--- a/src/metrics/metrics.service.ts
+++ b/src/metrics/metrics.service.ts
@@ -7,6 +7,7 @@ import {
   collectDefaultMetrics,
   type LabelValues,
 } from 'prom-client';
+import { isConclusive, type CapabilityName, type ProbeOutcome } from './capability-probe';
 
 /** knowledge_fact.status enum (schema ASSERT) — every value gets a series. */
 export const FACT_STATUSES = [
@@ -49,6 +50,10 @@ export interface MemoryQualitySnapshot {
  *   - scene_maintenance_total{outcome}        — ok|failed|skipped_no_dirty|skipped_budget
  *   - scene_maintenance_emitted_total{kind}   — conversation|scene|enriched|belief|dirty_cleared
  *   - scene_maintenance_duration_seconds      — histogram, per-tenant pass
+ *   - capability_probe_total{capability,outcome}  — active probes that RUN
+ *   - capability_probe_ok{capability}               a capability on a timer
+ *   - capability_probe_last_success_timestamp_seconds{capability}
+ *                                               (see capability-probe.ts)
  *   - retract_total / forget_total            — counters
  *   - compaction_facts_total                  — counter, summed across tenants
  *   - openai_tokens_total{kind, type}         — embed|chat × prompt|completion
@@ -109,6 +114,51 @@ export class MetricsService implements OnModuleInit {
     name: 'brain_embedder_fallback_serves_total',
     help: 'Embed calls served by the fallback provider because the primary was not ready',
     labelNames: ['primary'] as const,
+    registers: [this.registry],
+  });
+
+  // ── Capability probes (src/metrics/capability-probe.service.ts) ──────
+  // The ACTIVE signal for "the service reports healthy while a whole
+  // capability is dead" — the class behind #502 (scoped pool anonymous
+  // after ~59 min, /health green), #503 (/ready green through embedder
+  // warmup) and #510. `/ready` gained real checks in both fixes, but
+  // readiness is polled at DEPLOY time; a pool that lapses an hour later
+  // is invisible to it. These series come from a timer that actually RUNS
+  // each capability.
+  //
+  // Cardinality: (capability × outcome) only — 2 × 6 worst case. NO
+  // companyId label, the same rule as every other domain metric here. The
+  // failure is per-PROCESS (one scoped session serves every tenant on the
+  // pod), so one canary tenant proves the property for all of them, and
+  // the scraper's own `instance` label already pins which pod. The tenant
+  // is named in the log line and the runbook, where the operator needs it.
+  readonly capabilityProbes = new Counter({
+    name: 'brain_capability_probe_total',
+    help: 'Capability probe ticks by capability and outcome (serving|unauthorized|degraded|busy|error|skipped)',
+    labelNames: ['capability', 'outcome'] as const,
+    registers: [this.registry],
+  });
+
+  // 1/0 up-signal, written ONLY on a conclusive outcome. A `busy` tick
+  // (pool saturated) deliberately leaves the previous value standing: a
+  // saturated pool must not page anyone — the same call #502 made in
+  // readiness. The series does not exist until the first conclusive probe,
+  // so a booting pod (or a disabled probe) is absent, not down.
+  readonly capabilityProbeOk = new Gauge({
+    name: 'brain_capability_probe_ok',
+    help: 'Whether the last CONCLUSIVE probe found this capability serving (1/0); busy/skipped ticks leave it unchanged',
+    labelNames: ['capability'] as const,
+    registers: [this.registry],
+  });
+
+  // When the capability was last observed actually serving. Catches what
+  // the up-gauge cannot: a prober that is itself wedged (the gauge would
+  // sit at 1 forever) and a pool that has been nothing but busy for a long
+  // stretch. Alert on `time() - min by (capability)(…)`.
+  readonly capabilityProbeLastSuccess = new Gauge({
+    name: 'brain_capability_probe_last_success_timestamp_seconds',
+    help: 'Unix time of the last probe that found this capability serving',
+    labelNames: ['capability'] as const,
     registers: [this.registry],
   });
 
@@ -1143,6 +1193,33 @@ export class MetricsService implements OnModuleInit {
   ): void {
     this.jobsTotal.inc({ jobType, outcome } as LabelValues<'jobType' | 'outcome'>);
     this.jobDuration.observe({ jobType } as LabelValues<'jobType'>, durationSeconds);
+  }
+
+  /**
+   * Publish one capability-probe tick.
+   *
+   * The counter takes every outcome; the up-gauge takes only CONCLUSIVE
+   * ones, so a busy pool cannot flip a capability "down" — see
+   * `isConclusive` in capability-probe.ts for why that distinction lives
+   * in the metric rather than in the alert threshold.
+   */
+  recordCapabilityProbe(
+    capability: CapabilityName,
+    outcome: ProbeOutcome,
+    atMs: number = Date.now(),
+  ): void {
+    this.capabilityProbes.inc({ capability, outcome } as LabelValues<'capability' | 'outcome'>);
+    if (!isConclusive(outcome)) return;
+    this.capabilityProbeOk.set(
+      { capability } as LabelValues<'capability'>,
+      outcome === 'serving' ? 1 : 0,
+    );
+    if (outcome === 'serving') {
+      this.capabilityProbeLastSuccess.set(
+        { capability } as LabelValues<'capability'>,
+        Math.floor(atMs / 1000),
+      );
+    }
   }
 
   setWorkerLeader(isLeader: boolean): void {

--- a/test/capability-probe.e2e-spec.ts
+++ b/test/capability-probe.e2e-spec.ts
@@ -1,0 +1,169 @@
+/**
+ * Capability probe against a REAL SurrealDB (testcontainers, v3.2.4,
+ * started by test/global-setup.ts).
+ *
+ * WHAT THIS PINS. The probe must go RED exactly when the caller-facing read
+ * path cannot authorize — the state incident #502 produced for ~59 minutes
+ * of every process lifetime — and it must go green again by itself when the
+ * path recovers, without a restart.
+ *
+ * HOW THE DEAD STATE IS PRODUCED HERE. Not by waiting an hour, and not by
+ * mocking a clock (which poisons the SurrealDB session — learned in #481).
+ * The scoped user is provisioned with a 5-second token, so every acquire
+ * re-signs; rotating `brain_caller`'s password on the server then makes the
+ * very next acquire fail closed. That is the same terminal state as the
+ * original outage — the pool cannot authorize — reached in one statement.
+ *
+ * The control that matters is in the same test: while the probe is red,
+ * `ping()` — the signal `/health` reports, and the one that stayed green
+ * throughout the real outage — is still true.
+ */
+import { ConfigService } from '@nestjs/config';
+import { Surreal } from 'surrealdb';
+import { SurrealService } from '../src/db/surreal.service';
+import { MetricsService } from '../src/metrics/metrics.service';
+import { CapabilityProbeService } from '../src/metrics/capability-probe.service';
+import type { ApiKeyService } from '../src/auth/api-key.service';
+
+const SCOPED_USER = 'brain_caller';
+const SCOPED_PASS = 'capability-probe-spec';
+const ROTATED_PASS = 'capability-probe-spec-rotated';
+/** Short enough that every acquire re-signs (the keeper's margin is 5 min). */
+const TOKEN_DURATION = '5s';
+
+async function seriesValue(
+  metrics: MetricsService,
+  name: string,
+  labels: Record<string, string>,
+): Promise<number | undefined> {
+  const metric = metrics.registry.getSingleMetric(name);
+  if (!metric) return undefined;
+  const snapshot = (await metric.get()) as {
+    values: Array<{ labels: Record<string, string | number>; value: number }>;
+  };
+  return snapshot.values.find((v) =>
+    Object.entries(labels).every(([k, want]) => String(v.labels[k]) === want),
+  )?.value;
+}
+
+describe('Capability probe — scoped read path', () => {
+  const tenant = `capprobe${Date.now().toString(36)}`;
+  const saved: Record<string, string | undefined> = {};
+  let namespace: string;
+  let root: Surreal;
+  let svc: SurrealService;
+  let metrics: MetricsService;
+  let probe: CapabilityProbeService;
+
+  const setEnv = (key: string, value: string) => {
+    saved[key] = process.env[key];
+    process.env[key] = value;
+  };
+
+  const defineScopedUser = (password: string) =>
+    root.query(
+      `DEFINE USER OVERWRITE ${SCOPED_USER} ON NAMESPACE PASSWORD '${password}' ` +
+        `ROLES EDITOR DURATION FOR TOKEN ${TOKEN_DURATION}`,
+    );
+
+  const okGauge = () =>
+    seriesValue(metrics, 'brain_capability_probe_ok', {
+      capability: 'scoped_read',
+    });
+  const tickCount = (outcome: string) =>
+    seriesValue(metrics, 'brain_capability_probe_total', { capability: 'scoped_read', outcome });
+
+  beforeAll(async () => {
+    const url = process.env.SURREALDB_URL!;
+    namespace = process.env.SURREALDB_NAMESPACE ?? 'brain';
+
+    root = new Surreal();
+    await root.connect(url);
+    await root.signin({
+      username: process.env.SURREALDB_USERNAME!,
+      password: process.env.SURREALDB_PASSWORD!,
+    });
+    await root.query(`DEFINE NAMESPACE IF NOT EXISTS \`${namespace}\``);
+    await root.use({ namespace });
+
+    setEnv('SURREALDB_SCOPED_USER', SCOPED_USER);
+    setEnv('SURREALDB_SCOPED_PASS', SCOPED_PASS);
+    setEnv('SURREALDB_SCOPED_TOKEN_DURATION', TOKEN_DURATION);
+    setEnv('SURREALDB_POOL_SIZE', '2');
+    setEnv('SURREALDB_SCOPED_POOL_SIZE', '2');
+
+    svc = new SurrealService(new ConfigService());
+    await svc.onModuleInit();
+    // Root first: migration 0005 defines brain_caller, which brain then
+    // (re)provisions with the declared token lifetime — same order as boot.
+    await svc.withCompany(tenant, (db) => db.query('RETURN 1'));
+    await svc.withScopedCompany(tenant, ['brain:read'], (db) => db.query('RETURN 1'));
+
+    metrics = new MetricsService();
+    probe = new CapabilityProbeService(
+      svc,
+      { knownCompanyIds: () => [tenant] } as unknown as ApiKeyService,
+      metrics,
+      undefined,
+    );
+  }, 180_000);
+
+  afterAll(async () => {
+    await svc?.onApplicationShutdown();
+    // Put the shared container's scoped user back on the server default so
+    // later specs in this worker are not left signing in on every read.
+    await root
+      ?.query(
+        `DEFINE USER OVERWRITE ${SCOPED_USER} ON NAMESPACE PASSWORD '${SCOPED_PASS}' ROLES EDITOR`,
+      )
+      .catch(() => undefined);
+    await root?.close().catch(() => undefined);
+    for (const [key, value] of Object.entries(saved)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+
+  it('reports SERVING against a healthy scoped pool', async () => {
+    const [scoped] = await probe.runOnce();
+    expect(scoped).toEqual({ capability: 'scoped_read', outcome: 'serving' });
+    expect(await okGauge()).toBe(1);
+    expect(
+      await seriesValue(metrics, 'brain_capability_probe_last_success_timestamp_seconds', {
+        capability: 'scoped_read',
+      }),
+    ).toBeGreaterThan(0);
+  }, 60_000);
+
+  it('goes RED when the read path can no longer authorize — while ping() stays green', async () => {
+    await defineScopedUser(ROTATED_PASS);
+
+    const [scoped] = await probe.runOnce();
+
+    expect(scoped?.outcome).toBe('unauthorized');
+    expect(scoped?.detail).toContain(`tenant=${tenant}`);
+    expect(await okGauge()).toBe(0);
+    expect(await tickCount('unauthorized')).toBe(1);
+
+    // THE control. This is the signal that reported "ok" throughout the
+    // original outage: the socket is fine, the server is fine, and every
+    // caller-facing read is failing. A monitor that cannot separate these
+    // two is the monitor we already had.
+    await expect(svc.ping()).resolves.toBe(true);
+    await expect(
+      svc.withScopedCompany(tenant, ['brain:read'], (db) => db.query('RETURN 1')),
+    ).rejects.toThrow();
+  }, 60_000);
+
+  it('recovers by itself once the path can authorize again', async () => {
+    await defineScopedUser(SCOPED_PASS);
+
+    const [scoped] = await probe.runOnce();
+
+    expect(scoped?.outcome).toBe('serving');
+    // The alert clears without an operator touching it — a probe that
+    // latched would be indistinguishable from a stuck one.
+    expect(await okGauge()).toBe(1);
+    expect(await tickCount('serving')).toBe(2);
+  }, 60_000);
+});

--- a/test/capability-probe.unit-spec.ts
+++ b/test/capability-probe.unit-spec.ts
@@ -1,0 +1,379 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { MetricsService } from '../src/metrics/metrics.service';
+import { CapabilityProbeService } from '../src/metrics/capability-probe.service';
+import {
+  CAPABILITY_COVERAGE,
+  CAPABILITY_NAMES,
+  classifyProbeFailure,
+  isConclusive,
+  PROBE_OUTCOMES,
+} from '../src/metrics/capability-probe';
+
+/**
+ * The probe's decision rules, pinned. The failure class it exists for —
+ * "the service reports healthy while a whole capability is dead" — was
+ * produced twice this week (#502, #503) and reached production undetected
+ * both times, so the interesting assertions here are the ones about what
+ * the probe must NOT do: a saturated pool must not read as a dead pool.
+ */
+
+const ANONYMOUS = 'Anonymous access not allowed: Not enough permissions to perform this action';
+const ACQUIRE_TIMEOUT =
+  'Surreal scoped pool acquire timed out after 10000ms (pool=8, waiters=3). ' +
+  'Likely a connection leak — check long-running requests in /admin/now.';
+const FAIL_CLOSED =
+  'scoped DB signin unavailable — failing closed rather than serving the request root-authorized: bad credentials';
+
+type Stubs = {
+  surreal: { withScopedCompany: jest.Mock };
+  apiKeys: { knownCompanyIds: jest.Mock };
+  embedder: { primaryDimensions: jest.Mock; embedUncached: jest.Mock; activeSpaceId: jest.Mock };
+};
+
+function makeStubs(overrides: Partial<Stubs> = {}): Stubs {
+  return {
+    surreal: { withScopedCompany: jest.fn().mockResolvedValue([[]]) },
+    apiKeys: { knownCompanyIds: jest.fn().mockReturnValue(['acme']) },
+    embedder: {
+      primaryDimensions: jest.fn().mockReturnValue(1024),
+      embedUncached: jest.fn().mockResolvedValue(new Array(1024).fill(0.1)),
+      activeSpaceId: jest.fn().mockReturnValue('bge-m3/1024'),
+    },
+    ...overrides,
+  };
+}
+
+function build(stubs: Stubs): { svc: CapabilityProbeService; metrics: MetricsService } {
+  const metrics = new MetricsService();
+  const svc = new CapabilityProbeService(
+    stubs.surreal as any,
+    stubs.apiKeys as any,
+    metrics,
+    stubs.embedder as any,
+  );
+  return { svc, metrics };
+}
+
+/** Current value of a labelled gauge/counter series, or undefined. */
+async function series(
+  metrics: MetricsService,
+  name: string,
+  labels: Record<string, string>,
+): Promise<number | undefined> {
+  const metric = metrics.registry.getSingleMetric(name);
+  if (!metric) return undefined;
+  const snapshot = (await metric.get()) as {
+    values: Array<{ labels: Record<string, string | number>; value: number }>;
+  };
+  const hit = snapshot.values.find((v) =>
+    Object.entries(labels).every(([k, want]) => String(v.labels[k]) === want),
+  );
+  return hit?.value;
+}
+
+const ok = (metrics: MetricsService, capability: string) =>
+  series(metrics, 'brain_capability_probe_ok', { capability });
+const ticks = (metrics: MetricsService, capability: string, outcome: string) =>
+  series(metrics, 'brain_capability_probe_total', { capability, outcome });
+
+describe('capability probe — failure classification', () => {
+  it('reads a pool acquire timeout as BUSY, not as a failure', () => {
+    // The whole point: a saturated pool is answering, it is just not
+    // answering us. #502 made the same call in readiness — a busy pool
+    // must not pull the pod out of rotation, and must not page anyone.
+    expect(classifyProbeFailure(new Error(ACQUIRE_TIMEOUT))).toBe('busy');
+    expect(isConclusive('busy')).toBe(false);
+  });
+
+  it('reads the production anonymous-session error as UNAUTHORIZED', () => {
+    expect(classifyProbeFailure(new Error(ANONYMOUS))).toBe('unauthorized');
+  });
+
+  it("reads brain's own fail-closed signin wrapper as UNAUTHORIZED", () => {
+    // A rotated secret or a dropped brain_caller never reaches the DB's
+    // own refusal — acquireScoped fails closed first. Same operator
+    // problem, different first line.
+    expect(classifyProbeFailure(new Error(FAIL_CLOSED))).toBe('unauthorized');
+  });
+
+  it('reads anything else as an error', () => {
+    expect(classifyProbeFailure(new Error('connection refused'))).toBe('error');
+    expect(classifyProbeFailure('not even an Error')).toBe('error');
+  });
+
+  it('classifies saturation BEFORE authorization (an acquire says nothing about auth)', () => {
+    // A message that matches both patterns must land on busy: we never
+    // observed the authorization, so claiming it failed is a fabrication.
+    expect(classifyProbeFailure(new Error(`${ACQUIRE_TIMEOUT} — ${ANONYMOUS}`))).toBe('busy');
+  });
+});
+
+describe('capability probe — scoped read', () => {
+  const saved = process.env.CAPABILITY_PROBE_ENABLED;
+  afterEach(() => {
+    if (saved === undefined) delete process.env.CAPABILITY_PROBE_ENABLED;
+    else process.env.CAPABILITY_PROBE_ENABLED = saved;
+  });
+
+  it('exercises the tenant read path end to end and reports serving', async () => {
+    const stubs = makeStubs();
+    const { svc, metrics } = build(stubs);
+
+    const reports = await svc.runOnce();
+
+    expect(reports).toContainEqual({ capability: 'scoped_read', outcome: 'serving' });
+    expect(await ok(metrics, 'scoped_read')).toBe(1);
+    expect(await ticks(metrics, 'scoped_read', 'serving')).toBe(1);
+    // Not `pingScoped`'s RETURN 1: the probe goes through the tenant
+    // database, the schema check, the scope binding and a real table read.
+    const [companyId, scopes] = stubs.surreal.withScopedCompany.mock.calls[0];
+    expect(companyId).toBe('acme');
+    expect(scopes).toEqual(['brain:read']);
+  });
+
+  it('reports UNAUTHORIZED and names the pool + tenant when the session has lapsed', async () => {
+    const stubs = makeStubs();
+    stubs.surreal.withScopedCompany.mockRejectedValue(new Error(ANONYMOUS));
+    const { svc, metrics } = build(stubs);
+
+    const [scoped] = await svc.runOnce();
+
+    expect(scoped?.outcome).toBe('unauthorized');
+    // An operator must be able to act on the line alone.
+    expect(scoped?.detail).toContain('tenant=acme');
+    expect(scoped?.detail).toContain('db=co_acme');
+    expect(scoped?.detail).toContain('scoped pool');
+    expect(await ok(metrics, 'scoped_read')).toBe(0);
+  });
+
+  it('a BUSY tick leaves the up-gauge exactly where it was', async () => {
+    // The load-bearing assertion. If saturation could flip the gauge, the
+    // first traffic spike would page an operator about a healthy pool and
+    // the alert would be muted within a week.
+    const stubs = makeStubs();
+    const { svc, metrics } = build(stubs);
+    await svc.runOnce();
+    expect(await ok(metrics, 'scoped_read')).toBe(1);
+
+    stubs.surreal.withScopedCompany.mockRejectedValue(new Error(ACQUIRE_TIMEOUT));
+    const [scoped] = await svc.runOnce();
+
+    expect(await ok(metrics, 'scoped_read')).toBe(1);
+    expect(await ticks(metrics, 'scoped_read', 'busy')).toBe(1);
+    // …and it does not tell an operator to go restart a healthy pod.
+    expect(scoped?.detail).toContain('saturation, not a failure');
+    expect(scoped?.detail).not.toContain('restart it');
+  });
+
+  it('a busy tick does not backdate the last-success gauge either', async () => {
+    const stubs = makeStubs();
+    const { svc, metrics } = build(stubs);
+    await svc.runOnce();
+    const first = await series(metrics, 'brain_capability_probe_last_success_timestamp_seconds', {
+      capability: 'scoped_read',
+    });
+
+    stubs.surreal.withScopedCompany.mockRejectedValue(new Error(ACQUIRE_TIMEOUT));
+    await svc.runOnce();
+
+    expect(
+      await series(metrics, 'brain_capability_probe_last_success_timestamp_seconds', {
+        capability: 'scoped_read',
+      }),
+    ).toBe(first);
+  });
+
+  it('an empty tenant table is a healthy tenant, not a dead capability', async () => {
+    const stubs = makeStubs();
+    stubs.surreal.withScopedCompany.mockResolvedValue([[]]);
+    const { svc } = build(stubs);
+    const [scoped] = await svc.runOnce();
+    expect(scoped?.outcome).toBe('serving');
+  });
+
+  it('SKIPS (does not fail) when the roster has no tenant to probe', async () => {
+    const stubs = makeStubs();
+    stubs.apiKeys.knownCompanyIds.mockReturnValue([]);
+    const { svc, metrics } = build(stubs);
+
+    const [scoped] = await svc.runOnce();
+
+    expect(scoped?.outcome).toBe('skipped');
+    expect(stubs.surreal.withScopedCompany).not.toHaveBeenCalled();
+    expect(await ok(metrics, 'scoped_read')).toBeUndefined();
+  });
+
+  it('honours CAPABILITY_PROBE_TENANT over the roster', async () => {
+    process.env.CAPABILITY_PROBE_TENANT = 'canary';
+    try {
+      const stubs = makeStubs();
+      const { svc } = build(stubs);
+      await svc.runOnce();
+      expect(stubs.surreal.withScopedCompany.mock.calls[0][0]).toBe('canary');
+    } finally {
+      delete process.env.CAPABILITY_PROBE_TENANT;
+    }
+  });
+});
+
+describe('capability probe — embed', () => {
+  it('measures the width that came back, not the embedder’s opinion of itself', async () => {
+    // #503: isReady() was green from the first millisecond of boot while
+    // every vector came back 1536 wide for a 1024-wide corpus. A probe
+    // that asks the component the same question inherits its bugs.
+    const stubs = makeStubs();
+    stubs.embedder.embedUncached.mockResolvedValue(new Array(1536).fill(0.1));
+    const { svc, metrics } = build(stubs);
+
+    const reports = await svc.runOnce();
+    const embed = reports.find((r) => r.capability === 'embed');
+
+    expect(embed?.outcome).toBe('degraded');
+    expect(embed?.detail).toContain('1536-wide');
+    expect(embed?.detail).toContain('1024-wide');
+    expect(await ok(metrics, 'embed')).toBe(0);
+  });
+
+  it('reports serving when the vector is in the configured space', async () => {
+    const { svc, metrics } = build(makeStubs());
+    await svc.runOnce();
+    expect(await ok(metrics, 'embed')).toBe(1);
+  });
+
+  it('never lets a cached answer stand in for a live one', async () => {
+    const stubs = makeStubs();
+    const { svc } = build(stubs);
+    await svc.runOnce();
+    await svc.runOnce();
+    // Through embed() a fixed probe string would be an LRU hit from the
+    // second tick on, and the probe would be measuring the cache.
+    expect(stubs.embedder.embedUncached).toHaveBeenCalledTimes(2);
+  });
+
+  it('skips rather than fails when no embedder is wired into the process', async () => {
+    const metrics = new MetricsService();
+    const stubs = makeStubs();
+    const svc = new CapabilityProbeService(
+      stubs.surreal as any,
+      stubs.apiKeys as any,
+      metrics,
+      undefined,
+    );
+    const embed = (await svc.runOnce()).find((r) => r.capability === 'embed');
+    expect(embed?.outcome).toBe('skipped');
+    expect(await ok(metrics, 'embed')).toBeUndefined();
+  });
+});
+
+describe('capability probe — scheduling', () => {
+  const saved: Record<string, string | undefined> = {};
+  const setEnv = (k: string, v: string) => {
+    saved[k] = process.env[k];
+    process.env[k] = v;
+  };
+
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => {
+    jest.useRealTimers();
+    for (const [k, v] of Object.entries(saved)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  });
+
+  it('does nothing at all while the flag is off', async () => {
+    setEnv('CAPABILITY_PROBE_ENABLED', '0');
+    const stubs = makeStubs();
+    const { svc } = build(stubs);
+
+    svc.onApplicationBootstrap();
+    await jest.advanceTimersByTimeAsync(300_000);
+
+    expect(stubs.surreal.withScopedCompany).not.toHaveBeenCalled();
+    svc.onApplicationShutdown();
+  });
+
+  it('probes on the configured interval once enabled', async () => {
+    setEnv('CAPABILITY_PROBE_ENABLED', '1');
+    setEnv('CAPABILITY_PROBE_INTERVAL_MS', '5000');
+    const stubs = makeStubs();
+    const { svc, metrics } = build(stubs);
+
+    svc.onApplicationBootstrap();
+    await jest.advanceTimersByTimeAsync(11_000);
+    svc.onApplicationShutdown();
+
+    expect(stubs.surreal.withScopedCompany).toHaveBeenCalledTimes(2);
+    expect(await ticks(metrics, 'scoped_read', 'serving')).toBe(2);
+  });
+
+  it('does not stack ticks when a capability hangs', async () => {
+    setEnv('CAPABILITY_PROBE_ENABLED', '1');
+    setEnv('CAPABILITY_PROBE_INTERVAL_MS', '5000');
+    const stubs = makeStubs();
+    stubs.surreal.withScopedCompany.mockReturnValue(new Promise(() => undefined));
+    const { svc } = build(stubs);
+
+    svc.onApplicationBootstrap();
+    // Two further ticks land inside the first probe's 15s deadline.
+    await jest.advanceTimersByTimeAsync(14_000);
+    svc.onApplicationShutdown();
+
+    expect(stubs.surreal.withScopedCompany).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops probing on shutdown', async () => {
+    setEnv('CAPABILITY_PROBE_ENABLED', '1');
+    setEnv('CAPABILITY_PROBE_INTERVAL_MS', '5000');
+    const stubs = makeStubs();
+    const { svc } = build(stubs);
+
+    svc.onApplicationBootstrap();
+    await jest.advanceTimersByTimeAsync(6_000);
+    svc.onApplicationShutdown();
+    await jest.advanceTimersByTimeAsync(60_000);
+
+    expect(stubs.surreal.withScopedCompany).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('capability coverage gate', () => {
+  /**
+   * The generalisation, and its limit. Enumerating every capability brain
+   * claims (145 flags, every route) is not something a registry can keep
+   * honest. What IS enumerable is the service's own readiness contract:
+   * `/ready` names its checks, and each one is polled at deploy time and
+   * never again. This gate says every check has a CONTINUOUS counterpart,
+   * so the next check to ship cannot quietly be deploy-time-only.
+   *
+   * Renaming a check is caught by the compiler instead (CAPABILITY_COVERAGE
+   * is typed on `keyof ReadinessReport`); this catches ADDING one.
+   */
+  const health = readFileSync(join(__dirname, '..', 'src', 'common', 'health.service.ts'), 'utf8');
+
+  function readinessChecks(): string[] {
+    const block = /export interface ReadinessReport \{([\s\S]*?)\n\}/.exec(health);
+    if (!block) throw new Error('ReadinessReport interface not found — the gate cannot run');
+    return [...block[1]!.matchAll(/^\s{2}(\w+)\??:/gm)]
+      .map((m) => m[1]!)
+      .filter((name) => name !== 'ready');
+  }
+
+  it('finds the readiness checks it is supposed to gate', () => {
+    expect(readinessChecks().sort()).toEqual(['dbOk', 'embedderReady', 'scopedOk']);
+  });
+
+  it('every readiness check is continuously exercised by some probe', () => {
+    const covered = new Set(Object.values(CAPABILITY_COVERAGE).flat());
+    const orphans = readinessChecks().filter((check) => !covered.has(check as never));
+    expect(orphans).toEqual([]);
+  });
+
+  it('every declared capability has coverage, and every outcome is spelled once', () => {
+    for (const capability of CAPABILITY_NAMES) {
+      expect(CAPABILITY_COVERAGE[capability].length).toBeGreaterThan(0);
+    }
+    expect(new Set(PROBE_OUTCOMES).size).toBe(PROBE_OUTCOMES.length);
+  });
+});


### PR DESCRIPTION
## The class, not the incident

Three times in one week the service **reported healthy while a whole capability was dead**, and all three reached production undetected:

| # | Capability | What was green | Fixed in |
|---|---|---|---|
| 1 | Every caller-facing read (scoped pool went anonymous ~59 min after boot) | `/health` — `version()` is answered for anonymous sessions too | #502 |
| 2 | Vector writes (embedder answering 1536-wide into a 1024-wide corpus) | `/ready` — it ORed in an always-ready fallback provider | #503 |
| 3 | `POST /v1/ingest/mention` (400 for six days, two-flag interaction) | nothing was watching it at all | #510 |

The common property is **a green signal that does not exercise the thing it claims to cover.** #502 and #503 both fixed the signal, and both fixes landed in `/ready` — which is polled at **deploy** time and then never again. A pool that lapses 59 minutes after a successful deploy is invisible to a deploy-time gate by construction. That is the gap this PR closes.

## What this ships

`CapabilityProbeService` (`src/metrics/capability-probe.service.ts`) runs on a timer in **every pod** and *runs the capability*, rather than asking a component how it feels:

| Capability | What the probe actually executes | Covers `/ready` check |
|---|---|---|
| `scoped_read` | `withScopedCompany(canary, ['brain:read'], SELECT VALUE id FROM knowledge_fact LIMIT 1)` — acquire → renew-or-fail-closed → `use(co_<tenant>)` → schema check → `LET $caller_scopes` → an authorization-gated read of a real table. Strictly more than `pingScoped()`'s `RETURN 1`. | `dbOk`, `scopedOk` |
| `embed` | Embeds a short string **uncached** and measures the **width of the returned vector** against the configured space. | `embedderReady` |

Two design rules, both taken directly from the incidents, and both load-bearing:

1. **A probe asserts an observable property of the OUTPUT, never the component's own opinion of itself.** #503's `/ready` was wrong precisely because it asked "does *something* think it can answer". So the embed probe measures a width, not `isReady()`. A probe that asks the same question as the thing it monitors inherits its bugs.
2. **A probe must not be answerable from cache.** `embed()` is memoised by `(providerId, text)`, so a fixed probe string would be an LRU hit from the second tick onwards and the probe would be measuring the cache. `embedUncached()` is extracted from `embed()` for exactly this (the cache path is otherwise byte-identical).

An empty `knowledge_fact` table is deliberately a **pass**: a tenant with no facts is a healthy tenant, and a probe that pages on an empty table is a probe that gets muted.

### Outcomes — and busy is not a failure

`serving` · `unauthorized` (alive but refusing — incident 1's exact state) · `degraded` (answered, wrong property — incident 2's exact state) · `busy` (pool acquire timed out) · `error` · `skipped` (nothing to exercise).

`brain_capability_probe_ok` is written **only on a conclusive outcome**, so a `busy` tick leaves the previous value standing. The distinction lives in the metric, not in an alert threshold — the same call #502 made in readiness: a saturated pool is answering, it is just not answering *us*, and pulling pods (or paging) for that punishes the pods still carrying traffic. Classification checks saturation **first**, so a message matching both patterns lands on `busy` (we never observed the authorization; claiming it failed would be a fabrication).

### Metrics and cardinality

```
brain_capability_probe_total{capability,outcome}                    counter
brain_capability_probe_ok{capability}                               gauge 1/0
brain_capability_probe_last_success_timestamp_seconds{capability}   gauge
```

**Per-tenant / canary / aggregate: canary, and it is not a close call.** The scoped session is shared by every tenant on the pod, so one tenant's probe proves the property for all of them. Per-tenant probing multiplies series *and* per-tick DB load by a roster that grows, buys zero extra detection power on this class, and would *worsen* detection latency if the roster were swept one tenant per tick. The scraper's own `instance` label already pins the unit that actually fails (the pod); the tenant is named in the log line and the runbook. `CAPABILITY_PROBE_TENANT` pins the canary when an operator wants a specific one. Worst-case series count: 2 capabilities × 6 outcomes + 2 + 2.

**No leader lease, every pod.** The failure is per-*process* — a lapsed session inside one node process says nothing about its neighbours — so a leader-elected probe would prove one pod healthy and stay silent about the other four. The alert aggregates with `min()`.

**Cost per pod per minute:** one indexless `LIMIT 1` read and one embed of a four-word string. On `EMBEDDER_PROVIDER=bge-m3` the embed is local CPU; on `openai` it is a real (tiny) API call visible in `brain_openai_calls_total`. `CAPABILITY_PROBE_INTERVAL_MS` is the dial.

## What the alerts fire on — and what they will not

| Rule | Severity | `for:` | Fires on | Why that window |
|---|---|---|---|---|
| `ScopedReadCapabilityDead` | critical | 5m | `min(brain_capability_probe_ok{capability="scoped_read"}) < 1` | Five consecutive **conclusive** failures at the 60s cadence. The failure is sticky — a lapsed session stays lapsed until the process restarts — so waiting costs almost nothing and buys immunity from a single-tick blip (DB restart, rolling deploy, one dropped socket). The baseline it replaces is not "faster": it is *never* (a user reported #502; #510 ran six days). |
| `CapabilityProbeFailing` | warning | 20m | the same check for every **other** capability | Catch-all, so the next capability added gets an alert without anyone remembering to write one. Excludes `scoped_read` to avoid double-paging. 20m because `embed` is legitimately 0 through a cold bge-m3 warmup (~340MB ONNX pull). |
| `CapabilityProbeStale` | warning | 30m of no confirmed serve | `time() - min by (capability)(…last_success…) > 1800` | The two states the up-gauge cannot see: a prober that is itself **wedged** (the gauge would sit at 1 forever — the very blindness this PR is about) and a pool that has been nothing but **busy**. |

**It will not fire on:** a saturated pool (busy never moves the gauge — sustained saturation reaches only the 30m *warning*, and `brain_capability_probe_total{outcome="busy"}` tells an operator which it is); a single failed tick; a pod that has not probed yet (the series does not exist until the first conclusive probe, so a booting pod is *absent*, not *down*, and `noDataState: OK` on all three); an empty tenant; the flag being off; a cold embedder warmup under 20 minutes; a scrape outage (that is `BrainScrapeDown`'s job).

**It also will not fire on a broken write path** — see the honest walkthrough below.

## Default-on: yes, and it is set

The code default is `0` (byte-identical when off — no timer, no series), and the flag stays as the kill switch. **`CAPABILITY_PROBE_ENABLED=1` is set in the production enablement set** in `deploy-brain.yml`, deliberately and as one reviewable line: a monitor nobody enables repeats the bug it was written for. Both incidents it covers reached production while `/health` and `/ready` were green.

## How far the generalisation goes — and where I stopped

The invitation was to enumerate the capabilities the service claims and assert each is exercised by *something*. I built the bounded version and refused the framework:

**Built.** `CAPABILITY_COVERAGE` ties each probe to the readiness checks it continuously exercises, typed on `keyof ReadinessReport` — so **renaming** a check is a compile error, and a unit gate parses `src/common/health.service.ts` and fails when a check is **added** without a continuous counterpart. The set is three entries, derived from a contract the service already publishes, and it cannot silently drift.

**Not built.** A registry enumerating every capability brain claims — ~145 flags, every route, every lane. It would be a hand-maintained list with the same failure mode as the thing it guards: nobody can keep it honest, and an inventory that is 80% stale is another green signal that proves nothing. The honest cover for that surface is per-surface flag-set specs (the idiom #510 introduced) and the e2e suite, not a probe framework. One probe that works beats a framework that does not.

## The honest test: would this have caught the three incidents?

| # | Caught? | How, and with what caveat |
|---|---|---|
| 1 — scoped pool anonymous | **Yes, in ~5 minutes.** | The probe's whole point. `test/capability-probe.e2e-spec.ts` proves it against a real SurrealDB 3.2.4: the scoped user gets a 5-second token (so every acquire re-signs), the server-side password is then rotated, and the very next probe reports `unauthorized` with the pool and tenant named — while `svc.ping()`, the signal `/health` reports and the one that stayed green through the whole real outage, still answers `true` in the same test. Restore the password and the probe goes green again by itself. |
| 2 — `/ready` green through warmup | **Yes, but at 20 minutes and only because the probe measures the output.** | The probe embeds and checks the returned width, so the fallback serving 1536 into a 1024 corpus reads as `degraded` regardless of what `isReady()` claims. Caveat worth a reviewer's eye: this covers **"warmup never finished"**, which is the durable half of #503. It does **not** turn a legitimate 3-minute warmup into an alert, by design — and the specific damage in #503 (an operator running the reindex sweep against a green `/ready`) was a *deploy-time* gate failing, which #503 itself fixed. The probe is the standing signal that the fix keeps holding; it is not a second implementation of it. |
| 3 — `ingest/mention` 400 for six days | **No. It would have missed this one.** | Every probe here is read-only, on purpose: a write probe mutates a real tenant's data, and a probe that needs `forget()` to clean up after itself is a probe that can damage what it monitors. A synthetic write against a dedicated throwaway tenant is the shape that *would* catch it — considered, not built, and it is a separate PR with its own blast radius. What actually covers #510's class is what #510 shipped: a per-surface spec that turns on the **production flag set** for a shared write surface and walks every writer through it. The probe's contribution to that class is limited to the truth: if it cannot be exercised without writing, it is not covered here, and this PR does not pretend otherwise. |

Two of three, and the third named rather than papered over.

## Gates

Run un-piped, real exit codes:

| Gate | Exit |
| --- | --- |
| `npx tsc --noEmit -p tsconfig.json` | 0 |
| `npx tsc --noEmit -p tsconfig.spec.json` | 0 |
| `eslint "{src,test}/**/*.ts" --max-warnings 0` (`lint:ci`) | 0 |
| `npx prettier --check "src/**/*.ts" "test/**/*.ts"` | 0 |
| unit suite — 400 suites / 4900 tests | 0 |
| e2e suite — 137 suites / 703 tests | 0 |

Stand: the e2e testcontainer (SurrealDB 3.2.4, ephemeral mapped port). Port 3033 and container `loco-321` untouched.

## Reviewer notes

- **`embed()` refactor.** The cache read/write moved out into `embed()` and the provider call into `embedThrough()`; `embedUncached()` is the same call without the cache. No behaviour change on the request path — the gen_ai span, token accounting and cache keys are identical.
- **`/ready` is unchanged.** This adds a signal; it does not touch what takes pods out of rotation.
- **ABAC interaction checked:** `withScopedCompany` compiles the deny pushdown from the AsyncLocalStorage policy context when `ABAC_DB_FENCE_ENABLED=1` (it is, in production). Outside a request `getPolicyContext()` is `undefined` and `compileDenyPushdown(undefined)` is `[]`, so the probe runs clean — no request context is faked.
- **Read-only.** No `DELETE`/`UPDATE … WHERE` anywhere near this (the 3.2.4 indexed-field planner trap does not apply).
- **Dashboard diff** is large only because inserting a row shifts every `gridPos.y` below it; the JSON round-trips byte-identically otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB
