### PR TITLE
ci: run the gates in parallel, only the ones a change can break

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,29 +48,73 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
-  build-test:
+  # ---------------------------------------------------------------------
+  # Change detection. Decides which gates this diff can possibly break.
+  #
+  # Deny-list shaped on purpose: only buckets that provably feed no gate
+  # are skippable, and every other path — including one nobody has seen
+  # before — runs everything. See the docblock in
+  # scripts/ci/change-buckets.mjs for why an allowlist is the wrong shape
+  # for CI even though it is the right shape for the deploy trigger, and
+  # test/ci-change-buckets.unit-spec.ts for the guard that keeps a
+  # gate-bearing file from hiding inside a skip bucket.
+  # ---------------------------------------------------------------------
+  changes:
     runs-on: ubuntu-latest
-    # 45, not 30 — the same wall this job hit at 20 minutes in 2026-08, moved
-    # up by a wave of new suites (evidence plane, scenes, OCR, indexers). A
-    # timed-out job reports conclusion "cancelled", which reads like runner
-    # contention and is not: measured on main 2026-09-08, the successful runs
-    # sit at 26:38 / 27:09 / 28:09 and the failures all die at exactly 30:0x,
-    # i.e. on the cap, with no hang signature. Roughly half of all runs were
-    # being lost that way, which blocks every PR behind them.
-    #
-    # The cost of the ceiling is bounded: jest runs with forceExit, so a true hang
-    # cannot idle here for the full 45 — it is the serialized e2e suite
-    # (maxWorkers 1, the 2026-08 CI-stability fix) plus two testcontainer
-    # lifecycles and a cold install that legitimately need the headroom.
-    # Raise this again only with measured durations, never on a hunch; if the
-    # median crosses ~35 the answer is to shard the suite, not a bigger number.
-    timeout-minutes: 45
-
+    timeout-minutes: 5
+    outputs:
+      engine: ${{ steps.classify.outputs.engine }}
+      web: ${{ steps.classify.outputs.web }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          # Full history so the merge-base diff below resolves. A shallow
+          # clone yields no merge base and the classifier would then see an
+          # empty file list — which it treats as "run everything", so the
+          # failure mode is safe either way, just slow.
+          fetch-depth: 0
 
+      - name: Classify changed paths
+        id: classify
+        env:
+          EVENT: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT" != "pull_request" ]; then
+            # push to main, schedule and manual dispatch always run the full
+            # pipeline: main is what the deploy and the release ride on, and
+            # a partial verdict there is not a verdict.
+            echo "[ci] event=$EVENT — running every gate"
+            echo "engine=true" >> "$GITHUB_OUTPUT"
+            echo "web=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # actions/checkout gives us refs/pull/N/merge, whose merge base with
+          # base.sha IS base.sha, so the three-dot diff is exactly the PR's
+          # own changes. If that cannot be resolved — a force-push mid-run, a
+          # base branch rewritten under us — the list comes out empty, which
+          # the classifier deliberately reads as "run everything" rather than
+          # "skip everything". An unresolvable diff is a reason to be careful.
+          if ! git diff --name-only "$BASE_SHA...HEAD" > changed-files.txt; then
+            echo "[ci] could not diff against $BASE_SHA — running every gate"
+            : > changed-files.txt
+          fi
+          node scripts/ci/classify-changes.mjs < changed-files.txt
+
+  # ---------------------------------------------------------------------
+  # Engine static gates: lint, format, typecheck, build. Together ~95s of
+  # work, so they stay in one job — splitting them buys nothing but four
+  # more cold installs.
+  # ---------------------------------------------------------------------
+  engine-checks:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: changes
+    if: needs.changes.outputs.engine == 'true'
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413 # v6.1.0
-
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
         with:
           node-version: '22'
@@ -78,40 +122,6 @@ jobs:
 
       - name: Install
         run: pnpm install --frozen-lockfile --ignore-workspace
-
-      # ts-jest transform cache, persisted across runs.
-      #
-      # Jest's default cacheDirectory is os.tmpdir()/jest_<uid>, which dies
-      # with the runner, so every CI run re-compiled all 541 spec files from
-      # cold while the same suites locally reuse a warm cache. The jest
-      # configs now point at <rootDir>/.jest-cache and this step carries it
-      # between runs.
-      #
-      # The key is content-addressed twice over: the restore key pins the
-      # lockfile and tsconfig (ts-jest invalidates on compiler options and on
-      # its own version), and jest itself keys every cached entry on the
-      # source file's content hash — so a stale entry cannot be served, and
-      # the worst case of a cold or mismatched cache is the old behaviour.
-      # The github.sha suffix makes each run write a fresh entry; the
-      # restore-keys prefix then picks the most recent compatible one.
-      #
-      # MEASURED, AND THE RESULT IS NOT WHAT IT LOOKS LIKE. On a confirmed
-      # cache hit the unit step ran 1:26 against 1:27 on a confirmed miss,
-      # and an e2e shard 2:58 against 3:03 — i.e. nothing, inside the noise.
-      # Once ts-jest is transpile-only the per-file work is cheap enough
-      # that redoing it costs about what unpacking the cache costs. The
-      # entry is ~16MB and restores in two seconds, so this is kept as a
-      # hedge (it would matter again if the transpile-only change were ever
-      # reverted), but do NOT read a speed claim into it. The 13 minutes
-      # came from isolatedModules, not from here.
-      - name: Restore ts-jest transform cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
-        with:
-          path: .jest-cache
-          key: jest-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig.json') }}-${{ github.sha }}
-          restore-keys: |
-            jest-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig.json') }}-
-            jest-${{ runner.os }}-
 
       - name: Lint
         # lint:ci has no --fix and fails on any warning, so a fixable violation
@@ -133,23 +143,46 @@ jobs:
       # that spec — a skipped or never-run spec shipped its type error
       # green. tsconfig.spec.json re-includes test/ and gates it here.
       #
-      # Since tsconfig.json turned on isolatedModules, ts-jest transpiles
-      # without a program and this is the ONLY typecheck the specs get. It
-      # was already covering every one of them, over the same file set —
-      # what changed is that it is now load-bearing instead of duplicated,
-      # which is where the e2e speed-up came from. If this step is ever
-      # weakened or made conditional, put the typecheck back into ts-jest
-      # first.
+      # Since the transpile-only change this is also the ONLY typecheck the
+      # specs get: ts-jest runs isolatedModules and emits without a
+      # program. That makes this step load-bearing rather than duplicative,
+      # which is the trade the speed came from.
       - name: Typecheck (src + tests)
         run: pnpm typecheck
 
       - name: Build
         run: pnpm build
 
-      # Unit suite (79 specs: auth guard, calibration, CAS job-claim,
-      # conflict-explainer, chat-router gates, …). These were defined in
-      # package.json but never wired into CI, so a regression in any of
-      # them shipped green. Now a hard gate on every PR.
+  # ---------------------------------------------------------------------
+  # Unit suite + coverage ratchet.
+  # ---------------------------------------------------------------------
+  engine-unit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs: changes
+    if: needs.changes.outputs.engine == 'true'
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413 # v6.1.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install
+        run: pnpm install --frozen-lockfile --ignore-workspace
+
+      - name: Restore ts-jest transform cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: .jest-cache
+          key: jest-unit-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig.json') }}-${{ github.sha }}
+          restore-keys: |
+            jest-unit-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig.json') }}-
+            jest-unit-${{ runner.os }}-
+
+      # 403 specs: auth guard, calibration, CAS job-claim, conflict-explainer,
+      # chat-router gates, …
       # --coverage activates the coverageThreshold floor in jest-unit.json
       # (an all-src ratchet: statements/lines 52%, branches 40%, functions
       # 45% — a few points under the current ~57/45/50/58 to prevent
@@ -160,45 +193,184 @@ jobs:
       - name: Unit tests (+ coverage ratchet)
         run: pnpm test:unit:cov
 
-      # Socket suite: the 6 specs that bind real loopback HTTP servers
-      # (.listen(0, '127.0.0.1')) live behind their own *.socket-spec.ts
-      # config so `pnpm test` stays hermetic in sandboxes that forbid
-      # listen(). CI runs them right after the unit suite — coverage is
-      # unchanged, only the partition moved.
+  # ---------------------------------------------------------------------
+  # Socket suite: the 6 specs that bind real loopback HTTP servers
+  # (.listen(0, '127.0.0.1')) live behind their own *.socket-spec.ts
+  # config so `pnpm test` stays hermetic in sandboxes that forbid
+  # listen(). ~25s — it shares a job with nothing because it needs no
+  # database and finishes before any other job has finished installing.
+  # ---------------------------------------------------------------------
+  engine-socket:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: changes
+    if: needs.changes.outputs.engine == 'true'
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413 # v6.1.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install
+        run: pnpm install --frozen-lockfile --ignore-workspace
+
       - name: Socket unit tests (loopback listeners)
         run: pnpm test:socket
 
-      - name: In-process e2e (testcontainers + stubs)
-        run: pnpm test:e2e
+  # ---------------------------------------------------------------------
+  # In-process e2e, sharded.
+  #
+  # This is the only lever that moves the number: measured on main
+  # 2026-09-08 the whole build-test job ran 29:45 / 32:54 / 39:29 and the
+  # e2e step alone was 23:54 / 26:33 / 34:21 of it. Everything else in the
+  # old monolith was ≤3 minutes.
+  #
+  # Sharding was considered and rejected once — see the long docblock in
+  # test/jest-e2e.json. Read in full, the rejection is narrower than it
+  # looks: it says sharding "would not have prevented" the SIGABRT,
+  # because that abort landed on a fresh worker's FIRST file and so a
+  # fresh process per shard would not have avoided it. That is an argument
+  # against sharding as a CRASH FIX, and it was correct. It is not an
+  # argument against sharding as a SPEED FIX, and the crash it refers to
+  # was root-caused and removed in the fixture (the e2e app no longer
+  # loads any ONNX model), so the reason to leave the suite serial is
+  # gone. The same docblock's CI counterpart already pre-committed to
+  # this: "if the median crosses ~35 the answer is to shard the suite,
+  # not a bigger number."
+  #
+  # Each shard is a separate runner and therefore a separate jest process,
+  # a separate globalSetup and a separate SurrealDB container. That
+  # REDUCES cross-suite coupling rather than adding it: a shard's database
+  # now holds only that shard's tenants. The hazard is the mirror image —
+  # a spec that passes today only because a sibling suite's fixture
+  # populated a shared table (PR #474 had to fix exactly that class of
+  # assertion) will fail once the sibling lands in another shard. That is
+  # a real bug being surfaced, not one being introduced, and the shard
+  # split was run to green before this landed.
+  #
+  # maxWorkers stays 1 WITHIN a shard: the native-heap corruption the
+  # docblock documents is a property of the app's teardown path, not of
+  # the worker count, and nothing here re-litigates it.
+  # ---------------------------------------------------------------------
+  engine-e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    needs: changes
+    if: needs.changes.outputs.engine == 'true'
+    strategy:
+      # Do not cancel sibling shards when one fails: a single flaky shard
+      # would otherwise hide the results of the other three, and "which
+      # shards were green" is the first question when triaging a shard
+      # split.
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413 # v6.1.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+        with:
+          node-version: '22'
+          cache: 'pnpm'
 
-      # Real-Surreal job-queue suite (CAS claim / leader lease / zombie
-      # reap / backoff). No OpenAI, no SDK — pure DB correctness against
-      # testcontainers. Previously matched no CI pattern and never ran.
+      - name: Install
+        run: pnpm install --frozen-lockfile --ignore-workspace
+
+      - name: Restore ts-jest transform cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          # Per-shard key: each shard transforms a different slice of the
+          # tree, so one shared cache entry would be written four times
+          # with four partial contents and the last writer would win.
+          path: .jest-cache
+          key: jest-e2e-${{ matrix.shard }}-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig.json') }}-${{ github.sha }}
+          restore-keys: |
+            jest-e2e-${{ matrix.shard }}-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig.json') }}-
+            jest-e2e-${{ matrix.shard }}-${{ runner.os }}-
+
+      - name: In-process e2e (testcontainers + stubs) — shard ${{ matrix.shard }}/4
+        run: pnpm test:e2e -- --shard=${{ matrix.shard }}/4
+
+  # ---------------------------------------------------------------------
+  # Real-Surreal job-queue suite (CAS claim / leader lease / zombie
+  # reap / backoff). No OpenAI, no SDK — pure DB correctness against
+  # testcontainers. ~20s.
+  # ---------------------------------------------------------------------
+  engine-jobs-e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: changes
+    if: needs.changes.outputs.engine == 'true'
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413 # v6.1.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install
+        run: pnpm install --frozen-lockfile --ignore-workspace
+
       - name: Jobs e2e (real Surreal, no OpenAI)
         run: pnpm test:e2e:jobs
+
+  # ---------------------------------------------------------------------
+  # The landing app. Its own runner, its own lockfile, its own failure.
+  #
+  # Split out of the engine job because `build-test` is a required check
+  # and a landing lint violation was therefore blocking unrelated engine
+  # hotfixes. typecheck and build are here because eslint-config-next
+  # never typechecked: a type error in an admin component passed CI green
+  # and only surfaced as a failed Docker build during the landing deploy,
+  # where one `next build` covers every route — so a broken admin
+  # component blocked the SEO-critical public site from shipping.
+  # ---------------------------------------------------------------------
+  web:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs: changes
+    if: needs.changes.outputs.web == 'true'
+    defaults:
+      run:
+        working-directory: brain-landing
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413 # v6.1.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+          cache-dependency-path: brain-landing/pnpm-lock.yaml
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
 
       # i18n gate — admin components must use the getMessages() pipeline,
       # never hardcoded JSX literals. See brain-landing/eslint.config.mjs
       # and § Quality gates in CONTRIBUTING.md.
-      - name: Install brain-landing deps
-        working-directory: brain-landing
-        run: pnpm install --frozen-lockfile
-
       - name: i18n lint — admin components
-        working-directory: brain-landing
         run: pnpm lint:i18n
 
       # Full ESLint over the whole landing app (Next 16 removed `next lint`, so
       # this is eslint-config-next via the flat config). Gates on errors; the
       # stricter react-hooks-7 rules are warnings tracked as tech debt.
-      - name: Lint brain-landing (full)
-        working-directory: brain-landing
+      - name: Lint (full)
         run: pnpm lint
 
-      - name: Test brain-landing (sitemap + locale parity)
-        working-directory: brain-landing
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Test (sitemap + locale parity)
         run: pnpm test
 
+      # The same build the deploy image runs. Catches what lint cannot.
+      - name: Build
+        run: pnpm build
+
+  # ---------------------------------------------------------------------
   # Supply-chain CVE gate. scorecard.yml + dependency-review.yml are both
   # gated on `repository.private == false`, so they no-op while this repo
   # is private — a lockfile dependency with a known CVE could merge
@@ -206,14 +378,16 @@ jobs:
   # runs `pnpm audit` regardless of visibility and blocks on high/critical.
   # `--ignore-workspace` matches the install: it audits THIS repo's
   # lockfile only, never a stray parent pnpm workspace.
+  #
+  # Unconditional: it is its OWN required status check by name, so it must
+  # report on every PR including a docs-only one.
+  # ---------------------------------------------------------------------
   supply-chain:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
       - uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413 # v6.1.0
-
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v6
         with:
           node-version: '22'
@@ -227,6 +401,91 @@ jobs:
       # this is the gate that stops a known-vulnerable tree from merging.
       - name: pnpm audit (high+ blocks)
         run: pnpm audit --audit-level=high --ignore-workspace
+
+  # ---------------------------------------------------------------------
+  # Image build + smoke. No longer `needs: build-test` — it never needed
+  # the test results to build an image, and depending on the gate would
+  # be a cycle now that the gate depends on it.
+  # ---------------------------------------------------------------------
+  docker:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: changes
+    if: needs.changes.outputs.engine == 'true'
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Build image
+        run: docker build -t inite-brain-service:ci .
+
+      - name: Smoke run
+        run: |
+          docker network create brain-ci
+          docker run -d --name surreal --network brain-ci \
+            surrealdb/surrealdb:v3.2.4 \
+            start --user=root --pass=root --bind=0.0.0.0:8000 memory
+          sleep 5
+          docker run -d --name brain --network brain-ci -p 3030:3000 \
+            -e SURREALDB_URL=ws://surreal:8000 \
+            -e SURREALDB_USERNAME=root \
+            -e SURREALDB_PASSWORD=root \
+            -e SURREALDB_NAMESPACE=brain \
+            -e SURREALDB_SCOPED_USER=brain_caller \
+            -e SURREALDB_SCOPED_PASS=ci-scoped-pass \
+            -e OPENAI_API_KEY=sk-ci-stub \
+            -e BRAIN_API_KEYS='[]' \
+            -e FORGET_HMAC_KEY=ci-hmac-key-must-be-at-least-32-chars \
+            inite-brain-service:ci
+          for i in $(seq 1 30); do
+            if curl -fs http://localhost:3030/health >/dev/null; then
+              echo "service healthy"
+              curl -s http://localhost:3030/health
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "service did not become healthy"
+          docker logs brain
+          exit 1
+
+  # ---------------------------------------------------------------------
+  # THE GATE. `build-test` is a required status check on main and only a
+  # repo admin can change that list, so the NAME stays even though the job
+  # no longer runs a build or a test. It judges the jobs that do.
+  #
+  # The subtlety is that GitHub reports `skipped` both for "your `if:`
+  # said no" and for "something you needed failed", and the two must land
+  # on opposite sides of the gate. scripts/ci/gate.mjs disambiguates by
+  # checking each result against an expectation recomputed from the same
+  # change-detection outputs the job's own `if:` used;
+  # test/ci-gate-truth.unit-spec.ts pins that table to this YAML so the
+  # duplication cannot rot, and fails if a job is added here without being
+  # judged.
+  # ---------------------------------------------------------------------
+  build-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: always()
+    needs:
+      [
+        changes,
+        engine-checks,
+        engine-unit,
+        engine-socket,
+        engine-e2e,
+        engine-jobs-e2e,
+        web,
+        docker,
+      ]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Judge
+        env:
+          GATE_NEEDS: ${{ toJSON(needs) }}
+          GATE_ENGINE: ${{ needs.changes.outputs.engine }}
+          GATE_WEB: ${{ needs.changes.outputs.web }}
+        run: node scripts/ci/gate.mjs
 
   real-e2e:
     runs-on: ubuntu-latest
@@ -347,44 +606,3 @@ jobs:
           # snapshot — no ratchet. eval:diff blocks on regressions beyond
           # per-metric tolerances; improvements never block.
           pnpm eval:diff test/eval/golden-baseline.json .eval-current/report.json
-
-  docker:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    needs: build-test
-
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: Build image
-        run: docker build -t inite-brain-service:ci .
-
-      - name: Smoke run
-        run: |
-          docker network create brain-ci
-          docker run -d --name surreal --network brain-ci \
-            surrealdb/surrealdb:v3.2.4 \
-            start --user=root --pass=root --bind=0.0.0.0:8000 memory
-          sleep 5
-          docker run -d --name brain --network brain-ci -p 3030:3000 \
-            -e SURREALDB_URL=ws://surreal:8000 \
-            -e SURREALDB_USERNAME=root \
-            -e SURREALDB_PASSWORD=root \
-            -e SURREALDB_NAMESPACE=brain \
-            -e SURREALDB_SCOPED_USER=brain_caller \
-            -e SURREALDB_SCOPED_PASS=ci-scoped-pass \
-            -e OPENAI_API_KEY=sk-ci-stub \
-            -e BRAIN_API_KEYS='[]' \
-            -e FORGET_HMAC_KEY=ci-hmac-key-must-be-at-least-32-chars \
-            inite-brain-service:ci
-          for i in $(seq 1 30); do
-            if curl -fs http://localhost:3030/health >/dev/null; then
-              echo "service healthy"
-              curl -s http://localhost:3030/health
-              exit 0
-            fi
-            sleep 1
-          done
-          echo "service did not become healthy"
-          docker logs brain
-          exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,7 +173,7 @@ jobs:
         run: pnpm install --frozen-lockfile --ignore-workspace
 
       - name: Restore ts-jest transform cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: .jest-cache
           key: jest-unit-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml', 'tsconfig.json') }}-${{ github.sha }}
@@ -279,7 +279,7 @@ jobs:
         run: pnpm install --frozen-lockfile --ignore-workspace
 
       - name: Restore ts-jest transform cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           # Per-shard key: each shard transforms a different slice of the
           # tree, so one shared cache entry would be written four times
@@ -291,7 +291,11 @@ jobs:
             jest-e2e-${{ matrix.shard }}-${{ runner.os }}-
 
       - name: In-process e2e (testcontainers + stubs) — shard ${{ matrix.shard }}/4
-        run: pnpm test:e2e -- --shard=${{ matrix.shard }}/4
+        # `pnpm test:e2e -- --shard=N/4` does NOT work: the flag arrives
+        # after jest's own argv terminator and jest reads it as a positional
+        # test-path pattern, matching zero files and exiting 1 ("Pattern:
+        # --shard=1/4 - 0 matches"). Invoking jest directly is unambiguous.
+        run: pnpm exec jest --config ./test/jest-e2e.json --shard=${{ matrix.shard }}/4
 
   # ---------------------------------------------------------------------
   # Real-Surreal job-queue suite (CAS claim / leader lease / zombie

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,6 +172,14 @@ jobs:
       - name: Install
         run: pnpm install --frozen-lockfile --ignore-workspace
 
+      # MEASURED, AND THE RESULT IS NOT WHAT IT LOOKS LIKE. On a confirmed
+      # cache hit this step ran 1:26 against 1:27 on a confirmed miss, and
+      # an e2e shard 2:58 against 3:03 — nothing, inside the noise. Once
+      # ts-jest is transpile-only the per-file work is cheap enough that
+      # redoing it costs about what unpacking the cache costs. The entry is
+      # ~16MB and restores in two seconds, so it is kept as a hedge against
+      # the transpile-only change ever being reverted — but do NOT read a
+      # speed claim into it.
       - name: Restore ts-jest transform cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:

--- a/brain-landing/package.json
+++ b/brain-landing/package.json
@@ -11,6 +11,7 @@
     "start": "next start -p 3030",
     "lint": "eslint .",
     "lint:i18n": "eslint components/admin",
+    "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },
   "dependencies": {

--- a/scripts/ci/change-buckets.mjs
+++ b/scripts/ci/change-buckets.mjs
@@ -1,0 +1,116 @@
+// Path-based change detection for CI job selection.
+//
+// The design rule here is DENY-LIST, NOT ALLOW-LIST, and it is the whole
+// point of the file. deploy-brain.yml (#516) uses an allowlist of paths
+// that feed the engine image, guarded by a truth test — that is correct
+// for a DEPLOY, where the question is "does this bytes-for-bytes change
+// the artifact?" and the Dockerfile answers it mechanically.
+//
+// CI asks a different and much harder question: "could this change break
+// a gate?" Nothing mechanically answers that, because a spec may read any
+// file in the repo (test/openapi-doc.unit-spec.ts reads docs/openapi.json
+// and brain-landing/public/openapi.json — two paths that look inert and
+// are not). An allowlist that misses one of those SILENTLY SKIPS the gate
+// that would have caught the regression, which is strictly worse than
+// running too much.
+//
+// So: we enumerate only the buckets that provably feed no engine gate,
+// and EVERYTHING ELSE runs everything. A new top-level directory, an
+// unrecognised dotfile, a workflow edit — all default to the full suite.
+// Being wrong costs runner minutes; being wrong the other way ships a
+// regression. The asymmetry decides the default.
+//
+// SKIP_EXCEPTIONS is the escape hatch for paths that live inside a skip
+// bucket but are read by a spec. It is not maintained by hand-vigilance:
+// test/ci-change-buckets.unit-spec.ts scans every spec for repo-relative
+// reads and fails if any of them resolves into a skip bucket without an
+// exception. Add a spec that reads docs/, and CI tells you to come here.
+
+/** Globs whose contents feed the landing app's gates, not the engine's. */
+export const WEB_GLOBS = ['brain-landing/**', 'skills/**'];
+
+/** Prose and issue templates. No gate reads these. */
+export const DOCS_GLOBS = ['docs/**', '*.md', 'LICENSE', '.github/ISSUE_TEMPLATE/**'];
+
+/** Observability stack config, deployed by deploy-monitoring.yml alone. */
+export const MONITORING_GLOBS = ['monitoring/**'];
+
+/**
+ * Paths that fall inside a skip bucket above but are nevertheless read by
+ * a spec, so a change to them MUST still run the engine gates. Kept honest
+ * by test/ci-change-buckets.unit-spec.ts, which derives the required set
+ * from the spec sources rather than trusting this list.
+ */
+export const SKIP_EXCEPTIONS = ['docs/openapi.json', 'brain-landing/public/openapi.json'];
+
+/**
+ * Files that change the gates themselves. A CI workflow edit has to run
+ * every gate, or the edit is unreviewable — you cannot see the new
+ * pipeline's verdict on the PR that introduces it.
+ */
+export const ALWAYS_EVERYTHING = ['.github/workflows/ci.yml', 'scripts/ci/'];
+
+function matchesGlob(file, glob) {
+  if (glob.endsWith('/**')) {
+    const dir = glob.slice(0, -3);
+    return file === dir || file.startsWith(`${dir}/`);
+  }
+  if (glob.startsWith('*.')) {
+    // Root-level extension glob: '*.md' matches README.md, never docs/a.md.
+    return !file.includes('/') && file.endsWith(glob.slice(1));
+  }
+  return file === glob;
+}
+
+function inBucket(file, globs) {
+  return globs.some((glob) => matchesGlob(file, glob));
+}
+
+function forcesEverything(file) {
+  return ALWAYS_EVERYTHING.some((p) => (p.endsWith('/') ? file.startsWith(p) : file === p));
+}
+
+/**
+ * Classify one changed path.
+ * Returns 'everything' | 'web' | 'docs' | 'monitoring' | 'engine'.
+ */
+export function classifyFile(file) {
+  if (forcesEverything(file)) return 'everything';
+  if (SKIP_EXCEPTIONS.includes(file)) return 'engine';
+  if (inBucket(file, WEB_GLOBS)) return 'web';
+  if (inBucket(file, DOCS_GLOBS)) return 'docs';
+  if (inBucket(file, MONITORING_GLOBS)) return 'monitoring';
+  return 'engine';
+}
+
+/**
+ * Fold a changed-file list into the two booleans CI selects jobs on.
+ * `files` empty (no diff resolvable) is treated as "run everything" —
+ * an unresolvable base is a reason to be careful, not a reason to skip.
+ */
+export function classifyChanges(files) {
+  if (files.length === 0) return { engine: true, web: true, reasons: ['no-diff:run-everything'] };
+
+  const reasons = [];
+  let engine = false;
+  let web = false;
+
+  for (const file of files) {
+    const bucket = classifyFile(file);
+    if (bucket === 'everything') {
+      engine = true;
+      web = true;
+      reasons.push(`${file} -> everything`);
+    } else if (bucket === 'engine') {
+      engine = true;
+      reasons.push(`${file} -> engine`);
+    } else if (bucket === 'web') {
+      web = true;
+      reasons.push(`${file} -> web`);
+    } else {
+      reasons.push(`${file} -> ${bucket} (no gate)`);
+    }
+  }
+
+  return { engine, web, reasons };
+}

--- a/scripts/ci/classify-changes.mjs
+++ b/scripts/ci/classify-changes.mjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+// CI entrypoint for change detection. Reads the changed-file list on stdin
+// (one path per line, as `git diff --name-only` emits it), writes the job
+// selection booleans to $GITHUB_OUTPUT, and prints the per-file reasoning
+// to the log so a skipped gate is always explainable after the fact.
+//
+// Exits non-zero only on a real failure (missing $GITHUB_OUTPUT). A
+// classification is never a failure — every path classifies, because the
+// default bucket is "engine", i.e. run everything.
+
+import { appendFileSync, readFileSync } from 'node:fs';
+import { classifyChanges } from './change-buckets.mjs';
+
+function readStdin() {
+  try {
+    return readFileSync(0, 'utf8');
+  } catch {
+    return '';
+  }
+}
+
+const files = readStdin()
+  .split('\n')
+  .map((line) => line.trim())
+  .filter((line) => line.length > 0);
+
+const { engine, web, reasons } = classifyChanges(files);
+
+console.log(`[ci] ${files.length} changed file(s)`);
+for (const reason of reasons) console.log(`[ci]   ${reason}`);
+console.log(`[ci] engine=${engine} web=${web}`);
+
+const out = process.env.GITHUB_OUTPUT;
+if (!out) {
+  console.error('[ci] GITHUB_OUTPUT is not set — cannot publish job selection');
+  process.exit(1);
+}
+appendFileSync(out, `engine=${engine}\nweb=${web}\n`);

--- a/scripts/ci/gate.mjs
+++ b/scripts/ci/gate.mjs
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+// The `build-test` aggregating gate.
+//
+// WHY THIS FILE EXISTS. Branch protection on main requires four status
+// checks BY NAME: build-test, supply-chain, trufflehog, lint. Only a repo
+// admin can change that list. Sharding the old monolithic `build-test` job
+// into real parallel jobs would delete the required check — and GitHub's
+// failure mode there is the dangerous one: the branch stops requiring the
+// gate rather than blocking on it, so PRs merge ungated and nothing says
+// so. The name therefore stays, attached to a job that runs no tests and
+// only judges the jobs that do.
+//
+// THE HARD PART is that GitHub reports `skipped` for two opposite reasons:
+//   (a) the job's own `if:` was false     — not relevant to this change,
+//                                            and the gate must PASS on it;
+//   (b) something it `needs:` failed or   — the job never got to run, and
+//       was itself skipped                  the gate must FAIL on it.
+// `needs.<job>.result` is identical in both cases, so a gate that only
+// reads results cannot tell them apart, and the naive `contains(needs.*.result,
+// 'failure')` idiom passes case (b) — a silently ungated merge.
+//
+// The disambiguation is to check the result against an EXPECTATION derived
+// from the same change-detection outputs the job's own `if:` used. Expected
+// to run => must be 'success'. Not expected => must be 'skipped'. A job that
+// was expected and came back 'skipped' is case (b) and fails the gate.
+//
+// The expectation table below duplicates each job's `if:` condition, and
+// duplication rots. test/ci-gate-truth.unit-spec.ts parses ci.yml and fails
+// if the table and the YAML disagree, if a job exists that the gate does not
+// judge, or if the gate judges a job that no longer exists.
+
+/**
+ * Which change-detection output each job's `if:` gates on.
+ * `null` means the job has no `if:` and must always run.
+ */
+export const EXPECTATIONS = {
+  'engine-checks': 'engine',
+  'engine-unit': 'engine',
+  'engine-socket': 'engine',
+  'engine-e2e': 'engine',
+  'engine-jobs-e2e': 'engine',
+  docker: 'engine',
+  web: 'web',
+};
+
+const OK = 'success';
+const SKIPPED = 'skipped';
+
+/**
+ * Pure verdict function. `needs` is the parsed `toJSON(needs)` object,
+ * `selection` is `{ engine: boolean, web: boolean }`.
+ * Returns { ok, rows } where rows describe every judged job.
+ */
+export function judge(needs, selection) {
+  const rows = [];
+
+  for (const [job, bucket] of Object.entries(EXPECTATIONS)) {
+    const result = needs[job]?.result ?? 'missing';
+    const expected = bucket === null ? true : selection[bucket] === true;
+    const want = expected ? OK : SKIPPED;
+    // A not-expected job that ran anyway and passed is fine — change
+    // detection being conservative is never a gate failure. The reverse
+    // (expected, did not run) is exactly case (b) and is fatal.
+    const ok = expected ? result === OK : result === SKIPPED || result === OK;
+    rows.push({ job, expected, want, result, ok });
+  }
+
+  // `changes` itself has no expectation — if it failed, nothing downstream
+  // is trustworthy and every other row is meaningless.
+  const changesResult = needs.changes?.result ?? 'missing';
+  const changesOk = changesResult === OK;
+  rows.unshift({
+    job: 'changes',
+    expected: true,
+    want: OK,
+    result: changesResult,
+    ok: changesOk,
+  });
+
+  return { ok: rows.every((r) => r.ok), rows };
+}
+
+function main() {
+  const needsRaw = process.env.GATE_NEEDS;
+  const engine = process.env.GATE_ENGINE === 'true';
+  const web = process.env.GATE_WEB === 'true';
+
+  if (!needsRaw) {
+    console.error('[gate] GATE_NEEDS is empty — the gate cannot judge anything. Failing closed.');
+    process.exit(1);
+  }
+
+  let needs;
+  try {
+    needs = JSON.parse(needsRaw);
+  } catch (err) {
+    console.error(`[gate] GATE_NEEDS is not valid JSON: ${err.message}. Failing closed.`);
+    process.exit(1);
+  }
+
+  const { ok, rows } = judge(needs, { engine, web });
+
+  console.log(`[gate] change selection: engine=${engine} web=${web}`);
+  console.log('[gate] job                 expected  want      got');
+  for (const row of rows) {
+    const mark = row.ok ? 'ok ' : 'ERR';
+    console.log(
+      `[gate] ${mark} ${row.job.padEnd(18)} ${String(row.expected).padEnd(9)} ${row.want.padEnd(9)} ${row.result}`,
+    );
+  }
+
+  if (ok) {
+    console.log('[gate] every required job reported the result its relevance demanded.');
+    process.exit(0);
+  }
+
+  console.error('[gate] FAILED. A job either did not pass, or was expected to run and did not.');
+  console.error('[gate] A job expected=true that came back "skipped" means one of its');
+  console.error('[gate] dependencies failed — look upstream, not at the gate.');
+  process.exit(1);
+}
+
+if (process.argv[1] && process.argv[1].endsWith('gate.mjs')) main();

--- a/test/ci-change-buckets.unit-spec.ts
+++ b/test/ci-change-buckets.unit-spec.ts
@@ -60,7 +60,12 @@ function specReadPaths(): Map<string, string[]> {
     if (!name.endsWith('-spec.ts')) continue;
     const source = readFileSync(join(specDir, name), 'utf8');
 
-    for (const call of source.matchAll(/__dirname\s*,\s*((?:'[^']*'\s*,?\s*)+)\)/g)) {
+    // `[^)]*` rather than a repeated `(?:'…'\s*,?\s*)+` group: the latter
+    // nests two optional-whitespace quantifiers inside a `+`, which is the
+    // classic exponential-backtracking shape (CodeQL js/redos flagged it,
+    // correctly). A path literal never contains `)`, so a flat negated
+    // class captures the same argument list in linear time.
+    for (const call of source.matchAll(/__dirname\s*,([^)]*)\)/g)) {
       const literals = [...(call[1] ?? '').matchAll(/'([^']*)'/g)].map((m) => m[1] ?? '');
       const segments: string[] = [];
       for (const literal of literals) {

--- a/test/ci-change-buckets.unit-spec.ts
+++ b/test/ci-change-buckets.unit-spec.ts
@@ -1,0 +1,180 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, readdirSync, existsSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+/**
+ * Truth test for CI change detection (scripts/ci/change-buckets.mjs).
+ *
+ * The hazard this exists to prevent: a path-based filter that misses an
+ * entry SILENTLY SKIPS the gate that would have caught the regression.
+ * deploy-brain.yml's allowlist (#516) is guarded by deriving its
+ * expectations from the Dockerfile, because the Dockerfile mechanically
+ * answers "what enters the image". Nothing mechanically answers "what
+ * could break a gate" — a spec may read any file in the repo — so this
+ * test derives the answer from the specs themselves.
+ *
+ * The classifier is exercised as a SUBPROCESS, not an import: that is the
+ * exact entrypoint CI runs, exit code included, and it sidesteps ESM/CJS
+ * interop between an .mjs script and a ts-jest CommonJS test module.
+ */
+
+const ROOT = join(__dirname, '..');
+const CLASSIFY = join(ROOT, 'scripts', 'ci', 'classify-changes.mjs');
+
+/** Run the real classifier over a changed-file list; return its outputs. */
+function classify(files: string[]): { engine: boolean; web: boolean; log: string } {
+  const dir = mkdtempSync(join(tmpdir(), 'ci-buckets-'));
+  const outFile = join(dir, 'github_output');
+  writeFileSync(outFile, '');
+
+  const log = execFileSync('node', [CLASSIFY], {
+    input: files.join('\n'),
+    env: { ...process.env, GITHUB_OUTPUT: outFile },
+    encoding: 'utf8',
+  });
+
+  const written = readFileSync(outFile, 'utf8');
+  return {
+    engine: /^engine=true$/m.test(written),
+    web: /^web=true$/m.test(written),
+    log,
+  };
+}
+
+/**
+ * Every repo-relative path a spec reads via `__dirname`-anchored joins.
+ *
+ * Two shapes appear in this repo and both are matched:
+ *   join(__dirname, '..', 'docs', 'openapi.json')
+ *   join(__dirname, '../src/db/migrations')
+ * Only the leading literal segments are reconstructed — a path built from
+ * a variable stops the walk, which is safe: a partial prefix still lands
+ * in the right bucket, and bucket membership is all this test asks.
+ */
+function specReadPaths(): Map<string, string[]> {
+  const found = new Map<string, string[]>();
+  const specDir = join(ROOT, 'test');
+
+  for (const name of readdirSync(specDir)) {
+    if (!name.endsWith('-spec.ts')) continue;
+    const source = readFileSync(join(specDir, name), 'utf8');
+
+    for (const call of source.matchAll(/__dirname\s*,\s*((?:'[^']*'\s*,?\s*)+)\)/g)) {
+      const literals = [...(call[1] ?? '').matchAll(/'([^']*)'/g)].map((m) => m[1] ?? '');
+      const segments: string[] = [];
+      for (const literal of literals) {
+        for (const part of literal.split('/')) {
+          if (part === '' || part === '.') continue;
+          if (part === '..') {
+            segments.pop();
+            continue;
+          }
+          segments.push(part);
+        }
+      }
+      if (segments.length === 0) continue;
+      const path = segments.join('/');
+      const owners = found.get(path) ?? [];
+      owners.push(`test/${name}`);
+      found.set(path, owners);
+    }
+  }
+
+  return found;
+}
+
+describe('CI change detection is deny-list shaped and cannot silently skip a gate', () => {
+  it('classifies an unrecognised path as engine, so a new directory runs everything', () => {
+    const { engine } = classify(['some-brand-new-top-level-thing/file.ts']);
+    expect(engine).toBe(true);
+  });
+
+  it('runs nothing for a docs-only change', () => {
+    const { engine, web } = classify(['docs/architecture.md', 'README.md']);
+    expect(engine).toBe(false);
+    expect(web).toBe(false);
+  });
+
+  it('runs nothing engine-side for a monitoring-only change', () => {
+    const { engine, web } = classify(['monitoring/alerts/rules.yml']);
+    expect(engine).toBe(false);
+    expect(web).toBe(false);
+  });
+
+  it('runs only the web gates for a landing-only change', () => {
+    const { engine, web } = classify(['brain-landing/app/[lang]/page.tsx']);
+    expect(engine).toBe(false);
+    expect(web).toBe(true);
+  });
+
+  it('runs only the engine gates for a src-only change', () => {
+    const { engine, web } = classify(['src/search/search.service.ts']);
+    expect(engine).toBe(true);
+    expect(web).toBe(false);
+  });
+
+  it('runs everything when the CI workflow itself changes', () => {
+    // A pipeline edit whose own verdict you cannot see on the PR that
+    // introduces it is unreviewable.
+    const { engine, web } = classify(['.github/workflows/ci.yml']);
+    expect(engine).toBe(true);
+    expect(web).toBe(true);
+  });
+
+  it('runs everything when the change-detection scripts themselves change', () => {
+    const { engine, web } = classify(['scripts/ci/change-buckets.mjs']);
+    expect(engine).toBe(true);
+    expect(web).toBe(true);
+  });
+
+  it('treats an empty diff as "run everything", never as "skip everything"', () => {
+    const { engine, web } = classify([]);
+    expect(engine).toBe(true);
+    expect(web).toBe(true);
+  });
+
+  it('classifies a mixed change as the union of its buckets', () => {
+    const { engine, web } = classify(['src/app.module.ts', 'brain-landing/next.config.ts']);
+    expect(engine).toBe(true);
+    expect(web).toBe(true);
+  });
+});
+
+describe('no gate-bearing file hides inside a skip bucket', () => {
+  /**
+   * THE load-bearing assertion. Every path a spec reads must run the
+   * engine gates when it changes. If a spec starts reading docs/, this
+   * fails and names both the path and the spec — the skip bucket is then
+   * either wrong or needs a SKIP_EXCEPTIONS entry.
+   */
+  it('every path read by a spec still triggers the engine gates', () => {
+    const offenders: string[] = [];
+
+    for (const [path, owners] of specReadPaths()) {
+      if (!existsSync(join(ROOT, path))) continue;
+      const { engine } = classify([path]);
+      if (!engine) offenders.push(`${path} (read by ${owners.join(', ')})`);
+    }
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('the known exceptions are real — each is inside a skip bucket and read by a spec', () => {
+    // Guards the other direction: SKIP_EXCEPTIONS must not rot into a
+    // dumping ground of paths nobody reads, which would quietly widen
+    // the engine trigger back to "everything" and defeat the point.
+    const source = readFileSync(join(ROOT, 'scripts', 'ci', 'change-buckets.mjs'), 'utf8');
+    const block = /export const SKIP_EXCEPTIONS = \[([^\]]*)\]/.exec(source);
+    expect(block).not.toBeNull();
+
+    const exceptions = [...(block?.[1] ?? '').matchAll(/'([^']+)'/g)].map((m) => m[1] ?? '');
+    expect(exceptions.length).toBeGreaterThan(0);
+
+    const read = specReadPaths();
+    for (const exception of exceptions) {
+      expect(existsSync(join(ROOT, exception))).toBe(true);
+      expect(read.has(exception)).toBe(true);
+    }
+  });
+});

--- a/test/ci-gate-truth.unit-spec.ts
+++ b/test/ci-gate-truth.unit-spec.ts
@@ -1,0 +1,213 @@
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Truth test for the `build-test` aggregating gate (scripts/ci/gate.mjs).
+ *
+ * `build-test` is a REQUIRED status check on main (alongside supply-chain,
+ * trufflehog and lint) and only a repo admin can change that list. The name
+ * therefore has to survive the split of the old monolith into parallel
+ * jobs, attached to a job that judges rather than tests.
+ *
+ * Two ways that arrangement goes wrong, both silent, both checked here:
+ *
+ *   1. A new job is added to ci.yml and nobody adds it to the gate's
+ *      `needs:`. It reports its own red X, main's protection does not
+ *      require it by name, and the PR merges green. The gate must know
+ *      about every job.
+ *
+ *   2. The gate reads results without expectations. GitHub reports
+ *      `skipped` both for "your `if:` said no" and for "your dependency
+ *      failed", so a gate that accepts every `skipped` passes a PR whose
+ *      jobs never ran. The expectation table fixes that, and this test
+ *      pins the table to the YAML so the two cannot drift.
+ */
+
+const ROOT = join(__dirname, '..');
+const CI_YML = readFileSync(join(ROOT, '.github', 'workflows', 'ci.yml'), 'utf8');
+const GATE_SRC = readFileSync(join(ROOT, 'scripts', 'ci', 'gate.mjs'), 'utf8');
+const GATE = join(ROOT, 'scripts', 'ci', 'gate.mjs');
+
+/** The required-check name that branch protection pins. Do not rename. */
+const GATE_JOB = 'build-test';
+
+/**
+ * Jobs deliberately outside the gate, with the reason each is exempt.
+ * Anything not listed here and not in the gate's table fails the test.
+ */
+const UNGATED: Record<string, string> = {
+  'build-test': 'is the gate itself',
+  changes: 'is the gate’s own input, judged separately',
+  'supply-chain': 'is its own required status check, gated by name on main',
+  'real-e2e': 'runs only on manual dispatch with a real OpenAI key',
+  'quality-eval': 'runs only on the nightly schedule or manual dispatch',
+};
+
+/** Top-level job ids, in file order. */
+function ciJobNames(): string[] {
+  const jobsBlock = CI_YML.slice(CI_YML.indexOf('\njobs:'));
+  return [...jobsBlock.matchAll(/^ {2}([a-z][a-z0-9-]*):$/gm)].map((m) => m[1] ?? '');
+}
+
+/** The raw text of one job's block. */
+function jobBlock(name: string): string {
+  const start = CI_YML.indexOf(`\n  ${name}:\n`);
+  expect(start).toBeGreaterThan(-1);
+  const rest = CI_YML.slice(start + 1);
+  const next = rest.search(/\n {2}[a-z][a-z0-9-]*:\n/);
+  return next === -1 ? rest : rest.slice(0, next);
+}
+
+/** Bucket names referenced by a job's `if:` condition. */
+function bucketsInJobCondition(name: string): string[] {
+  const block = jobBlock(name);
+  return [...block.matchAll(/needs\.changes\.outputs\.([a-z]+)/g)].map((m) => m[1] ?? '');
+}
+
+/** The expectation table the gate script judges against. */
+function gateExpectations(): Record<string, string> {
+  const block = /export const EXPECTATIONS = \{([^}]*)\}/.exec(GATE_SRC);
+  expect(block).not.toBeNull();
+  const table: Record<string, string> = {};
+  for (const entry of (block?.[1] ?? '').matchAll(/'?([a-z][a-z0-9-]*)'?\s*:\s*'([a-z]+)'/g)) {
+    table[entry[1] ?? ''] = entry[2] ?? '';
+  }
+  return table;
+}
+
+/** Job ids listed in the gate job's `needs:`. */
+function gateNeeds(): string[] {
+  const block = jobBlock(GATE_JOB);
+  const needs = /needs:\s*\[([^\]]*)\]/.exec(block);
+  expect(needs).not.toBeNull();
+  return (needs?.[1] ?? '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+/** Run the real gate with a synthetic needs payload; return its exit code. */
+function runGate(
+  needs: Record<string, { result: string }>,
+  selection: { engine: boolean; web: boolean },
+): number {
+  try {
+    execFileSync('node', [GATE], {
+      env: {
+        ...process.env,
+        GATE_NEEDS: JSON.stringify(needs),
+        GATE_ENGINE: String(selection.engine),
+        GATE_WEB: String(selection.web),
+      },
+      encoding: 'utf8',
+    });
+    return 0;
+  } catch (err) {
+    return (err as { status?: number }).status ?? -1;
+  }
+}
+
+/** A full green payload for the given selection. */
+function allGreen(selection: {
+  engine: boolean;
+  web: boolean;
+}): Record<string, { result: string }> {
+  const needs: Record<string, { result: string }> = { changes: { result: 'success' } };
+  for (const [job, bucket] of Object.entries(gateExpectations())) {
+    const expected = bucket === 'engine' ? selection.engine : selection.web;
+    needs[job] = { result: expected ? 'success' : 'skipped' };
+  }
+  return needs;
+}
+
+describe('the required check keeps its name and covers every job', () => {
+  it('ci.yml still defines a job literally named build-test', () => {
+    // Renaming this deletes a required status check from main's protection.
+    // GitHub's failure mode is the dangerous one: the branch stops
+    // requiring the gate rather than blocking on it.
+    expect(ciJobNames()).toContain(GATE_JOB);
+  });
+
+  it('the gate needs every job that is not explicitly exempt', () => {
+    const judged = new Set(gateNeeds());
+    const missing = ciJobNames().filter((job) => !judged.has(job) && !(job in UNGATED));
+    expect(missing).toEqual([]);
+  });
+
+  it('the gate does not need a job that no longer exists', () => {
+    const defined = new Set(ciJobNames());
+    expect(gateNeeds().filter((job) => !defined.has(job))).toEqual([]);
+  });
+
+  it('every judged job has an expectation, and every expectation a job', () => {
+    const table = gateExpectations();
+    const judged = gateNeeds().filter((job) => job !== 'changes');
+    expect(Object.keys(table).sort()).toEqual([...judged].sort());
+  });
+});
+
+describe('the expectation table matches the conditions in the YAML', () => {
+  it('each job gates on exactly the bucket the table says it does', () => {
+    for (const [job, bucket] of Object.entries(gateExpectations())) {
+      const buckets = bucketsInJobCondition(job);
+      expect(buckets.length).toBeGreaterThan(0);
+      expect(new Set(buckets)).toEqual(new Set([bucket]));
+    }
+  });
+
+  it('the gate job itself runs unconditionally', () => {
+    // Without always(), the gate inherits the default "skip if a dependency
+    // failed" behaviour and never reports at all — which on a required
+    // check reads as perpetually pending, not as failed.
+    expect(jobBlock(GATE_JOB)).toMatch(/if:\s*always\(\)/);
+  });
+});
+
+describe('skipped-because-irrelevant passes, skipped-because-broken does not', () => {
+  it('passes when every relevant job succeeded', () => {
+    expect(runGate(allGreen({ engine: true, web: true }), { engine: true, web: true })).toBe(0);
+  });
+
+  it('passes a docs-only change where every job legitimately skipped', () => {
+    expect(runGate(allGreen({ engine: false, web: false }), { engine: false, web: false })).toBe(0);
+  });
+
+  it('passes an engine-only change where the web job legitimately skipped', () => {
+    expect(runGate(allGreen({ engine: true, web: false }), { engine: true, web: false })).toBe(0);
+  });
+
+  it('FAILS when a relevant job came back skipped because a dependency broke', () => {
+    // This is the case the naive contains(needs.*.result, 'failure') idiom
+    // lets through, and the reason this gate exists at all.
+    const needs = allGreen({ engine: true, web: true });
+    const victim = Object.keys(gateExpectations()).find((j) => gateExpectations()[j] === 'engine');
+    expect(victim).toBeDefined();
+    needs[victim as string] = { result: 'skipped' };
+    expect(runGate(needs, { engine: true, web: true })).toBe(1);
+  });
+
+  it('FAILS when a relevant job failed outright', () => {
+    const needs = allGreen({ engine: true, web: true });
+    needs['engine-unit'] = { result: 'failure' };
+    expect(runGate(needs, { engine: true, web: true })).toBe(1);
+  });
+
+  it('FAILS when change detection itself failed', () => {
+    const needs = allGreen({ engine: true, web: true });
+    needs['changes'] = { result: 'failure' };
+    expect(runGate(needs, { engine: true, web: true })).toBe(1);
+  });
+
+  it('FAILS closed when it is handed no results at all', () => {
+    expect(runGate({}, { engine: true, web: true })).toBe(1);
+  });
+
+  it('tolerates a job that ran despite not being required to', () => {
+    // Change detection erring on the side of running more is never a
+    // gate failure; erring on the side of running less always is.
+    const needs = allGreen({ engine: false, web: false });
+    needs['engine-unit'] = { result: 'success' };
+    expect(runGate(needs, { engine: false, web: false })).toBe(0);
+  });
+});


### PR DESCRIPTION
Second of four, and **stacked on #519** — this branch contains #519's commit as well as its own, because CI only triggers on PRs targeting `main` and a stacked base would leave this measured by nothing. Review the second commit (`ci: run the gates in parallel...`); merge #519 first and this diff collapses to it. Revert order is the reverse of the merge order.

Replaces one 30-40 minute serial job with a graph of jobs selected by what changed.

## How the required-check problem is handled

`main` requires four status checks *by name*: `build-test`, `supply-chain`, `trufflehog`, `lint`. Only a repo admin can change that list, and GitHub's failure mode when a required check vanishes is the dangerous one — the branch stops *requiring* the gate rather than blocking on it, so PRs merge ungated and nothing announces it.

So `build-test` **keeps its name** and becomes an aggregating gate. It runs no build and no test; it `needs:` every real job and judges them.

Judging is harder than the usual `contains(needs.*.result, 'failure')`, which this deliberately does not use. GitHub reports `skipped` for two opposite reasons:

- **(a)** the job's own `if:` was false — not relevant to this change, and the gate must **pass**;
- **(b)** something the job needed failed, so it never ran — and the gate must **fail**.

`needs.<job>.result` is identical in both cases. `scripts/ci/gate.mjs` disambiguates by checking each result against an *expectation* recomputed from the same change-detection outputs the job's own `if:` used:

| | expected to run | not expected |
|---|---|---|
| `success` | pass | pass (running extra is never a failure) |
| `skipped` | **fail** — this is case (b) | pass |
| `failure` / `cancelled` | **fail** | **fail** |

That table duplicates the YAML, and duplication rots. `test/ci-gate-truth.unit-spec.ts` parses `ci.yml` and fails if the table and the workflow disagree, if a job exists that the gate does not judge, or if the gate judges a job that no longer exists — so adding a job without wiring it into the gate is a red test, not a silent hole. It also drives the real script as a subprocess and asserts the exit codes, including the case-(b) failure.

**Also: do not name a job `lint`.** The required check by that name is `pr-title.yml`'s conventional-commit linter, not ESLint. A second check with the same name makes the requirement ambiguous. The engine's ESLint step lives in `engine-checks`.

**No required-check name changes in this PR.** See "needs an admin" below for the optional follow-up.

## Change detection is deny-list shaped, on purpose

`deploy-brain.yml` (#516) uses an *allowlist*, and that is right for a deploy: the Dockerfile mechanically answers "what enters the image", and the guard test derives its expectations from it.

Nothing mechanically answers CI's question, which is "what could break a gate" — a spec may read any file in the repo. `test/openapi-doc.unit-spec.ts` reads `docs/openapi.json` **and** `brain-landing/public/openapi.json`: two paths that look inert and are not. An allowlist that misses one of those silently skips the gate that would have caught the regression, which is worse than running too much.

So `scripts/ci/change-buckets.mjs` enumerates only the buckets that provably feed no gate — docs, monitoring, the landing app — and **everything else runs everything**: a new top-level directory, an unrecognised dotfile, an unresolvable diff, an empty file list. Being wrong costs runner minutes; being wrong the other way ships a regression.

`test/ci-change-buckets.unit-spec.ts` scans every spec for `__dirname`-relative reads and fails if one resolves into a skip bucket without an explicit exception — and fails the other way too, if an exception is listed that no spec actually reads. Add a spec that reads `docs/` and CI tells you where to go.

Effect: a docs-only PR runs nothing but `supply-chain` and the gate. A landing-only PR runs `web`. An engine PR does not run the landing gates.

## Sharding, re-opened on the evidence

The long docblock in `test/jest-e2e.json` rejects sharding. Read in full, that rejection is narrower than it looks:

> Sharding the CI step was considered and rejected on the same ground: a fresh process per shard halves the RSS peak but the abort landed on a fresh worker's first file, so sharding would not have prevented it.

That is an argument against sharding as a **crash fix**, and it was correct. It is not an argument against sharding as a **speed fix** — and the crash it refers to was root-caused and removed in the fixture, so the e2e app no longer loads an ONNX model at all. The same file's CI counterpart had already pre-committed to this lever:

> Raise this again only with measured durations, never on a hunch; if the median crosses ~35 the answer is to shard the suite, not a bigger number.

The median crossed it (29:45 / 32:54 / 39:29 on 2026-09-08).

**On the shared database.** Each shard is its own runner, jest process, `globalSetup` and SurrealDB container — so a shard's database now holds only that shard's tenants. That *reduces* cross-suite coupling. The mirror-image hazard is real and known: a spec that passes today only because a sibling suite's fixture populated a shared table will fail once the sibling lands in another shard. #474 had to fix exactly that class of assertion, and its fix is the pattern (filter `run.tenants` to your own `companyId`; never assert the roster's length). Any such failure here is a latent bug being surfaced, not one being introduced, and the shard split is run to green before this merges.

`maxWorkers: 1` stays *within* a shard. Nothing here re-litigates the native-heap corruption investigation.

`fail-fast: false` on the matrix, so one flaky shard does not hide the other three.

## Measured

Baseline = the three successful runs of 2026-09-08 plus the successful `main` push. "Whole run" is first job start to last job end.

| | whole run | e2e |
|---|---|---|
| baseline PR [34276401740](https://github.com/inite-ai/inite-brain-service/actions/runs/34276401740) | 30:56 | 23:54 |
| baseline PR [34282483459](https://github.com/inite-ai/inite-brain-service/actions/runs/34282483459) | 34:01 | 26:33 |
| baseline PR [34274897073](https://github.com/inite-ai/inite-brain-service/actions/runs/34274897073) | 40:32 | 34:21 |
| baseline `main` push [34278328794](https://github.com/inite-ai/inite-brain-service/actions/runs/34278328794) | 33:06 | — |
| #519 alone (this stack's first commit) [34314088995](https://github.com/inite-ai/inite-brain-service/actions/runs/34314088995) | 21:08 | 15:46 |
| **this branch, PR run** [34314442979](https://github.com/inite-ai/inite-brain-service/actions/runs/34314442979) | **5:12** | 3:31 / 3:49 / 4:11 / 4:54 |
| **this branch, PR run, warm cache** [34315689425](https://github.com/inite-ai/inite-brain-service/actions/runs/34315689425) | **3:58** | 2:58 / 3:27 / 3:38 / 3:38 |
| **this branch, full pipeline (main-shaped)** [34315271871](https://github.com/inite-ai/inite-brain-service/actions/runs/34315271871) | **4:50** | 3:03 / 3:07 / 3:50 / 4:31 |
| **this branch, PR run, head of branch** [34316083474](https://github.com/inite-ai/inite-brain-service/actions/runs/34316083474) | **5:39** | 3:21 / 3:38 / 4:11 / 5:21 |

Four green runs of the new pipeline: 5:12, 4:50, 3:58, 5:39 — median about five minutes against a baseline median of 34. The spread is runner variance on the slowest shard, not the design.

The `main`-shaped number is a `workflow_dispatch` run, which takes the same "run every gate" branch of change detection that a push to `main` takes. It is the closest measurable proxy; an actual `main` run cannot be measured before merge.

**Nothing is lost across the shards.** 35 + 35 + 34 + 34 = 138 suites and 181 + 184 + 156 + 192 = 713 tests, matching a single-process run of the same commit exactly (713 tests, 24:38, measured locally).

Four shards, not six: the slowest shard is 4:22 of jest against ~60-70s of per-shard setup, so the overhead fraction is already ~30% and a sixth runner buys about ninety seconds. If the suite grows again, this is the dial.

## The gate, verified live (by accident)

A force-push cancelled run [34314442979](https://github.com/inite-ai/inite-brain-service/actions/runs/34314442979) mid-flight, leaving three `engine-e2e` shards `cancelled`. This is exactly the state a naive `contains(needs.*.result, 'failure')` gate would wave through. The gate failed:

```
[gate] change selection: engine=true web=true
[gate] job                 expected  want      got
[gate] ok  changes            true      success   success
[gate] ok  engine-checks      true      success   success
[gate] ok  engine-unit        true      success   success
[gate] ok  engine-socket      true      success   success
[gate] ERR engine-e2e         true      success   cancelled
[gate] ok  engine-jobs-e2e    true      success   success
[gate] ok  docker             true      success   success
[gate] ok  web                true      success   success
```

## What is proven by test rather than by a live run

The docs-only and landing-only skip paths cannot be observed on these PRs, and that is structural rather than an omission: any PR that introduces `ci.yml` classifies as "everything" by design, so the first PR that can demonstrate a skip is the first one merged *after* this. `test/ci-change-buckets.unit-spec.ts` drives the real classifier as a subprocess over those inputs and asserts the outputs, which is the strongest evidence available before merge.

## Other changes

- `docker` no longer `needs: build-test`. It never needed test results to build an image, and depending on the gate would now be a cycle.
- `supply-chain` is unconditional — it is its own required check by name and must report even on a docs-only PR.
- The landing app keeps the standalone job #517 gave it, **including the `typecheck` and `next build` that `eslint-config-next` never provided**, moved into the new topology rather than re-derived. If #517 lands first this conflicts in `ci.yml`; the resolution is to take this branch's version, which already contains that job.

## Needs a repo admin (optional, and safe to defer)

Nothing here requires an admin — `build-test` still reports and still gates. Optionally, adding `web` to the required list would make landing failures blocking as well; today `web` reports but the gate is what blocks. The gate already fails when `web` fails, so this is belt-and-braces, not a hole.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB


