### PR TITLE
fix(feedback): a vote must pass the fact's visibility fence, not just an existence check

### DIFF
--- a/src/feedback/feedback.controller.ts
+++ b/src/feedback/feedback.controller.ts
@@ -21,6 +21,7 @@ export class FeedbackController {
       verdict: body.verdict,
       reason: body.reason,
       actor: req.brainAuth.keyHash,
+      scopes: req.brainAuth.scopes,
     });
   }
 }

--- a/src/feedback/feedback.module.ts
+++ b/src/feedback/feedback.module.ts
@@ -1,11 +1,12 @@
 import { Module } from '@nestjs/common';
 import { OutcomesModule } from '../outcomes/outcomes.module';
+import { FactsModule } from '../facts/facts.module';
 import { FeedbackController } from './feedback.controller';
 import { FeedbackService } from './feedback.service';
 
 @Module({
   // OutcomesModule supplies the 0107 confirmed/rejected outcome writer.
-  imports: [OutcomesModule],
+  imports: [OutcomesModule, FactsModule],
   controllers: [FeedbackController],
   providers: [FeedbackService],
   exports: [FeedbackService],

--- a/src/feedback/feedback.service.ts
+++ b/src/feedback/feedback.service.ts
@@ -1,4 +1,6 @@
-import { Injectable, Logger, NotFoundException, Optional } from '@nestjs/common';
+import { Injectable, Logger, Optional } from '@nestjs/common';
+import type { BrainScope } from '../auth/api-key.types';
+import { FactsService } from '../facts/facts.service';
 import { StringRecordId } from 'surrealdb';
 import { SurrealService } from '../db/surreal.service';
 import { MetricsService } from '../metrics/metrics.service';
@@ -55,8 +57,10 @@ const OUTCOME_BUCKET: Record<FeedbackVerdict, OutcomeCounter | null> = {
 export class FeedbackService {
   private readonly logger = new Logger(FeedbackService.name);
 
+  // eslint-disable-next-line max-params -- Nest DI constructor; each param is an injection token
   constructor(
     private readonly surreal: SurrealService,
+    private readonly facts: FactsService,
     @Optional() private readonly metrics?: MetricsService,
     @Optional() private readonly outcomes?: MemoryOutcomeService,
   ) {}
@@ -67,16 +71,17 @@ export class FeedbackService {
     verdict: FeedbackVerdict;
     reason?: string | undefined;
     actor: string;
+    /** The caller's scopes — the visibility fence is the read path's. */
+    scopes: readonly BrainScope[];
   }): Promise<RecordFeedbackResult> {
+    // A vote changes a fact's trust signals, so the caller must be allowed
+    // to SEE the fact: same tenant, same user scope (a user-bound token
+    // cannot rate another user's personal memory), same row policy. This
+    // is the read path's own fence (FactsService.getFact) and it answers
+    // 404 for every miss, so existence never leaks through a 201/404 split.
+    // Before this, `brain:write` plus a guessed id was enough.
+    await this.facts.getFact({ companyId: p.companyId, factId: p.factId, scopes: p.scopes });
     return this.surreal.withCompany(p.companyId, async (db) => {
-      const [factRows] = await db.query<[Array<{ id: unknown }>]>(
-        `SELECT id FROM type::record('knowledge_fact', $tail)`,
-        { tail: idTailOf(p.factId) },
-      );
-      if (!((factRows as Array<{ id: unknown }>) ?? [])[0]) {
-        throw new NotFoundException('fact not found');
-      }
-
       const fact = new StringRecordId(`knowledge_fact:${idTailOf(p.factId)}`);
       // One standing vote per (fact, actor): the UNIQUE index routes a
       // repeat into the UPDATE branch — verdict replaced, not stacked.

--- a/src/mcp/write-tools.ts
+++ b/src/mcp/write-tools.ts
@@ -249,7 +249,7 @@ export function registerWriteTools({
     },
   );
 
-  registerFeedbackTool({ server, companyId, deps, actorKeyHash });
+  registerFeedbackTool({ server, companyId, deps, actorKeyHash, scopes });
 
   // ── record_procedure ───────────────────────────────────────────
   server.registerTool(
@@ -320,11 +320,13 @@ function registerFeedbackTool({
   companyId,
   deps,
   actorKeyHash,
+  scopes,
 }: {
   server: McpServer;
   companyId: string;
   deps: WriteToolDeps;
   actorKeyHash?: string | undefined;
+  scopes: readonly BrainScope[];
 }): void {
   if (!deps.feedback) return;
   const feedback = deps.feedback;
@@ -347,6 +349,7 @@ function registerFeedbackTool({
         verdict: args.verdict,
         ...(args.reason !== undefined ? { reason: args.reason } : {}),
         actor: actorKeyHash ?? `mcp:${companyId}`,
+        scopes,
       });
       return {
         content: [{ type: 'text', text: JSON.stringify(out, null, 2) }],

--- a/test/feedback.e2e-spec.ts
+++ b/test/feedback.e2e-spec.ts
@@ -13,7 +13,12 @@ describe('retrieval feedback loop', () => {
   const auth = () => ({ Authorization: `Bearer ${f.apiKey}` });
 
   beforeAll(async () => {
-    f = await createApp({ companyId: 'co_feedback_e2e' });
+    f = await createApp({
+      companyId: 'co_feedback_e2e',
+      // A USER-BOUND key: may read tenant-global facts and its own user's,
+      // never another user's personal memory (0055).
+      extraKeys: [{ scopes: ['brain:read', 'brain:write'], userId: 'bob' }],
+    });
   });
 
   afterAll(async () => {
@@ -95,5 +100,48 @@ describe('retrieval feedback loop', () => {
       expect(trust!.lossCount).toBeGreaterThanOrEqual(1);
       expect(trust!.sampleCount).toBeGreaterThanOrEqual(2);
     });
+  });
+
+  it("a user-bound key cannot rate another user's personal fact — 404, never 201", async () => {
+    // F2 (audit 2026-09-06): feedback used to check only that the fact id
+    // existed, so `brain:write` plus a guessed id could move the trust
+    // signals of a fact the caller was not allowed to see, and the 404/201
+    // split confirmed the id existed. The vote now passes the read path's
+    // own visibility fence.
+    const ingest = await f.http
+      .post('/v1/ingest/fact')
+      .set(auth())
+      .send({
+        entityRef: { vertical: 'rent', id: 'fb_alice_subject' },
+        predicate: 'tier',
+        object: 'platinum',
+        validFrom: '2026-01-01',
+        confidence: 0.9,
+        userId: 'alice',
+        source: { vertical: 'rent', recorder: 'fb_bot' },
+      });
+    expect(ingest.status).toBe(201);
+    const factId = ingest.body.factId as string;
+
+    const asBob = { Authorization: `Bearer ${f.extraApiKeys[0]}` };
+    const foreign = await f.http
+      .post('/v1/feedback')
+      .set(asBob)
+      .send({ factId, verdict: 'incorrect' });
+    expect(foreign.status).toBe(404);
+
+    // The tenant-wide (M2M) key still may.
+    const own = await f.http.post('/v1/feedback').set(auth()).send({ factId, verdict: 'helpful' });
+    expect(own.status).toBe(201);
+
+    const surreal = f.app.get(SurrealService);
+    const votes = await surreal.withCompany(f.companyId, async (db) => {
+      const [rows] = await db.query<[unknown[]]>(
+        `SELECT id FROM retrieval_feedback WHERE factId = type::record($fid)`,
+        { fid: factId },
+      );
+      return (rows as unknown[]) ?? [];
+    });
+    expect(votes).toHaveLength(1);
   });
 });


### PR DESCRIPTION
Audit 2026-09-06 **F2** (P1), reproduced there against a real DB: `POST /v1/feedback` (and the MCP `record_feedback` tool) checked only that the fact id existed. A user-bound token could move the trust signals — and, at the nightly refit, the source reputation — of another user's personal fact it was never allowed to read; the 404-on-read / 201-on-feedback split also confirmed the id existed.

## Change
- `FeedbackService.record` runs the read path's own fence first — `FactsService.getFact` (tenant, user scope 0055, scope tags, row policy) — and answers **404 for every miss**, exactly like `GET /v1/facts/:id`. The bespoke existence check is gone.
- The caller's scopes travel with the request on both surfaces (HTTP controller, MCP tool via the session's scopes). `FeedbackModule` imports `FactsModule`.

## Proof
`test/feedback.e2e-spec.ts` (real SurrealDB): a user-bound key gets 404 on another user's fact and leaves no vote behind; the tenant-wide key still gets 201. Existing feedback / MCP e2e and unit specs unchanged; tsc, eslint, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhrQxeisXJZEt4sg3PGyU6
