### PR TITLE
fix(compaction): a promotion summary keeps the validity of the memory it replaces, and lands with the compaction in one transaction

### DIFF
--- a/src/compaction/promotion-runner.service.ts
+++ b/src/compaction/promotion-runner.service.ts
@@ -1,7 +1,7 @@
 import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { StringRecordId, Surreal } from 'surrealdb';
-import { SurrealService, dbCreate } from '../db/surreal.service';
+import { SurrealService, runTransaction } from '../db/surreal.service';
 import { EmbedderService } from '../ai/embedder.service';
 import { PREDICATE_POLICIES } from '../ingest/conflict-resolver';
 import { ConcatSummaryGenerator, FactToSummarize, SummaryGenerator } from './summary-generator';
@@ -32,6 +32,14 @@ import { compactionOverridesFor } from './compaction-overrides';
  * Unlike compaction rollups the summary IS embedded (best-effort) — it
  * REPLACES the originals in the active set, so it must stay reachable
  * on the vector leg, not just BM25.
+ *
+ * Because it replaces active memory, the summary's VALIDITY is the
+ * originals' validity (open-ended if any member is open-ended; else the
+ * latest member close) and the span of the summarised events is kept
+ * separately as `source.eventRange` — see summaryValidityOf. The
+ * replacement and the compaction of the originals are ONE transaction:
+ * at no point are the originals hidden without a summary standing in
+ * for them.
  *
  * Deliberately narrow:
  *   - append_only semantics only (single_active keeps one live value;
@@ -341,45 +349,66 @@ export class PromotionRunnerService {
     const first = members[0];
     const last = members[members.length - 1];
     if (!first || !last) return 0; // members non-empty (length ≥ minGroup)
-    const earliest = first.validFrom;
     const meanConfidence = members.reduce((acc, m) => acc + m.confidence, 0) / members.length;
+    const validity = summaryValidityOf(members);
 
     // Evidence plane (PROVENANCE_SUMMARY_EPISODE_STAMP): the summary
     // carries the union of its members' grounding stamps (window-deriver
-    // idiom, capped 64). Flag off → empty union → the source object is
-    // byte-identical to today's `{ kind: 'promotion' }`.
+    // idiom, capped 64). Flag off → empty union.
     const episodeIds = summaryEpisodeStampEnabled()
       ? unionEpisodeIds(members.map((m) => m.eps))
       : [];
 
-    const summary = await dbCreate(db, 'knowledge_fact', {
+    const doc: Record<string, unknown> = {
       entityId: first.entityId,
       predicate: `summary_${group.predicate}`,
       object: summaryText,
       confidence: meanConfidence,
-      validFrom: earliest,
-      validUntil: last.validUntil ?? last.validFrom,
-      source: { kind: 'promotion', ...(episodeIds.length ? { episodeIds } : {}) },
+      validFrom: validity.validFrom,
+      // Open-ended stays open-ended: `validUntil` is omitted, not null —
+      // `option<datetime>` reads NONE either way, and the search filter
+      // `validUntil IS NONE OR validUntil > time::now()` admits it.
+      ...(validity.validUntil ? { validUntil: validity.validUntil } : {}),
+      source: {
+        kind: 'promotion',
+        // The interval the summarised EVENTS span — provenance, not
+        // validity. This used to be smuggled into validUntil, which is
+        // what made every summary of open-ended history expire at birth.
+        eventRange: validity.eventRange,
+        ...(episodeIds.length ? { episodeIds } : {}),
+      },
       derivedFrom: members.map((m) => m.id),
       status: 'active',
       ...(group.userId ? { userId: group.userId } : {}),
       ...(embedding ? { embedding } : {}),
+    };
+
+    // One transaction: the replacement lands and the originals close
+    // together, or neither does. Two round-trips used to leave a window
+    // (crash, pool loss) where the originals were compacted — hidden from
+    // every read surface, embeddings dropped — with no summary carrying
+    // their content, or a summary next to five still-active originals.
+    // Record-id params — 3.x does not coerce string↔record (see
+    // compaction-runner).
+    const ids = members.map((m) => new StringRecordId(String(m.id)));
+    const createdRows = await runTransaction<Array<{ id: unknown }> | undefined>(db, (tx) => {
+      tx.add(`LET $created = (CREATE knowledge_fact CONTENT $doc RETURN AFTER)`).bind('doc', doc);
+      tx.add(
+        `UPDATE knowledge_fact
+           SET status = 'compacted', embedding = NONE
+           WHERE id INSIDE $ids`,
+      ).bind('ids', ids);
+      tx.add(`RETURN $created`);
     });
+    const summary = createdRows?.[0];
+    if (!summary?.id) {
+      throw new Error(`promotion transaction returned no summary row for ${group.predicate}`);
+    }
 
     await this.mirrorDerivedFromEdges(db, {
       summaryId: String(summary.id),
       memberIds: members.map((m) => String(m.id)),
     });
-
-    // Record-id params — 3.x does not coerce string↔record (see
-    // compaction-runner).
-    const ids = members.map((m) => new StringRecordId(String(m.id)));
-    await db.query(
-      `UPDATE knowledge_fact
-         SET status = 'compacted', embedding = NONE
-         WHERE id INSIDE $ids`,
-      { ids },
-    );
     return members.length;
   }
 
@@ -408,6 +437,63 @@ export class PromotionRunnerService {
 
 function isoOf(v: unknown): string {
   return v instanceof Date ? v.toISOString() : String(v);
+}
+
+/** What the promotion summary is valid for, and what it summarises. */
+export interface SummaryValidity {
+  /** Earliest member validFrom — the summary holds from the first event. */
+  validFrom: string | Date;
+  /**
+   * The validity the originals actually had: open-ended (undefined) if
+   * ANY member is open-ended, else the latest member validUntil. Never
+   * derived from validFrom — a group of open-ended events used to get
+   * `validUntil = last.validFrom`, i.e. a replacement born expired.
+   */
+  validUntil?: string | Date;
+  /** The interval the summarised events span (member validFrom..last
+   *  event boundary) — provenance stored on `source`, not validity. */
+  eventRange: { from: string; to: string };
+}
+
+/**
+ * Validity of a promotion summary, derived from its members (sorted by
+ * validFrom ASC, as the member SELECT orders them).
+ *
+ * A summary REPLACES active memory — the originals are compacted and
+ * hidden from every read surface — so it must be visible for exactly as
+ * long as the originals would have been: open-ended events yield an
+ * open-ended summary; a group whose every member has closed yields a
+ * summary closed at the latest of those closings. The events' own time
+ * span is kept separately as `eventRange` so nothing the old
+ * `validUntil` encoded is lost — it just no longer decides visibility.
+ */
+export function summaryValidityOf(
+  // The SDK hands datetime columns back as Date; a stub may pass ISO text.
+  members: ReadonlyArray<{ validFrom: string | Date; validUntil?: string | Date | null }>,
+): SummaryValidity {
+  const first = members[0];
+  const last = members[members.length - 1];
+  if (!first || !last) throw new Error('summaryValidityOf: no members');
+  const open = members.some((m) => m.validUntil === undefined || m.validUntil === null);
+  let latestClose: string | Date | undefined;
+  if (!open) {
+    for (const m of members) {
+      const until = m.validUntil as string | Date;
+      if (latestClose === undefined || toMs(until) > toMs(latestClose)) latestClose = until;
+    }
+  }
+  return {
+    validFrom: first.validFrom,
+    ...(latestClose !== undefined ? { validUntil: latestClose } : {}),
+    eventRange: {
+      from: isoOf(first.validFrom),
+      to: isoOf(last.validUntil ?? last.validFrom),
+    },
+  };
+}
+
+function toMs(v: string | Date): number {
+  return v instanceof Date ? v.getTime() : new Date(v).getTime();
 }
 
 /** User-scope member filter (0055) — shared by the member SELECT and the

--- a/test/compaction.unit-spec.ts
+++ b/test/compaction.unit-spec.ts
@@ -425,7 +425,9 @@ describe('CompactionRunnerService — summary episode stamping', () => {
  * Evidence plane (PROVENANCE_SUMMARY_EPISODE_STAMP) on the promotion
  * runner: the episodic→semantic summary carries the union of the folded
  * members' grounding stamps. Off (default) the written source
- * deep-equals today's `{ kind: 'promotion' }` exactly.
+ * is `{ kind: 'promotion', eventRange }` exactly — the range the summarised
+ * events span is provenance every summary carries; the stamp is the only
+ * flag-dependent key.
  */
 describe('PromotionRunnerService — summary episode stamping', () => {
   const saved = process.env.PROVENANCE_SUMMARY_EPISODE_STAMP;
@@ -465,9 +467,12 @@ describe('PromotionRunnerService — summary episode stamping', () => {
             })),
           ] as unknown as R;
         }
-        if (sql.startsWith('CREATE type::table($t)')) {
-          created.push(params!.d as Record<string, unknown>);
-          return [[{ id: 'knowledge_fact:summary1' }]] as unknown as R;
+        if (sql.startsWith('BEGIN TRANSACTION')) {
+          // The replacement and the compaction land in ONE batch:
+          // BEGIN, LET (create), UPDATE (compact), RETURN, COMMIT — the
+          // 3.x slot shape runTransaction reads the RETURN from.
+          created.push(params!.doc as Record<string, unknown>);
+          return [null, null, [], [{ id: 'knowledge_fact:summary1' }], null] as unknown as R;
         }
         return [[]] as unknown as R;
       },
@@ -504,13 +509,16 @@ describe('PromotionRunnerService — summary episode stamping', () => {
     },
   ];
 
-  it('flag OFF (default): written source deep-equals today’s { kind: promotion }', async () => {
+  it('flag OFF (default): written source is kind + the summarised event range, no stamp', async () => {
     delete process.env.PROVENANCE_SUMMARY_EPISODE_STAMP;
     const { runner, created } = makePromotionStack(SEEDS);
     const stats = await runner.promoteCompany('co_a');
     expect(stats.groupsPromoted).toBe(1);
     expect(created).toHaveLength(1);
-    expect(created[0]!.source).toEqual({ kind: 'promotion' });
+    expect(created[0]!.source).toEqual({
+      kind: 'promotion',
+      eventRange: { from: '2025-01-01T00:00:00Z', to: '2025-02-01T00:00:00Z' },
+    });
   });
 
   it('flag ON: source carries the member union — member order, deduped', async () => {
@@ -519,15 +527,19 @@ describe('PromotionRunnerService — summary episode stamping', () => {
     await runner.promoteCompany('co_a');
     expect(created[0]!.source).toEqual({
       kind: 'promotion',
+      eventRange: { from: '2025-01-01T00:00:00Z', to: '2025-02-01T00:00:00Z' },
       episodeIds: ['episode:e1', 'episode:shared', 'episode:e2'],
     });
   });
 
-  it('flag ON: unstamped members yield today’s source (no empty key)', async () => {
+  it('flag ON: unstamped members yield no episodeIds key at all', async () => {
     process.env.PROVENANCE_SUMMARY_EPISODE_STAMP = '1';
     const { runner, created } = makePromotionStack(SEEDS.map(({ eps: _eps, ...s }) => s));
     await runner.promoteCompany('co_a');
-    expect(created[0]!.source).toEqual({ kind: 'promotion' });
+    expect(created[0]!.source).toEqual({
+      kind: 'promotion',
+      eventRange: { from: '2025-01-01T00:00:00Z', to: '2025-02-01T00:00:00Z' },
+    });
   });
 
   it('the member SELECT carries the grounding stamp column', async () => {
@@ -568,6 +580,16 @@ describe('summary runners — derived_from edge mirror (PROVENANCE_SUPPORT_EDGES
           sql.includes('WHERE entityId = $entity AND predicate = $predicate')
         ) {
           return [candidates] as unknown as R;
+        }
+        if (sql.startsWith('BEGIN TRANSACTION')) {
+          // Promotion: create + compact in one batch (BEGIN, LET, UPDATE, RETURN, COMMIT).
+          return [
+            null,
+            null,
+            [],
+            [{ ...(params!.doc as object), id: 'knowledge_fact:sum1' }],
+            null,
+          ] as unknown as R;
         }
         if (sql.startsWith('CREATE type::table($t)')) {
           return [[{ ...(params!.d as object), id: 'knowledge_fact:sum1' }]] as unknown as R;
@@ -662,7 +684,8 @@ describe('summary runners — derived_from edge mirror (PROVENANCE_SUPPORT_EDGES
     process.env.PROVENANCE_SUPPORT_EDGES = '1';
     const { surreal, calls } = makeMirrorSurreal(PROMOTION_SEEDS);
     await promotionRunner(surreal).promoteCompany('co_a');
-    const createIdx = calls.findIndex((c) => c.sql.startsWith('CREATE type::table($t)'));
+    // The summary is created inside the promotion transaction (BEGIN…COMMIT).
+    const createIdx = calls.findIndex((c) => c.sql.startsWith('BEGIN TRANSACTION'));
     const insertIdx = calls.findIndex((c) => c.sql.includes('memory_support'));
     expect(createIdx).toBeGreaterThanOrEqual(0);
     expect(insertIdx).toBeGreaterThan(createIdx);

--- a/test/promotion-gate.unit-spec.ts
+++ b/test/promotion-gate.unit-spec.ts
@@ -80,9 +80,12 @@ function makePromotionStack(
           })),
         ] as unknown as R;
       }
-      if (sql.startsWith('CREATE type::table($t)')) {
-        created.push(params!.d as Record<string, unknown>);
-        return [[{ id: 'knowledge_fact:summary1' }]] as unknown as R;
+      if (sql.startsWith('BEGIN TRANSACTION')) {
+        // The replacement and the compaction land in ONE batch:
+        // BEGIN, LET (create), UPDATE (compact), RETURN, COMMIT — the
+        // 3.x slot shape runTransaction reads the RETURN from.
+        created.push(params!.doc as Record<string, unknown>);
+        return [null, null, [], [{ id: 'knowledge_fact:summary1' }], null] as unknown as R;
       }
       return [[]] as unknown as R;
     },
@@ -225,7 +228,10 @@ describe('PromotionRunnerService — gate off/unset is byte-identical (pin)', ()
     expect(summary.predicate).toBe('summary_said');
     expect(summary.object).toBe('promoted summary');
     expect(summary.status).toBe('active');
-    expect(summary.source).toEqual({ kind: 'promotion' });
+    expect(summary.source).toEqual({
+      kind: 'promotion',
+      eventRange: { from: '2025-01-01T00:00:00Z', to: '2025-05-01T00:00:00Z' },
+    });
     expect((summary.derivedFrom as unknown[]).length).toBe(5);
     // No consolidation-gate query was issued.
     expect(calls.some((c) => c.sql.includes("status = 'competing'"))).toBe(false);

--- a/test/promotion-validity.unit-spec.ts
+++ b/test/promotion-validity.unit-spec.ts
@@ -1,0 +1,223 @@
+/**
+ * Promotion summary validity and the atomic replace (audit 2026-09-06 F4).
+ *
+ * A promotion summary REPLACES active memory: the originals are compacted
+ * and hidden from every read surface. It used to be created with
+ * `validUntil = last.validUntil ?? last.validFrom`, so a group of old
+ * open-ended events — the ordinary case for append_only history — got a
+ * replacement that was already expired under the default "actual now"
+ * search filter. Five facts promoted, zero rows visible.
+ *
+ * Pinned here:
+ *   - validity is the originals' validity: open-ended if any member is
+ *     open-ended, else the latest member close — never derived from
+ *     validFrom;
+ *   - the events' own span survives as `source.eventRange`;
+ *   - the summary CREATE and the members' compaction travel in ONE
+ *     transaction, never as two round-trips.
+ */
+import { ConfigService } from '@nestjs/config';
+import {
+  PromotionRunnerService,
+  summaryValidityOf,
+} from '../src/compaction/promotion-runner.service';
+import type { EmbedderService } from '../src/ai/embedder.service';
+import type { SurrealService } from '../src/db/surreal.service';
+
+describe('summaryValidityOf', () => {
+  it('open-ended members → open-ended summary (validUntil absent), range = first..last validFrom', () => {
+    const v = summaryValidityOf([
+      { validFrom: '2025-01-01T00:00:00Z' },
+      { validFrom: '2025-03-01T00:00:00Z', validUntil: null },
+      { validFrom: '2025-05-01T00:00:00Z' },
+    ]);
+    expect(v.validFrom).toBe('2025-01-01T00:00:00Z');
+    expect('validUntil' in v).toBe(false);
+    expect(v.eventRange).toEqual({ from: '2025-01-01T00:00:00Z', to: '2025-05-01T00:00:00Z' });
+  });
+
+  it('every member closed → summary closes at the LATEST close, not the last row', () => {
+    const v = summaryValidityOf([
+      { validFrom: '2025-01-01T00:00:00Z', validUntil: '2025-12-01T00:00:00Z' },
+      { validFrom: '2025-02-01T00:00:00Z', validUntil: '2025-02-02T00:00:00Z' },
+    ]);
+    expect(v.validUntil).toBe('2025-12-01T00:00:00Z');
+    expect(v.eventRange).toEqual({ from: '2025-01-01T00:00:00Z', to: '2025-02-02T00:00:00Z' });
+  });
+
+  it('one open-ended member keeps the whole summary open-ended', () => {
+    const v = summaryValidityOf([
+      { validFrom: '2025-01-01T00:00:00Z', validUntil: '2025-01-02T00:00:00Z' },
+      { validFrom: '2025-02-01T00:00:00Z' },
+    ]);
+    expect('validUntil' in v).toBe(false);
+  });
+
+  it('accepts the Date objects the SDK returns and reports the range as ISO', () => {
+    const v = summaryValidityOf([
+      { validFrom: new Date('2025-01-01T00:00:00Z'), validUntil: new Date('2025-06-01T00:00:00Z') },
+      { validFrom: new Date('2025-02-01T00:00:00Z'), validUntil: new Date('2025-03-01T00:00:00Z') },
+    ]);
+    expect(v.validUntil).toEqual(new Date('2025-06-01T00:00:00Z'));
+    expect(v.eventRange).toEqual({
+      from: '2025-01-01T00:00:00.000Z',
+      to: '2025-03-01T00:00:00.000Z',
+    });
+  });
+});
+
+describe('PromotionRunnerService — the replace is one transaction', () => {
+  class StubConfig {
+    constructor(private readonly map: Record<string, string> = {}) {}
+    get<T = string>(key: string, fallback?: T): T {
+      return (this.map[key] as unknown as T) ?? (fallback as T);
+    }
+  }
+
+  function stack(members: Array<{ validFrom: string; validUntil?: string }>) {
+    const sqls: string[] = [];
+    let txParams: Record<string, unknown> | undefined;
+    const fakeDb = {
+      async query<R>(sql: string, params?: Record<string, unknown>): Promise<R> {
+        sqls.push(sql);
+        if (sql.includes('GROUP BY entityId, predicate, userId')) {
+          return [
+            [{ entityId: 'knowledge_entity:e1', predicate: 'said', n: members.length }],
+          ] as unknown as R;
+        }
+        if (sql.includes('WHERE entityId = $entity AND predicate = $predicate')) {
+          return [
+            members.map((m, i) => ({
+              id: `knowledge_fact:s${i}`,
+              entityId: 'knowledge_entity:e1',
+              predicate: 'said',
+              object: `old remark ${i}`,
+              validFrom: m.validFrom,
+              ...(m.validUntil ? { validUntil: m.validUntil } : {}),
+              confidence: 0.9,
+            })),
+          ] as unknown as R;
+        }
+        if (sql.startsWith('BEGIN TRANSACTION')) {
+          txParams = params;
+          return [null, null, [], [{ id: 'knowledge_fact:summary1' }], null] as unknown as R;
+        }
+        return [[]] as unknown as R;
+      },
+    };
+    const surreal = {
+      withCompany: async <T>(_c: string, fn: (db: unknown) => Promise<T>) => fn(fakeDb),
+    } as unknown as SurrealService;
+    const embedder = { embedForWrite: async () => [1, 0] } as unknown as EmbedderService;
+    const runner = new PromotionRunnerService(
+      surreal,
+      new StubConfig({
+        COMPACTION_PROMOTION_ENABLED: '1',
+        COMPACTION_PROMOTION_MIN_GROUP: '2',
+      }) as unknown as ConfigService,
+      embedder,
+      { generate: async () => 'promoted summary' },
+    );
+    return { runner, sqls, tx: () => txParams };
+  }
+
+  it('creates the summary and compacts the originals in ONE batch, with no standalone UPDATE', async () => {
+    const { runner, sqls, tx } = stack([
+      { validFrom: '2025-01-01T00:00:00Z' },
+      { validFrom: '2025-02-01T00:00:00Z' },
+    ]);
+    const stats = await runner.promoteCompany('co_a');
+    expect(stats).toEqual({ companyId: 'co_a', groupsPromoted: 1, factsPromoted: 2 });
+
+    const batches = sqls.filter((s) => s.startsWith('BEGIN TRANSACTION'));
+    expect(batches).toHaveLength(1);
+    const batch = batches[0]!;
+    expect(batch).toContain('CREATE knowledge_fact CONTENT $doc');
+    expect(batch).toContain("SET status = 'compacted', embedding = NONE");
+    expect(batch.trim().endsWith('COMMIT TRANSACTION;')).toBe(true);
+    // The compaction never travels on its own — that was the window where
+    // the originals were hidden with nothing standing in for them.
+    expect(sqls.filter((s) => s.trimStart().startsWith('UPDATE knowledge_fact'))).toHaveLength(0);
+
+    const params = tx()!;
+    expect((params.ids as unknown[]).map(String)).toEqual([
+      'knowledge_fact:s0',
+      'knowledge_fact:s1',
+    ]);
+    const doc = params.doc as Record<string, unknown>;
+    expect(doc.predicate).toBe('summary_said');
+    expect(doc.status).toBe('active');
+    expect(doc.validFrom).toBe('2025-01-01T00:00:00Z');
+    // Open-ended originals → an open-ended replacement: the key is absent.
+    expect('validUntil' in doc).toBe(false);
+    expect(doc.source).toEqual({
+      kind: 'promotion',
+      eventRange: { from: '2025-01-01T00:00:00Z', to: '2025-02-01T00:00:00Z' },
+    });
+    expect(doc.embedding).toEqual([1, 0]);
+  });
+
+  it('closed originals give the replacement their latest close', async () => {
+    const { runner, tx } = stack([
+      { validFrom: '2025-01-01T00:00:00Z', validUntil: '2025-04-01T00:00:00Z' },
+      { validFrom: '2025-02-01T00:00:00Z', validUntil: '2025-03-01T00:00:00Z' },
+    ]);
+    await runner.promoteCompany('co_a');
+    const doc = tx()!.doc as Record<string, unknown>;
+    expect(doc.validUntil).toBe('2025-04-01T00:00:00Z');
+    expect((doc.source as { eventRange: unknown }).eventRange).toEqual({
+      from: '2025-01-01T00:00:00Z',
+      to: '2025-03-01T00:00:00Z',
+    });
+  });
+
+  it('a transaction that returns no summary row is an error, not a silent success', async () => {
+    const { runner, sqls } = stack([
+      { validFrom: '2025-01-01T00:00:00Z' },
+      { validFrom: '2025-02-01T00:00:00Z' },
+    ]);
+    // Simulate a batch whose RETURN slot is empty (aborted server-side).
+    const db = (runner as unknown as { surreal: SurrealService }).surreal;
+    (db as unknown as { withCompany: unknown }).withCompany = async <T>(
+      _c: string,
+      fn: (d: unknown) => Promise<T>,
+    ) =>
+      fn({
+        async query<R>(sql: string): Promise<R> {
+          sqls.push(sql);
+          if (sql.includes('GROUP BY entityId, predicate, userId')) {
+            return [[{ entityId: 'knowledge_entity:e1', predicate: 'said', n: 2 }]] as unknown as R;
+          }
+          if (sql.includes('WHERE entityId = $entity AND predicate = $predicate')) {
+            return [
+              [
+                {
+                  id: 'knowledge_fact:s0',
+                  entityId: 'knowledge_entity:e1',
+                  predicate: 'said',
+                  object: 'a',
+                  validFrom: '2025-01-01T00:00:00Z',
+                  confidence: 0.9,
+                },
+                {
+                  id: 'knowledge_fact:s1',
+                  entityId: 'knowledge_entity:e1',
+                  predicate: 'said',
+                  object: 'b',
+                  validFrom: '2025-02-01T00:00:00Z',
+                  confidence: 0.9,
+                },
+              ],
+            ] as unknown as R;
+          }
+          if (sql.startsWith('BEGIN TRANSACTION'))
+            return [null, null, [], [], null] as unknown as R;
+          return [[]] as unknown as R;
+        },
+      });
+    // promoteCompany logs and counts a failed group as not promoted.
+    const stats = await runner.promoteCompany('co_a');
+    expect(stats.groupsPromoted).toBe(0);
+    expect(stats.factsPromoted).toBe(0);
+  });
+});

--- a/test/promotion-visibility.e2e-spec.ts
+++ b/test/promotion-visibility.e2e-spec.ts
@@ -1,0 +1,186 @@
+/**
+ * Promotion keeps active memory VISIBLE — against a REAL SurrealDB
+ * (audit 2026-09-06, F4).
+ *
+ * The audit's repro: five old open-ended `said` facts → `factsPromoted=5`
+ * → five compacted originals and one active summary whose `validUntil`
+ * was already in the past — so the default "actual now" search filter
+ * dropped the summary AND the originals, and the memory vanished from
+ * every public read surface. Preprod runs COMPACTION_PROMOTION_ENABLED=1.
+ *
+ * Pinned here through the PUBLIC surface, not the table:
+ *   - after promotion, /v1/search returns the summary for the memory's
+ *     content, and never a compacted original;
+ *   - the summary is open-ended because its originals were, and the span
+ *     of the summarised events is kept as `source.eventRange`;
+ *   - the audit's own visibility query returns exactly the summary.
+ */
+import { AppFixture, createApp } from './app-fixture';
+import { StringRecordId } from 'surrealdb';
+import { SurrealService } from '../src/db/surreal.service';
+import { PromotionRunnerService } from '../src/compaction/promotion-runner.service';
+
+describe('promotion summary visibility (real SurrealDB)', () => {
+  let f: AppFixture;
+  const auth = () => ({ Authorization: `Bearer ${f.apiKey}` });
+  /** Every fact the public search surfaced, across its per-entity hits. */
+  const factsOf = (body: {
+    results: Array<{ facts: Array<{ factId: string; predicate: string }> }>;
+  }) => body.results.flatMap((hit) => hit.facts);
+
+  beforeAll(async () => {
+    // Read at service construction — must be set before createApp.
+    process.env.COMPACTION_PROMOTION_ENABLED = '1';
+    f = await createApp({ companyId: 'co_promotion_visibility_e2e' });
+  });
+
+  afterAll(async () => {
+    delete process.env.COMPACTION_PROMOTION_ENABLED;
+    if (f) await f.close();
+  });
+
+  it('an open-ended group folds into a summary the public search still returns', async () => {
+    const surreal = f.app.get(SurrealService);
+    const aged: string[] = [];
+    for (let i = 1; i <= 5; i++) {
+      const res = await f.http
+        .post('/v1/ingest/fact')
+        .set(auth())
+        .send({
+          entityRef: { vertical: 'rent', id: 'promotion_visibility_subject' },
+          predicate: 'said',
+          object: `historic lease memory number ${i}`,
+          validFrom: '2025-01-01',
+          confidence: 0.9,
+          source: { vertical: 'rent', recorder: 'bot' },
+        });
+      expect([200, 201]).toContain(res.status);
+      aged.push(res.body.factId as string);
+    }
+    // Age the group past COMPACTION_PROMOTION_AGE_DAYS (180).
+    await surreal.withCompany(f.companyId, async (db) => {
+      await db.query(`UPDATE knowledge_fact SET recordedAt = $recordedAt WHERE id INSIDE $ids`, {
+        recordedAt: new Date(Date.now() - 365 * 24 * 60 * 60 * 1000),
+        ids: aged.map((id) => new StringRecordId(id)),
+      });
+    });
+
+    // The memory is reachable BEFORE promotion.
+    const before = await f.http
+      .post('/v1/search')
+      .set(auth())
+      .send({ query: 'historic lease memory' });
+    expect([200, 201]).toContain(before.status);
+    expect(factsOf(before.body).some((r) => aged.includes(r.factId))).toBe(true);
+
+    const stats = await f.app.get(PromotionRunnerService).promoteCompany(f.companyId);
+    expect(stats.groupsPromoted).toBe(1);
+    expect(stats.factsPromoted).toBe(5);
+
+    // ...and still reachable AFTER: the replacement answers, the originals
+    // do not. This is the assertion the audit found false.
+    const after = await f.http
+      .post('/v1/search')
+      .set(auth())
+      .send({ query: 'historic lease memory' });
+    expect([200, 201]).toContain(after.status);
+    const results = factsOf(after.body);
+    expect(results.some((r) => r.predicate === 'summary_said')).toBe(true);
+    expect(results.some((r) => aged.includes(r.factId))).toBe(false);
+
+    await surreal.withCompany(f.companyId, async (db) => {
+      const [rows] = await db.query<
+        [
+          Array<{
+            predicate: string;
+            status: string;
+            validFrom: Date;
+            validUntil?: Date | null;
+            source: { kind: string; eventRange?: { from: string; to: string } };
+          }>,
+        ]
+      >(
+        `SELECT predicate, status, validFrom, validUntil, source FROM knowledge_fact
+          WHERE predicate = 'summary_said'`,
+      );
+      const summaries = rows as Array<{
+        predicate: string;
+        status: string;
+        validFrom: Date;
+        validUntil?: Date | null;
+        source: { kind: string; eventRange?: { from: string; to: string } };
+      }>;
+      expect(summaries).toHaveLength(1);
+      const summary = summaries[0]!;
+      expect(summary.status).toBe('active');
+      // Open-ended originals → open-ended summary; not "expired at birth".
+      expect(summary.validUntil ?? null).toBeNull();
+      expect(new Date(summary.validFrom).toISOString()).toBe('2025-01-01T00:00:00.000Z');
+      // The events' span survives as provenance.
+      expect(summary.source.kind).toBe('promotion');
+      expect(summary.source.eventRange).toEqual({
+        from: '2025-01-01T00:00:00.000Z',
+        to: '2025-01-01T00:00:00.000Z',
+      });
+
+      // The audit's own visibility probe: exactly the summary passes the
+      // default actual-now filter; the five originals are compacted.
+      const [visible] = await db.query<[Array<{ predicate: string }>]>(
+        `SELECT predicate FROM knowledge_fact
+          WHERE predicate INSIDE ['said', 'summary_said']
+            AND validFrom <= time::now() AND (validUntil IS NONE OR validUntil > time::now())
+            AND status != 'compacted'`,
+      );
+      expect((visible as Array<{ predicate: string }>).map((r) => r.predicate)).toEqual([
+        'summary_said',
+      ]);
+      const [compacted] = await db.query<[Array<{ id: unknown }>]>(
+        `SELECT id FROM knowledge_fact WHERE predicate = 'said' AND status = 'compacted'`,
+      );
+      expect(compacted as unknown[]).toHaveLength(5);
+    });
+  });
+
+  it('a group whose every member has closed folds into a summary closed at the latest close', async () => {
+    const surreal = f.app.get(SurrealService);
+    const ids: string[] = [];
+    for (let i = 1; i <= 5; i++) {
+      const res = await f.http
+        .post('/v1/ingest/fact')
+        .set(auth())
+        .send({
+          entityRef: { vertical: 'rent', id: 'promotion_closed_subject' },
+          predicate: 'said',
+          object: `closed remark number ${i}`,
+          validFrom: `2024-0${i}-01`,
+          validUntil: `2024-0${i}-15`,
+          confidence: 0.9,
+          source: { vertical: 'rent', recorder: 'bot' },
+        });
+      expect([200, 201]).toContain(res.status);
+      ids.push(res.body.factId as string);
+    }
+    await surreal.withCompany(f.companyId, async (db) => {
+      await db.query(`UPDATE knowledge_fact SET recordedAt = $recordedAt WHERE id INSIDE $ids`, {
+        recordedAt: new Date(Date.now() - 365 * 24 * 60 * 60 * 1000),
+        ids: ids.map((id) => new StringRecordId(id)),
+      });
+    });
+    const stats = await f.app.get(PromotionRunnerService).promoteCompany(f.companyId);
+    // This group, plus whatever an earlier case left promotable in the tenant.
+    expect(stats.factsPromoted).toBeGreaterThanOrEqual(5);
+
+    await surreal.withCompany(f.companyId, async (db) => {
+      const [rows] = await db.query<[Array<{ validUntil?: Date | null; derivedFrom: unknown[] }>]>(
+        `SELECT validUntil, derivedFrom FROM knowledge_fact
+          WHERE predicate = 'summary_said' AND array::len(derivedFrom) = 5
+            AND derivedFrom[0] INSIDE $ids`,
+        { ids: ids.map((id) => new StringRecordId(id)) },
+      );
+      const summary = (rows as Array<{ validUntil?: Date | null }>)[0]!;
+      // Closed history stays closed — the summary carries the validity the
+      // originals had, which is exactly as (in)visible as they were.
+      expect(new Date(summary.validUntil!).toISOString()).toBe('2024-05-15T00:00:00.000Z');
+    });
+  });
+});


### PR DESCRIPTION
Finding **F4 (P1)** of the 2026-09-06 current-state audit: promotion makes active memory invisible.

## Symptom
Episodic→semantic promotion folds an aged group of append_only facts into one summary, compacts the originals and drops their embeddings. The summary was created with `validUntil = last.validUntil ?? last.validFrom`, so for a group of open-ended events — the ordinary shape of `said` history — the replacement was **born already expired**. The default "actual now" search filter (`where-builder.ts`) then dropped the summary and the compacted originals alike: five facts promoted, **zero rows visible** on every public read surface. Preprod runs `COMPACTION_PROMOTION_ENABLED=1`, so this was live.

## Change (`src/compaction/promotion-runner.service.ts`)
- **Validity is the originals' validity.** `summaryValidityOf(members)`: open-ended if any member is open-ended, else the latest member close — the summary is visible for exactly as long as the memory it replaces would have been, never "expired at birth".
- **The events' span is kept, not dropped.** What `validUntil` used to smuggle (first event → last event boundary) is stored as `source.eventRange { from, to }` — provenance, not visibility.
- **One transaction.** The summary `CREATE` and the members' compaction (`status='compacted', embedding=NONE`) are a single `BEGIN…COMMIT` batch via `runTransaction`; at no point are the originals hidden with nothing standing in for them. A batch that returns no summary row is an error the per-group `try/catch` reports, not a silent success. The best-effort support-edge mirror (default off) still follows the write, as before.

Compaction rollups (`compaction-runner`) are untouched: they summarise **closed** history, where an expired summary is the truthful shape.

## Proof
- **Unit** — `test/promotion-validity.unit-spec.ts`: the derivation (open-ended, all-closed → latest close, mixed → open-ended, SDK `Date`s); the write is exactly one `BEGIN…COMMIT` batch containing the `CREATE` and the compaction `UPDATE`, with no standalone `UPDATE`; open-ended originals leave `validUntil` absent; an empty RETURN slot is an error. The existing `promotion-gate` and `compaction.unit` stubs follow the transactional shape and the source now carries `eventRange`.
- **Real SurrealDB** — `test/promotion-visibility.e2e-spec.ts`: the audit's scenario (five old open-ended `said` facts, backdated past the age cutoff) asserted through **`POST /v1/search`**: the memory is reachable before promotion, and after it the summary is returned while no compacted original is; the summary is `active`, open-ended, with the events' range on its source; the audit's own visibility probe returns exactly the summary; a fully-closed group folds into a summary closed at its latest close. The existing `promotion.e2e-spec` stays green.
- On the previous service the new e2e fails with the audit's result verbatim (`summary_said` absent from the public search).

Unit 45/45 across the three suites, e2e 12/12 across the three promotion suites, tsc (app + spec), eslint, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhrQxeisXJZEt4sg3PGyU6