### PR TITLE
fix(compaction): keep the recompose changefeed cursor bigint so the nightly job stops failing on 3.x

### DIFF
--- a/src/compaction/recompose.service.ts
+++ b/src/compaction/recompose.service.ts
@@ -28,15 +28,22 @@ const CURSOR = 'recompose:knowledge_fact';
  */
 const CONTENT_CHANGED = new Set(['superseded', 'retracted']);
 
-/** One `SHOW CHANGES` batch row: a versionstamp plus its changefeed items. */
+/**
+ * One `SHOW CHANGES` batch row: a versionstamp plus its changefeed items.
+ *
+ * On SurrealDB 3.x the versionstamp is a u64 (~1.17e17 — above
+ * Number.MAX_SAFE_INTEGER) and the SDK hands it over as a bigint. A unit
+ * stub may still emit a plain number; both are normalised with BigInt() at
+ * the one place they are read.
+ */
 interface ShowChangesRow {
-  versionstamp?: number | string;
+  versionstamp?: number | bigint | string;
   changes?: unknown[];
 }
 
 /** The `changefeed_state` cursor row this pass reads/advances. */
 interface CursorRow {
-  lastVersionstamp?: number;
+  lastVersionstamp?: number | bigint;
 }
 
 /** A stale compaction summary awaiting re-derivation. */
@@ -179,7 +186,12 @@ export class RecomposeService implements OnModuleInit {
       let highest = since;
       const changed: string[] = [];
       for (const c of changes) {
-        const vs = Number(c.versionstamp ?? 0);
+        // bigint, never Number(): a 3.x versionstamp does not fit a double,
+        // and the SDK refuses to encode an unsafe integer back into the cursor
+        // UPSERT ("Number too big to be encoded") — which is how every nightly
+        // recompose failed in production while the unit stub's small integers
+        // kept passing. Same idiom as changefeed-drain.service.ts.
+        const vs = BigInt(c.versionstamp ?? 0);
         // SINCE is inclusive of the boundary — skip the row the cursor sits on.
         if (vs <= since) continue;
         if (vs > highest) highest = vs;
@@ -376,16 +388,21 @@ export class RecomposeService implements OnModuleInit {
   }
 }
 
-async function loadCursor(db: Surreal): Promise<number> {
+/**
+ * bigint throughout — see ShowChangesRow. BigInt() accepts the stored int
+ * (number or bigint) and the 0 cold-start default alike, and a bigint
+ * interpolates into `SINCE ${since}` as plain digits.
+ */
+async function loadCursor(db: Surreal): Promise<bigint> {
   const row = await queryFirst<CursorRow>(
     db,
     `SELECT lastVersionstamp FROM changefeed_state WHERE source = $s LIMIT 1`,
     { s: CURSOR },
   );
-  return row?.lastVersionstamp ?? 0;
+  return BigInt(row?.lastVersionstamp ?? 0);
 }
 
-async function advanceCursor(db: Surreal, versionstamp: number): Promise<void> {
+async function advanceCursor(db: Surreal, versionstamp: bigint): Promise<void> {
   await db.query(
     `UPSERT changefeed_state:[$s] CONTENT {
        source: $s, lastVersionstamp: $v, updatedAt: time::now()

--- a/test/recompose-cursor.e2e-spec.ts
+++ b/test/recompose-cursor.e2e-spec.ts
@@ -1,0 +1,89 @@
+/**
+ * Recompose changefeed cursor against a REAL SurrealDB — regression for the
+ * nightly `recompose` job failing on every run since the 3.1.5 upgrade with
+ * `CborNumberError: Number too big to be encoded`.
+ *
+ * A 3.x `SHOW CHANGES` versionstamp is a u64 (~1.17e17, above
+ * Number.MAX_SAFE_INTEGER). `invalidate()` funnelled it through Number()
+ * and then bound the result into the cursor UPSERT, which the SDK refuses to
+ * encode. The unit suite stubs small integers and no e2e drove
+ * `invalidate()` against the real changefeed, so CI never saw it — the same
+ * blind spot as the compaction `d$cutoff` regression (compaction.e2e-spec).
+ *
+ * The drain must (1) not throw, (2) leave the cursor at the real u64 stamp,
+ * (3) be a no-op on the next run — SINCE is inclusive, so a cursor that was
+ * rounded or truncated would re-mark the same change forever.
+ */
+import { AppFixture, createApp } from './app-fixture';
+import { SurrealService } from '../src/db/surreal.service';
+import { RecomposeService } from '../src/compaction/recompose.service';
+
+const CURSOR = 'recompose:knowledge_fact';
+
+describe('recompose changefeed cursor (real SurrealDB)', () => {
+  let f: AppFixture;
+  const auth = () => ({ Authorization: `Bearer ${f.apiKey}` });
+
+  beforeAll(async () => {
+    f = await createApp({ companyId: 'co_recompose_cursor_e2e' });
+  });
+
+  afterAll(async () => {
+    if (f) await f.close();
+  });
+
+  async function cursorValue(): Promise<bigint | null> {
+    const surreal = f.app.get(SurrealService);
+    return surreal.withCompany(f.companyId, async (db) => {
+      const [rows] = await db.query<[Array<{ lastVersionstamp: number | bigint }>]>(
+        `SELECT lastVersionstamp FROM changefeed_state WHERE source = $s LIMIT 1`,
+        { s: CURSOR },
+      );
+      const row = (rows as Array<{ lastVersionstamp: number | bigint }>)[0];
+      return row ? BigInt(row.lastVersionstamp) : null;
+    });
+  }
+
+  it('drains a u64 versionstamp without throwing, and the next run is a no-op', async () => {
+    const ingest = await f.http
+      .post('/v1/ingest/fact')
+      .set(auth())
+      .send({
+        entityRef: { vertical: 'rent', id: 'recompose_cursor_subject' },
+        predicate: 'claim_probe',
+        object: 'a claim whose retraction lands on the changefeed',
+        validFrom: '2026-01-01',
+        confidence: 0.9,
+        source: { vertical: 'rent', recorder: 'bot' },
+      });
+    expect([200, 201]).toContain(ingest.status);
+    const factId = ingest.body.factId as string;
+
+    // A content change the drain must act on (not merely skip): the fact
+    // goes 'retracted', which is in CONTENT_CHANGED, so invalidate() takes
+    // the mark_derived_stale + advanceCursor path — the one that threw.
+    const surreal = f.app.get(SurrealService);
+    await surreal.withCompany(f.companyId, async (db) => {
+      await db.query(
+        `UPDATE type::record('knowledge_fact', $tail)
+           SET status = 'retracted', retractedAt = time::now()`,
+        { tail: factId.split(':')[1] },
+      );
+    });
+
+    const recompose = f.app.get(RecomposeService);
+    await expect(recompose.invalidate(f.companyId)).resolves.toBeGreaterThanOrEqual(0);
+
+    const after = await cursorValue();
+    expect(after).not.toBeNull();
+    // The stamp the server actually issues — a u64 the old Number() path
+    // could neither represent nor re-encode. If this ever fails with a small
+    // value, the stand's versionstamp scheme changed, not the drain.
+    expect(after! > BigInt(Number.MAX_SAFE_INTEGER)).toBe(true);
+
+    // Idempotent: SINCE is inclusive of the cursor, so the same change is
+    // skipped and the cursor does not move (a rounded cursor would re-drain).
+    await expect(recompose.invalidate(f.companyId)).resolves.toBe(0);
+    expect(await cursorValue()).toBe(after);
+  });
+});

--- a/test/recompose.unit-spec.ts
+++ b/test/recompose.unit-spec.ts
@@ -19,7 +19,7 @@ describe('RecomposeService', () => {
 
   function make(opts: {
     changes?: any[];
-    cursor?: number;
+    cursor?: number | bigint;
     stale?: any[];
     parents?: Record<string, any>;
     summaryText?: string;
@@ -60,7 +60,7 @@ describe('RecomposeService', () => {
     return { svc, queries, generator };
   }
 
-  const change = (versionstamp: number, id: string, status: string) => ({
+  const change = (versionstamp: number | bigint, id: string, status: string) => ({
     versionstamp,
     changes: [{ update: { id, status } }],
   });
@@ -126,7 +126,8 @@ describe('RecomposeService', () => {
       });
       await svc.invalidate('co_x');
       const upsert = queries.find((q) => q.sql.includes('UPSERT changefeed_state'));
-      expect(upsert!.params.v).toBe(14);
+      // bigint even from a plain-number stub — the cursor is bigint-typed end to end.
+      expect(upsert!.params.v).toBe(14n);
     });
 
     it('skips changes at or below the cursor (SINCE is inclusive)', async () => {
@@ -136,6 +137,35 @@ describe('RecomposeService', () => {
       });
       expect(await svc.invalidate('co_x')).toBe(0);
       expect(queries.some((q) => q.sql.includes('fn::mark_derived_stale'))).toBe(false);
+    });
+
+    it('carries a u64 versionstamp as bigint end to end (3.x stamps exceed 2^53)', async () => {
+      // Production: every nightly recompose failed with
+      // `CborNumberError: Number too big to be encoded` because the u64
+      // SHOW CHANGES versionstamp (~1.17e17) went through Number() and was
+      // then bound into the cursor UPSERT. The stub emits what the SDK emits.
+      const cursor = 117205247460507647n;
+      const stamp = 117205247460507648n;
+      const { svc, queries } = make({
+        cursor,
+        changes: [change(stamp, 'knowledge_fact:p1', 'superseded')],
+      });
+      expect(await svc.invalidate('co_x')).toBe(1);
+      const show = queries.find((q) => q.sql.includes('SHOW CHANGES'));
+      expect(show!.sql).toContain(`SINCE ${cursor} `);
+      const upsert = queries.find((q) => q.sql.includes('UPSERT changefeed_state'));
+      expect(typeof upsert!.params.v).toBe('bigint');
+      expect(upsert!.params.v).toBe(stamp);
+    });
+
+    it('does not advance past a u64 stamp at or below a bigint cursor', async () => {
+      const cursor = 117205247460507648n;
+      const { svc, queries } = make({
+        cursor,
+        changes: [change(cursor, 'knowledge_fact:old', 'superseded')],
+      });
+      expect(await svc.invalidate('co_x')).toBe(0);
+      expect(queries.some((q) => q.sql.includes('UPSERT changefeed_state'))).toBe(false);
     });
   });
 


### PR DESCRIPTION
Found on the server during the #501-wave step-0 inventory (2026-09-09), not by review.

## Symptom
`job_run` in the registered tenant: 24 succeeded, **6 failed — every one `jobType: recompose`**, `error: { name: "CborNumberError", message: "Number too big to be encoded" }`, `attempts: 2/2`, dedup keys `recompose_2026-09-06` / `recompose_2026-09-08`. The nightly recompose has not completed once since the 3.1.5 upgrade, so a compaction summary whose parent was superseded or retracted is never re-derived by the backstop drain.

## Cause
A 3.x `SHOW CHANGES` versionstamp is a u64 (`117205247460507648` on the server — above `Number.MAX_SAFE_INTEGER`). `RecomposeService.invalidate()` did `Number(c.versionstamp)` and then bound the result into the `changefeed_state` UPSERT; the SDK refuses to encode an unsafe integer. The audit drain (`changefeed-drain.service.ts`) had already moved to bigint for exactly this reason; recompose was left on `Number()`. Nothing could tell: the unit stub emits small integers, and no e2e drove `invalidate()` against a real changefeed — the same blind spot as the compaction `d$cutoff` regression.

## Change
- `src/compaction/recompose.service.ts` — the cursor is bigint end to end: the SHOW CHANGES stamp and the stored cursor are normalised with `BigInt()` where they are read, compared as bigint, and bound as bigint. A plain-number stub still works (`BigInt(10)`). `SINCE ${since}` interpolates a bigint as plain digits, as before.

## Proof
- **Unit** (`test/recompose.unit-spec.ts`): a real u64 stamp is bound as a `bigint` equal to the stamp; a stamp at or below a bigint cursor does not advance it; the existing "advances the cursor" case now expects `14n`.
- **Real SurrealDB** (`test/recompose-cursor.e2e-spec.ts`): ingest a fact, retract it (a CONTENT_CHANGED status, so the drain takes the mark + advance path), run `invalidate()` twice — it resolves, the stored cursor equals the server's own u64 stamp (asserted `> MAX_SAFE_INTEGER`), and the second run is a no-op with the cursor unchanged. On the previous code the same spec fails with the production error verbatim:
  ```
  Rejected to value: {"message": "Number too big to be encoded", "name": "CborNumberError"}
  ```

Unit 23/23, e2e 1/1, tsc (app + spec), eslint, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhrQxeisXJZEt4sg3PGyU6
