### PR TITLE
fix(ops): edge liveness on /health, a runbook that matches the code, and the probe on by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,8 +50,9 @@ SURREALDB_SCOPED_POOL_SIZE=8
 # /ready, which a deploy polls once and never again; this is the continuous
 # half. Emits brain_capability_probe_{total,ok,last_success_timestamp_seconds}.
 # Every pod probes itself — no leader lease, because the failure is
-# per-process. Off = no timer and no series at all.
-CAPABILITY_PROBE_ENABLED=0
+# per-process. ON by default (a forgotten flag must not recreate the
+# blindness); set 0 for no timer and no series at all.
+# CAPABILITY_PROBE_ENABLED=1
 # Cadence, and therefore the detection-latency floor (minimum 5000).
 # CAPABILITY_PROBE_INTERVAL_MS=60000
 # Canary tenant for the scoped-read probe; unset = first id of the roster.

--- a/.github/workflows/deploy-brain.yml
+++ b/.github/workflows/deploy-brain.yml
@@ -808,6 +808,16 @@ jobs:
                 - "traefik.http.routers.${PROJECT_NAME}.tls.certresolver=letsencrypt"
                 - "traefik.http.services.${PROJECT_NAME}.loadbalancer.server.port=${PORT}"
                 - "traefik.http.services.${PROJECT_NAME}.loadbalancer.responseForwarding.flushInterval=-1"
+                # Edge liveness: a wedged process answers 503 at Traefik instead of
+                # timing out client connections. Deliberately /health, NOT /ready:
+                # this is a single replica, and the process degrades on its own
+                # (lexical-only search while the embedder warms, 503 on scoped reads
+                # while writes still work) — pulling it out of rotation on /ready
+                # would turn every partial outage into a total one. /ready is the
+                # deploy gate and the k8s readinessProbe for a multi-replica layout.
+                - "traefik.http.services.${PROJECT_NAME}.loadbalancer.healthcheck.path=/health"
+                - "traefik.http.services.${PROJECT_NAME}.loadbalancer.healthcheck.interval=15s"
+                - "traefik.http.services.${PROJECT_NAME}.loadbalancer.healthcheck.timeout=5s"
                 # http→https redirect for the same backend paths (landing has its own).
                 - "traefik.http.routers.${PROJECT_NAME}-http.rule=Host(\`${DOMAIN}\`) && (PathPrefix(\`/v1\`) || PathPrefix(\`/mcp\`) || PathPrefix(\`/health\`) || PathPrefix(\`/registry\`))"
                 - "traefik.http.routers.${PROJECT_NAME}-http.priority=200"

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -684,9 +684,23 @@ thing it claims to cover.
 
 `/ready` gained real checks in the first two fixes, but **readiness is polled
 at deploy time**: a pool that lapses an hour after a successful deploy is
-invisible to it by construction. `CAPABILITY_PROBE_ENABLED=1` arms a timer
-(default 60s, every pod, no leader lease — the failure is per-process) that
-RUNS each capability and publishes what happened.
+invisible to it by construction. The capability probe — on by default,
+`CAPABILITY_PROBE_ENABLED=0` disables it — arms a timer (default 60s, every
+pod, no leader lease — the failure is per-process) that RUNS each capability
+and publishes what happened.
+
+**Readiness vs traffic.** This is a single-replica deployment, and the
+process degrades on its own: hybrid search answers lexical-only (marked
+`degraded`) while the embedder warms or is down, scoped reads answer 503
+while writes keep working. Traefik therefore health-checks `/health`
+(liveness — a wedged process answers 503 at the edge instead of hanging
+clients) and deliberately **not** `/ready`: pulling the only replica out of
+rotation on a partial failure would turn it into a total one. `/ready` is the
+deploy-time check (the workflow waits up to five minutes for it and fails
+the job — not the rollout — if it never goes green) and the readinessProbe
+for a multi-replica layout. The continuous signal between deploys is the
+probe below; the actuator for what it finds is the runbook, because after
+#502 every self-healable failure already heals itself.
 
 | Capability | What the probe actually does | Covers `/ready` check |
 |---|---|---|
@@ -724,7 +738,7 @@ property for all of them and the scraper's `instance` label already pins
 
 Rules in `monitoring/grafana/provisioning/alerting/rules.yaml`:
 
-- **ScopedReadCapabilityDead** (critical, `for: 5m`) — `min(brain_capability_probe_ok{capability="scoped_read"}) < 1`. Five consecutive conclusive failures at the default cadence. The failure is sticky (a lapsed session stays lapsed until restart), so the wait costs almost nothing and buys immunity from a single-tick blip.
+- **ScopedReadCapabilityDead** (critical, `for: 5m`) — `min(brain_capability_probe_ok{capability="scoped_read"}) < 1`. Five consecutive conclusive failures at the default cadence. A lapsed session is no longer sticky (the pool re-signs on the next acquire), so five failures in a row mean the pool cannot sign in at all; the wait buys immunity from a single-tick blip.
 - **CapabilityProbeFailing** (warning, `for: 20m`) — the same check for every *other* capability, so a newly added one is alerted on without anyone remembering to write a rule. Long window because `embed` is legitimately 0 during a cold bge-m3 warmup.
 - **CapabilityProbeStale** (warning) — no confirmed serve for 30m.
 
@@ -733,12 +747,19 @@ Rules in `monitoring/grafana/provisioning/alerting/rules.yaml`:
 1. The `instance` label names the pod. Reads are failing **there** while
    writes, `/health` and MCP may still answer — see § Long-lived DB sessions
    for why.
-2. Restart that pod: a fresh process re-establishes the scoped session.
-3. If it recurs across restarts, the pool cannot authenticate at all —
-   check `SURREALDB_SCOPED_USER` / `SURREALDB_SCOPED_PASS` against the server
-   and that migration 0005's `brain_caller` still exists. The probe's error
-   log carries the DB's own message.
-4. `brain_capability_probe_total{outcome="busy"}` climbing instead means
+2. **Do not start with a restart.** The pool re-signs a lapsed session on
+   the next acquire and rebuilds a dead socket, so a probe that stays
+   `unauthorized` means the pool cannot *sign in* — a restart reproduces the
+   same failure. Read the probe's error log: it carries the DB's own message.
+3. `There was a problem with authentication` / `not found` → check
+   `SURREALDB_SCOPED_USER` / `SURREALDB_SCOPED_PASS` against the server and
+   that migration 0005's `brain_caller` still exists (`INFO FOR NS` on the
+   brain namespace). Brain OVERWRITEs the user on boot from those two
+   variables, so a rotated secret takes effect on the next deploy.
+4. `timed out` → the rebuild could not replace a wedged socket (half-open
+   TCP to the DB). Check the DB container and the network first; restart
+   the pod only if the DB is healthy and the timeouts persist.
+5. `brain_capability_probe_total{outcome="busy"}` climbing instead means
    saturation, not authorization — that is a pool-size / slow-query problem
    and never fires this alert.
 

--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -3265,11 +3265,11 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
   {
     key: 'CAPABILITY_PROBE_ENABLED',
     category: 'misc',
-    defaultValue: '0',
+    defaultValue: '1',
     runtimeMutable: false,
     isBooleanFlag: true,
     description:
-      'Periodically RUN each capability the service claims and publish the result (brain_capability_probe_*). Covers the class where the service reports healthy while a capability is dead: the scoped pool that went anonymous ~59 min after boot with /health green (#502), and the embedder answering outside the configured space while /ready was green (#503). Both fixes landed in /ready, which is only polled at deploy time — this is the continuous counterpart. Per pod, no leader lease (the failure is per-process). Off = no timer, no series.',
+      'Periodically RUN each capability the service claims (scoped read, embed) and publish the result as brain_capability_probe_* — the continuous counterpart of /ready, which a deploy polls once. On by default so a forgotten flag cannot recreate a green /health over a dead read path; set 0 to disable (no timer, no series). Per pod, no leader lease. See docs/operations.md § Capability probes.',
   },
   {
     key: 'CAPABILITY_PROBE_INTERVAL_MS',

--- a/src/metrics/capability-probe.service.ts
+++ b/src/metrics/capability-probe.service.ts
@@ -9,7 +9,7 @@ import { SurrealService } from '../db/surreal.service';
 import { ApiKeyService } from '../auth/api-key.service';
 import { EmbedderService } from '../ai/embedder.service';
 import { MetricsService } from './metrics.service';
-import { envFlagEnabled } from '../common/env-validation';
+import { envFlagNotDisabled } from '../common/env-validation';
 import {
   CAPABILITY_NAMES,
   classifyProbeFailure,
@@ -49,11 +49,18 @@ const EMBED_PROBE_TEXT = 'brain capability probe';
 
 const RUNBOOK = 'runbook: docs/operations.md § Capability probes';
 
-/** What an operator should do about a scoped read path that cannot authorize. */
+/**
+ * What an operator should do about a scoped read path that cannot authorize.
+ * A lapsed session heals on the next acquire (SurrealService.ensureSession),
+ * so a probe that stays `unauthorized` means the pool cannot SIGN IN at all —
+ * credentials or the user definition, which a restart cannot fix.
+ */
 const REMEDY =
-  'Reads are failing on THIS pod while writes and /health may still answer; ' +
-  'restart it to re-establish the session, then check SURREALDB_SCOPED_USER/PASS ' +
-  "and that migration 0005's brain_caller still exists";
+  'Reads are failing on THIS pod while writes and /health may still answer. ' +
+  'The pool re-signs on every acquire, so this is not a lapsed session: check ' +
+  "SURREALDB_SCOPED_USER/PASS against the server and that migration 0005's " +
+  "brain_caller still exists (the error above is the DB's own message). Restart " +
+  'only if the error is a timeout — a wedged socket the rebuild could not replace';
 
 /**
  * CapabilityProbeService — periodically RUNS each capability the service
@@ -78,7 +85,10 @@ const REMEDY =
 @Injectable()
 export class CapabilityProbeService implements OnApplicationBootstrap, OnApplicationShutdown {
   private readonly logger = new Logger(CapabilityProbeService.name);
-  private readonly enabled = envFlagEnabled(process.env.CAPABILITY_PROBE_ENABLED);
+  // Default ON: a deployment that forgets the flag must not get the exact
+  // blindness this probe exists for (a green /health over a dead read path).
+  // The cost is one LIMIT 1 read and one short embed per minute per pod.
+  private readonly enabled = envFlagNotDisabled(process.env.CAPABILITY_PROBE_ENABLED);
   private readonly intervalMs = Math.max(
     MIN_INTERVAL_MS,
     parseInt(process.env.CAPABILITY_PROBE_INTERVAL_MS ?? String(DEFAULT_INTERVAL_MS), 10) ||

--- a/test/app-fixture.ts
+++ b/test/app-fixture.ts
@@ -97,6 +97,9 @@ export async function createApp(
   // served the punctuation fallback — this only makes that deterministic
   // and stops the load/teardown churn. See test/jest-e2e.json.
   process.env.CHAT_ROUTE_NLI_ENABLED = 'false';
+  // The capability probe is on by default in production; a spec that wants
+  // its timer (test/capability-probe.e2e-spec.ts) arms it explicitly.
+  process.env.CAPABILITY_PROBE_ENABLED = '0';
   if (opts.enableScopedPool) {
     process.env.SURREALDB_SCOPED_USER = 'brain_caller';
     process.env.SURREALDB_SCOPED_PASS = 'brain-caller-password-must-be-overridden-via-env';

--- a/test/capability-probe.unit-spec.ts
+++ b/test/capability-probe.unit-spec.ts
@@ -294,6 +294,19 @@ describe('capability probe — scheduling', () => {
     svc.onApplicationShutdown();
   });
 
+  it('is armed by default — a forgotten flag must not recreate the blindness', async () => {
+    delete process.env.CAPABILITY_PROBE_ENABLED;
+    setEnv('CAPABILITY_PROBE_INTERVAL_MS', '5000');
+    const stubs = makeStubs();
+    const { svc } = build(stubs);
+
+    svc.onApplicationBootstrap();
+    await jest.advanceTimersByTimeAsync(5_000);
+
+    expect(stubs.surreal.withScopedCompany).toHaveBeenCalledTimes(1);
+    svc.onApplicationShutdown();
+  });
+
   it('probes on the configured interval once enabled', async () => {
     setEnv('CAPABILITY_PROBE_ENABLED', '1');
     setEnv('CAPABILITY_PROBE_INTERVAL_MS', '5000');


### PR DESCRIPTION
From the review of the #501 wave (A-1, A-2, A-6, M-4). No behaviour change on the request path.

## Runbook vs code (A-2)
`docs/operations.md` § *When ScopedReadCapabilityDead fires* and the probe's `REMEDY` string told the on-call to **restart the pod**. After #502 and #521 a lapsed session re-signs on the next acquire and a dead socket is rebuilt, so a probe that *stays* `unauthorized` means the pool cannot sign in at all — credentials or the `brain_caller` definition — which a restart reproduces. Both now say: read the DB's own message, check `SURREALDB_SCOPED_USER/PASS` and migration 0005 first, restart only for a timeout the rebuild could not clear. The alert description no longer calls the failure "sticky".

## Edge liveness (A-1)
Traefik gained `loadbalancer.healthcheck.path=/health` (15s / 5s): a wedged replica answers 503 at the edge instead of hanging clients. **Deliberately `/health`, not `/ready`** — a deviation from the plan, on purpose: this is a single replica and, with #518, the process degrades on its own (lexical-only search while the embedder warms; 503 on scoped reads while writes still work). Pulling the only replica out of rotation on a partial failure would turn it into a total one. `/ready` stays the deploy-time check and the readinessProbe for a multi-replica layout; the reasoning is written down in § *Readiness vs traffic*.

## Deploy step honesty (M-4)
"Internal readiness gate" ran after `up -d` with no rollback. It is now "Post-deploy readiness check", and its failure message says the container is live and degraded, what degraded means, and how to roll back.

## Probe on by default (A-6)
`CAPABILITY_PROBE_ENABLED` defaulted to `0`, and its alert rules have `noDataState: OK` — a deployment that dropped the flag got exactly the blindness the probe exists for. Default is now on (`envFlagNotDisabled`; set `0` to disable). The e2e fixture pins it off so specs stay deterministic; `test/capability-probe.e2e-spec.ts` arms it explicitly. Catalog and `.env.example` updated; a unit test pins "armed with the flag unset".

## Checks
tsc (app + spec), eslint, prettier on the TS files; unit: capability-probe, config-catalog-truth, flag-budget, env-validation, health-ready, contracts-admin-config (74 tests); e2e: capability-probe + health specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhrQxeisXJZEt4sg3PGyU6
