### PR TITLE
ci: give the web app its own job, and actually typecheck and build it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,13 +135,45 @@ jobs:
       - name: Jobs e2e (real Surreal, no OpenAI)
         run: pnpm test:e2e:jobs
 
-      # i18n gate — admin components must use the getMessages() pipeline,
-      # never hardcoded JSX literals. See brain-landing/eslint.config.mjs
-      # and § Quality gates in CONTRIBUTING.md.
+  # The web app's own gates, in their OWN job — they used to be four steps
+  # tacked onto the end of build-test, which had two costs.
+  #
+  # First, build-test is a REQUIRED status check, so a hardcoded JSX literal
+  # in an admin component blocked merging an unrelated engine hotfix. The two
+  # deliverables now fail independently.
+  #
+  # Second, and worse, this set had a hole: there was no typecheck and no
+  # build. eslint-config-next does not typecheck, so a type error in
+  # brain-landing passed CI green, merged, and first surfaced as a FAILED
+  # DOCKER BUILD in the marketing site's deploy — the landing image runs one
+  # `next build` over every route, so a broken admin component stopped the
+  # SEO-critical public site from shipping. That is the actual mechanism by
+  # which admin breaks the landing, and it is fixed here rather than by
+  # splitting them into separate apps: what reaches main is now built and
+  # typechecked first.
+  web:
+    runs-on: ubuntu-latest
+    # Well under build-test's 45: this is one install plus lint/tsc/next
+    # build/vitest on a small app, with no containers.
+    timeout-minutes: 20
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
       - name: Install brain-landing deps
         working-directory: brain-landing
         run: pnpm install --frozen-lockfile
 
+      # i18n gate — admin components must use the getMessages() pipeline,
+      # never hardcoded JSX literals. See brain-landing/eslint.config.mjs
+      # and § Quality gates in CONTRIBUTING.md.
       - name: i18n lint — admin components
         working-directory: brain-landing
         run: pnpm lint:i18n
@@ -152,6 +184,17 @@ jobs:
       - name: Lint brain-landing (full)
         working-directory: brain-landing
         run: pnpm lint
+
+      # NEW. The gap described above: nothing typechecked this app.
+      - name: Typecheck brain-landing
+        working-directory: brain-landing
+        run: pnpm typecheck
+
+      # NEW. Runs the same `next build` the production Dockerfile runs, so a
+      # build that cannot ship is caught here instead of in the deploy.
+      - name: Build brain-landing (same build the deploy image runs)
+        working-directory: brain-landing
+        run: pnpm build
 
       - name: Test brain-landing (sitemap + locale parity)
         working-directory: brain-landing

--- a/brain-landing/package.json
+++ b/brain-landing/package.json
@@ -11,7 +11,8 @@
     "start": "next start -p 3030",
     "lint": "eslint .",
     "lint:i18n": "eslint components/admin",
-    "test": "vitest run"
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit"
   },
   "dependencies": {
     "@dagrejs/dagre": "^3.1.1",


### PR DESCRIPTION
Two problems, one cause: the landing's gates were four steps bolted onto the end of `build-test`, and that set had a hole in it.

## The hole is the important half

`brain-landing` had **no `typecheck` script and CI ran no build for it** — only eslint and vitest, and `eslint-config-next` does not typecheck.

So a type error in an admin component passed CI green, merged, and first surfaced as a **failed Docker build in the marketing site's deploy**: the landing image runs one `next build` over every route, so a broken admin component stopped the SEO-critical public site from shipping.

**That is the actual mechanism by which admin breaks the landing.**

## Why this instead of splitting the apps

The split was the plan until the import graph was measured:

| shared by | files | loc |
| --- | --- | --- |
| all three surfaces | 7 | 2,147 — of which 1,700 is two locale JSON files |
| admin + user app | 21 | 3,499 |
| public ∩ admin, excluding what the user app also uses | **0** | **0** |

The public surface barely touches the other two — about **440 lines of actual TypeScript** plus the locale dictionaries. Admin and the user app are the pair that genuinely shares code, including `lib/bff-proxy.ts`, whose own header says it exists so a security fix "can't drift between the two routes". A split would put that file across a package boundary between two independently deployable images — creating precisely the drift it was written to prevent.

The seam the code actually has is `{marketing} | {admin + user}`, not the three-way cut. And a split would not have fixed the breakage anyway; it would have hidden it. Stopping the break from reaching `main` does fix it.

## The second problem

`build-test` is a **required status check**, so a hardcoded JSX literal in an admin component blocked merging an unrelated engine hotfix. Engine and web now fail independently.

## What is new

- `web` job: install → i18n lint → full eslint → **typecheck (new)** → **`next build`, the same build the deploy image runs (new)** → vitest.
- `brain-landing` gains a `typecheck` script.

The landing typechecks and builds clean today (`tsc --noEmit` exit 0, `next build` exit 0), so both new gates land without a backlog to clear first.

## Needs a repo admin

Add `web` to the required status checks — currently `build-test`, `supply-chain`, `trufflehog`, `lint`. Until then the new job reports but does not block, which means the hole is visible but not yet closed.

## Still open, if deploy *cadence* is the real pain

This fixes the failure coupling, not the cadence coupling: an admin change still redeploys the marketing site (harmless — same content, new container), and an urgent copy fix still carries whatever admin code is on `main`. If that is the actual complaint, the next cheapest step is two build targets from one source tree rather than three apps. Worth noting either way: two Next apps on one Host need the multi-zone `assetPrefix` work, because Traefik gives the landing `/_next/*` as a catch-all and a second app's chunks would 404 into it — rendering a blank page with no server-side error anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB