### PR TITLE
fix(search): remember a tenant's missing HNSW index instead of rediscovering it on every query

### DIFF
--- a/src/admin/hnsw-maintenance.service.ts
+++ b/src/admin/hnsw-maintenance.service.ts
@@ -3,6 +3,7 @@ import type { Surreal } from 'surrealdb';
 import { SurrealService } from '../db/surreal.service';
 import { EmbedderService } from '../ai/embedder.service';
 import { envFlagEnabled } from '../common/env-validation';
+import { probeHnswIndex, resetKnnIndexMemo } from '../db/knn-index';
 
 /**
  * HnswMaintenanceService — per-tenant HNSW index lifecycle.
@@ -193,7 +194,7 @@ const INDEX_SPECS = [
  * with the first probe.
  */
 const DEFAULT_BUILD_WAIT_MS = 60_000;
-const BUILD_POLL_MS = 500;
+const BUILD_POLL_MS = 2_000;
 
 /**
  * The one DEFINE INDEX failure `ensure` treats as success. Measured verbatim
@@ -236,31 +237,44 @@ export class HnswMaintenanceService {
     // `ensure` is concurrent by construction, not by flag — see the
     // docstring. The reported value is what the DDL actually used.
     const concurrent = action === 'ensure' || HnswMaintenanceService.concurrentEnabled();
-    return this.surreal.withCompany(companyId, async (db) => {
-      const created: string[] = [];
+    // The DDL and the first probe share one pool hold; the build WAIT does
+    // not — each poll takes a connection for the INFO statements and gives
+    // it back, so a 60 s wait no longer pins a root-pool slot (and the
+    // migrator, which needs one, cannot deadlock behind it).
+    const created: string[] = [];
+    let builds = await this.surreal.withCompany(companyId, async (db) => {
       if (action === 'create') await this.create(db, dimension, concurrent);
       else if (action === 'drop') await this.drop(db);
       else if (action === 'ensure') created.push(...(await this.ensure(db, dimension)));
-      const builds = await this.probeBuilds(db);
-      const mismatched = builds
-        .filter((b) => b.dimension !== undefined && b.dimension !== dimension)
-        .map((b) => b.index);
-      const ready =
-        action !== 'drop' && mismatched.length === 0 && builds.every((b) => b.state === 'ready');
-      this.report(companyId, { action, dimension, concurrent, ready, builds, mismatched, created });
-      return {
-        companyId,
-        action,
-        dimension,
-        space: this.embedder.primarySpaceId(),
-        indexes: INDEX_SPECS.map((s) => s.index),
-        concurrent,
-        ready,
-        builds,
-        mismatched,
-        created,
-      };
+      return this.probeBuilds(db);
     });
+    // Only an explicit create waits: `ensure` is the provisioner's sweep
+    // action and returns as soon as the DDL is issued (the sweep moves on;
+    // the tenant registry records the build state as it is observed).
+    if (action === 'create' && concurrent && !builds.every((b) => b.state === 'ready')) {
+      builds = await this.waitForBuilds(companyId, builds);
+    }
+    // The legs remember an index they saw missing or building; a build or
+    // drop makes that memory stale on every pod that shares this process.
+    if (action !== 'status') resetKnnIndexMemo();
+    const mismatched = builds
+      .filter((b) => b.dimension !== undefined && b.dimension !== dimension)
+      .map((b) => b.index);
+    const ready =
+      action !== 'drop' && mismatched.length === 0 && builds.every((b) => b.state === 'ready');
+    this.report(companyId, { action, dimension, concurrent, ready, builds, mismatched, created });
+    return {
+      companyId,
+      action,
+      dimension,
+      space: this.embedder.primarySpaceId(),
+      indexes: INDEX_SPECS.map((s) => s.index),
+      concurrent,
+      ready,
+      builds,
+      mismatched,
+      created,
+    };
   }
 
   /** Every log line `apply` emits, kept out of the happy path's way. */
@@ -378,7 +392,6 @@ export class HnswMaintenanceService {
     }
     await this.drop(db);
     for (const spec of INDEX_SPECS) await db.query(define(spec, ' CONCURRENTLY'));
-    await this.waitForBuilds(db);
   }
 
   private async drop(db: Surreal): Promise<void> {
@@ -390,62 +403,40 @@ export class HnswMaintenanceService {
     );
   }
 
-  /** Poll until every build reports ready, or the wait ceiling elapses. */
-  private async waitForBuilds(db: Surreal): Promise<void> {
+  /**
+   * Poll until every build reports ready, or the wait ceiling elapses.
+   * Each poll acquires and releases its own connection; the wait itself
+   * holds nothing. Returns the last observation either way.
+   */
+  private async waitForBuilds(
+    companyId: string,
+    last: HnswIndexBuild[],
+  ): Promise<HnswIndexBuild[]> {
     const deadline = Date.now() + HnswMaintenanceService.buildWaitMs();
-    for (;;) {
-      const builds = await this.probeBuilds(db);
-      if (builds.every((b) => b.state === 'ready')) return;
-      if (Date.now() >= deadline) return;
+    let builds = last;
+    while (Date.now() < deadline) {
       await new Promise((r) => setTimeout(r, BUILD_POLL_MS));
+      builds = await this.surreal.withCompany(companyId, (db) => this.probeBuilds(db));
+      if (builds.every((b) => b.state === 'ready')) return builds;
     }
+    return builds;
   }
 
   /**
-   * Per-index build state. `INFO FOR INDEX` THROWS on an index that does
-   * not exist, so existence is probed on the table first; a synchronously
-   * built index reports no `building` block at all, which is `ready`.
+   * Per-index build state, through the same probe the KNN legs use
+   * (knn-index.ts): `INFO FOR INDEX` THROWS on an index that does not
+   * exist, so existence is probed on the table first; a synchronously built
+   * index reports no `building` block at all, which is `ready`. The probe
+   * also reads the DIMENSION the engine echoes back, which is how a width
+   * mismatch is detected.
    */
   private async probeBuilds(db: Surreal): Promise<HnswIndexBuild[]> {
     const out: HnswIndexBuild[] = [];
     for (const spec of INDEX_SPECS) {
-      out.push({ index: spec.index, table: spec.table, ...(await this.probeOne(db, spec)) });
+      const probe = await probeHnswIndex(db, spec);
+      if (probe.state === 'unknown') this.logger.warn(`hnsw probe failed for ${spec.index}`);
+      out.push({ index: spec.index, table: spec.table, ...probe });
     }
     return out;
-  }
-
-  private async probeOne(
-    db: Surreal,
-    spec: (typeof INDEX_SPECS)[number],
-  ): Promise<Omit<HnswIndexBuild, 'index' | 'table'>> {
-    try {
-      const [info] = await db.query<[{ indexes?: Record<string, string> }]>(
-        `INFO FOR TABLE ${spec.table};`,
-      );
-      const indexes = (info as { indexes?: Record<string, string> } | undefined)?.indexes;
-      const ddl = indexes?.[spec.index];
-      if (typeof ddl !== 'string') return { state: 'absent' };
-      // The declared width, from the DDL the engine echoes back. Absent
-      // (rather than guessed) when the shape is not what we expect, so a
-      // parse miss reads as "not checked", never as "matches".
-      const declared = /DIMENSION\s+(\d+)/i.exec(ddl);
-      const dimension = declared ? { dimension: parseInt(declared[1]!, 10) } : {};
-      const [detail] = await db.query<
-        [{ building?: { status?: string; initial?: number; pending?: number } }]
-      >(`INFO FOR INDEX ${spec.index} ON ${spec.table};`);
-      const building = (
-        detail as { building?: { status?: string; initial?: number; pending?: number } } | undefined
-      )?.building;
-      if (!building || building.status === undefined) return { state: 'ready', ...dimension };
-      return {
-        state: building.status === 'ready' ? 'ready' : 'building',
-        ...(typeof building.initial === 'number' ? { initial: building.initial } : {}),
-        ...(typeof building.pending === 'number' ? { pending: building.pending } : {}),
-        ...dimension,
-      };
-    } catch (e) {
-      this.logger.warn(`hnsw probe failed for ${spec.index}: ${(e as Error).message}`);
-      return { state: 'unknown' };
-    }
   }
 }

--- a/src/db/knn-index.ts
+++ b/src/db/knn-index.ts
@@ -3,40 +3,29 @@ import type { Surreal } from 'surrealdb';
 /**
  * Missing-HNSW-index detection for the `<|k,ef|>` KNN legs.
  *
- * THE DEFECT. SurrealDB does not error when the `<|K,EF|>` operator has no
- * index to ride. It drops the operator from the plan and answers the rest
- * of the statement — `EXPLAIN` shows a bare `TableScan` — so the query
- * returns the first k rows in TABLE ORDER with `vector::distance::knn()`
- * projecting NULL. Measured on `surrealdb/surrealdb:v3.2.4` (3 000 × 1024-d,
- * scratch container):
+ * SurrealDB (3.2.4) does not error when the `<|K,EF|>` operator has no index
+ * to ride — or an index that is still building CONCURRENTLY. It drops the
+ * operator from the plan (`EXPLAIN` shows a bare `TableScan`) and answers
+ * with the table's first k rows in storage order, `vector::distance::knn()`
+ * projecting NULL on every one of them. Every KNN leg was written against
+ * the opposite assumption ("throws when the tenant has no index"), so the
+ * fallback never fired and un-indexed tenants were served unranked rows that
+ * looked exactly like ranked ones. Production runs `SEARCH_HNSW_ENABLED=1`
+ * while index creation is a per-tenant admin call, so that is the common
+ * state, not an edge case.
  *
- *   no index   → [{"knnDist":null,"n":1144},{"knnDist":null,"n":2781}, …]
- *                EXPLAIN → SelectProject → TableScan (no KnnScan node)
- *   index ready→ [{"knnDist":0.8998…,"n":1802},{"knnDist":0.8999…,"n":2007}, …]
+ * THE SIGNAL is the rows themselves: a numeric distance on any row means
+ * the operator ran; NULL on every row means it was dropped. Exact and free.
  *
- * Every KNN leg in this repo was written against the OPPOSITE assumption —
- * "throws when the tenant has no index — the caller falls back to the scan"
- * — so the `catch` that implements the fallback never fires and the leg
- * hands its caller k arbitrary rows with no similarity score. Production
- * runs `SEARCH_HNSW_ENABLED=1` while index creation is a manual per-tenant
- * admin call, so any tenant whose index was never built is served unranked
- * rows that look exactly like ranked ones.
- *
- * THE SIGNAL. `knnDist === null` on every returned row is a DIRECT
- * observation that the operator was not applied — not an inference from an
- * error that never arrives. It costs nothing (the rows are already in hand)
- * and it is exact: when the index rides, SurrealDB projects a number on
- * every row; when it is dropped, it projects NULL on every row.
- *
- * It also covers a second state that `INFO FOR TABLE` alone cannot see.
- * A `DEFINE INDEX … CONCURRENTLY` build EXISTS from the moment the DDL
- * returns but is not usable until it reports `ready`, and during the build
- * the KNN operator is dropped exactly as if no index existed (measured: at
- * `t+0.1s`, `{"initial":16,"pending":0,"status":"indexing"}` returned the
- * same three null-distance rows as the un-indexed table; at `t+1.2s`,
- * `status:"ready"` returned real distances). So "the index exists" is not
- * the property a KNN leg needs — "the operator was applied" is, and that is
- * what this module tests.
+ * THE MEMO. Detecting the drop after the fact still costs the KNN table
+ * scan, the exact scan, and two `INFO` round-trips per query — on every
+ * search, dense-scan lane, ingest mention and dedup seed of an un-indexed
+ * tenant. So a dropped operator is remembered per (namespace, database,
+ * table, index) for `KNN_INDEX_MEMO_TTL_MS`: while the memo is fresh the
+ * legs skip the KNN attempt and run the exact scan directly (one scan, no
+ * diagnostics), and the operator-facing line is emitted once per
+ * `KNN_INDEX_WARN_EVERY_MS` rather than per request. Index builds clear the
+ * memo (`resetKnnIndexMemo`); the TTL bounds the lag when they do not.
  */
 
 /**
@@ -57,59 +46,162 @@ export function knnOperatorDropped(
   return rows.every((row) => typeof (row as Record<string, unknown>)?.[distanceField] !== 'number');
 }
 
-/** What an HNSW index is doing on a tenant, for the diagnostic log. */
+/** What an HNSW index is doing on a tenant. */
 export type HnswIndexState = 'ready' | 'building' | 'absent' | 'unknown';
 
+export interface HnswIndexSpec {
+  table: string;
+  index: string;
+}
+
+export interface HnswIndexProbe {
+  state: HnswIndexState;
+  /** Rows walked by the initial build, when the engine reports it. */
+  initial?: number;
+  /** Rows queued behind the build (live writes), when reported. */
+  pending?: number;
+  /** The DIMENSION the engine echoes back in the index DDL; absent when the
+   *  DDL shape is not the one we expect, so a parse miss reads as "not
+   *  checked", never as "matches". */
+  dimension?: number;
+}
+
+type ProbeDb = Pick<Surreal, 'query'>;
+type MemoDb = ProbeDb & Partial<Pick<Surreal, 'namespace' | 'database'>>;
+/** The legs' logger shape; `debug` is optional because plain objects stand in for Nest's Logger in tests. */
+export interface KnnDiagnosticLogger {
+  warn: (msg: string) => void;
+  error?: (msg: string) => void;
+  debug?: (msg: string) => void;
+}
+
 /**
- * Why the KNN operator was dropped, for the operator-facing log line.
+ * The one INFO probe every consumer shares — read-only and best-effort: any
+ * error answers `unknown` rather than escalating, because a diagnostic must
+ * not turn a recovered query into a failed one.
  *
- * Read-only and best-effort: it runs ONLY on the failure path (never on the
- * hot path), and any error answers `'unknown'` rather than escalating — a
- * diagnostic must not turn a recovered query into a failed one.
- *
- * `INFO FOR TABLE` is the existence probe because `INFO FOR INDEX` THROWS
- * on an absent index ("The index 'x' does not exist"); `INFO FOR INDEX` is
- * then consulted only when the index does exist, to separate a finished
- * index from one still building (`{building:{status:'indexing'|'ready',…}}`).
+ * `INFO FOR TABLE` is the existence probe because `INFO FOR INDEX` THROWS on
+ * an absent index; `INFO FOR INDEX` is then consulted only when the index
+ * exists, to separate a finished index from one still building. A
+ * synchronously built index reports no `building` block at all — `ready`.
  */
-export async function hnswIndexState(
-  db: Pick<Surreal, 'query'>,
-  spec: { table: string; index: string },
-): Promise<HnswIndexState> {
+export async function probeHnswIndex(db: ProbeDb, spec: HnswIndexSpec): Promise<HnswIndexProbe> {
   try {
     const [info] = await db.query<[{ indexes?: Record<string, string> }]>(
       `INFO FOR TABLE ${spec.table};`,
     );
     const indexes = (info as { indexes?: Record<string, string> } | undefined)?.indexes;
-    if (!indexes || typeof indexes[spec.index] !== 'string') return 'absent';
+    const ddl = indexes?.[spec.index];
+    if (typeof ddl !== 'string') return { state: 'absent' };
+    const declared = /DIMENSION\s+(\d+)/i.exec(ddl);
+    const dimension = declared ? { dimension: parseInt(declared[1]!, 10) } : {};
+    const [detail] = await db.query<
+      [{ building?: { status?: string; initial?: number; pending?: number } }]
+    >(`INFO FOR INDEX ${spec.index} ON ${spec.table};`);
+    const building = (
+      detail as { building?: { status?: string; initial?: number; pending?: number } } | undefined
+    )?.building;
+    if (!building || building.status === undefined) return { state: 'ready', ...dimension };
+    return {
+      state: building.status === 'ready' ? 'ready' : 'building',
+      ...(typeof building.initial === 'number' ? { initial: building.initial } : {}),
+      ...(typeof building.pending === 'number' ? { pending: building.pending } : {}),
+      ...dimension,
+    };
   } catch {
-    return 'unknown';
-  }
-  try {
-    const [detail] = await db.query<[{ building?: { status?: string } }]>(
-      `INFO FOR INDEX ${spec.index} ON ${spec.table};`,
-    );
-    const status = (detail as { building?: { status?: string } } | undefined)?.building?.status;
-    if (status === undefined) return 'ready';
-    return status === 'ready' ? 'ready' : 'building';
-  } catch {
-    return 'unknown';
+    return { state: 'unknown' };
   }
 }
 
+/** `probeHnswIndex` reduced to its state. */
+export async function hnswIndexState(db: ProbeDb, spec: HnswIndexSpec): Promise<HnswIndexState> {
+  return (await probeHnswIndex(db, spec)).state;
+}
+
+/** How long a dropped-operator observation keeps the KNN attempt skipped. */
+export const KNN_INDEX_MEMO_TTL_MS = 60_000;
+/** Minimum gap between two operator-facing lines about the same index. */
+export const KNN_INDEX_WARN_EVERY_MS = 60 * 60_000;
+
+interface MemoEntry {
+  state: HnswIndexState;
+  at: number;
+  warnedAt: number;
+}
+
+const memo = new Map<string, MemoEntry>();
+
 /**
- * The single operator-facing sentence for a dropped KNN operator. ERROR,
- * not WARN: with `SEARCH_HNSW_ENABLED=1` this is a live misconfiguration
- * that has been answering searches with unranked rows, and the remedy is
- * one admin call. The exact scan the caller falls back to is the same query
- * every tenant runs with the flag off, so the request is still answered
- * correctly — the shout is about the tenant being un-indexed, not about the
- * request failing.
+ * The memo key: the connection's selected namespace/database plus the index.
+ * A connection that has not selected a database (unit fakes, admin paths)
+ * yields null, which disables the memo for that call — every such call then
+ * behaves as before: probe and log.
  */
-export function knnDroppedMessage(
-  spec: { table: string; index: string },
-  state: HnswIndexState,
-): string {
+export function knnIndexKey(db: MemoDb, spec: HnswIndexSpec): string | null {
+  const ns = db.namespace;
+  const database = db.database;
+  if (!ns || !database) return null;
+  return `${ns}/${database}/${spec.table}/${spec.index}`;
+}
+
+/**
+ * True when this tenant's index was observed absent or still building
+ * within the TTL — the leg should run its exact scan directly instead of
+ * paying for a KNN statement it knows will come back unranked.
+ */
+export function knnIndexKnownUnusable(
+  db: MemoDb,
+  spec: HnswIndexSpec,
+  now: number = Date.now(),
+): boolean {
+  const key = knnIndexKey(db, spec);
+  if (!key) return false;
+  const entry = memo.get(key);
+  if (!entry || now - entry.at >= KNN_INDEX_MEMO_TTL_MS) return false;
+  return entry.state === 'absent' || entry.state === 'building';
+}
+
+/**
+ * Record that a `<|k,ef|>` statement came back with the operator dropped:
+ * find out why (probing at most once per TTL per index), remember it, and
+ * tell the operator — ERROR the first time in an hour (with
+ * `SEARCH_HNSW_ENABLED=1` this is a live misconfiguration whose remedy is
+ * one admin call), a debug crumb after that. Returns the observed state.
+ */
+export async function noteKnnOperatorDropped(
+  db: MemoDb,
+  spec: HnswIndexSpec,
+  opts: { logger?: KnnDiagnosticLogger | undefined; now?: number | undefined } = {},
+): Promise<HnswIndexState> {
+  const { logger } = opts;
+  const now = opts.now ?? Date.now();
+  const key = knnIndexKey(db, spec);
+  const prev = key ? memo.get(key) : undefined;
+  const fresh = prev !== undefined && now - prev.at < KNN_INDEX_MEMO_TTL_MS;
+  const state = fresh ? prev.state : await hnswIndexState(db, spec);
+  const warnedAt = prev?.warnedAt ?? 0;
+  const shout = now - warnedAt >= KNN_INDEX_WARN_EVERY_MS;
+  // `at` is the PROBE time: a cached observation must not extend the skip,
+  // or a tenant could stay skipped indefinitely on repeated observations.
+  if (key) memo.set(key, { state, at: fresh ? prev.at : now, warnedAt: shout ? now : warnedAt });
+  const message = knnDroppedMessage(spec, state);
+  if (shout) (logger?.error ?? logger?.warn)?.(message);
+  else logger?.debug?.(message);
+  return state;
+}
+
+/** Forget every observation — after an index build, or between tests. */
+export function resetKnnIndexMemo(): void {
+  memo.clear();
+}
+
+/**
+ * The single operator-facing sentence for a dropped KNN operator. The exact
+ * scan the caller falls back to is the same query every tenant runs with
+ * the flag off, so the request is still answered correctly — the shout is
+ * about the tenant being un-indexed, not about the request failing.
+ */
+export function knnDroppedMessage(spec: HnswIndexSpec, state: HnswIndexState): string {
   const why =
     state === 'absent'
       ? `index '${spec.index}' does not exist on this tenant — build it with POST /v1/admin/maintenance/hnsw`
@@ -118,6 +210,7 @@ export function knnDroppedMessage(
         : `index '${spec.index}' state could not be determined`;
   return (
     `hnsw KNN operator was DROPPED on ${spec.table} (every row came back with a null ` +
-    `distance, i.e. unranked table-order rows): ${why}. Falling back to the exact scan.`
+    `distance, i.e. unranked table-order rows): ${why}. Falling back to the exact scan` +
+    ` (skipping KNN on this tenant for the next ${KNN_INDEX_MEMO_TTL_MS / 1000}s).`
   );
 }

--- a/src/dreams/dedup.service.ts
+++ b/src/dreams/dedup.service.ts
@@ -5,7 +5,10 @@ import { EntityJudgeService } from '../ai/entity-judge.service';
 import { withSpan } from '../common/tracing';
 import { envFlagEnabled } from '../common/env-validation';
 import { derivedVersionFence } from '../episodes/read-pin.service';
-import { hnswIndexState, knnDroppedMessage, knnOperatorDropped } from '../db/knn-index';
+import { knnIndexKnownUnusable, knnOperatorDropped, noteKnnOperatorDropped } from '../db/knn-index';
+
+/** The index the entity-dedup seed KNN rides — for the diagnostic. */
+const DEDUP_HNSW = { table: 'knowledge_fact', index: 'fact_embedding_hnsw' } as const;
 
 /**
  * DreamsDedupService — find near-duplicate ENTITIES inside a tenant
@@ -225,7 +228,7 @@ export class DreamsDedupService {
           AND entityId.mergedInto IS NONE
           ${fence.clause}`;
     type Row = { entityId: unknown; sim: number };
-    if (envFlagEnabled(process.env.SEARCH_HNSW_ENABLED)) {
+    if (envFlagEnabled(process.env.SEARCH_HNSW_ENABLED) && !knnIndexKnownUnusable(db, DEDUP_HNSW)) {
       const ef = parseInt(process.env.SEARCH_HNSW_EF ?? '100', 10);
       const overfetch = parseInt(process.env.SEARCH_HNSW_OVERFETCH ?? '4', 10);
       const kOver = Math.min(5 * overfetch, 1000);
@@ -246,10 +249,13 @@ export class DreamsDedupService {
         );
         const knnRows = (res[1] as Array<{ entityId: unknown; dist: number }>) ?? [];
         if (knnOperatorDropped(knnRows, 'dist')) {
-          const spec = { table: 'knowledge_fact', index: 'fact_embedding_hnsw' };
-          this.logger.error(
-            `[dreams.dedup] ${knnDroppedMessage(spec, await hnswIndexState(db, spec))}`,
-          );
+          await noteKnnOperatorDropped(db, DEDUP_HNSW, {
+            logger: {
+              warn: (m) => this.logger.warn(`[dreams.dedup] ${m}`),
+              error: (m) => this.logger.error(`[dreams.dedup] ${m}`),
+              debug: (m) => this.logger.debug(`[dreams.dedup] ${m}`),
+            },
+          });
         } else {
           return knnRows.map(({ entityId, dist }) => ({
             entityId,

--- a/src/ingest/entity-resolver.service.ts
+++ b/src/ingest/entity-resolver.service.ts
@@ -5,7 +5,7 @@ import { EmbedderService } from '../ai/embedder.service';
 import { EntityJudgeService, EntityVerdict } from '../ai/entity-judge.service';
 import { envFlagEnabled } from '../common/env-validation';
 import { dbCreate } from '../db/surreal.service';
-import { hnswIndexState, knnDroppedMessage, knnOperatorDropped } from '../db/knn-index';
+import { knnIndexKnownUnusable, knnOperatorDropped, noteKnnOperatorDropped } from '../db/knn-index';
 
 /** The index the name-candidate KNN scan rides — for the diagnostic. */
 const NAME_HNSW = { table: 'knowledge_fact', index: 'fact_embedding_hnsw' } as const;
@@ -282,6 +282,9 @@ export class EntityResolverService {
     db: Surreal,
     q: number[],
   ): Promise<Array<{ entityId: unknown; etype: string; sim: number }> | null> {
+    // Observed un-indexed within the memo TTL: let the caller run its exact
+    // scan without paying for a KNN statement that comes back unranked.
+    if (knnIndexKnownUnusable(db, NAME_HNSW)) return null;
     const kOver = Math.min(this.candidateK * this.hnswOverfetch, 1000);
     // `<|K,EF|>` takes literals, not params — kOver/ef are validated ints.
     // vector::distance::knn() reuses the walk's distance — projecting a
@@ -304,9 +307,13 @@ export class EntityResolverService {
     );
     const knnRows = (rows as Array<{ entityId: unknown; etype: string; dist: number }>) ?? [];
     if (knnOperatorDropped(knnRows, 'dist')) {
-      this.logger.error(
-        `[ingest.inline_resolution] ${knnDroppedMessage(NAME_HNSW, await hnswIndexState(db, NAME_HNSW))}`,
-      );
+      await noteKnnOperatorDropped(db, NAME_HNSW, {
+        logger: {
+          warn: (m) => this.logger.warn(`[ingest.inline_resolution] ${m}`),
+          error: (m) => this.logger.error(`[ingest.inline_resolution] ${m}`),
+          debug: (m) => this.logger.debug(`[ingest.inline_resolution] ${m}`),
+        },
+      });
       return null;
     }
     return knnRows.map(({ dist, ...rest }) => ({

--- a/src/search/internals/legs.ts
+++ b/src/search/internals/legs.ts
@@ -3,7 +3,11 @@ import type { EmbedderService } from '../../ai/embedder.service';
 import type { FactRow } from './types';
 import type { SearchTuning } from '../retrieval-profile';
 import { buildEdgeFence, type EdgeFence } from './edge-fence';
-import { hnswIndexState, knnDroppedMessage, knnOperatorDropped } from '../../db/knn-index';
+import {
+  knnIndexKnownUnusable,
+  knnOperatorDropped,
+  noteKnnOperatorDropped,
+} from '../../db/knn-index';
 
 /** The index the fact vector leg rides; named here for the diagnostic. */
 const FACT_HNSW = { table: 'knowledge_fact', index: 'fact_embedding_hnsw' } as const;
@@ -79,24 +83,17 @@ export async function runVectorLeg({
   //
   //   - the statement throws → the legacy catch below;
   //   - the statement SUCCEEDS with the KNN operator silently dropped from
-  //     the plan, because the tenant has no (or a still-building) index.
-  //     SurrealDB then answers with the table's first k rows and a NULL
-  //     distance on each — unranked rows that are indistinguishable from
-  //     ranked ones downstream. See src/db/knn-index.ts for the 3.2.4
-  //     measurement.
+  //     the plan, because the tenant has no (or a still-building) index —
+  //     unranked table-order rows with a NULL distance (src/db/knn-index.ts).
   //
-  // The second case is the one production is in: SEARCH_HNSW_ENABLED=1 is
-  // set globally while index creation is a manual per-tenant admin call.
-  // Both now fall back to the exact scan below, which is byte-identical to
-  // what the tenant is served with the flag off.
-  if (tuning.hnswEnabled) {
+  // Both fall back to the exact scan below, byte-identical to what the
+  // tenant is served with the flag off. A tenant observed un-indexed within
+  // the memo TTL skips the KNN attempt outright — one scan, no diagnostics.
+  if (tuning.hnswEnabled && !knnIndexKnownUnusable(db, FACT_HNSW)) {
     try {
       const knnRows = await runVectorLegKnn({ db, queryEmbedding, k, baseWhere, tuning });
       if (knnRows !== null) return knnRows;
-      const state = await hnswIndexState(db, FACT_HNSW);
-      const message = knnDroppedMessage(FACT_HNSW, state);
-      if (logger?.error) logger.error(message);
-      else logger?.warn(message);
+      await noteKnnOperatorDropped(db, FACT_HNSW, { logger });
     } catch (e) {
       logger?.warn(`hnsw vector leg fell back to full scan: ${(e as Error).message}`);
     }

--- a/src/synthesize/scan-leg.ts
+++ b/src/synthesize/scan-leg.ts
@@ -1,6 +1,6 @@
 import type { Surreal } from 'surrealdb';
 import type { CoverageScanMode } from '../search/retrieval-profile';
-import { hnswIndexState, knnDroppedMessage, knnOperatorDropped } from '../db/knn-index';
+import { knnIndexKnownUnusable, knnOperatorDropped, noteKnnOperatorDropped } from '../db/knn-index';
 
 /** The HNSW index each coverage-scan table rides — for the diagnostic. */
 const SCAN_HNSW: Record<DenseScanLegRequest['table'], string> = {
@@ -80,6 +80,9 @@ export interface DenseScanLegRequest {
 export async function runDenseScanLeg<Row>(req: DenseScanLegRequest): Promise<Row[]> {
   const { db, params, k, tuning, logger } = req;
   if (tuning.mode !== 'hnsw') return runBrute(req);
+  const spec = { table: req.table, index: SCAN_HNSW[req.table] };
+  // Observed un-indexed within the memo TTL: straight to the brute scan.
+  if (knnIndexKnownUnusable(db, spec)) return runBrute(req);
   const kOver = Math.min(k * tuning.overfetch, SCAN_KNN_K_CAP);
   // ef below the candidate count is never useful in HNSW; the knob only
   // matters when raised ABOVE the overfetched k.
@@ -107,10 +110,7 @@ export async function runDenseScanLeg<Row>(req: DenseScanLegRequest): Promise<Ro
       params,
     );
     if (knnOperatorDropped(rows, 'knnDist')) {
-      const spec = { table: req.table, index: SCAN_HNSW[req.table] };
-      const message = knnDroppedMessage(spec, await hnswIndexState(db, spec));
-      if (logger?.error) logger.error(message);
-      else logger?.warn(message);
+      await noteKnnOperatorDropped(db, spec, { logger });
       return runBrute(req);
     }
     if (rows && rows.length > 0) {

--- a/test/knn-index-memo.unit-spec.ts
+++ b/test/knn-index-memo.unit-spec.ts
@@ -1,0 +1,271 @@
+/**
+ * The dropped-KNN-operator memo (review 2026-09-09, V-3).
+ *
+ * Detecting a dropped `<|k,ef|>` operator after the fact used to cost, on
+ * EVERY query of an un-indexed tenant: the KNN table scan, two INFO
+ * round-trips, an ERROR log line, then the exact scan. With
+ * `SEARCH_HNSW_ENABLED=1` global and index creation per tenant, that was
+ * the steady state of production. These pin the memo: skip the KNN attempt
+ * while the observation is fresh, probe once per TTL, shout once per hour.
+ */
+import {
+  KNN_INDEX_MEMO_TTL_MS,
+  KNN_INDEX_WARN_EVERY_MS,
+  knnIndexKnownUnusable,
+  noteKnnOperatorDropped,
+  resetKnnIndexMemo,
+} from '../src/db/knn-index';
+import { runVectorLeg } from '../src/search/internals/legs';
+import { HnswMaintenanceService } from '../src/admin/hnsw-maintenance.service';
+
+const SPEC = { table: 'knowledge_fact', index: 'fact_embedding_hnsw' };
+const INFO_TABLE_NO_INDEX = [{ events: {}, fields: {}, indexes: {}, lives: {}, tables: {} }];
+const INFO_TABLE_WITH_INDEX = [
+  {
+    events: {},
+    fields: {},
+    indexes: { fact_embedding_hnsw: 'DEFINE INDEX …' },
+    lives: {},
+    tables: {},
+  },
+];
+
+/** A tenant-selected connection whose successive queries answer in order. */
+function tenantDb(results: unknown[][], database = 'co_x') {
+  const calls: string[] = [];
+  let i = 0;
+  return {
+    namespace: 'brain',
+    database,
+    calls,
+    query: jest.fn(async (sql: string) => {
+      calls.push(sql);
+      const r = results[Math.min(i, results.length - 1)];
+      i += 1;
+      return r;
+    }),
+  };
+}
+
+function recordingLogger() {
+  const errors: string[] = [];
+  const debugs: string[] = [];
+  return {
+    errors,
+    debugs,
+    logger: {
+      warn: () => {},
+      error: (m: string) => errors.push(m),
+      debug: (m: string) => debugs.push(m),
+    },
+  };
+}
+
+beforeEach(() => resetKnnIndexMemo());
+
+describe('knn index memo', () => {
+  it('is inert for a connection with no selected database (unit fakes, admin paths)', async () => {
+    const db = { query: jest.fn(async () => INFO_TABLE_NO_INDEX) };
+    const { logger, errors } = recordingLogger();
+    await noteKnnOperatorDropped(db as never, SPEC, { logger });
+    await noteKnnOperatorDropped(db as never, SPEC, { logger });
+    // No key → no memo: probed and shouted both times, exactly as before.
+    expect(db.query).toHaveBeenCalledTimes(2);
+    expect(errors).toHaveLength(2);
+    expect(knnIndexKnownUnusable(db as never, SPEC)).toBe(false);
+  });
+
+  it('probes once per TTL, shouts once per hour, and marks the tenant unusable meanwhile', async () => {
+    const db = tenantDb([INFO_TABLE_NO_INDEX]);
+    const { logger, errors, debugs } = recordingLogger();
+    const t0 = 1_800_000_000_000;
+
+    expect(await noteKnnOperatorDropped(db as never, SPEC, { logger, now: t0 })).toBe('absent');
+    expect(db.calls).toEqual(['INFO FOR TABLE knowledge_fact;']);
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain('/v1/admin/maintenance/hnsw');
+    expect(knnIndexKnownUnusable(db as never, SPEC, t0 + 1)).toBe(true);
+
+    // Inside the TTL: no probe, no shout — and no extension of the skip.
+    await noteKnnOperatorDropped(db as never, SPEC, {
+      logger,
+      now: t0 + KNN_INDEX_MEMO_TTL_MS - 1,
+    });
+    expect(db.calls).toHaveLength(1);
+    expect(errors).toHaveLength(1);
+    expect(debugs).toHaveLength(1);
+
+    // Past the TTL: the skip lapses and the next drop probes again — but
+    // the operator has already been told this hour.
+    expect(knnIndexKnownUnusable(db as never, SPEC, t0 + KNN_INDEX_MEMO_TTL_MS)).toBe(false);
+    await noteKnnOperatorDropped(db as never, SPEC, { logger, now: t0 + KNN_INDEX_MEMO_TTL_MS });
+    expect(db.calls).toHaveLength(2);
+    expect(errors).toHaveLength(1);
+    expect(debugs).toHaveLength(2);
+
+    // An hour on, the shout is due again.
+    await noteKnnOperatorDropped(db as never, SPEC, { logger, now: t0 + KNN_INDEX_WARN_EVERY_MS });
+    expect(errors).toHaveLength(2);
+  });
+
+  it('keys per tenant database and per index', async () => {
+    const a = tenantDb([INFO_TABLE_NO_INDEX], 'co_a');
+    const b = tenantDb([INFO_TABLE_NO_INDEX], 'co_b');
+    await noteKnnOperatorDropped(a as never, SPEC);
+    expect(knnIndexKnownUnusable(a as never, SPEC)).toBe(true);
+    expect(knnIndexKnownUnusable(b as never, SPEC)).toBe(false);
+    expect(
+      knnIndexKnownUnusable(a as never, {
+        table: 'episode_segment',
+        index: 'segment_embedding_hnsw',
+      }),
+    ).toBe(false);
+  });
+
+  it('does not skip on an inconclusive probe, and forgets everything on reset', async () => {
+    const failing = {
+      namespace: 'brain',
+      database: 'co_x',
+      query: jest.fn(async () => {
+        throw new Error('connection reset');
+      }),
+    };
+    expect(await noteKnnOperatorDropped(failing as never, SPEC)).toBe('unknown');
+    // `unknown` could be transient: keep trying the index.
+    expect(knnIndexKnownUnusable(failing as never, SPEC)).toBe(false);
+
+    const absent = tenantDb([INFO_TABLE_NO_INDEX], 'co_y');
+    await noteKnnOperatorDropped(absent as never, SPEC);
+    expect(knnIndexKnownUnusable(absent as never, SPEC)).toBe(true);
+    resetKnnIndexMemo();
+    expect(knnIndexKnownUnusable(absent as never, SPEC)).toBe(false);
+  });
+
+  it('a still-building index is skipped too (it serves the same unranked rows)', async () => {
+    const db = tenantDb([
+      INFO_TABLE_WITH_INDEX,
+      [{ building: { initial: 16, pending: 0, status: 'indexing' } }],
+    ]);
+    expect(await noteKnnOperatorDropped(db as never, SPEC)).toBe('building');
+    expect(knnIndexKnownUnusable(db as never, SPEC)).toBe(true);
+  });
+});
+
+describe('search vector leg with the memo', () => {
+  const embedder = { embed: async () => [0.1, 0.2, 0.3] };
+  const tuning = {
+    combinedVectorGraph: false,
+    hnswEnabled: true,
+    hnswEf: 100,
+    hnswOverfetch: 4,
+    highlightEnabled: false,
+  };
+  const legArgs = (db: unknown, logger: unknown) => ({
+    db: db as never,
+    embedder: embedder as never,
+    query: 'who is ada',
+    k: 5,
+    baseWhere: { sql: '', params: {} },
+    tuning,
+    logger: logger as never,
+  });
+
+  it('pays the KNN scan and the probe once, then goes straight to the exact scan', async () => {
+    const { logger, errors } = recordingLogger();
+    const first = tenantDb([
+      [[{ id: 'f1', knnDist: null }]],
+      INFO_TABLE_NO_INDEX,
+      [[{ id: 'f9', simScore: 0.91 }]],
+    ]);
+    expect(await runVectorLeg(legArgs(first, logger))).toEqual([{ id: 'f9', simScore: 0.91 }]);
+    expect(first.calls).toHaveLength(3);
+    expect(errors).toHaveLength(1);
+
+    // Same tenant, another pooled connection: one statement, no diagnostics.
+    const second = tenantDb([[[{ id: 'f9', simScore: 0.91 }]]]);
+    expect(await runVectorLeg(legArgs(second, logger))).toEqual([{ id: 'f9', simScore: 0.91 }]);
+    expect(second.calls).toHaveLength(1);
+    expect(second.calls[0]).toContain('vector::similarity::cosine');
+    expect(errors).toHaveLength(1);
+  });
+});
+
+describe('hnsw maintenance and the memo', () => {
+  const INFO = (state: 'ready' | 'absent') => [
+    {
+      events: {},
+      fields: {},
+      indexes:
+        state === 'absent'
+          ? {}
+          : Object.fromEntries(
+              [
+                'fact_embedding_hnsw',
+                'fact_alt_embedding_hnsw',
+                'entity_embedding_hnsw',
+                'segment_embedding_hnsw',
+              ].map((n) => [n, `DEFINE INDEX ${n} …`]),
+            ),
+      lives: {},
+      tables: {},
+    },
+  ];
+
+  function maintenance(state: 'ready' | 'indexing') {
+    const withCompany = jest.fn(async <T>(_c: string, fn: (d: unknown) => Promise<T>) =>
+      fn({
+        namespace: 'brain',
+        database: 'co_x',
+        query: async (sql: string) => {
+          if (sql.startsWith('INFO FOR TABLE')) return INFO('ready');
+          if (sql.startsWith('INFO FOR INDEX')) return [{ building: { status: state } }];
+          return [null];
+        },
+      }),
+    );
+    const svc = new HnswMaintenanceService(
+      { withCompany } as never,
+      { primaryDimensions: () => 1024, primarySpaceId: () => 'bge-m3:Xenova/bge-m3:1024' } as never,
+    );
+    return { svc, withCompany };
+  }
+
+  afterEach(() => {
+    delete process.env.SEARCH_HNSW_CONCURRENT;
+    delete process.env.SEARCH_HNSW_BUILD_WAIT_MS;
+    jest.useRealTimers();
+  });
+
+  it('a build clears the memo so the legs try the index again at once', async () => {
+    const tenant = tenantDb([INFO_TABLE_NO_INDEX]);
+    await noteKnnOperatorDropped(tenant as never, SPEC);
+    expect(knnIndexKnownUnusable(tenant as never, SPEC)).toBe(true);
+    process.env.SEARCH_HNSW_BUILD_WAIT_MS = '0';
+    await maintenance('ready').svc.apply('co_x', 'create');
+    expect(knnIndexKnownUnusable(tenant as never, SPEC)).toBe(false);
+  });
+
+  it("action:'status' leaves the memo alone", async () => {
+    const tenant = tenantDb([INFO_TABLE_NO_INDEX]);
+    await noteKnnOperatorDropped(tenant as never, SPEC);
+    await maintenance('ready').svc.apply('co_x', 'status');
+    expect(knnIndexKnownUnusable(tenant as never, SPEC)).toBe(true);
+  });
+
+  it('waits for a concurrent build with a fresh pool hold per poll, never one long one', async () => {
+    jest.useFakeTimers();
+    process.env.SEARCH_HNSW_CONCURRENT = '1';
+    process.env.SEARCH_HNSW_BUILD_WAIT_MS = '2500';
+    const { svc, withCompany } = maintenance('indexing');
+    const pending = svc.apply('co_x', 'create');
+    await jest.advanceTimersByTimeAsync(0);
+    // DDL + first probe: one hold, released before the wait begins.
+    expect(withCompany).toHaveBeenCalledTimes(1);
+    await jest.advanceTimersByTimeAsync(2_000);
+    expect(withCompany).toHaveBeenCalledTimes(2);
+    await jest.advanceTimersByTimeAsync(2_000);
+    const res = await pending;
+    expect(withCompany).toHaveBeenCalledTimes(3);
+    expect(res.ready).toBe(false);
+  });
+});


### PR DESCRIPTION
From the review of the #501 wave (V-3, V-9, and the duplicated INFO probe).

## What was wrong

With `SEARCH_HNSW_ENABLED=1` global and index creation a per-tenant admin call, an **un-indexed tenant is the common state**. Since #506 every KNN leg correctly detects the dropped `<|k,ef|>` operator from the null distances — and then, on *every* query of that tenant, paid the KNN table scan, two `INFO` round-trips, an ERROR log line, and finally the exact scan. On search, both dense-scan lanes, ingest mention resolution and the dedup seed loop. `knn-index.ts` said the probe "runs ONLY on the failure path" — true per call, false in aggregate: the failure path *is* the hot path for those tenants.

## What changed

- **Memo** per (namespace, database, table, index), 60 s TTL. While fresh, the legs skip the KNN attempt and run the exact scan directly — one statement, no diagnostics. The operator line is emitted once per hour per index (ERROR the first time: still a live misconfiguration with a one-call remedy; debug after). The memo records the *probe* time, so a cached observation never extends the skip; an inconclusive probe (`unknown`) is not memoised as unusable. A build or drop via `HnswMaintenanceService` clears the memo; the TTL bounds the lag when a build happens on another pod.
- **One probe.** `probeHnswIndex` in `knn-index.ts` now serves both the legs and the maintenance service (which had its own copy and its own identical state union).
- **Poll without the pool hold** (V-9): the concurrent-build wait ran 8 `INFO` statements every 500 ms for up to 60 s inside a single root-pool `withCompany`. Each poll now acquires and releases its own connection, every 2 s.

Connections without a selected database (unit fakes, admin paths) have no memo key and behave exactly as before, so the existing #506 tests are untouched.

## Proof

- `test/knn-index-memo.unit-spec.ts` — probe once per TTL, shout once per hour, no extension on cached observations, per-tenant/per-index keys, `unknown` not skipped, a `building` index skipped; vector leg pays the scan+probe once then goes straight to the exact scan; a build clears the memo, `status` does not; the wait takes a fresh pool hold per poll.
- Existing `knn-missing-index`, `hnsw-concurrent-build`, entity-resolver, dedup and scan-leg specs unchanged and green; `hnsw` e2e against a real SurrealDB 3.2.4 (3 suites / 11); full unit suite 404 suites / 4934; tsc, eslint, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhrQxeisXJZEt4sg3PGyU6
