### PR TITLE
fix(db): one session discipline for both pools, LIVE channels and the scoped fail-closed path

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -635,14 +635,21 @@ Nothing expires server-side; `DURATION FOR SESSION NONE` does **not** help,
 because the driver reads the JWT `exp` and never asks the server.
 
 Every long-lived connection in brain therefore re-signs before that timer
-fires:
+fires. Both pools follow one discipline (`SurrealService.ensureSession`): on
+every acquire, a connection whose socket is up and whose token has more than
+5 minutes of life runs a `RETURN 1` probe (~0.3 ms; fails on a half-open
+socket and on an anonymous session alike); otherwise it re-signs (~16 ms, the
+server-side password KDF). If either fails the pool builds a replacement
+first and closes the old connection only once the replacement signed in. The
+root pool used to re-sign on every acquire instead — correct, but paying the
+KDF on every write and admin query.
 
-| Connection | Renewal |
-|---|---|
-| Root pool (`withCompany`, `withAdminDb`, `dropCompanyDatabase`) | `signin` on every acquire (also its zombie-websocket liveness probe). |
-| Migrator connection | Same, via `ensureRootSession`. |
-| Scoped pool (`withScopedCompany` — every caller-facing read) | Checks the live connection/token and re-signs when authorization is lost or the access token enters a 5-minute margin. A signin runs the server-side password KDF (~16ms vs ~0.3ms for a `SELECT`), so paying it per read is not free; the margin comfortably clears the driver's 60s invalidate lead time. Fails **closed** if it cannot — a request errors rather than being served root-authorized. |
-| LIVE subscription channels | Renewed on the catch-up tick, same margin. |
+| Connection | Identity | On failure |
+|---|---|---|
+| Root pool (`withCompany`, `withAdminDb`, `dropCompanyDatabase`) and the migrator connection | root | Error propagates. |
+| Scoped pool (`withScopedCompany` — every caller-facing read) | `brain_caller` | Fails **closed** with a 503 — never served root-authorized; the connection stays in the pool for the next acquire's retry. |
+| LIVE subscription channels | `brain_caller` when the scoped pool is configured, root otherwise | Renewed on the catch-up tick (bounded by a timeout, ticks never stack); whatever the driver-side invalidate does to the standing `LIVE` query, the changefeed replay on the next tick delivers what it missed. |
+| `scripts/backfill-lang-attribution.ts` | root | Re-signs per batch. |
 
 Symptoms to recognise if this ever regresses: reads answer
 `Anonymous access not allowed: Not enough permissions to perform this action`
@@ -658,7 +665,9 @@ read path on a timer and alerts when it stops authorizing.
 (a SurrealDB duration literal; unset = the server's 1h default). It is a
 tuning knob, not the fix — brain OVERWRITEs the user definition on every
 boot, so it exists mainly so a duration set by hand on the server is not
-silently discarded on the next deploy.
+silently discarded on the next deploy. A value at or below the 5-minute
+re-auth margin is honoured but logged at error level: every scoped acquire
+then re-signs, which only the expiry e2e wants.
 
 ## Capability probes
 

--- a/src/db/session-keeper.ts
+++ b/src/db/session-keeper.ts
@@ -3,49 +3,22 @@ import type { Surreal } from 'surrealdb';
 /**
  * Token-expiry bookkeeping for LONG-LIVED SurrealDB connections.
  *
- * ── The failure this exists to prevent ───────────────────────────────────
- * surrealdb-js 2.0.8 owns session renewal, and it only owns it for sessions
- * it opened itself. `ConnectionController` records `authOverriden = true` the
- * moment `db.signin()` is called from application code (dist/surrealdb.mjs
- * `signin(auth, session, skipOverride = false)`), and its own type
- * declarations say so out loud:
+ * Contract: surrealdb-js (2.0.8) renews only sessions it opened itself. A
+ * session established by `db.signin()` from application code is INVALIDATED
+ * by the driver at `exp − 60s` — client-side, from the JWT `exp`, regardless
+ * of any server `DURATION FOR SESSION` — after which the socket stays open,
+ * `version()` still answers, and every authorization-gated statement fails
+ * with "Anonymous access not allowed". So every connection that outlives its
+ * token must re-`signin()` before that timer fires. This class records each
+ * connection's token expiry and answers whether it must be re-signed now:
+ * inside the margin, or never seen, or holding an unreadable token — never
+ * "assume valid". The margin must exceed the driver's 60s lead time; 5 min
+ * costs one signin (≈16 ms, the server-side KDF) per connection per ~55 min
+ * on a default 1h token.
  *
- *   "When this method is called, the `authentication` property passed to
- *    `connect()` will be ignored. You will be responsible for handling
- *    session invalidation by listening to the `auth` event."
- *
- * What "handling" means concretely: on signin the driver schedules a timer at
- * `exp - expiryMargin` (margin defaults to 60s). When it fires,
- * `#applyAuthentication` cannot reuse the near-dead access token, has no
- * refresh token for a system user, and — because `authOverriden` is set —
- * refuses to consult the connect-time auth provider. It falls through to
- * `#abortAuthentication`, which calls `invalidate()`. The socket stays open,
- * `version()` still answers, and every authorization-gated statement from
- * that point on fails with:
- *
- *   "Anonymous access not allowed: Not enough permissions to perform this
- *    action"
- *
- * …for the rest of the process. Nothing expired server-side: `DEFINE USER`
- * defaults to `DURATION FOR TOKEN 1h`, and setting `DURATION FOR SESSION
- * NONE` does NOT help, because the driver reads the JWT `exp` and never asks
- * the server. Verified empirically against surrealdb/surrealdb:v3.2.4 — see
- * test/scoped-session-expiry.e2e-spec.ts.
- *
- * ── The discipline ───────────────────────────────────────────────────────
- * Any connection that outlives its access token must re-`signin()` BEFORE the
- * driver's invalidation timer fires. The root pool already did this the
- * expensive way (unconditionally, on every acquire — see
- * `SurrealService.ensureRootSession`), which is why writes never showed the
- * bug. Doing the same unconditionally on the READ path is not free: a Surreal
- * `signin` runs the server-side password KDF and measures ~16ms against a
- * local v3.2.4, versus ~0.3ms for a `SELECT` — a ~48x tax on every read.
- *
- * So this class tracks the access token's own expiry and re-signs only when
- * the remaining life drops inside a margin. The margin MUST exceed the
- * driver's own `expiryMargin` (60s) or we lose the race with its invalidate
- * timer; 5 minutes leaves a 4-minute buffer on a default 1h token while
- * costing one signin per connection per ~55 minutes.
+ * Owners: SurrealService (both pools), LiveSubscriptionManager, the backfill
+ * script. Proof against a real server: test/scoped-session-expiry.e2e-spec.ts.
+ * Incident: docs/audits/runtime-auth-embedding-2026-09-08.md.
  */
 export const SESSION_REAUTH_MARGIN_MS = 5 * 60_000;
 

--- a/src/db/surreal.service.ts
+++ b/src/db/surreal.service.ts
@@ -1,10 +1,17 @@
-import { Injectable, Logger, OnApplicationShutdown, OnModuleInit } from '@nestjs/common';
+import {
+  Injectable,
+  Logger,
+  OnApplicationShutdown,
+  OnModuleInit,
+  Optional,
+  ServiceUnavailableException,
+} from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Surreal } from 'surrealdb';
 import { join } from 'node:path';
 import { SchemaMigrator } from './migrator.service';
 import { enrichTransactionError } from './surreal-retry';
-import { SurrealSessionKeeper } from './session-keeper';
+import { SESSION_REAUTH_MARGIN_MS, SurrealSessionKeeper } from './session-keeper';
 import { envFlagEnabled } from '../common/env-validation';
 import { getPolicyContext } from '../common/request-context';
 import { compileDenyPushdown } from '../policy/db-fence';
@@ -23,6 +30,16 @@ export {
  * the pool the benefit of the doubt. Short on purpose — see `pingScoped`.
  */
 const SCOPED_PROBE_ACQUIRE_MS = 2000;
+/** Bound on the per-acquire `RETURN 1` liveness probe (see ensureSession). */
+const SESSION_PROBE_TIMEOUT_MS = 3000;
+
+type PoolRole = 'root' | 'scoped';
+
+/** Test-only construction options; production wiring passes none. */
+export interface SurrealServiceOptions {
+  /** Re-auth margin for both pools' session keepers (default 5 min). */
+  sessionReauthMarginMs?: number;
+}
 
 /**
  * SurrealService — pooled connections with per-tenant database routing.
@@ -38,43 +55,33 @@ const SCOPED_PROBE_ACQUIRE_MS = 2000;
  *
  * Tenancy: NS=brain, DB=co_<companyId>. Cross-tenant queries are
  * physically impossible from outside `withCompany`.
+ *
+ * Two pools: root (admin paths — schema apply, GDPR forget, drop database,
+ * compaction, ops scripts) and scoped (`brain_caller`, caller-facing reads).
+ * NOTE (R4 audit): the DB-level PERMISSIONS fence does NOT fire for
+ * `brain_caller` — a namespace-level system user — so the application-layer
+ * row filter is the effective PII/row barrier on both pools; the scoped pool
+ * is kept for the Record Access track that will make PERMISSIONS apply. See
+ * docs/abac.md.
  */
 @Injectable()
 export class SurrealService implements OnModuleInit, OnApplicationShutdown {
   private readonly logger = new Logger(SurrealService.name);
-  // Two pools — admin (root) and scoped (brain_caller user).
-  // Caller-facing reads route through scopedPool. NOTE (R4 audit): the
-  // DB-level field/table PERMISSIONS fence (migrations 0005/0057) does NOT
-  // currently fire — SurrealDB skips PERMISSIONS for SYSTEM users, and
-  // brain_caller is a NAMESPACE-level EDITOR (a system user); `LET` session
-  // vars also don't persist across query() boundaries. The EFFECTIVE
-  // PII/row barrier is the application-layer filter. The scoped pool is
-  // kept for the future Record Access (DEFINE ACCESS … TYPE RECORD WITH
-  // JWT) track that WILL make PERMISSIONS apply — see withScopedCompany
-  // and docs/abac.md. Admin paths (migration apply, GDPR forget, drop
-  // database) use rootPool (root bypasses PERMISSIONS by design).
   private readonly all: Surreal[] = [];
   private readonly rootIdle: Surreal[] = [];
   private readonly scopedIdle: Surreal[] = [];
   /**
-   * Scoped-pool connections currently authorized as ROOT (scoped signin
-   * failed at boot or after a migration). Audit 2026-08-19 P1: such a
-   * connection previously stayed root-authorized FOREVER once busy at
-   * resign time — every acquire now retries the scoped signin first and
-   * never hands out a root-authorized conn silently.
+   * Access-token expiry per pooled connection, one keeper per pool.
+   * surrealdb-js invalidates a `signin()`-established session at `exp − 60s`
+   * (it renews only sessions it opened itself), so every long-lived
+   * connection must re-sign before that — see db/session-keeper.ts. Both
+   * pools follow the same discipline in `ensureSession`.
    */
-  private readonly rootFallbackConns = new Set<Surreal>();
-  /**
-   * Access-token expiry bookkeeping for the SCOPED pool. Audit 2026-09-08:
-   * scoped connections signed in exactly ONCE, at boot, and surrealdb-js
-   * 2.0.8 answers a `signin()`-established session's expiry by calling
-   * `invalidate()` — so ~59 minutes after boot every caller-facing read
-   * failed with "Anonymous access not allowed" while writes (root pool,
-   * re-signed per acquire) and /health kept answering. The keeper re-signs a
-   * scoped connection before the driver can invalidate it. See
-   * db/session-keeper.ts for the full mechanism.
-   */
-  private readonly scopedSessions = new SurrealSessionKeeper();
+  private readonly sessionReauthMarginMs: number;
+  private readonly rootSessions: SurrealSessionKeeper;
+  private readonly scopedSessions: SurrealSessionKeeper;
+  /** Every scoped-pool connection, idle or in flight (see resignScopedConns). */
+  private readonly scopedAll = new Set<Surreal>();
   private scopedCreds?: { username: string; password: string; namespace: string };
   private readonly rootWaiters: Array<(c: Surreal) => void> = [];
   private readonly scopedWaiters: Array<(c: Surreal) => void> = [];
@@ -122,119 +129,77 @@ export class SurrealService implements OnModuleInit, OnApplicationShutdown {
   private rootCreds!: { username: string; password: string };
   private surrealUrl!: string;
 
-  constructor(private readonly configService: ConfigService) {
+  constructor(
+    private readonly configService: ConfigService,
+    @Optional() opts?: SurrealServiceOptions,
+  ) {
     this.migrator = new SchemaMigrator(join(__dirname, 'migrations'));
+    this.sessionReauthMarginMs = opts?.sessionReauthMarginMs ?? SESSION_REAUTH_MARGIN_MS;
+    this.rootSessions = new SurrealSessionKeeper(this.sessionReauthMarginMs);
+    this.scopedSessions = new SurrealSessionKeeper(this.sessionReauthMarginMs);
   }
 
   /**
-   * Test conn liveness with a bounded-time signin. On failure (timeout
-   * or rejection), tear the conn down and rebuild it fresh.
+   * Guarantee `conn` is connected and authenticated for `role` before it is
+   * handed out. One discipline for both pools:
    *
-   * Why signin specifically: surrealdb-js v2.0.3 known issues —
-   *   - gh#618 (zombie ws): conn.status stays "connected" forever after
-   *     a half-open TCP drop; no reconnect event fires.
-   *   - sessions less-than-60s and bearer-greater-than-24.8d cases
-   *     silently invalidate the session timer, so queries succeed with
-   *     no auth (IAM error).
-   * Issuing signin actually exercises the auth path AND is idempotent
-   * for a healthy conn. With a 3s timeout the call cannot wedge.
+   *   1. socket connected, session holds a token, token outside the re-auth
+   *      margin → a `RETURN 1` probe (≈0.3 ms), which fails on a half-open
+   *      socket (surrealdb-js gh#618: status stays "connected") and on an
+   *      anonymous session alike;
+   *   2. otherwise re-sign (≈16 ms, the server-side password KDF) — this is
+   *      also what heals a session the driver already invalidated;
+   *   3. if either fails, build a replacement connection FIRST and close the
+   *      old one only once the replacement signed in, swapping the pool slot.
+   *      If the replacement cannot sign in either, throw with the original
+   *      still open — root callers propagate, `acquireScoped` fails closed.
    *
-   * Returns the original conn when signin succeeded; returns a brand-new
-   * authenticated conn when signin had to be rebuilt. Caller MUST use
-   * the returned reference (we replace the pool slot with the new conn
-   * since the old one's lifecycle is now this function's problem).
+   * The root pool used to re-sign unconditionally on every acquire (which is
+   * why writes never showed the expiry bug, at the KDF's cost on every
+   * query); the scoped pool skipped the liveness probe. Returns the
+   * connection to use — callers MUST use the returned reference.
    */
-  private async ensureRootSession(conn: Surreal): Promise<Surreal> {
+  private async ensureSession(conn: Surreal, role: PoolRole): Promise<Surreal> {
+    const keeper = role === 'root' ? this.rootSessions : this.scopedSessions;
     try {
-      await withTimeout(conn.signin(this.rootCreds), 3000, 'signin');
+      if (conn.isConnected && conn.accessToken && !keeper.needsSignin(conn)) {
+        await withTimeout(conn.query('RETURN 1'), SESSION_PROBE_TIMEOUT_MS, `${role} probe`);
+      } else {
+        await this.signin(conn, role);
+      }
       return conn;
     } catch (e) {
       this.logger.warn(
-        `Root signin failed (${(e as Error).message?.slice(0, 120)}) — rebuilding conn`,
+        `${role} session check failed (${(e as Error).message?.slice(0, 120)}) — rebuilding conn`,
       );
-      try {
-        await withTimeout(conn.close(), 1000, 'close').catch(() => undefined);
-      } catch {
-        // Closing a dead conn can throw — ignored intentionally.
-      }
-      const fresh = new Surreal();
-      try {
-        await withTimeout(fresh.connect(this.surrealUrl), 5000, 'connect');
-        await withTimeout(fresh.signin(this.rootCreds), 3000, 'signin');
-      } catch (rebuildErr) {
-        await withTimeout(fresh.close(), 1000, 'close').catch(() => undefined);
-        throw rebuildErr;
-      }
-      // Swap the conn in `all` so process shutdown closes the new one.
-      const oldIdx = this.all.indexOf(conn);
-      if (oldIdx >= 0) this.all[oldIdx] = fresh;
-      return fresh;
     }
-  }
-
-  /**
-   * Sign a connection in as the scoped (`brain_caller`) user and record the
-   * access token's expiry so the pool knows when it must re-sign.
-   */
-  private async signinScoped(conn: Surreal): Promise<void> {
-    if (!this.scopedCreds) throw new Error('scoped credentials not configured');
-    const tokens = await withTimeout(conn.signin(this.scopedCreds), 3000, 'scoped signin');
-    this.scopedSessions.record(conn, tokens?.access);
-    this.rootFallbackConns.delete(conn);
-  }
-
-  /**
-   * The scoped-pool counterpart of `ensureRootSession`: guarantee the
-   * connection about to serve a caller-facing read is still authorized as
-   * `brain_caller`.
-   *
-   * Unlike the root path this does NOT sign in unconditionally. A Surreal
-   * `signin` runs the server-side password KDF (~16ms locally, vs ~0.3ms for
-   * a SELECT), and reads are the hot path — paying it per request would be a
-   * ~48x tax on the cheapest queries. Instead we re-sign only when the access
-   * token is inside the re-auth margin, which is the condition that actually
-   * matters: past it, surrealdb-js invalidates the session and the connection
-   * goes anonymous (see db/session-keeper.ts).
-   *
-   * A signin failure means the socket is gone (zombie ws, gh#618) or the
-   * credentials no longer work. Rebuild once; if the rebuilt connection also
-   * cannot sign in scoped, throw — `acquireScoped` turns that into a
-   * fail-closed error rather than serving the request root-authorized.
-   *
-   * Returns the connection to use: the original, or a freshly built
-   * replacement. Callers MUST use the returned reference.
-   */
-  private async ensureScopedSession(conn: Surreal): Promise<Surreal> {
-    if (
-      !this.rootFallbackConns.has(conn) &&
-      conn.isConnected &&
-      conn.accessToken &&
-      !this.scopedSessions.needsSignin(conn)
-    )
-      return conn;
+    const fresh = new Surreal();
     try {
-      await this.signinScoped(conn);
-      return conn;
-    } catch (e) {
-      this.logger.warn(
-        `Scoped signin failed (${(e as Error).message?.slice(0, 120)}) — rebuilding conn`,
-      );
-      this.scopedSessions.forget(conn);
-      this.rootFallbackConns.delete(conn);
-      await withTimeout(conn.close(), 1000, 'close').catch(() => undefined);
-      const fresh = new Surreal();
-      try {
-        await withTimeout(fresh.connect(this.surrealUrl), 5000, 'connect');
-        await this.signinScoped(fresh);
-      } catch (rebuildErr) {
-        await withTimeout(fresh.close(), 1000, 'close').catch(() => undefined);
-        throw rebuildErr;
-      }
-      const oldIdx = this.all.indexOf(conn);
-      if (oldIdx >= 0) this.all[oldIdx] = fresh;
-      else this.all.push(fresh);
-      return fresh;
+      await withTimeout(fresh.connect(this.surrealUrl), 5000, 'connect');
+      await this.signin(fresh, role);
+    } catch (rebuildErr) {
+      await withTimeout(fresh.close(), 1000, 'close').catch(() => undefined);
+      throw rebuildErr;
     }
+    keeper.forget(conn);
+    await withTimeout(conn.close(), 1000, 'close').catch(() => undefined);
+    // Swap the slot in `all` so process shutdown closes the replacement.
+    const oldIdx = this.all.indexOf(conn);
+    if (oldIdx >= 0) this.all[oldIdx] = fresh;
+    else this.all.push(fresh);
+    if (role === 'scoped') {
+      this.scopedAll.delete(conn);
+      this.scopedAll.add(fresh);
+    }
+    return fresh;
+  }
+
+  /** Sign `conn` in for `role` and record the access token's expiry. */
+  private async signin(conn: Surreal, role: PoolRole): Promise<void> {
+    const creds = role === 'root' ? this.rootCreds : this.scopedCreds;
+    if (!creds) throw new Error(`${role} credentials not configured`);
+    const tokens = await withTimeout(conn.signin(creds), 3000, `${role} signin`);
+    (role === 'root' ? this.rootSessions : this.scopedSessions).record(conn, tokens?.access);
   }
 
   async onModuleInit() {
@@ -258,7 +223,7 @@ export class SurrealService implements OnModuleInit, OnApplicationShutdown {
       throw new Error('SURREALDB_ACQUIRE_TIMEOUT_MS must be >= 100ms');
     }
 
-    // Cache for re-signin / rebuild on ws drops (see ensureRootSession).
+    // Cache for re-signin / rebuild on ws drops (see ensureSession).
     this.rootCreds = { username, password };
     this.surrealUrl = url;
 
@@ -268,35 +233,24 @@ export class SurrealService implements OnModuleInit, OnApplicationShutdown {
     // a fresh root conn from a saturated pool.
     this.migratorConn = new Surreal();
     await this.migratorConn.connect(url);
-    await this.migratorConn.signin({ username, password });
+    await this.signin(this.migratorConn, 'root');
     this.all.push(this.migratorConn);
 
     // Root pool — admin signin.
     for (let i = 0; i < this.poolSize; i++) {
       const conn = new Surreal();
       await conn.connect(url);
-      await conn.signin({ username, password });
+      await this.signin(conn, 'root');
       this.all.push(conn);
       this.rootIdle.push(conn);
     }
 
     // Scoped pool — sign in as `brain_caller` (defined in migration 0005).
-    // Disabled cleanly when the user/password aren't set; falls back to the
-    // root pool for everything. NOTE (R4 audit): the DB-level PERMISSIONS
-    // fence does NOT fire even when the scoped pool IS enabled — SurrealDB
-    // skips PERMISSIONS for the system `brain_caller` user, so the
-    // application-layer filter is the effective barrier either way. The
-    // scoped pool is retained for the future Record Access track; set
-    // SURREALDB_SCOPED_USER + SURREALDB_SCOPED_PASS to exercise it. See
-    // docs/abac.md.
+    // Disabled cleanly when the user/password aren't set: reads then run on
+    // the root pool (same effective app-layer barrier — see the class note).
     const scopedUser = this.configService.get<string>('SURREALDB_SCOPED_USER');
     const scopedPass = this.configService.get<string>('SURREALDB_SCOPED_PASS');
     if (scopedUser && scopedPass) {
-      // Apply migrations on a root conn FIRST so brain_caller user exists.
-      // The first withCompany call that targets a fresh tenant DB still
-      // runs the migrations queue — but the root pool is already up,
-      // so any scoped pool signin failures with "user not found" are
-      // contained to that tenant's first request and resolve on retry.
       this.scopedEnabled = true;
       this.scopedCreds = {
         username: scopedUser,
@@ -307,20 +261,20 @@ export class SurrealService implements OnModuleInit, OnApplicationShutdown {
         const conn = new Surreal();
         await conn.connect(url);
         try {
-          await this.signinScoped(conn);
+          await this.signin(conn, 'scoped');
         } catch (e) {
-          // brain_caller user not yet defined (first boot, no migrations
-          // applied yet). Fall back to root signin so the conn is at
-          // least usable; on first scoped request, withScopedCompany
-          // re-signs in as scoped after migrations land.
+          // First boot: `brain_caller` does not exist until migration 0005
+          // lands (the tenant-registry refresh runs it right after boot).
+          // Leave the connection unauthenticated — the keeper holds no
+          // record for it, so the next acquire re-signs, and fails closed
+          // if that still does not work. It is never signed in as root.
           this.logger.warn(
-            `Scoped signin failed (likely first boot before migrations): ${(e as Error).message}. ` +
-              `Falling back to root for this connection until first migration runs.`,
+            `Scoped signin failed (${(e as Error).message}) — ` +
+              `the connection will re-sign on its first acquire`,
           );
-          await conn.signin({ username, password });
-          this.rootFallbackConns.add(conn);
         }
         this.all.push(conn);
+        this.scopedAll.add(conn);
         this.scopedIdle.push(conn);
       }
     }
@@ -358,34 +312,17 @@ export class SurrealService implements OnModuleInit, OnApplicationShutdown {
   }
 
   /**
-   * Readiness probe for the CALLER-FACING read path.
+   * Readiness probe for the CALLER-FACING read path: takes a scoped
+   * connection and runs the same authorization-gated check a request runs
+   * (`ensureSession`). `ping()` cannot see an anonymous session — `version()`
+   * is answered for one too — which is how /ready stayed green through the
+   * 2026-09-08 outage.
    *
-   * `ping()` cannot see this class of failure: `version()` is answered for an
-   * anonymous connection too (verified against surrealdb 3.2.4), so during
-   * the 2026-09-08 scoped-session-expiry outage /health and /ready both
-   * reported "ok" while every search, entity read and fact read 500'd. A
-   * readiness check that cannot observe the request path is not a readiness
-   * check — so this takes a real scoped connection and runs an
-   * authorization-gated statement on it.
-   *
-   * `RETURN 1` is the cheapest such statement: SurrealDB refuses it for an
-   * anonymous session with the same "Anonymous access not allowed" it refuses
-   * a SELECT with. Going through `ensureScopedSession` is deliberate — the probe
-   * exercises the same renew-or-fail-closed path a request takes, so a pool
-   * that can no longer authenticate at all (rotated secret, dropped user,
-   * unreachable DB) makes readiness fail instead of reporting a healthy read
-   * path. Traffic removal additionally requires a balancer readiness probe.
-   *
-   * A BUSY pool is deliberately NOT a readiness failure. Saturation is a
-   * different signal — already visible as acquire-timeout 5xx and in
-   * /admin/now — and answering "not ready" for it would pull pods out of
-   * rotation exactly when the remaining pods are the most loaded. So the
-   * probe waits only briefly for a connection and reports ready if it does
-   * not get one; the question it answers is "can the read path authorize",
-   * not "is the read path idle".
-   *
-   * Returns true when the scoped pool is disabled: reads run on the root
-   * pool then, and `ping()` already covers it.
+   * A BUSY pool is deliberately NOT a readiness failure: saturation is
+   * already visible as acquire-timeout 5xx, and answering "not ready" for
+   * it would pull pods out of rotation when the rest are most loaded. The
+   * question here is "can the read path authorize", not "is it idle".
+   * Returns true when the scoped pool is disabled (`ping()` covers root).
    */
   async pingScoped(): Promise<boolean> {
     if (!this.scopedEnabled) return true;
@@ -414,8 +351,9 @@ export class SurrealService implements OnModuleInit, OnApplicationShutdown {
       return true;
     }
     try {
-      if (this.scopedCreds) conn = await this.ensureScopedSession(conn);
-      await withTimeout(conn.query('RETURN 1'), 3000, 'scoped ping');
+      // ensureSession already ran the authorization-gated probe (or a fresh
+      // signin) on this connection — that IS the readiness check.
+      conn = await this.ensureSession(conn, 'scoped');
       return true;
     } catch {
       return false;
@@ -442,11 +380,9 @@ export class SurrealService implements OnModuleInit, OnApplicationShutdown {
     const database = `co_${companyId}`;
     let conn = await this.acquireRoot();
     try {
-      // Pool conns can lose auth (zombie ws, session-timer bugs in
-      // surrealdb-js v2.0.3) — ensureRootSession either re-signs the
-      // existing conn or hands back a freshly-built one. Always use
-      // the returned reference.
-      conn = await this.ensureRootSession(conn);
+      // ensureSession may hand back a rebuilt connection — always use the
+      // returned reference.
+      conn = await this.ensureSession(conn, 'root');
       await conn.use({ namespace: this.namespace, database });
       await this.ensureSchema(conn, database);
       return await fn(conn);
@@ -472,7 +408,7 @@ export class SurrealService implements OnModuleInit, OnApplicationShutdown {
     const database = 'system';
     let conn = await this.acquireRoot();
     try {
-      conn = await this.ensureRootSession(conn);
+      conn = await this.ensureSession(conn, 'root');
       await conn.use({ namespace: this.namespace, database });
       await this.ensureSchema(conn, database);
       return await fn(conn);
@@ -482,30 +418,21 @@ export class SurrealService implements OnModuleInit, OnApplicationShutdown {
   }
 
   /**
-   * Run a callback inside a per-tenant DB scope on a SCOPED connection.
-   * The connection is signed in as `brain_caller` (EDITOR role, not root).
+   * Run a callback inside a per-tenant DB scope on a SCOPED connection
+   * (`brain_caller`, EDITOR role, not root).
    *
-   * IMPORTANT (R4 audit — do not claim a barrier that does not exist): the
-   * DB-level field/table PERMISSIONS fence DOES NOT CURRENTLY FIRE on this
-   * connection. `brain_caller` is a NAMESPACE-level system (EDITOR) user,
-   * and SurrealDB evaluates table/field PERMISSIONS for RECORD
-   * (ACCESS/SCOPE) users only — system users bypass them entirely.
-   * Independently, `LET $caller_scopes` / `$caller_policy_deny` do not
-   * persist across query() boundaries on this driver/server, so a later
-   * statement reads them as NONE. The EFFECTIVE PII/row barrier is the
-   * APPLICATION-LAYER filter (policy/row-filter.ts, entity-read.helpers),
-   * which covers every read surface and is e2e-enforced.
+   * R4 audit — do not claim a barrier that does not exist: SurrealDB skips
+   * table/field PERMISSIONS for system users, and `LET` session variables
+   * do not persist across query() calls, so the DB-level fence is INERT on
+   * this connection. The effective PII/row barrier is the application-layer
+   * filter (policy/row-filter.ts, entity-read.helpers). The scoped identity
+   * and the `$caller_scopes` / `$caller_policy_deny` binding are kept so a
+   * real fence can be switched on with Record Access; the 0057 canary
+   * (test/abac-db-fence.e2e-spec.ts) fails loudly if PERMISSIONS ever start
+   * firing. See docs/abac.md § DB-level fence status.
    *
-   * The scoped connection and the `$caller_scopes` / `$caller_policy_deny`
-   * `LET` binding below are kept intact so a real DB fence can be switched
-   * on the day callers move to Record Access (DEFINE ACCESS … TYPE RECORD
-   * WITH JWT) — a future track. The 0057 canary
-   * (test/abac-db-fence.e2e-spec.ts) fails loudly if the stack ever starts
-   * honoring PERMISSIONS. See docs/abac.md § DB-level fence status.
-   *
-   * If the scoped pool is disabled (env var unset, dev without a non-root
-   * user), this falls back to `withCompany` semantics — identical effective
-   * enforcement, since the app-layer filter is the gate either way.
+   * With the scoped pool disabled this runs on the root pool — identical
+   * effective enforcement.
    */
   async withScopedCompany<T>(
     companyId: string,
@@ -571,7 +498,7 @@ export class SurrealService implements OnModuleInit, OnApplicationShutdown {
     const database = `co_${companyId}`;
     let conn = await this.acquireRoot();
     try {
-      conn = await this.ensureRootSession(conn);
+      conn = await this.ensureSession(conn, 'root');
       await conn.use({ namespace: this.namespace, database });
       await conn.query(`REMOVE DATABASE ${database};`);
       this.knownDatabases.delete(database);
@@ -613,24 +540,17 @@ export class SurrealService implements OnModuleInit, OnApplicationShutdown {
 
   private async acquireScoped(): Promise<Surreal> {
     const conn = await this.acquireWithTimeout(this.scopedIdle, this.scopedWaiters, 'scoped');
-    if (!this.scopedCreds) return conn;
-    // Audit 2026-08-19 P1 / 2026-08-21 P1: a root-fallback conn
-    // re-attempts the scoped signin on EVERY acquire — and FAILS CLOSED
-    // when it can't. A deployment that configured the scoped pool asked
-    // for a DB-level fence; silently serving the request root-authorized
-    // widens privilege exactly when the caller believes it narrowed.
-    // Audit 2026-09-08 P0: the SAME acquire now also renews a session whose
-    // access token is about to lapse. Without it, surrealdb-js invalidated
-    // the session ~59 minutes after boot and every caller-facing read
-    // answered "Anonymous access not allowed" until the process restarted,
-    // with writes and /health none the wiser.
-    // Either way the conn goes back to the pool for the next acquire's
-    // retry; this request errors instead of degrading.
     try {
-      return await this.ensureScopedSession(conn);
+      return await this.ensureSession(conn, 'scoped');
     } catch (e) {
+      // Fail CLOSED. A deployment that configured the scoped pool asked for
+      // the narrower identity; serving the request root-authorized would
+      // widen privilege exactly when the caller believes it narrowed. The
+      // (still open) connection goes back for the next acquire's retry; a
+      // 503 tells balancers and retrying clients this is availability, not
+      // a bug.
       this.releaseScoped(conn);
-      throw new Error(
+      throw new ServiceUnavailableException(
         `scoped DB signin unavailable — failing closed rather than ` +
           `serving the request root-authorized: ${(e as Error).message}`,
       );
@@ -699,9 +619,9 @@ export class SurrealService implements OnModuleInit, OnApplicationShutdown {
       // Use the dedicated migrator conn rather than acquiring from
       // the pool. Avoids the deadlock where every pool conn is
       // currently held in withCompany awaiting THIS migration to
-      // finish. ensureRootSession may return a rebuilt conn — track
+      // finish. ensureSession may return a rebuilt conn — track
       // the swap so future migrations use the live reference.
-      this.migratorConn = await this.ensureRootSession(this.migratorConn);
+      this.migratorConn = await this.ensureSession(this.migratorConn, 'root');
       // SurrealDB 3.x no longer auto-creates a namespace/database on first
       // DEFINE — `use()` + DDL against a non-existent NS/DB errors ("The
       // namespace 'brain' does not exist"). 2.x created them implicitly.
@@ -810,7 +730,7 @@ export class SurrealService implements OnModuleInit, OnApplicationShutdown {
    * deploy — the knob makes the token lifetime brain's declared property
    * rather than an invisible server default. It is NOT the fix for session
    * expiry (a longer token only moves the cliff; the pool re-signs before
-   * either lapses — see ensureScopedSession), but it makes the lifetime
+   * either lapses — see ensureSession), but it makes the lifetime
    * explicit and lets the expiry path be tested in seconds instead of an
    * hour.
    *
@@ -820,29 +740,41 @@ export class SurrealService implements OnModuleInit, OnApplicationShutdown {
   private scopedTokenDurationClause(): string {
     const raw = this.configService.get<string>('SURREALDB_SCOPED_TOKEN_DURATION')?.trim();
     if (!raw) return '';
-    if (!/^\d+(ns|us|ms|s|m|h|d|w|y)$/.test(raw)) {
+    const ms = surrealDurationToMs(raw);
+    if (ms === undefined) {
       this.logger.error(
         `Ignoring SURREALDB_SCOPED_TOKEN_DURATION='${raw}' — not a SurrealDB duration literal`,
       );
       return '';
     }
+    if (ms <= this.sessionReauthMarginMs) {
+      // Honoured, but loudly: a token that lives shorter than the re-auth
+      // margin is always "about to expire", so every scoped acquire pays
+      // the ~16 ms signin KDF. Only the expiry e2e wants that.
+      this.logger.error(
+        `SURREALDB_SCOPED_TOKEN_DURATION='${raw}' is within the ${this.sessionReauthMarginMs}ms ` +
+          `session re-auth margin: every scoped acquire will re-sign. Intended for tests only.`,
+      );
+    }
     return ` DURATION FOR TOKEN ${raw}`;
   }
 
   /**
-   * Re-sign all idle scoped pool connections as `brain_caller` after
-   * migration 0005 lands. Connections currently in flight will be
-   * re-signed on their next acquire (we mark them via shadow Set).
-   * Best-effort — failures fall back to root-signed (still functional,
-   * just no PERMISSIONS enforcement).
+   * Re-sign the idle scoped connections after migration 0005 lands or the
+   * scoped password was rotated. In-flight connections re-sign on their
+   * next acquire (the keeper record is dropped here so they must).
    */
   private async resignScopedConns(): Promise<void> {
     if (!this.scopedCreds) return;
-    for (const conn of this.scopedIdle) {
+    for (const conn of this.scopedAll) {
+      if (!this.scopedIdle.includes(conn)) {
+        this.scopedSessions.forget(conn);
+        continue;
+      }
       try {
-        await this.signinScoped(conn);
+        await this.signin(conn, 'scoped');
       } catch (e) {
-        this.rootFallbackConns.add(conn);
+        this.scopedSessions.forget(conn);
         this.logger.warn(`Re-signin to scoped failed for an idle conn: ${(e as Error).message}`);
       }
     }
@@ -1022,13 +954,35 @@ export async function runTransaction<T>(db: Surreal, build: (tx: TxBuilder) => v
 }
 
 /**
+ * A SurrealDB duration literal (`5s`, `1h`, `30m`…) in milliseconds, or
+ * undefined when the string is not one. Sub-millisecond units round down.
+ */
+export function surrealDurationToMs(raw: string): number | undefined {
+  const m = /^(\d+)(ns|us|ms|s|m|h|d|w|y)$/.exec(raw);
+  if (!m) return undefined;
+  const n = Number(m[1]);
+  const unit: Record<string, number> = {
+    ns: 1e-6,
+    us: 1e-3,
+    ms: 1,
+    s: 1_000,
+    m: 60_000,
+    h: 3_600_000,
+    d: 86_400_000,
+    w: 604_800_000,
+    y: 31_536_000_000,
+  };
+  return Math.floor(n * unit[m[2]!]!);
+}
+
+/**
  * Race a promise against a timer; reject if the timer wins. Used to guard
  * surrealdb-js calls against zombie-websocket hangs (gh#618) where the
  * underlying socket is half-open and queries / signin never get a
- * response. Without this, ensureRootSession could wedge a request for
+ * response. Without this, ensureSession could wedge a request for
  * minutes before the OS reaps the TCP connection.
  */
-async function withTimeout<T>(p: Promise<T>, ms: number, label: string): Promise<T> {
+export async function withTimeout<T>(p: Promise<T>, ms: number, label: string): Promise<T> {
   let timer: NodeJS.Timeout | undefined;
   try {
     return await Promise.race([

--- a/src/live/live-subscription.manager.ts
+++ b/src/live/live-subscription.manager.ts
@@ -3,7 +3,7 @@ import { ConfigService } from '@nestjs/config';
 import { Surreal, Table } from 'surrealdb';
 import type { LiveSubscription } from 'surrealdb';
 import { envFlagEnabled } from '../common/env-validation';
-import { queryRows } from '../db/surreal.service';
+import { queryRows, withTimeout } from '../db/surreal.service';
 import { SurrealSessionKeeper } from '../db/session-keeper';
 import { changefeedRow } from '../db/changefeed-row';
 import { makeRowPolicyFilter, type PredicatePolicyLookup } from '../policy/row-filter';
@@ -72,9 +72,18 @@ interface TenantChannel {
   /** Fact ids the LIVE path already delivered, so replay doesn't double-send. */
   delivered: Set<string>;
   timer: NodeJS.Timeout | null;
+  /** A catch-up tick is running; the interval must not stack another. */
+  catchingUp: boolean;
 }
 
 const TABLE = 'knowledge_fact';
+/** Bounds on the two statements a catch-up tick issues on a standing socket. */
+const SIGNIN_TIMEOUT_MS = 3_000;
+const CATCHUP_QUERY_TIMEOUT_MS = 10_000;
+
+type LiveCredentials =
+  | { username: string; password: string }
+  | { username: string; password: string; namespace: string };
 
 /**
  * LiveSubscriptionManager — realtime fact subscriptions (flag
@@ -114,18 +123,16 @@ export class LiveSubscriptionManager implements OnApplicationShutdown {
   private readonly enabled: boolean;
   private readonly url: string;
   private readonly namespace: string;
-  private readonly creds: { username: string; password: string };
+  private readonly creds: LiveCredentials;
   private readonly maxSubscribersPerTenant: number;
   private readonly maxQueuePerSubscriber: number;
   private readonly catchUpMs: number;
   /**
-   * Subscription connections live OUTSIDE both pools and used to sign in
-   * exactly once, at channel open — the same shape that took the scoped pool
-   * anonymous ~59 minutes after boot (audit 2026-09-08, see
-   * db/session-keeper.ts). A standing subscription is the longest-lived
-   * connection in the process, so it is the most exposed: past the driver's
-   * invalidate timer the LIVE session dies and every catch-up tick fails with
-   * "Anonymous access not allowed". The keeper re-signs before that happens.
+   * Subscription connections live OUTSIDE both pools, so they follow the
+   * same expiry discipline on their own: surrealdb-js invalidates a
+   * `signin()`-established session at `exp − 60s`, and a standing
+   * subscription is the longest-lived connection in the process. The
+   * catch-up tick re-signs before that (see db/session-keeper.ts).
    */
   private readonly sessions = new SurrealSessionKeeper();
   private seq = 0;
@@ -134,10 +141,18 @@ export class LiveSubscriptionManager implements OnApplicationShutdown {
     this.enabled = envFlagEnabled(config.get<string>('LIVE_SUBSCRIPTIONS_ENABLED'));
     this.url = config.get<string>('SURREALDB_URL', '');
     this.namespace = config.get<string>('SURREALDB_NAMESPACE', 'brain');
-    this.creds = {
-      username: config.get<string>('SURREALDB_USERNAME', ''),
-      password: config.get<string>('SURREALDB_PASSWORD', ''),
-    };
+    // Same identity as the caller-facing read pool: `brain_caller` when the
+    // scoped pool is configured, root otherwise. A push path is a read path;
+    // it must not hold a wider identity than `/v1/search` does.
+    const scopedUser = config.get<string>('SURREALDB_SCOPED_USER');
+    const scopedPass = config.get<string>('SURREALDB_SCOPED_PASS');
+    this.creds =
+      scopedUser && scopedPass
+        ? { username: scopedUser, password: scopedPass, namespace: this.namespace }
+        : {
+            username: config.get<string>('SURREALDB_USERNAME', ''),
+            password: config.get<string>('SURREALDB_PASSWORD', ''),
+          };
     this.maxSubscribersPerTenant = parseInt(
       config.get<string>('LIVE_MAX_SUBSCRIBERS_PER_TENANT', '20'),
       10,
@@ -212,6 +227,7 @@ export class LiveSubscriptionManager implements OnApplicationShutdown {
       versionstamp,
       delivered: new Set(),
       timer: null,
+      catchingUp: false,
     };
     channel.unsubscribe = sub.subscribe((msg) => {
       const event = toFactEvent(msg, 'live');
@@ -241,16 +257,32 @@ export class LiveSubscriptionManager implements OnApplicationShutdown {
   async catchUp(companyId: string): Promise<number> {
     const channel = this.channels.get(companyId);
     if (!channel) return 0;
-    // The catch-up tick is the only thing that touches this connection on a
-    // schedule, so it is where the session gets renewed. A re-signin does not
-    // disturb the selected namespace/database (verified against v3.2.4) and
-    // does not tear down the standing LIVE query — unlike the driver-side
-    // invalidate it is racing.
-    await this.signin(channel.conn);
-    const changes = await queryRows<ChangefeedShowRow>(
-      channel.conn,
-      `SHOW CHANGES FOR TABLE ${TABLE} SINCE ${channel.versionstamp} LIMIT 1000`,
-    );
+    // A tick that outlives the interval (half-open socket, slow server)
+    // must not stack the next one on top of it.
+    if (channel.catchingUp) return 0;
+    channel.catchingUp = true;
+    try {
+      // The catch-up tick is the only thing that touches this connection on
+      // a schedule, so it is where the session gets renewed. The changefeed
+      // makes the renewal safe regardless of what the driver-side invalidate
+      // does to the standing LIVE query: anything LIVE misses in the gap is
+      // replayed from here (test/scoped-session-expiry.e2e-spec.ts).
+      await this.signin(channel.conn);
+      const changes = await withTimeout(
+        queryRows<ChangefeedShowRow>(
+          channel.conn,
+          `SHOW CHANGES FOR TABLE ${TABLE} SINCE ${channel.versionstamp} LIMIT 1000`,
+        ),
+        CATCHUP_QUERY_TIMEOUT_MS,
+        'live catch-up',
+      );
+      return this.replay(channel, changes);
+    } finally {
+      channel.catchingUp = false;
+    }
+  }
+
+  private replay(channel: TenantChannel, changes: ChangefeedShowRow[]): number {
     let emitted = 0;
     let highest = channel.versionstamp;
     for (const change of changes) {
@@ -322,7 +354,7 @@ export class LiveSubscriptionManager implements OnApplicationShutdown {
    */
   private async signin(conn: Surreal): Promise<void> {
     if (!this.sessions.needsSignin(conn)) return;
-    const tokens = await conn.signin(this.creds);
+    const tokens = await withTimeout(conn.signin(this.creds), SIGNIN_TIMEOUT_MS, 'live signin');
     this.sessions.record(conn, tokens?.access);
   }
 

--- a/test/scoped-session-expiry.e2e-spec.ts
+++ b/test/scoped-session-expiry.e2e-spec.ts
@@ -22,6 +22,7 @@
 import { ConfigService } from '@nestjs/config';
 import { Surreal } from 'surrealdb';
 import { SurrealService } from '../src/db/surreal.service';
+import { LiveSubscriptionManager } from '../src/live/live-subscription.manager';
 
 const SCOPED_USER = 'brain_caller';
 const SCOPED_PASS = 'scoped-session-expiry-spec';
@@ -202,4 +203,82 @@ describe('Scoped pool — session expiry', () => {
     expect(svc.poolStats().scopedIdle).toBe(2);
     expect(svc.poolStats().scopedWaiters).toBe(0);
   });
+
+  it('FIX: a LIVE subscription channel keeps delivering across the lapse', async () => {
+    // Back on 5-second tokens: the channel opens its own connection, as
+    // brain_caller (the same identity as the read pool).
+    await root.query(
+      `DEFINE USER OVERWRITE ${SCOPED_USER} ON NAMESPACE PASSWORD '${SCOPED_PASS}' ROLES EDITOR DURATION FOR TOKEN ${TOKEN_DURATION}`,
+    );
+    setEnv('LIVE_SUBSCRIPTIONS_ENABLED', '1');
+    const mgr = new LiveSubscriptionManager(new ConfigService());
+    const received: string[] = [];
+    const handle = await mgr.subscribe(tenant, {
+      callerScopes: ['brain:read'],
+      sink: (e) => {
+        if (e.kind === 'fact') received.push(e.object);
+      },
+    });
+    const entityId = await svc.withCompany(tenant, async (db) => {
+      const [ents] = await db.query<[Array<{ id: unknown }>]>(
+        `CREATE knowledge_entity SET type = 'other', canonicalName = 'lapse probe'`,
+      );
+      return (ents as Array<{ id: unknown }>)[0]!.id;
+    });
+    const createFact = (object: string) =>
+      svc.withCompany(tenant, (db) =>
+        db.query(
+          `CREATE knowledge_fact SET entityId = $e, predicate = 'lapse_probe', object = $o,
+             confidence = 0.9, validFrom = time::now(),
+             source = { vertical: 'rent', eventId: 'lapse.probe' }`,
+          { e: entityId, o: object },
+        ),
+      );
+    await createFact('before-lapse');
+    await sleep(PAST_EXPIRY_MS);
+    // The driver has invalidated the channel's session by now. Whatever that
+    // did to the standing LIVE query, the catch-up tick re-signs and replays
+    // from the changefeed — the subscriber sees every fact either way.
+    await createFact('after-lapse');
+    await mgr.catchUp(tenant);
+    expect(received).toEqual(expect.arrayContaining(['before-lapse', 'after-lapse']));
+    await handle.close();
+    await mgr.onApplicationShutdown();
+  }, 60_000);
+
+  it('FIX: renewal is expiry-driven — no re-signin while the token has life, one before the driver acts', async () => {
+    // 80-second tokens against a 65-second re-auth margin. A 5-second token
+    // cannot tell the keeper apart from "re-sign on every acquire" (it is
+    // always inside the margin), so this leg gets its own service and its
+    // own token lifetime: the keeper must hold off while >65s remain and
+    // act once ≤65s remain — before the driver's own timer at exp−60s.
+    process.env.SURREALDB_SCOPED_TOKEN_DURATION = '80s';
+    const timed = new SurrealService(new ConfigService(), { sessionReauthMarginMs: 65_000 });
+    await timed.onModuleInit();
+    // The first root touch re-provisions the user with the 80s lifetime and
+    // re-signs the idle scoped connections: t0 for their tokens.
+    await timed.withCompany(tenant, readOne);
+    const t0 = Date.now();
+    let signins = 0;
+    for (const c of (timed as unknown as { all: Surreal[] }).all) {
+      const original = c.signin.bind(c) as (...args: unknown[]) => Promise<unknown>;
+      (c as unknown as { signin: unknown }).signin = (...args: unknown[]) => {
+        signins += 1;
+        return original(...args);
+      };
+    }
+    // Four acquires over two slots with ~80s of token life: probe only.
+    for (let i = 0; i < 4; i++) {
+      await expect(timed.withScopedCompany(tenant, ['brain:read'], readOne)).resolves.toEqual([1]);
+    }
+    expect(signins).toBe(0);
+    await sleep(Math.max(0, 16_000 - (Date.now() - t0)));
+    // ≤65s remain on both slots: the next two acquires re-sign, and do so
+    // before the driver's exp−60s timer (t0+20s) can invalidate anything.
+    await expect(timed.withScopedCompany(tenant, ['brain:read'], readOne)).resolves.toEqual([1]);
+    await expect(timed.withScopedCompany(tenant, ['brain:read'], readOne)).resolves.toEqual([1]);
+    expect(signins).toBe(2);
+    expect(Date.now() - t0).toBeLessThan(20_000);
+    await timed.onApplicationShutdown();
+  }, 90_000);
 });

--- a/test/surreal-readiness.unit-spec.ts
+++ b/test/surreal-readiness.unit-spec.ts
@@ -7,6 +7,7 @@ describe('SurrealService readiness under connection faults', () => {
     const state = svc as any;
     state.scopedEnabled = true;
     state.scopedCreds = { username: 'reader', password: 'test', namespace: 'brain' };
+    state.rootCreds = { username: 'root', password: 'root' };
     state.acquireTimeoutMs = 10_000;
     return { svc, state };
   }
@@ -19,7 +20,7 @@ describe('SurrealService readiness under connection faults', () => {
     const conn = { query: jest.fn() };
     state.scopedIdle.push(conn);
     jest
-      .spyOn(state, 'ensureScopedSession')
+      .spyOn(state, 'ensureSession')
       .mockImplementation(
         () => new Promise((_, reject) => setTimeout(() => reject(new Error('auth down')), 2500)),
       );
@@ -38,7 +39,7 @@ describe('SurrealService readiness under connection faults', () => {
 
   it('returns a late queued connection without leaking it or authenticating it', async () => {
     const { svc, state } = setup();
-    const auth = jest.spyOn(state, 'ensureScopedSession');
+    const auth = jest.spyOn(state, 'ensureSession');
     const probe = svc.pingScoped();
     await jest.advanceTimersByTimeAsync(2001);
     await expect(probe).resolves.toBe(true);


### PR DESCRIPTION
## What was wrong

Follow-up to #502 from the review of the #501 wave (D-1…D-8, A-4, A-8). The two pools guarded their sessions with two routines of the same shape and different discipline:

- **Root** re-signed unconditionally on every acquire — ~16 ms of server-side password KDF on every write, admin query and migration touch, doubling as its zombie-socket probe.
- **Scoped** was keeper-gated but never probed the socket, closed the old connection *before* its replacement had signed in (a failed rebuild left a closed socket in the pool, re-connected on every acquire), kept a `rootFallbackConns` set whose connections were never served as root, signed scoped-pool sockets in **as root** at boot for nothing, and reported a fail-closed refusal as a plain 500.
- **LIVE channels** ran root-authorized (a push path holding a wider identity than `/v1/search`), had no timeout on their tick, could stack ticks on a half-open socket, and carried a comment claiming a re-signin was "verified" not to disturb the LIVE query — with no test behind it.
- The 5-second-token e2e could not distinguish the keeper from "re-sign on every acquire" (a 5 s token is always inside a 5 min margin).

## What changed

- `ensureSession(conn, role)` serves both pools: socket up + token outside the margin → `RETURN 1` probe (~0.3 ms; fails on a half-open socket and on an anonymous session alike); otherwise re-sign; on failure build the replacement first, close the old one only once the replacement signed in. Scoped acquire fails closed with a **503**; the still-open connection returns to the pool for the next retry. Root and scoped keepers are separate.
- Boot-time root fallback and `rootFallbackConns` removed — the keeper's "never seen → re-sign" covered every case they did.
- `LiveSubscriptionManager` signs in as `brain_caller` when the scoped pool is configured, bounds signin and `SHOW CHANGES` with timeouts, never stacks a tick.
- `SURREALDB_SCOPED_TOKEN_DURATION` at or below the margin is honoured but logged at error level.
- Comment debt in `surreal.service.ts` / `session-keeper.ts` collapsed to contracts; the incident narrative lives in docs/operations.md and the audit doc.

## Proof (real SurrealDB 3.2.4, `test/scoped-session-expiry.e2e-spec.ts`, 9/9)

- **New:** a LIVE channel keeps delivering across a token lapse (the tick re-signs and the changefeed replays what LIVE missed) — as `brain_caller`, so an NS EDITOR can `LIVE SELECT` and `SHOW CHANGES`.
- **New:** 80-second tokens against a 65-second margin (test-only construction option, no env knob): four acquires with ~80 s of life → zero re-signins; once ≤65 s remain → exactly one per slot, before the driver's own `exp−60s` timer.
- Existing legs unchanged; neighbouring e2e (capability-probe, scoped-pool, abac-db-fence, health, live) 13/13; full unit suite 403 suites / 4925 tests; tsc (app + spec), eslint, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhrQxeisXJZEt4sg3PGyU6
