### PR TITLE
ci: deploy the image CI built and tested, by digest, and only when CI is green

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -440,28 +440,28 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      # Pull-request runs — including from forks, which get no secrets at
+      # all — build locally and never touch the registry. This is the plain
+      # `docker build` that has always run here, kept deliberately: routing
+      # the PR path through buildx with `load: true` would be a new,
+      # untested build mechanism on the path that runs most often, in
+      # exchange for nothing. The publish path below uses the same
+      # build-push-action invocation deploy-brain.yml has been running in
+      # production, so neither path is new.
+      - name: Build image (PR — local only, not published)
+        if: "!(github.event_name == 'push' && github.ref == 'refs/heads/main')"
+        run: docker build -t inite-brain-service:ci .
+
       - name: Set up Docker Buildx
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
 
-      # Pull-request runs — including from forks, which get no secrets at
-      # all — build locally and never touch the registry. Only a push to
-      # main publishes.
       - name: Login to Docker Hub
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Build image (PR — local only, not published)
-        if: "!(github.event_name == 'push' && github.ref == 'refs/heads/main')"
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        with:
-          context: .
-          push: false
-          load: true
-          tags: inite-brain-service:ci
-          platforms: linux/amd64
 
       - name: Build and publish image (main)
         id: publish

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -415,20 +415,82 @@ jobs:
         run: pnpm audit --audit-level=high --ignore-workspace
 
   # ---------------------------------------------------------------------
-  # Image build + smoke. No longer `needs: build-test` — it never needed
-  # the test results to build an image, and depending on the gate would
-  # be a cycle now that the gate depends on it.
+  # Image build + smoke, and on main the PUBLISH.
+  #
+  # This job used to build an image, smoke it, and throw it away; the
+  # deploy then rebuilt the same source on a self-hosted runner and shipped
+  # whatever that produced. Nothing tied the artifact that was tested to
+  # the artifact that ran in production — same source, different build, no
+  # identity between them.
+  #
+  # Now the image is built once, here, and on main it is pushed and its
+  # DIGEST recorded. The smoke test then pulls that digest back and runs
+  # THAT, so what CI verified is the same bytes the deploy pins. The
+  # digest travels to deploy-brain.yml in the deploy-manifest artifact.
+  #
+  # No longer `needs: build-test` — it never needed the test results to
+  # build an image, and depending on the gate would be a cycle now that the
+  # gate depends on it.
   # ---------------------------------------------------------------------
   docker:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     needs: changes
     if: needs.changes.outputs.engine == 'true'
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - name: Build image
-        run: docker build -t inite-brain-service:ci .
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
+
+      # Pull-request runs — including from forks, which get no secrets at
+      # all — build locally and never touch the registry. Only a push to
+      # main publishes.
+      - name: Login to Docker Hub
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build image (PR — local only, not published)
+        if: "!(github.event_name == 'push' && github.ref == 'refs/heads/main')"
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          push: false
+          load: true
+          tags: inite-brain-service:ci
+          platforms: linux/amd64
+
+      - name: Build and publish image (main)
+        id: publish
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/inite-brain-service:latest
+            ${{ secrets.DOCKERHUB_USERNAME }}/inite-brain-service:${{ github.sha }}
+          cache-from: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/inite-brain-service:buildcache
+          cache-to: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/inite-brain-service:buildcache,mode=max
+          platforms: linux/amd64
+
+      # Re-tag the PUBLISHED digest as the local name the smoke step uses,
+      # so on main the thing being smoke-tested is fetched back from the
+      # registry by digest rather than taken on trust from the build cache.
+      # If the registry ever served something other than what we pushed,
+      # this is where it shows up.
+      - name: Pull back the published digest
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        env:
+          IMAGE: ${{ secrets.DOCKERHUB_USERNAME }}/inite-brain-service@${{ steps.publish.outputs.digest }}
+        run: |
+          set -euo pipefail
+          echo "[ci] pulling $IMAGE"
+          docker pull "$IMAGE"
+          docker tag "$IMAGE" inite-brain-service:ci
 
       - name: Smoke run
         run: |
@@ -459,6 +521,37 @@ jobs:
           echo "service did not become healthy"
           docker logs brain
           exit 1
+
+      # The handoff to the deploy. Written only on main, only after the
+      # smoke test above passed, and carrying the digest — not a tag.
+      # A tag is a mutable pointer that says "whatever :latest means when
+      # you pull"; a digest is the artifact. deploy-brain.yml refuses to
+      # deploy without this file, so a deploy whose image CI never
+      # verified fails loudly instead of shipping.
+      - name: Record the deploy manifest
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        env:
+          IMAGE_REPO: ${{ secrets.DOCKERHUB_USERNAME }}/inite-brain-service
+          DIGEST: ${{ steps.publish.outputs.digest }}
+        run: |
+          set -euo pipefail
+          if [ -z "$DIGEST" ]; then
+            echo "[ci] the publish step produced no digest — refusing to write a manifest"
+            exit 1
+          fi
+          printf '{"sha":"%s","image":"%s@%s","digest":"%s","runId":"%s"}\n' \
+            "${{ github.sha }}" "$IMAGE_REPO" "$DIGEST" "$DIGEST" "${{ github.run_id }}" \
+            > deploy-manifest.json
+          cat deploy-manifest.json
+
+      - name: Upload the deploy manifest
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: deploy-manifest
+          path: deploy-manifest.json
+          retention-days: 30
+          if-no-files-found: error
 
   # ---------------------------------------------------------------------
   # THE GATE. `build-test` is a required status check on main and only a

--- a/.github/workflows/deploy-brain.yml
+++ b/.github/workflows/deploy-brain.yml
@@ -39,56 +39,82 @@ permissions:
   contents: read
 
 jobs:
-  build-and-push:
-    # Skip build for restart/logs ops. Push events have no inputs,
-    # so the inputs.action check defaults to true (build runs).
+  # ---------------------------------------------------------------------
+  # The deploy no longer builds anything.
+  #
+  # It used to: this workflow rebuilt the image from source on the
+  # self-hosted runner, pushed it as :latest, and the deploy pulled
+  # :latest. Two things were wrong with that, and they compound.
+  #
+  # First, nothing connected the artifact CI tested to the artifact
+  # production ran. Same source, two builds, no identity between them —
+  # and the SHA tag this workflow already pushed was never consumed by
+  # anything, so it could not even serve as a manual rollback target
+  # without hand-editing the compose file.
+  #
+  # Second, ci.yml and this workflow both fired on `push` to main, in
+  # parallel, with no ordering. A red main deployed; the only thing
+  # between a broken merge and brain.inite.ai was whether the deploy's
+  # build happened to be slower than the test suite.
+  #
+  # So this job does neither: it waits for CI's verdict on THIS commit,
+  # then takes the digest CI recorded after it smoke-tested the pushed
+  # image. It runs on a GitHub-hosted runner, deliberately — the wait can
+  # be twenty minutes and the single self-hosted deploy runner should not
+  # spend them idle.
+  #
+  # `on: workflow_run` would give the CI conclusion for free and is
+  # rejected: it carries no `paths:` filter, and this workflow's path
+  # trigger is a guarded, load-bearing thing. Trading a tested trigger for
+  # an untested one to save a poll loop is a bad trade.
+  # ---------------------------------------------------------------------
+  verify:
+    # restart and logs do not change the image, so they need no artifact.
     if: github.event_name == 'push' || (github.event.inputs.action != 'restart' && github.event.inputs.action != 'logs')
-    runs-on: [self-hosted, sfo]
-
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      # Reading another workflow's run status, and downloading its artifact.
+      actions: read
+    outputs:
+      image: ${{ steps.manifest.outputs.image }}
+      digest: ${{ steps.manifest.outputs.digest }}
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      # @inite/knowledge SDK is a test-only import (TS path mapping in
-      # tsconfig.json points at ../inite-shared/...). Production build
-      # only compiles src/ and ships dist/main.js — no SDK code is
-      # bundled. So we skip the inite-shared checkout: nothing to fetch.
+      - name: Wait for CI to conclude on this commit
+        id: ci
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          AWAIT_SHA: ${{ github.sha }}
+          AWAIT_TIMEOUT_MINUTES: '45'
+        run: node scripts/ci/await-ci.mjs
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
-
-      - name: Login to Docker Hub
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
+      - name: Download the deploy manifest CI published
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          name: deploy-manifest
+          run-id: ${{ steps.ci.outputs.run_id }}
+          github-token: ${{ github.token }}
 
-      - name: Build and push Docker image
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
-        with:
-          context: .
-          push: true
-          tags: |
-            ${{ secrets.DOCKERHUB_USERNAME }}/inite-brain-service:latest
-            ${{ secrets.DOCKERHUB_USERNAME }}/inite-brain-service:${{ github.sha }}
-          cache-from: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/inite-brain-service:buildcache
-          cache-to: type=registry,ref=${{ secrets.DOCKERHUB_USERNAME }}/inite-brain-service:buildcache,mode=max
-          platforms: linux/amd64
-
-      - name: Build info
-        run: |
-          echo "[ok] Image pushed: ${{ secrets.DOCKERHUB_USERNAME }}/inite-brain-service:${{ github.sha }}"
+      - name: Resolve the image digest
+        id: manifest
+        env:
+          EXPECTED_SHA: ${{ github.sha }}
+        run: node scripts/ci/read-deploy-manifest.mjs
 
   deploy:
-    needs: build-and-push
+    needs: verify
     # Run the deploy job when:
-    #   - push event: only after a successful build
-    #   - workflow_dispatch deploy: only after a successful build
-    #   - workflow_dispatch restart/logs: skip build, run anyway
+    #   - push event: only after CI went green and a digest was resolved
+    #   - workflow_dispatch deploy: same
+    #   - workflow_dispatch restart/logs: no image needed, run anyway
     if: |
       always() && (
-        (github.event_name == 'push' && needs.build-and-push.result == 'success') ||
-        (github.event_name == 'workflow_dispatch' && (needs.build-and-push.result == 'success' || github.event.inputs.action == 'restart' || github.event.inputs.action == 'logs'))
+        (github.event_name == 'push' && needs.verify.result == 'success') ||
+        (github.event_name == 'workflow_dispatch' && (needs.verify.result == 'success' || github.event.inputs.action == 'restart' || github.event.inputs.action == 'logs'))
       )
     runs-on: [self-hosted, sfo]
 
@@ -385,6 +411,27 @@ jobs:
           mkdir -p /opt/projects/${{ env.PROJECT_NAME }}
           cd /opt/projects/${{ env.PROJECT_NAME }}
 
+          # The image is a DIGEST resolved from the manifest CI published
+          # after it smoke-tested that exact artifact — never `:latest`,
+          # which is a mutable pointer and cannot carry the claim "this is
+          # what CI tested".
+          #
+          # restart/logs skip the verify job, so there is no digest to
+          # resolve; those reuse whatever the compose file on disk already
+          # pins, which is the last thing this workflow deployed. An empty
+          # image after both attempts is fatal — writing a compose file
+          # with a blank image would silently resolve to something else.
+          IMAGE_REF="${{ needs.verify.outputs.image }}"
+          if [ -z "$IMAGE_REF" ] && [ -f docker-compose.yml ]; then
+            IMAGE_REF="$(awk '/^[[:space:]]+image:/ {print $2; exit}' docker-compose.yml)"
+            echo "[deploy] reusing the pinned image already on disk: $IMAGE_REF"
+          fi
+          if [ -z "$IMAGE_REF" ]; then
+            echo "[err] no image to deploy: CI published no digest and no compose file is pinned."
+            exit 1
+          fi
+          echo "[deploy] image: $IMAGE_REF"
+
           # Brain talks to the SHARED inite-surrealdb container that lives in
           # the temporal stack (inite-temporal/docker-compose). Brain owns
           # NS=brain (separate from gateway's NS=inite); per-tenant DBs are
@@ -395,7 +442,7 @@ jobs:
           tee docker-compose.yml > /dev/null << EOF
           services:
             ${{ env.PROJECT_NAME }}:
-              image: ${{ secrets.DOCKERHUB_USERNAME }}/inite-brain-service:latest
+              image: ${IMAGE_REF}
               container_name: ${{ env.PROJECT_NAME }}
               restart: unless-stopped
               # PID-1 init (tini): reaps zombie children from the worker

--- a/scripts/ci/await-ci.mjs
+++ b/scripts/ci/await-ci.mjs
@@ -28,6 +28,13 @@ const SHA = process.env.AWAIT_SHA;
 const WORKFLOW = process.env.AWAIT_WORKFLOW ?? 'ci.yml';
 const TIMEOUT_MIN = Number(process.env.AWAIT_TIMEOUT_MINUTES ?? '45');
 const POLL_SECONDS = Number(process.env.AWAIT_POLL_SECONDS ?? '20');
+// "CI is slow" and "CI does not exist for this commit" are different
+// problems and deserve different waits. A run appears within seconds of
+// the push that created it, so if none has shown up after this long there
+// is not going to be one — most often a manual deploy dispatched from a
+// branch that was never pushed to main. Holding a runner for the full
+// 45 minutes to tell someone that is just rude.
+const NOT_FOUND_GRACE_MIN = Number(process.env.AWAIT_NOT_FOUND_GRACE_MINUTES ?? '10');
 
 function fail(message) {
   console.error(`[await-ci] ${message}`);
@@ -66,6 +73,7 @@ const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 async function main() {
   const deadline = Date.now() + TIMEOUT_MIN * 60_000;
+  const graceDeadline = Date.now() + NOT_FOUND_GRACE_MIN * 60_000;
   let announced = false;
 
   while (Date.now() < deadline) {
@@ -94,8 +102,18 @@ async function main() {
       );
     }
 
-    if (!run) console.log(`[await-ci] no CI run for ${SHA} yet; waiting`);
-    else console.log(`[await-ci] CI is ${run.status}; waiting`);
+    if (!run) {
+      if (Date.now() > graceDeadline) {
+        fail(
+          `no CI push-run exists for ${SHA} after ${NOT_FOUND_GRACE_MIN} min. It is not ` +
+            'coming. This usually means the commit was never pushed to main — a manual ' +
+            'deploy can only ship a commit CI has already built and verified.',
+        );
+      }
+      console.log(`[await-ci] no CI run for ${SHA} yet; waiting`);
+    } else {
+      console.log(`[await-ci] CI is ${run.status}; waiting`);
+    }
 
     await sleep(POLL_SECONDS * 1000);
   }

--- a/scripts/ci/await-ci.mjs
+++ b/scripts/ci/await-ci.mjs
@@ -1,0 +1,109 @@
+#!/usr/bin/env node
+// Blocks until the CI workflow run for a given commit has finished, and
+// fails if it did not finish green.
+//
+// WHY. deploy-brain.yml and ci.yml both fire on `push` to main, in
+// parallel, with no ordering between them. The deploy therefore ships
+// whatever the merge produced regardless of whether the tests agreed —
+// a red main reached production, and the only thing standing between a
+// broken merge and brain.inite.ai was how long the deploy's own build
+// happened to take relative to the test suite.
+//
+// The obvious alternative is `on: workflow_run`, which hands you CI's
+// conclusion for free. It is rejected here because workflow_run carries
+// no `paths:` filter, and the deploy's path allowlist is a guarded,
+// load-bearing thing (see test/deploy-trigger-truth.unit-spec.ts).
+// Trading a tested trigger for an untested one to avoid ~40 lines of
+// polling is a bad trade. So the trigger stays as it is and the deploy
+// waits, explicitly, on a GitHub-hosted runner so the single self-hosted
+// deploy runner is not held idle for the duration.
+//
+// Exit codes: 0 = CI succeeded, 1 = anything else (red, cancelled, timed
+// out, never started). Fails closed in every case — "I could not tell"
+// is not permission to deploy.
+
+const REPO = process.env.GITHUB_REPOSITORY;
+const TOKEN = process.env.GITHUB_TOKEN;
+const SHA = process.env.AWAIT_SHA;
+const WORKFLOW = process.env.AWAIT_WORKFLOW ?? 'ci.yml';
+const TIMEOUT_MIN = Number(process.env.AWAIT_TIMEOUT_MINUTES ?? '45');
+const POLL_SECONDS = Number(process.env.AWAIT_POLL_SECONDS ?? '20');
+
+function fail(message) {
+  console.error(`[await-ci] ${message}`);
+  process.exit(1);
+}
+
+if (!REPO) fail('GITHUB_REPOSITORY is not set');
+if (!TOKEN) fail('GITHUB_TOKEN is not set');
+if (!SHA) fail('AWAIT_SHA is not set');
+
+const api = `https://api.github.com/repos/${REPO}/actions/workflows/${WORKFLOW}/runs?head_sha=${SHA}&per_page=20`;
+
+async function latestRun() {
+  const res = await fetch(api, {
+    headers: {
+      authorization: `Bearer ${TOKEN}`,
+      accept: 'application/vnd.github+json',
+      'x-github-api-version': '2022-11-28',
+    },
+  });
+  if (!res.ok) {
+    // A transient 5xx must not be read as "no run exists"; the caller
+    // retries, and only the overall deadline ends the wait.
+    console.error(`[await-ci] GitHub API returned ${res.status}; retrying`);
+    return null;
+  }
+  const body = await res.json();
+  const runs = (body.workflow_runs ?? []).filter((r) => r.event === 'push');
+  if (runs.length === 0) return null;
+  // Newest first: a re-run replaces the verdict of the run it re-ran.
+  runs.sort((a, b) => new Date(b.created_at) - new Date(a.created_at));
+  return runs[0];
+}
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function main() {
+  const deadline = Date.now() + TIMEOUT_MIN * 60_000;
+  let announced = false;
+
+  while (Date.now() < deadline) {
+    const run = await latestRun().catch((err) => {
+      console.error(`[await-ci] poll failed: ${err.message}; retrying`);
+      return null;
+    });
+
+    if (run && !announced) {
+      console.log(`[await-ci] watching ${run.html_url}`);
+      announced = true;
+    }
+
+    if (run && run.status === 'completed') {
+      const out = process.env.GITHUB_OUTPUT;
+      if (out) {
+        const { appendFileSync } = await import('node:fs');
+        appendFileSync(out, `run_id=${run.id}\nconclusion=${run.conclusion}\n`);
+      }
+      if (run.conclusion === 'success') {
+        console.log(`[await-ci] CI passed for ${SHA} (run ${run.id})`);
+        process.exit(0);
+      }
+      fail(
+        `CI concluded "${run.conclusion}" for ${SHA}. Not deploying. See ${run.html_url}`,
+      );
+    }
+
+    if (!run) console.log(`[await-ci] no CI run for ${SHA} yet; waiting`);
+    else console.log(`[await-ci] CI is ${run.status}; waiting`);
+
+    await sleep(POLL_SECONDS * 1000);
+  }
+
+  fail(
+    `timed out after ${TIMEOUT_MIN} min waiting for CI on ${SHA}. Not deploying — ` +
+      'a deploy that cannot confirm its commit is green is the thing this gate exists to stop.',
+  );
+}
+
+main().catch((err) => fail(err.stack ?? String(err)));

--- a/scripts/ci/read-deploy-manifest.mjs
+++ b/scripts/ci/read-deploy-manifest.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+// Reads the deploy manifest CI published for this commit and emits the
+// image reference the deploy must pin.
+//
+// The manifest is written by ci.yml's `docker` job on main, after that
+// job has pushed the image AND pulled the published digest back and
+// smoke-tested it. It carries a digest, not a tag: a tag is a mutable
+// pointer that resolves to whatever the registry says at pull time, and
+// "deploy the image CI tested" is not a claim a tag can support.
+//
+// Three ways this refuses to produce an image, all of them loud:
+//   - the manifest is missing        => CI did not publish for this commit
+//   - its sha is not our sha         => the artifact belongs to another commit
+//   - its image is not digest-pinned => somebody replaced the digest with a tag
+// Each exits 1. A deploy with no verified artifact does not proceed.
+
+import { readFileSync, appendFileSync, existsSync } from 'node:fs';
+
+const PATH = process.env.MANIFEST_PATH ?? 'deploy-manifest.json';
+const EXPECTED_SHA = process.env.EXPECTED_SHA;
+
+function fail(message) {
+  console.error(`[manifest] ${message}`);
+  process.exit(1);
+}
+
+if (!existsSync(PATH)) {
+  fail(
+    `${PATH} not found. CI publishes it from the docker job on main; its absence ` +
+      'means no verified image exists for this commit. Re-run CI on this commit ' +
+      'before deploying.',
+  );
+}
+
+let manifest;
+try {
+  manifest = JSON.parse(readFileSync(PATH, 'utf8'));
+} catch (err) {
+  fail(`${PATH} is not valid JSON: ${err.message}`);
+}
+
+if (!EXPECTED_SHA) fail('EXPECTED_SHA is not set — cannot confirm the manifest is ours');
+
+if (manifest.sha !== EXPECTED_SHA) {
+  fail(
+    `manifest is for commit ${manifest.sha}, but this deploy is for ${EXPECTED_SHA}. ` +
+      'Deploying it would ship a different commit than the one that triggered this run.',
+  );
+}
+
+const image = String(manifest.image ?? '');
+if (!image.includes('@sha256:')) {
+  fail(`manifest image "${image}" is not digest-pinned. Refusing to deploy a mutable tag.`);
+}
+
+console.log(`[manifest] commit ${manifest.sha} -> ${image}`);
+
+const out = process.env.GITHUB_OUTPUT;
+if (!out) fail('GITHUB_OUTPUT is not set');
+appendFileSync(out, `image=${image}\ndigest=${manifest.digest}\n`);

--- a/test/deploy-artifact-truth.unit-spec.ts
+++ b/test/deploy-artifact-truth.unit-spec.ts
@@ -1,0 +1,129 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, readFileSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+/**
+ * Truth test for "build once, deploy that artifact".
+ *
+ * The property being defended is narrow and easy to lose by accident:
+ * the image running in production must be the image CI built and
+ * smoke-tested, identified by digest. Every plausible regression here is
+ * silent — swapping the digest back to `:latest` still deploys something
+ * that works, and nobody notices that "what CI approved" and "what is
+ * running" have come apart again until they disagree.
+ *
+ * So this pins the shape rather than the behaviour: the deploy does not
+ * build, the compose image is not a tag, CI publishes a manifest, and the
+ * manifest reader refuses everything it should refuse.
+ */
+
+const ROOT = join(__dirname, '..');
+const DEPLOY = readFileSync(join(ROOT, '.github', 'workflows', 'deploy-brain.yml'), 'utf8');
+const CI = readFileSync(join(ROOT, '.github', 'workflows', 'ci.yml'), 'utf8');
+const READER = join(ROOT, 'scripts', 'ci', 'read-deploy-manifest.mjs');
+
+/** Run the manifest reader over a manifest body; return its exit code. */
+function readManifest(body: string | null, expectedSha: string): number {
+  const dir = mkdtempSync(join(tmpdir(), 'deploy-manifest-'));
+  const manifestPath = join(dir, 'deploy-manifest.json');
+  if (body !== null) writeFileSync(manifestPath, body);
+  const outPath = join(dir, 'github_output');
+  writeFileSync(outPath, '');
+
+  try {
+    execFileSync('node', [READER], {
+      env: {
+        ...process.env,
+        MANIFEST_PATH: manifestPath,
+        EXPECTED_SHA: expectedSha,
+        GITHUB_OUTPUT: outPath,
+      },
+      encoding: 'utf8',
+    });
+    return 0;
+  } catch (err) {
+    return (err as { status?: number }).status ?? -1;
+  }
+}
+
+describe('the deploy consumes an artifact instead of producing one', () => {
+  it('deploy-brain.yml no longer builds or pushes an image', () => {
+    // A rebuild on the deploy runner is what broke the identity between
+    // "tested" and "running" in the first place.
+    expect(DEPLOY).not.toMatch(/docker\/build-push-action/);
+    expect(DEPLOY).not.toMatch(/\bpush:\s*true\b/);
+  });
+
+  it('the compose file pins the resolved digest, not a floating tag', () => {
+    // Two `image:` keys live in this file: the verify job's output, and
+    // the one written into the compose heredoc. Both must be the resolved
+    // digest — never a literal tag.
+    const images = [...DEPLOY.matchAll(/^\s+image:\s*(.+)$/gm)].map((m) => (m[1] ?? '').trim());
+    expect(images).toContain('${IMAGE_REF}');
+    for (const image of images) {
+      expect(image).toMatch(/^\$\{/);
+    }
+    // The specific regression this forbids: going back to :latest, which
+    // resolves to whatever the registry holds at pull time.
+    expect(DEPLOY).not.toMatch(/image:[^\n]*:latest/);
+  });
+
+  it('the deploy waits for CI on this commit before resolving anything', () => {
+    expect(DEPLOY).toMatch(/scripts\/ci\/await-ci\.mjs/);
+    // Ordering matters: the artifact download uses the run id the wait
+    // produced, so a download placed before the wait would read a stale run.
+    expect(DEPLOY.indexOf('await-ci.mjs')).toBeLessThan(DEPLOY.indexOf('download-artifact'));
+  });
+
+  it('the deploy job will not run unless verification succeeded', () => {
+    expect(DEPLOY).toMatch(/needs\.verify\.result == 'success'/);
+  });
+});
+
+describe('CI publishes exactly what the deploy expects to find', () => {
+  it('records a deploy manifest and uploads it under the agreed name', () => {
+    expect(CI).toMatch(/deploy-manifest\.json/);
+    expect(CI).toMatch(/name:\s*deploy-manifest/);
+    // Without this the artifact silently uploads empty and the deploy
+    // fails much later, at digest resolution, with a worse message.
+    expect(CI).toMatch(/if-no-files-found:\s*error/);
+  });
+
+  it('smoke-tests the published digest, not the local build cache', () => {
+    // The pull-back is what makes "CI tested this exact artifact" true
+    // rather than merely likely.
+    expect(CI).toMatch(/Pull back the published digest/);
+  });
+});
+
+describe('the manifest reader refuses every unverified image', () => {
+  const SHA = 'a'.repeat(40);
+  const OTHER = 'b'.repeat(40);
+  const good = JSON.stringify({
+    sha: SHA,
+    image: 'acme/inite-brain-service@sha256:' + 'c'.repeat(64),
+    digest: 'sha256:' + 'c'.repeat(64),
+  });
+
+  it('accepts a digest-pinned manifest for the right commit', () => {
+    expect(readManifest(good, SHA)).toBe(0);
+  });
+
+  it('refuses a manifest belonging to another commit', () => {
+    expect(readManifest(good, OTHER)).toBe(1);
+  });
+
+  it('refuses a tag-pinned image', () => {
+    const tagged = JSON.stringify({ sha: SHA, image: 'acme/inite-brain-service:latest' });
+    expect(readManifest(tagged, SHA)).toBe(1);
+  });
+
+  it('refuses a missing manifest rather than defaulting to something', () => {
+    expect(readManifest(null, SHA)).toBe(1);
+  });
+
+  it('refuses a corrupt manifest', () => {
+    expect(readManifest('{not json', SHA)).toBe(1);
+  });
+});


### PR DESCRIPTION
Third of four. **Base is `ci/parallel-gates` (#520)**, so this diff shows only its own change; GitHub retargets to `main` as the stack lands. Note that CI does not run on a PR whose base is not `main` — the two unit specs added here were run locally and will gate normally once #520 merges.

Two gaps that compound, closed together because closing either alone leaves the other load-bearing.

## Nothing tied the tested artifact to the running one

`ci.yml` built an image, smoke-tested it, and threw it away. `deploy-brain.yml` then rebuilt the same source on the self-hosted runner, pushed it as `:latest`, and the deploy pulled `:latest`. Same source, two builds, no identity between them.

The `:${{ github.sha }}` tag the deploy already pushed was consumed by **nothing at all** — no compose file referenced it, no workflow read it — so it could not even serve as a manual rollback target without hand-editing the compose file on the box.

Now:

1. CI builds the image once. On `main` it pushes, then **pulls the published digest back** and smoke-tests *that* — so "CI tested this artifact" becomes a fact about bytes rather than about source. If the registry ever served something other than what was pushed, that is where it surfaces.
2. CI writes a `deploy-manifest` artifact carrying `{sha, image@sha256:…}`.
3. The deploy reads it and pins `user/inite-brain-service@sha256:…` in the compose file.

A tag cannot carry this claim. `:latest` is a mutable pointer that resolves to whatever the registry holds at pull time.

`scripts/ci/read-deploy-manifest.mjs` refuses, loudly and with exit 1, on: a missing manifest (CI published nothing for this commit), a manifest whose `sha` is not this commit's, an image that is not digest-pinned, and a corrupt file.

## A red `main` deployed

`ci.yml` and `deploy-brain.yml` both fired on `push` to `main`, in parallel, with no ordering between them. The only thing standing between a broken merge and brain.inite.ai was whether the deploy's own build happened to be slower than the test suite.

A new `verify` job waits for CI's verdict **on its own commit** and refuses to proceed on anything but success — including *CI never ran*, *CI is still running at the 45-minute deadline*, and *the manifest belongs to another commit*. It fails closed everywhere: not being able to tell is not permission to deploy.

### Why not `on: workflow_run`

It would hand us the conclusion for free, and it is rejected on purpose: `workflow_run` carries no `paths:` filter, and this workflow's path trigger is a guarded, load-bearing thing (`test/deploy-trigger-truth.unit-spec.ts`, #516). Trading a tested trigger for an untested one to avoid a poll loop is a bad trade. So the trigger is untouched and the wait is explicit — on a GitHub-hosted runner, so the single self-hosted deploy runner does not spend twenty minutes idle.

## Details

- `restart` and `logs` skip verification (they change no image) and reuse the digest already pinned in the compose file on disk. An empty image after both paths is **fatal**, not silently resolved — writing a blank `image:` would resolve to something else entirely.
- PR runs, including from forks that get no secrets, build locally and never touch the registry — on the plain `docker build` that has always run there. Routing the PR path through buildx with `load: true` would put a new, untested build mechanism on the path that runs most often, in exchange for nothing; buildx is set up only on the branch that needs it. The publish path uses the same `build-push-action` invocation `deploy-brain.yml` has been running in production, so neither path is new.
- `test/deploy-artifact-truth.unit-spec.ts` pins the shape, because every regression here is silent: reverting to `:latest` still deploys something that works, and nobody notices that "approved" and "running" have come apart until they disagree.

## Two waits, not one

`await-ci.mjs` distinguishes "CI is slow" from "CI does not exist for this commit". A run appears within seconds of the push that created it, so a ten-minute grace period is enough to conclude none is coming — usually a manual deploy dispatched for a commit that was never pushed to `main`. Holding a hosted runner for the full 45 minutes to report an operator's typo, and burying the diagnosis under a generic timeout, helps nobody. Verified against the live API: the poller finds the real push-run for a `main` commit and waits on it; the not-found path exits 1 with the specific message.

## Needs a repo admin

Nothing new. The existing `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` secrets are now also read by `ci.yml` — they are repo-level secrets, so no action is required, but it is worth knowing that CI can now push to the registry where before only the deploy could.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB

