### PR TITLE
ci(deploy): smoke-test the surface each service owns, and give a failed deploy a way back

### DIFF
--- a/.github/workflows/deploy-brain-landing.yml
+++ b/.github/workflows/deploy-brain-landing.yml
@@ -232,35 +232,38 @@ jobs:
           docker-compose logs --tail=120 ${{ env.PROJECT_NAME }}
           exit 1
 
-      - name: External health probe
-        if: github.event.inputs.action != 'logs'
-        run: |
-          # Unreachable domain stays a WARNING (DNS/Traefik propagation on a
-          # fresh deploy is not this job's fault — the container-level probe
-          # above already gates the deploy). But once the domain answers,
-          # every artifact path must be a 200: a 404 here is a broken deploy,
-          # not a flake (audit 2026-08-19: this step was warning-only and
-          # /openapi.json 404'd for months while it ran green).
-          for i in $(seq 1 12); do
-            if curl -fs "https://${{ env.DOMAIN }}/en" > /dev/null 2>&1; then
-              echo "[ok] https://${{ env.DOMAIN }}/en responds"
-              fail=0
-              for path in /skills.tar.gz /install.sh /health /openapi.json; do
-                code=$(curl -s -o /dev/null -w '%{http_code}' "https://${{ env.DOMAIN }}$path")
-                if [ "$code" = "200" ]; then
-                  echo "[ok]  $path -> $code"
-                else
-                  echo "[err] $path -> $code"
-                  fail=1
-                fi
-              done
-              exit $fail
-            fi
-            echo "[info] external probe retry ($i/12)..."
-            sleep 10
-          done
-          echo "[warn] https://${{ env.DOMAIN }}/en never responded — check DNS + Traefik routing"
+      # The external check now asserts only the paths LANDING owns.
+      #
+      # It used to include /health, and on the shared brain.inite.ai host
+      # /health is claimed by the BACKEND router (PathPrefix, priority 200
+      # — see the Traefik labels in deploy-brain.yml). So this step was
+      # gating the landing's release on the ENGINE's health: a landing
+      # deploy could fail because a different service was down, and the
+      # failure read as "the landing is broken", which it was not.
+      #
+      # The path list is otherwise unchanged, and the 2026-08-19 finding it
+      # was written for still holds: once the domain answers, a 404 on a
+      # published artifact is a broken deploy, not a flake. Unreachability
+      # itself is still tolerated for the DNS/cert window and only then
+      # becomes a failure.
+      # (moved to the `smoke` job below — it needs a checkout, and running
+      # an external HTTPS probe from the deploy box buys nothing.)
 
       - name: Cleanup
         if: always() && github.event.inputs.action != 'logs'
         run: docker system prune -f
+
+  smoke:
+    needs: deploy
+    if: needs.deploy.result == 'success' && github.event.inputs.action != 'logs'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Smoke the deployed surface
+        env:
+          SMOKE_BASE_URL: https://${{ env.DOMAIN }}
+          SMOKE_SURFACE: landing
+        run: node scripts/ci/smoke.mjs

--- a/.github/workflows/deploy-brain.yml
+++ b/.github/workflows/deploy-brain.yml
@@ -17,7 +17,12 @@ on:
   workflow_dispatch:
     inputs:
       action:
-        description: 'deploy | restart | logs'
+        # `rollback` redeploys the last image that passed BOTH the
+        # readiness gate and the external smoke test, recorded on the box
+        # at .last-good-image. It is the manual twin of the automatic
+        # rollback the deploy job performs when its own verification
+        # fails; see § Rollback in docs/operations.md.
+        description: 'deploy | restart | logs | rollback'
         required: false
         default: 'deploy'
 
@@ -69,8 +74,10 @@ jobs:
   # an untested one to save a poll loop is a bad trade.
   # ---------------------------------------------------------------------
   verify:
-    # restart and logs do not change the image, so they need no artifact.
-    if: github.event_name == 'push' || (github.event.inputs.action != 'restart' && github.event.inputs.action != 'logs')
+    # restart, logs and rollback do not deploy a NEW image, so none of
+    # them needs a freshly verified artifact. rollback in particular must
+    # work when CI is red — that is the situation it exists for.
+    if: github.event_name == 'push' || (github.event.inputs.action == 'deploy' || github.event.inputs.action == '')
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
@@ -114,7 +121,7 @@ jobs:
     if: |
       always() && (
         (github.event_name == 'push' && needs.verify.result == 'success') ||
-        (github.event_name == 'workflow_dispatch' && (needs.verify.result == 'success' || github.event.inputs.action == 'restart' || github.event.inputs.action == 'logs'))
+        (github.event_name == 'workflow_dispatch' && (needs.verify.result == 'success' || github.event.inputs.action == 'restart' || github.event.inputs.action == 'logs' || github.event.inputs.action == 'rollback'))
       )
     runs-on: [self-hosted, sfo]
 
@@ -421,16 +428,47 @@ jobs:
           # pins, which is the last thing this workflow deployed. An empty
           # image after both attempts is fatal — writing a compose file
           # with a blank image would silently resolve to something else.
+          # Whatever is pinned right now is what we roll back TO if this
+          # deploy fails its own verification. Captured before the compose
+          # file is rewritten, because rewriting destroys the only record.
+          PREVIOUS_IMAGE=""
+          if [ -f docker-compose.yml ]; then
+            PREVIOUS_IMAGE="$(awk '/^[[:space:]]+image:/ {print $2; exit}' docker-compose.yml)"
+          fi
+          echo "PREVIOUS_IMAGE=${PREVIOUS_IMAGE}" >> "$GITHUB_ENV"
+          echo "[deploy] currently pinned: ${PREVIOUS_IMAGE:-<nothing>}"
+
           IMAGE_REF="${{ needs.verify.outputs.image }}"
-          if [ -z "$IMAGE_REF" ] && [ -f docker-compose.yml ]; then
-            IMAGE_REF="$(awk '/^[[:space:]]+image:/ {print $2; exit}' docker-compose.yml)"
+          if [ "${{ github.event.inputs.action }}" = "rollback" ]; then
+            # The manual escape hatch. .last-good-image is only written
+            # after a deploy passed BOTH the readiness gate and the
+            # external smoke test, so it is a known-good target rather
+            # than merely a previous one.
+            if [ ! -s .last-good-image ]; then
+              echo "[err] no .last-good-image recorded on this host — nothing to roll back to."
+              echo "[err] Deploy a known-good commit instead, or pin a digest by hand."
+              exit 1
+            fi
+            IMAGE_REF="$(cat .last-good-image)"
+            echo "[deploy] ROLLBACK to last known-good image: $IMAGE_REF"
+          fi
+          if [ -z "$IMAGE_REF" ]; then
+            IMAGE_REF="$PREVIOUS_IMAGE"
             echo "[deploy] reusing the pinned image already on disk: $IMAGE_REF"
           fi
           if [ -z "$IMAGE_REF" ]; then
             echo "[err] no image to deploy: CI published no digest and no compose file is pinned."
             exit 1
           fi
+          echo "IMAGE_REF=${IMAGE_REF}" >> "$GITHUB_ENV"
           echo "[deploy] image: $IMAGE_REF"
+
+          # Persisted to disk, not just to $GITHUB_ENV, because the
+          # promote/rollback decision is made in a LATER job (after the
+          # external smoke test, which runs off-box) and job env does not
+          # survive that hop.
+          printf '%s' "$PREVIOUS_IMAGE" > .previous-image
+          printf '%s' "$IMAGE_REF" > .pending-image
 
           # Brain talks to the SHARED inite-surrealdb container that lives in
           # the temporal stack (inite-temporal/docker-compose). Brain owns
@@ -851,25 +889,123 @@ jobs:
           echo "[err] Inspect scoped DB credentials and primary embedder warmup logs; do not start reindex until /ready is 200."
           exit 1
 
-      - name: External health probe (warning-only)
-        if: github.event.inputs.action != 'logs'
-        continue-on-error: true
-        run: |
-          # Best-effort — DNS may not be wired yet, Let's Encrypt cert
-          # provisioning can take 30-90s on first deploy. Failure here
-          # surfaces as a workflow warning, not a deploy block.
-          for i in $(seq 1 12); do
-            if curl -fs https://${{ env.DOMAIN }}/health > /dev/null 2>&1; then
-              echo "[ok] https://${{ env.DOMAIN }}/health responds"
-              curl -s https://${{ env.DOMAIN }}/health | head -c 500
-              echo ""
-              exit 0
-            fi
-            echo "[info] external probe retry ($i/12)..."
-            sleep 10
-          done
-          echo "[warn] https://${{ env.DOMAIN }}/health never responded — check DNS A-record + Traefik cert in droplet logs"
+      # The external check moved OUT of this job and into `smoke` below.
+      # It used to be `curl -fs .../health`, warning-only — which verified
+      # that Nest had bound a port and nothing else, and could not fail a
+      # deploy even when it did notice something. Liveness is already
+      # covered by the two internal gates above; what was missing was any
+      # assertion about the surface actually being served.
 
       - name: Cleanup
         if: always() && github.event.inputs.action != 'logs'
         run: docker system prune -f
+
+  # ---------------------------------------------------------------------
+  # Post-deploy smoke test of the real surface, off-box and through
+  # Traefik — so it exercises DNS, the certificate, the router rules and
+  # the container, which is the whole path a caller uses.
+  #
+  # It asserts behaviour a dead or misrouted deploy cannot fake: an
+  # unauthenticated POST to /v1/search must come back 401. A 404 means the
+  # API is not mounted; a 200 means auth is not enforced. Only 401 says
+  # the surface is there and fail-closed. See scripts/ci/smoke.mjs.
+  #
+  # This job BLOCKS. Its failure is what triggers the rollback below.
+  # ---------------------------------------------------------------------
+  smoke:
+    needs: deploy
+    if: needs.deploy.result == 'success' && github.event.inputs.action != 'logs' && github.event.inputs.action != 'restart'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Smoke the deployed surface
+        env:
+          SMOKE_BASE_URL: https://${{ env.DOMAIN }}
+          SMOKE_SURFACE: brain
+        run: node scripts/ci/smoke.mjs
+
+  # ---------------------------------------------------------------------
+  # Promote or roll back, depending on what the verification said.
+  #
+  # There was previously no way back at all: a failed probe dumped logs,
+  # exited 1, and left the broken container running. The SHA-tagged image
+  # the old build pushed was referenced by nothing, so even a manual
+  # rollback meant hand-editing the compose file on the box.
+  #
+  # `.last-good-image` is written ONLY here, only after both the readiness
+  # gate and the external smoke passed — so it is a known-good target
+  # rather than merely a previous one. `workflow_dispatch` with
+  # action=rollback redeploys it.
+  # ---------------------------------------------------------------------
+  finalize:
+    needs: [deploy, smoke]
+    if: always() && github.event.inputs.action != 'logs' && github.event.inputs.action != 'restart'
+    runs-on: [self-hosted, sfo]
+    timeout-minutes: 15
+    steps:
+      - name: Promote this image to last-known-good
+        if: needs.deploy.result == 'success' && needs.smoke.result == 'success'
+        run: |
+          set -euo pipefail
+          cd /opt/projects/${{ env.PROJECT_NAME }}
+          if [ ! -s .pending-image ]; then
+            echo "[promote] nothing pending — leaving .last-good-image untouched"
+            exit 0
+          fi
+          cp .pending-image .last-good-image
+          echo "[promote] last known-good is now $(cat .last-good-image)"
+
+      - name: Roll back to the previous image
+        if: needs.deploy.result != 'success' || needs.smoke.result != 'success'
+        run: |
+          set -euo pipefail
+          cd /opt/projects/${{ env.PROJECT_NAME }}
+
+          # Prefer the last image that passed BOTH gates over merely "the
+          # one that was pinned before this run" — if the previous deploy
+          # was itself broken, rolling back to it achieves nothing.
+          TARGET=""
+          if [ -s .last-good-image ]; then
+            TARGET="$(cat .last-good-image)"
+          elif [ -s .previous-image ]; then
+            TARGET="$(cat .previous-image)"
+          fi
+
+          if [ -z "$TARGET" ]; then
+            echo "[rollback] no known-good or previous image recorded on this host."
+            echo "[rollback] The broken deploy is still running and MUST be handled by hand:"
+            echo "[rollback]   pin a digest in /opt/projects/${{ env.PROJECT_NAME }}/docker-compose.yml"
+            echo "[rollback]   then: docker-compose up -d"
+            exit 1
+          fi
+
+          CURRENT="$(awk '/^[[:space:]]+image:/ {print $2; exit}' docker-compose.yml || true)"
+          if [ "$TARGET" = "$CURRENT" ]; then
+            echo "[rollback] already running $TARGET — the failure is not the image."
+            echo "[rollback] Not restarting into the same thing. Investigate the deploy logs."
+            exit 1
+          fi
+
+          echo "[rollback] $CURRENT -> $TARGET"
+          sed -i "s|^\([[:space:]]*image:\).*|\1 ${TARGET}|" docker-compose.yml
+          docker-compose pull ${{ env.PROJECT_NAME }}
+          docker-compose up -d --remove-orphans
+
+          # A rollback that is not itself verified is just a second
+          # unverified deploy.
+          deadline=$((SECONDS + 300))
+          while [ "$SECONDS" -lt "$deadline" ]; do
+            if timeout 15s docker-compose exec -T ${{ env.PROJECT_NAME }} wget -T 12 -qO- http://localhost:${{ env.PORT }}/ready > /dev/null 2>&1; then
+              echo "[rollback] $TARGET is READY. Production is back on the last known-good image."
+              echo "[rollback] The commit that failed is still on main — fix forward or revert it."
+              exit 1
+            fi
+            echo "[rollback] waiting for readiness on the rolled-back image..."
+            sleep 5
+          done
+          echo "[rollback] FAILED — the rolled-back image did not become ready either."
+          docker-compose logs --tail=120 ${{ env.PROJECT_NAME }}
+          exit 1

--- a/.github/workflows/deploy-brain.yml
+++ b/.github/workflows/deploy-brain.yml
@@ -958,8 +958,14 @@ jobs:
           cp .pending-image .last-good-image
           echo "[promote] last known-good is now $(cat .last-good-image)"
 
+      # Deliberately NOT `!= 'success'`. When `verify` fails — a red CI, no
+      # manifest — `deploy` is *skipped*, which is also not 'success', and
+      # rolling back then would restart production over a deploy that never
+      # happened. Nothing was touched, so nothing needs undoing. Only a
+      # deploy that actually ran and went wrong, or a smoke test that
+      # actually failed, is a reason to move the running image.
       - name: Roll back to the previous image
-        if: needs.deploy.result != 'success' || needs.smoke.result != 'success'
+        if: needs.deploy.result == 'failure' || needs.deploy.result == 'cancelled' || needs.smoke.result == 'failure'
         run: |
           set -euo pipefail
           cd /opt/projects/${{ env.PROJECT_NAME }}

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -85,11 +85,20 @@ retries for 2 minutes.
    `default`).
 3. Run **Actions → Deploy brain.inite.ai → Run workflow** with `action=deploy`.
 4. Workflow flow:
-   - Builds the docker image, pushes to `dockerhub/inite-brain-service:<sha>` and `:latest`.
-   - On the droplet: writes `/opt/projects/inite-brain-service/docker-compose.yml`,
-     pulls the new image, `docker-compose up -d`.
-   - Waits 25s for the container, then probes `https://brain.inite.ai/health`
-     with retries (cert provisioning).
+   - **`verify`** — waits for the CI run on this exact commit and refuses
+     to continue on anything but success. CI, not this workflow, builds
+     and publishes the image; `verify` reads the digest CI recorded after
+     smoke-testing it.
+   - **`deploy`** (droplet) — writes
+     `/opt/projects/inite-brain-service/docker-compose.yml` pinned to
+     `dockerhub/inite-brain-service@sha256:…`, pulls, `docker-compose up -d`,
+     then gates on `/health` (liveness) and `/ready` (database, scoped
+     authorization, primary embedder) from inside the container.
+   - **`smoke`** — external, through DNS + Traefik: asserts `/health` is
+     200, an unauthenticated `POST /v1/search` is **401**, and `/mcp/…`
+     refuses rather than 404s. Blocking.
+   - **`finalize`** (droplet) — records `.last-good-image` on success, or
+     rolls back to it on failure. See § Rollback.
 5. First request to any tenant triggers `ensureSchema` — every numbered
    migration in `src/db/migrations/` (0001 through the current head) applies
    on the per-tenant `co_<companyId>` DB, including 0005 (PII PERMISSIONS +
@@ -150,22 +159,51 @@ Internal: `wget -qO- http://localhost:3000/health` (configured in the
 container healthcheck — Docker marks unhealthy after 5 failures × 15s).
 
 External: `https://brain.inite.ai/health` returns brain's standard
-HealthController shape. The `Health probe` step in the workflow polls
-this for 2 minutes after `up -d`.
+HealthController shape. The `smoke` job polls it after `up -d` — and
+does not stop there: a 200 on `/health` only means Nest bound a port, so
+the same job asserts that an unauthenticated `POST /v1/search` returns
+**401** (404 would mean the API is not mounted; 200 would mean auth is
+not enforced).
 
 ## Rollback
+
+**The old recipe on this page no longer works and has been removed.** It
+retagged a previous sha as `:latest` and relied on the compose file
+pulling `:latest`. The compose file now pins an immutable digest, so
+moving a tag changes nothing on the box.
+
+Preferred: **Actions → Deploy brain.inite.ai → Run workflow →
+`action: rollback`.** This skips CI verification entirely — it has to
+work while `main` is red, which is the situation it exists for — and
+redeploys `/opt/projects/inite-brain-service/.last-good-image`, the last
+digest that passed both the readiness gate and the external smoke test.
+
+It usually will not be needed: if a deploy fails its own verification,
+the `finalize` job performs that rollback automatically and then reports
+the run as **failed anyway** — production is back, but the commit on
+`main` is still broken and wants a fix-forward or a revert.
+
+By hand, when there is no recorded known-good image (a fresh host, wiped
+state):
 
 ```bash
 ssh root@<droplet>
 cd /opt/projects/inite-brain-service
-docker pull dockerhub/inite-brain-service:<previous-sha>
-docker tag dockerhub/inite-brain-service:<previous-sha> dockerhub/inite-brain-service:latest
-docker-compose up -d --force-recreate inite-brain-service
+sed -i 's|^\( *image:\).*|\1 dockerhub/inite-brain-service@sha256:<digest>|' docker-compose.yml
+docker-compose pull inite-brain-service && docker-compose up -d
 ```
 
-The `:latest` tag is what the docker-compose pulls; pinning a previous
-sha as `:latest` rolls back without changing the workflow file. Or
-re-run the workflow on a previous commit.
+Get `<digest>` from the CI run that built the commit you want (the
+`docker` job's publish step), or from
+`docker inspect --format '{{index .RepoDigests 0}}' <image-id>`.
+
+**A rollback does not cross a migration.** Migrations run forward on boot
+and pinning an older image does not reverse them. If the bad deploy
+changed the schema, roll the image back to stop the bleeding and then
+handle the schema deliberately.
+
+See also § *Deploys, and how to undo one* in
+[`operations.md`](operations.md).
 
 ## Observability
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -743,6 +743,83 @@ This is intentional — better to refuse to start than to dribble out
 flight requests. A 15s deadline guards against a hung shutdown so
 docker / fly / k8s don't `SIGKILL` you with no log line.
 
+## Deploys, and how to undo one
+
+The engine deploy does not build. CI builds the image once, pushes it,
+pulls the published **digest** back, smoke-tests that, and records it in a
+`deploy-manifest` artifact. `deploy-brain.yml` waits for CI's verdict on
+its own commit, reads that manifest, and pins
+`inite-brain-service@sha256:…` in the compose file. A tag is never
+deployed: `:latest` resolves to whatever the registry holds at pull time
+and cannot carry the claim "this is what CI tested".
+
+Consequences worth knowing:
+
+- **A red `main` does not deploy.** The `verify` job fails and nothing
+  downstream runs. So does "CI never ran for this commit" and "CI is still
+  running 45 minutes later" — not being able to confirm green is not
+  permission to ship.
+- **The commit and the running image are the same thing.**
+  `docker inspect inite-brain-service --format '{{index .RepoDigests 0}}'`
+  on the box gives you a digest you can match against the CI run that
+  produced it.
+
+### Verification after a deploy
+
+Two internal gates on the box (`/health` for liveness, `/ready` for the
+database, scoped authorization and the primary embedder), then an external
+`smoke` job that goes through DNS, the certificate and Traefik —
+`scripts/ci/smoke.mjs`, surface `brain`. It asserts more than liveness: an
+unauthenticated `POST /v1/search` must return **401**. A 404 means the API
+is not mounted; a 200 means auth is not enforced. Only 401 says the
+surface is there and fail-closed.
+
+The landing has its own surface (`/en`, `/skills.tar.gz`, `/install.sh`,
+`/openapi.json`) and deliberately does **not** assert `/health` — Traefik
+routes that path to the engine, so asserting it made the landing's release
+gate on a different service's health.
+
+### Rollback
+
+Three files live in `/opt/projects/inite-brain-service/`:
+
+| File | Meaning |
+|---|---|
+| `.pending-image` | the digest this run is deploying |
+| `.previous-image` | whatever was pinned before this run started |
+| `.last-good-image` | the last digest that passed **both** the readiness gate and the external smoke test |
+
+`.last-good-image` is written only by the `finalize` job, only when the
+smoke test passed. It is a known-good target rather than merely a previous
+one — which matters, because rolling back to a previous deploy that was
+itself broken achieves nothing.
+
+**Automatic.** If the deploy job or the smoke job fails, `finalize`
+rewrites the compose image to `.last-good-image` (falling back to
+`.previous-image`), pulls, restarts, and then waits for `/ready` on the
+rolled-back container. It reports the run as **failed** even when the
+rollback succeeds — production is safe, but the commit on `main` is still
+broken and needs a fix-forward or a revert.
+
+**By hand.** Actions → *Deploy brain.inite.ai* → Run workflow →
+`action: rollback`. This skips verification entirely (it must work while
+CI is red — that is what it is for) and redeploys `.last-good-image`.
+
+**When there is nothing to roll back to** — a first deploy, or a host
+whose state files were wiped — the rollback step says so and exits 1
+rather than pretending. Recover by pinning a digest by hand:
+
+```bash
+cd /opt/projects/inite-brain-service
+sed -i 's|^\( *image:\).*|\1 <user>/inite-brain-service@sha256:…|' docker-compose.yml
+docker-compose pull inite-brain-service && docker-compose up -d
+```
+
+A `rollback` cannot cross a database migration. Migrations run forward on
+boot and are not reversed by pinning an older image; if the bad deploy
+introduced a schema change, roll back the image to stop the bleeding and
+then handle the schema deliberately.
+
 ## Tests
 
 | Command | What it does | When to run |

--- a/scripts/ci/smoke.mjs
+++ b/scripts/ci/smoke.mjs
@@ -1,0 +1,131 @@
+#!/usr/bin/env node
+// Post-deploy smoke test of the surface that was actually deployed.
+//
+// WHAT WAS WRONG. Both deploys verified liveness and called it done. The
+// engine's external check was `curl -fs https://brain.inite.ai/health`,
+// and warning-only besides. `/health` returns 200 as soon as Nest binds a
+// port — it says nothing about whether the API is mounted, whether auth
+// is enforced, or whether Traefik is routing to the new container rather
+// than to a stale one.
+//
+// Worse, the landing's check asserted `/health` too, and on the shared
+// brain.inite.ai host `/health` is claimed by the BACKEND router
+// (PathPrefix, priority 200) — so the landing's deploy was gating on the
+// engine's health. One service's release could fail because a different
+// service was down, and a landing deploy could report green while landing
+// itself served nothing but the paths it was asked about.
+//
+// So each surface asserts the routes IT owns, and the assertions are
+// about behaviour a dead or misrouted deploy cannot fake: an unauthenticated
+// POST to /v1/search must come back 401, not 404. 404 means the route is
+// not mounted; 200 means auth is not enforced. Only 401 means the surface
+// is there and fail-closed.
+
+const SURFACES = {
+  brain: [
+    { path: '/health', method: 'GET', expect: [200], why: 'engine is live behind Traefik' },
+    {
+      path: '/v1/search',
+      method: 'POST',
+      expect: [401],
+      why: 'API surface is mounted AND fail-closed (404 = not mounted, 200 = auth bypassed)',
+    },
+    {
+      path: '/mcp/smoke-probe',
+      method: 'GET',
+      // The Streamable-HTTP transport answers a bare GET in several
+      // legitimate ways depending on headers; what matters is that the
+      // route exists and refuses. 404 or 5xx is a broken deploy.
+      expect: [400, 401, 405, 406],
+      why: 'MCP transport is mounted and refuses an unauthenticated probe',
+    },
+  ],
+  landing: [
+    { path: '/en', method: 'GET', expect: [200], why: 'the localized site renders' },
+    { path: '/skills.tar.gz', method: 'GET', expect: [200], why: 'the skills bundle is published' },
+    { path: '/install.sh', method: 'GET', expect: [200], why: 'the installer is published' },
+    { path: '/openapi.json', method: 'GET', expect: [200], why: 'the published spec is served' },
+    // NOTE: /health is deliberately absent. Traefik routes it to the
+    // engine, so asserting it here made the landing's deploy fail
+    // whenever the engine was unhealthy — a cross-service gate nobody
+    // asked for.
+  ],
+};
+
+const BASE = (process.env.SMOKE_BASE_URL ?? '').replace(/\/+$/, '');
+const SURFACE = process.env.SMOKE_SURFACE ?? '';
+const REACH_ATTEMPTS = Number(process.env.SMOKE_REACH_ATTEMPTS ?? '12');
+const REACH_DELAY_SECONDS = Number(process.env.SMOKE_REACH_DELAY_SECONDS ?? '10');
+
+function fail(message) {
+  console.error(`[smoke] ${message}`);
+  process.exit(1);
+}
+
+if (!BASE) fail('SMOKE_BASE_URL is not set');
+const checks = SURFACES[SURFACE];
+if (!checks) fail(`unknown SMOKE_SURFACE "${SURFACE}" (expected one of: ${Object.keys(SURFACES)})`);
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function status(check) {
+  const res = await fetch(`${BASE}${check.path}`, {
+    method: check.method,
+    redirect: 'manual',
+    headers: { accept: 'application/json' },
+    // A hung upstream must not hang the deploy.
+    signal: AbortSignal.timeout(15_000),
+  });
+  return res.status;
+}
+
+/**
+ * Wait for the host to answer at all before judging individual routes.
+ * On a first deploy, DNS and the Let's Encrypt cert can take a minute,
+ * and that is not the same failure as a broken route.
+ */
+async function waitForReachable() {
+  const probe = checks[0];
+  for (let attempt = 1; attempt <= REACH_ATTEMPTS; attempt += 1) {
+    try {
+      await status(probe);
+      return true;
+    } catch (err) {
+      console.log(`[smoke] ${BASE} not reachable yet (${attempt}/${REACH_ATTEMPTS}): ${err.message}`);
+      await sleep(REACH_DELAY_SECONDS * 1000);
+    }
+  }
+  return false;
+}
+
+async function main() {
+  if (!(await waitForReachable())) {
+    fail(
+      `${BASE} never answered. If this is a first deploy, check the DNS A record and the ` +
+        'Traefik certificate; otherwise the container is not being routed to.',
+    );
+  }
+
+  let failed = 0;
+  for (const check of checks) {
+    let got;
+    try {
+      got = await status(check);
+    } catch (err) {
+      console.error(`[smoke] ERR ${check.method} ${check.path} — request failed: ${err.message}`);
+      failed += 1;
+      continue;
+    }
+    const ok = check.expect.includes(got);
+    if (!ok) failed += 1;
+    console.log(
+      `[smoke] ${ok ? 'ok ' : 'ERR'} ${check.method} ${check.path} -> ${got} ` +
+        `(want ${check.expect.join('|')}) — ${check.why}`,
+    );
+  }
+
+  if (failed > 0) fail(`${failed} of ${checks.length} checks failed on ${BASE}`);
+  console.log(`[smoke] all ${checks.length} checks passed on ${BASE}`);
+}
+
+main().catch((err) => fail(err.stack ?? String(err)));

--- a/test/deploy-smoke-truth.unit-spec.ts
+++ b/test/deploy-smoke-truth.unit-spec.ts
@@ -80,10 +80,19 @@ describe('a failed deploy has a way back', () => {
     expect(promote?.[0]).toMatch(/needs\.smoke\.result == 'success'/);
   });
 
-  it('rollback triggers when either the deploy or the smoke test failed', () => {
-    expect(BRAIN).toMatch(
-      /needs\.deploy\.result != 'success' \|\| needs\.smoke\.result != 'success'/,
-    );
+  it('rollback triggers when the deploy or the smoke test actually failed', () => {
+    expect(BRAIN).toMatch(/needs\.deploy\.result == 'failure'/);
+    expect(BRAIN).toMatch(/needs\.smoke\.result == 'failure'/);
+  });
+
+  it('rollback does NOT trigger when the deploy was merely skipped', () => {
+    // `verify` failing (red CI, no manifest) skips `deploy`, which is also
+    // "not success". Rolling back then would restart production over a
+    // deploy that never happened — nothing was touched, so nothing needs
+    // undoing. The condition must test for failure, not for non-success.
+    const start = BRAIN.indexOf('Roll back to the previous image');
+    const condition = BRAIN.slice(start, start + 400);
+    expect(condition).not.toMatch(/result != 'success'/);
   });
 
   it('the rollback re-verifies readiness instead of trusting the restart', () => {

--- a/test/deploy-smoke-truth.unit-spec.ts
+++ b/test/deploy-smoke-truth.unit-spec.ts
@@ -1,0 +1,132 @@
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Truth test for post-deploy verification and the way back.
+ *
+ * Two properties, both of which regress silently:
+ *
+ *   1. Each service's smoke test asserts the routes IT owns. On the
+ *      shared brain.inite.ai host, Traefik gives /health to the BACKEND
+ *      router (PathPrefix, priority 200) and everything else to the
+ *      landing's Host-only catch-all. The landing's deploy used to assert
+ *      /health, so it was gating its own release on the engine's health —
+ *      and a green landing deploy said nothing about landing.
+ *
+ *   2. A deploy that fails verification has somewhere to go. Before this,
+ *      a failed probe dumped logs, exited 1, and left the broken
+ *      container running.
+ */
+
+const ROOT = join(__dirname, '..');
+const SMOKE = join(ROOT, 'scripts', 'ci', 'smoke.mjs');
+const BRAIN = readFileSync(join(ROOT, '.github', 'workflows', 'deploy-brain.yml'), 'utf8');
+const LANDING = readFileSync(
+  join(ROOT, '.github', 'workflows', 'deploy-brain-landing.yml'),
+  'utf8',
+);
+const SMOKE_SRC = readFileSync(SMOKE, 'utf8');
+
+/** Paths one surface asserts, read out of the script's own table. */
+function surfacePaths(surface: string): string[] {
+  const block = new RegExp(`${surface}: \\[([\\s\\S]*?)\\n  \\]`).exec(SMOKE_SRC);
+  expect(block).not.toBeNull();
+  return [...(block?.[1] ?? '').matchAll(/path: '([^']+)'/g)].map((m) => m[1] ?? '');
+}
+
+describe('each surface smoke-tests only what it owns', () => {
+  it('the landing does not assert /health, which Traefik routes to the engine', () => {
+    expect(surfacePaths('landing')).not.toContain('/health');
+    // And the old inline curl loop that did assert it is gone.
+    expect(LANDING).not.toMatch(/for path in[^\n]*\/health/);
+  });
+
+  it('the landing still asserts every artifact it publishes', () => {
+    const paths = surfacePaths('landing');
+    for (const required of ['/en', '/skills.tar.gz', '/install.sh', '/openapi.json']) {
+      expect(paths).toContain(required);
+    }
+  });
+
+  it('the engine asserts more than liveness', () => {
+    const paths = surfacePaths('brain');
+    expect(paths).toContain('/health');
+    // The point of the change: a route whose 401 proves the API is
+    // mounted and fail-closed. /health alone proves only that Nest bound
+    // a port.
+    expect(paths).toContain('/v1/search');
+    expect(SMOKE_SRC).toMatch(/expect: \[401\]/);
+  });
+
+  it('both deploys run the smoke test as a blocking job', () => {
+    expect(BRAIN).toMatch(/SMOKE_SURFACE: brain/);
+    expect(LANDING).toMatch(/SMOKE_SURFACE: landing/);
+    // The engine's external check used to be continue-on-error, i.e. it
+    // could notice a broken deploy and pass anyway.
+    expect(BRAIN).not.toMatch(/External health probe \(warning-only\)/);
+  });
+});
+
+describe('a failed deploy has a way back', () => {
+  it('the engine deploy records what it is replacing before replacing it', () => {
+    expect(BRAIN).toMatch(/\.previous-image/);
+    expect(BRAIN).toMatch(/\.pending-image/);
+  });
+
+  it('last-known-good is promoted only after the smoke test passed', () => {
+    const promote = /Promote this image to last-known-good[\s\S]*?run: \|/.exec(BRAIN);
+    expect(promote).not.toBeNull();
+    expect(promote?.[0]).toMatch(/needs\.smoke\.result == 'success'/);
+  });
+
+  it('rollback triggers when either the deploy or the smoke test failed', () => {
+    expect(BRAIN).toMatch(
+      /needs\.deploy\.result != 'success' \|\| needs\.smoke\.result != 'success'/,
+    );
+  });
+
+  it('the rollback re-verifies readiness instead of trusting the restart', () => {
+    // A rollback that is not itself verified is just a second unverified
+    // deploy. The step is the last in the file, so take it to the end.
+    const start = BRAIN.indexOf('Roll back to the previous image');
+    expect(start).toBeGreaterThan(-1);
+    const rollback = BRAIN.slice(start);
+    expect(rollback).toMatch(/\/ready/);
+    expect(rollback).toMatch(/docker-compose up -d/);
+  });
+
+  it('a rollback is reachable by hand without editing the box', () => {
+    expect(BRAIN).toMatch(/deploy \| restart \| logs \| rollback/);
+    expect(BRAIN).toMatch(/inputs\.action == 'rollback'/);
+  });
+});
+
+describe('the smoke script fails closed', () => {
+  function run(env: Record<string, string>): number {
+    try {
+      execFileSync('node', [SMOKE], {
+        env: { ...process.env, ...env, SMOKE_REACH_ATTEMPTS: '1', SMOKE_REACH_DELAY_SECONDS: '0' },
+        encoding: 'utf8',
+        stdio: 'pipe',
+      });
+      return 0;
+    } catch (err) {
+      return (err as { status?: number }).status ?? -1;
+    }
+  }
+
+  it('refuses an unknown surface rather than passing vacuously', () => {
+    expect(run({ SMOKE_BASE_URL: 'https://example.invalid', SMOKE_SURFACE: 'nope' })).toBe(1);
+  });
+
+  it('refuses a missing base URL', () => {
+    expect(run({ SMOKE_BASE_URL: '', SMOKE_SURFACE: 'brain' })).toBe(1);
+  });
+
+  it('fails when the host never answers', () => {
+    // .invalid is reserved by RFC 2606 and never resolves, so this
+    // exercises the unreachable path without touching the network.
+    expect(run({ SMOKE_BASE_URL: 'https://brain.invalid', SMOKE_SURFACE: 'brain' })).toBe(1);
+  });
+});


### PR DESCRIPTION
Fourth and last. **Base is `ci/build-once-deploy-digest` (#523)**, so this diff shows only its own change. CI does not run on a PR based off `main`'s siblings; the specs added here were run locally and gate normally once the stack lands.

## Verification was liveness only, and could not fail

The engine's external check was `curl -fs https://brain.inite.ai/health`, marked `continue-on-error: true`.

`/health` returns 200 as soon as Nest binds a port. It says nothing about whether the API is mounted, whether auth is enforced, or whether Traefik is routing to the *new* container rather than a stale one. And being warning-only, it could notice a problem and pass anyway.

The replacement (`scripts/ci/smoke.mjs`) asserts behaviour a dead or misrouted deploy cannot fake:

| check | expect | why |
|---|---|---|
| `GET /health` | 200 | engine is live behind Traefik |
| `POST /v1/search` | **401** | API surface mounted **and** fail-closed — 404 means not mounted, 200 means auth bypassed |
| `GET /mcp/smoke-probe` | 400/401/405/406 | MCP transport mounted and refusing; 404 or 5xx is a broken deploy |

It runs off-box, so it goes through DNS, the certificate, the Traefik router rules and the container — the path a caller actually uses — and it **blocks**.

## The landing's deploy was gating on the engine's health

Its external probe asserted `/health` among the artifact paths. On the shared `brain.inite.ai` host, Traefik gives `/health` to the **backend** router (`PathPrefix`, `priority=200`) while the landing takes the Host-only catch-all at `priority=100`. So a landing deploy failed whenever the *engine* was unhealthy, and the failure read as "the landing is broken", which it was not.

Each surface now asserts only what it owns. The landing keeps `/en`, `/skills.tar.gz`, `/install.sh`, `/openapi.json` — and the 2026-08-19 finding that motivated that list is preserved: once the domain answers, a 404 on a published artifact is a broken deploy, not a flake.

## There was no way back

A failed probe dumped logs, exited 1, and left the broken container running. Since the SHA-tagged image was referenced by nothing, even a manual rollback meant hand-editing the compose file on the box.

Three files now live in `/opt/projects/inite-brain-service/`:

| file | meaning |
|---|---|
| `.pending-image` | the digest this run is deploying |
| `.previous-image` | whatever was pinned before this run started |
| `.last-good-image` | the last digest that passed **both** the readiness gate and the external smoke |

`.last-good-image` is written only by the new `finalize` job, only when smoke passed. **Known-good, not merely previous** — rolling back to a deploy that was itself broken achieves nothing.

The rollback fires on **failure**, not on "not success" — those differ. When `verify` fails (red CI, no manifest) the deploy is *skipped*, which is also not success; rolling back then would restart production over a change that was never applied, turning a correctly-refused deploy into an unnecessary outage window. A spec pins that distinction.

- **Automatic:** deploy fails, or smoke fails → `finalize` restores that image, pulls, restarts, and **re-verifies `/ready`** (a rollback that is not itself verified is just a second unverified deploy). It then reports the run as **failed** anyway: production being safe does not make the commit on `main` good.
- **By hand:** Run workflow → `action: rollback`. This skips verification entirely, because it has to work while CI is red — that is the situation it exists for.

## Stated gaps, deliberately not automated

- **A rollback cannot cross a migration.** Migrations run forward on boot and pinning an older image does not reverse them. If the bad deploy changed the schema, roll the image back to stop the bleeding and handle the schema deliberately. Documented, not automated — an automatic down-migration is a much bigger and more dangerous thing than this PR.
- **First deploy on a fresh host has nothing to roll back to.** The step says so and exits 1 rather than pretending; `docs/operations.md` carries the two-line manual recipe.
- **`deploy-monitoring.yml` is untouched.** It rsyncs config and pulls upstream images — there is no image of ours to pin, so "deploy the artifact CI built" does not apply, and it has no rollback. Bringing it under the same discipline is a separate piece of work with a different shape.
- **`release-image.yml` still pushes `:latest`, and so does CI now.** Two writers to one mutable tag. This is deliberately left alone because nothing reads `:latest` any more — production pins digests — so a race between them cannot reach the running service. `:latest` is advisory from here on.
- **No canary or traffic-shifting.** Single container behind Traefik; the rollback is a restart, which means a brief window of unavailability. Adding a second replica and draining is a real change to the topology and does not belong in a CI PR.

Documented in `docs/operations.md` § *Deploys, and how to undo one*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB

