### PR TITLE
fix(deps): move the multer and js-yaml overrides onto their patched versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "overrides": {
       "sharp": "^0.35.4",
       "ws": "^8.21.0",
-      "multer": "^2.2.0",
+      "multer": "^2.3.0",
       "qs": "^6.16.0",
       "hono": "^4.12.34",
       "@hono/node-server": "^2.0.5",
@@ -153,7 +153,7 @@
       "body-parser": "^2.3.0",
       "form-data": "^4.0.6",
       "tmp": "^0.2.6",
-      "js-yaml": "^4.3.1",
+      "js-yaml": "^4.3.2",
       "@babel/core": "^7.29.6",
       "undici": "^7.29.0",
       "minimatch@10": "^10.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 overrides:
   sharp: ^0.35.4
   ws: ^8.21.0
-  multer: ^2.2.0
+  multer: ^2.3.0
   qs: ^6.16.0
   hono: ^4.12.34
   '@hono/node-server': ^2.0.5
@@ -19,7 +19,7 @@ overrides:
   body-parser: ^2.3.0
   form-data: ^4.0.6
   tmp: ^0.2.6
-  js-yaml: ^4.3.1
+  js-yaml: ^4.3.2
   '@babel/core': ^7.29.6
   undici: ^7.29.0
   minimatch@10: ^10.2.3
@@ -3679,10 +3679,6 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.1:
-    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
-    hasBin: true
-
   js-yaml@4.3.2:
     resolution: {integrity: sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==}
     hasBin: true
@@ -3907,8 +3903,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  multer@2.2.0:
-    resolution: {integrity: sha512-6rdyFg2kLrMh9Jee7/BMPuV9lEAd7lLW2YUpF9/YxR7njyoUwwQ0ZPh3TaIY50Sw6vlyD2HW3wGOkTS4P79xrQ==}
+  multer@2.3.0:
+    resolution: {integrity: sha512-cjNbm3sttszgZeGfJR124D+jFEfkXCVAsoPBmFn9X7UxmDSFHWqE2CoEj0vrmSpuAFnqWR1Szcm9QTsiHr60Xw==}
     engines: {node: '>= 10.16.0'}
 
   mute-stream@2.0.0:
@@ -4144,7 +4140,6 @@ packages:
     resolution: {integrity: sha512-QErPemxRHDI2RUli3+9/mv4V6Ib9VWI+UoP2S82yXEQtoXzWvu9NSjjo3vyiUiVJv+CJFuzNiKUI+UFFUdv8Lg==}
     engines: {node: '>=20.18.0'}
     hasBin: true
-    bundledDependencies: []
 
   pg-int8@1.0.1:
     resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
@@ -5416,7 +5411,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.1
+      js-yaml: 4.3.2
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -6091,7 +6086,7 @@ snapshots:
       '@nestjs/core': 11.1.29(@nestjs/common@11.2.3(class-transformer@0.5.1)(class-validator@0.15.1)(reflect-metadata@0.2.2)(rxjs@7.8.2))(@nestjs/platform-express@11.1.29)(reflect-metadata@0.2.2)(rxjs@7.8.2)
       cors: 2.8.6
       express: 5.2.1
-      multer: 2.2.0
+      multer: 2.3.0
       path-to-regexp: 8.4.2
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -7895,7 +7890,7 @@ snapshots:
   cosmiconfig@8.3.6(typescript@5.9.3):
     dependencies:
       import-fresh: 3.3.1
-      js-yaml: 4.3.1
+      js-yaml: 4.3.2
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
@@ -9305,10 +9300,6 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.1:
-    dependencies:
-      argparse: 2.0.1
-
   js-yaml@4.3.2:
     dependencies:
       argparse: 2.0.1
@@ -9480,7 +9471,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  multer@2.2.0:
+  multer@2.3.0:
     dependencies:
       append-field: 1.0.0
       busboy: 1.6.0


### PR DESCRIPTION
The supply-chain gate is failing **on `main`**, and with it every PR queued behind it — `pnpm audit --audit-level=high` reports four high advisories. Both packages were already pinned by a pnpm override; the pins had simply stopped short of the fix.

| package | pinned at | patched in | reachable from |
| --- | --- | --- | --- |
| `multer` | `^2.2.0` | **2.3.0** | `@nestjs/platform-express` → the evidence blob-upload path |
| `js-yaml` | `^4.3.1` | **4.3.2** | `@nestjs/cli` — build tooling only |

`multer` was held at exactly the version named in three DoS advisories (crafted upload, file-count abuse, oversized field). **This one is not theoretical**: it sits on the evidence blob-upload path, so it is reachable by anyone who can POST a file. The `js-yaml` advisory (`maxTotalMergeKeys` does not bound CPU) is build-tooling only — the exposure there is a slow CI job, not a served request.

Both moves stay within the same major, so no API change.

## After

```
3 vulnerabilities found
Severity: 3 moderate
```

Four high → zero. The gate blocks on high, so this clears it **without silencing anything** — the remaining moderates are untouched and still reported.

## Note

This does not overlap the open Dependabot PRs (`@nestjs/config`, `@nestjs/cli`, `@nestjs/schedule`, `vitest`) — none of them bump `platform-express`, so none of them would have fixed the `multer` chain. Those are separate major-version upgrades and deserve their own review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB