### PR TITLE
fix(feedback,auth): one rollup delta per standing vote, and suspension that survives activity

### DIFF
--- a/src/auth/credential-resolver.service.ts
+++ b/src/auth/credential-resolver.service.ts
@@ -75,12 +75,15 @@ export class CredentialResolverService {
     if (record) {
       recordTier(tokenTrackerKey(token), record.entitlements);
       // Registration hook (R4): a resolved credential proves its tenant is
-      // live. Routed through ApiKeyService (which owns the roster) rather
-      // than injecting the registry here — this service's DI list is capped
-      // at 3 by design. Synchronous cache-add + throttled fire-and-forget
-      // write; never blocks or fails the request. This is how tenant_registry
-      // fills under a remote verifier (JWKS / introspection), where the
-      // static key table is disabled and the roster would otherwise be empty.
+      // live — SEEN, not necessarily active: roster membership follows the
+      // registry status (a suspended tenant's key may still verify), the
+      // activity only bumps lastSeen. Routed through ApiKeyService (which
+      // owns the roster) rather than injecting the registry here — this
+      // service's DI list is capped at 3 by design. Throttled
+      // fire-and-forget write; never blocks or fails the request. This is
+      // how tenant_registry fills under a remote verifier (JWKS /
+      // introspection), where the static key table is disabled and the
+      // roster would otherwise be empty.
       this.apiKeys.noteResolvedTenant(record.companyId);
     }
     return record;

--- a/src/auth/tenant-registry.service.ts
+++ b/src/auth/tenant-registry.service.ts
@@ -35,23 +35,31 @@ export interface TenantIndexStateRow extends TenantIndexState {
 const COMPANY_ID = /^[a-zA-Z0-9_-]+$/;
 
 /**
- * How often the in-memory active-roster cache is refreshed from the
- * system-DB `tenant_registry` table. 60s is far below any fan-out cron
- * cadence, so a tenant that authenticates is visible to the next sweep
- * well within one interval — and register()/touch() update the cache
- * synchronously anyway, so the timer is only a backstop for rows written
- * by OTHER pods.
+ * How often the in-memory roster cache is refreshed from the system-DB
+ * `tenant_registry` table. 60s is far below any fan-out cron cadence, so
+ * a tenant that authenticates is visible to the next sweep well within
+ * one interval — and register()/touch() reconcile the cache as they learn
+ * a tenant's status anyway, so the timer is only a backstop for rows
+ * written by OTHER pods (a suspension issued elsewhere lands here within
+ * one interval).
  */
 const REFRESH_MS = 60_000;
 
 /**
  * Per-tenant throttle on the lastSeen DB write from touch(). touch() runs
- * on the hot auth path (every authenticated request); the cache add is
- * synchronous and unconditional, but the DB round-trip is coalesced to at
- * most once per tenant per window so a busy tenant does not hammer the
- * system DB just to bump a timestamp.
+ * on the hot auth path (every authenticated request); the roster cache is
+ * reconciled synchronously from the status this pod already knows, but the
+ * DB round-trip is coalesced to at most once per tenant per window so a
+ * busy tenant does not hammer the system DB just to bump a timestamp.
  */
 const TOUCH_THROTTLE_MS = 5 * 60_000;
+
+type TenantStatus = NonNullable<TenantRegistryMeta['status']>;
+
+/** A roster row as the registry reads it back — companyId plus lifecycle status. */
+interface RosterRow extends TenantRow {
+  status?: string;
+}
 
 /**
  * TenantRegistryService — the production tenant roster (R4 finding #1).
@@ -83,6 +91,15 @@ export class TenantRegistryService implements OnModuleInit, OnModuleDestroy {
   private readonly logger = new Logger(TenantRegistryService.name);
   /** Active companyIds as last read from / written to the registry. */
   private readonly activeCache = new Set<string>();
+  /**
+   * companyId -> lifecycle status as this pod last learned it (a refresh
+   * read, a register() write, or the status a touch() write echoed back).
+   * Membership in `activeCache` is derived from THIS, never from activity:
+   * a suspended tenant that keeps authenticating with a still-valid
+   * credential must not re-enter the fan-out roster, not even for the
+   * window until the next refresh (audit 2026-09-06, F9).
+   */
+  private readonly knownStatus = new Map<string, TenantStatus>();
   /** companyId -> last epoch-ms we wrote lastSeen (touch throttle). */
   private readonly lastWriteAt = new Map<string, number>();
   private refreshTimer?: ReturnType<typeof setInterval>;
@@ -139,9 +156,9 @@ export class TenantRegistryService implements OnModuleInit, OnModuleDestroy {
     }
     const status = meta.status ?? 'active';
     // Reconcile the cache first so the tenant is visible immediately even
-    // if the DB write is briefly delayed; a non-active status drops it.
-    if (status === 'active') this.activeCache.add(companyId);
-    else this.activeCache.delete(companyId);
+    // if the DB write is briefly delayed; a non-active status drops it —
+    // and is remembered, so a later touch() cannot lift it.
+    this.noteStatus(companyId, status);
     if (!this.surreal) return;
     // Only SET the optional metadata that was actually supplied: the fields
     // are option<string>, and SurrealDB rejects a bound NULL on an option
@@ -179,20 +196,38 @@ export class TenantRegistryService implements OnModuleInit, OnModuleDestroy {
   }
 
   /**
-   * Hot-path "this tenant just authenticated" hook. Synchronously adds the
-   * tenant to the active cache (so the very first authenticated request in a
-   * prod-JWKS deployment makes the tenant visible to fan-out immediately),
-   * then fires a throttled, non-blocking lastSeen upsert. Never throws — a
-   * registry write must not fail an authenticated request.
+   * Hot-path "this tenant just authenticated" hook: records that the tenant
+   * was seen (a throttled, non-blocking lastSeen upsert) and reconciles the
+   * roster cache from the tenant's lifecycle STATUS — never from the
+   * activity itself. Never throws — a registry write must not fail an
+   * authenticated request.
    *
-   * A brand-new row is created with the field DEFAULT status 'active'; an
-   * existing row keeps its status (a suspended tenant is not silently
-   * reactivated — the next refresh() drops it back out of the cache).
+   * Activity and membership are separate on purpose. A suspended tenant's
+   * credentials may still be valid (suspension is a registry state, not a
+   * key revocation), so it keeps arriving here; it used to be re-added to
+   * the fan-out roster on every request, until the next refresh() dropped
+   * it again — a suspended tenant in and out of background sweeps by the
+   * minute. Now:
+   *   - a tenant this pod knows to be active is visible synchronously, as
+   *     before (the very first request in a prod-JWKS deployment makes it
+   *     visible to fan-out at once);
+   *   - a tenant this pod knows to be suspended/provisioning stays out;
+   *   - an UNKNOWN tenant is added only after the write echoes the row's
+   *     status back — a brand-new row is created with the field DEFAULT
+   *     'active', an existing row keeps whatever status it has. The few
+   *     milliseconds of the round-trip are the price of never lifting a
+   *     suspension, even transiently.
    */
   touch(companyId: string): void {
     if (!COMPANY_ID.test(companyId)) return;
-    this.activeCache.add(companyId);
-    if (!this.surreal) return;
+    const known = this.knownStatus.get(companyId);
+    if (!this.surreal) {
+      // In-memory mode (dev / unit fixtures): register() is the only thing
+      // that can suspend, and it is remembered; anything else is active.
+      if (known === undefined) this.noteStatus(companyId, 'active');
+      return;
+    }
+    if (known === 'active') this.activeCache.add(companyId);
     const now = Date.now();
     const last = this.lastWriteAt.get(companyId);
     if (last !== undefined && now - last < TOUCH_THROTTLE_MS) return;
@@ -200,15 +235,36 @@ export class TenantRegistryService implements OnModuleInit, OnModuleDestroy {
     // Fire-and-forget: the request path does not wait on the registry.
     void this.surreal
       .withAdminDb(async (db) => {
-        await db.query(
+        const [rows] = await db.query<[Array<{ status?: string }>]>(
           `UPSERT type::record('tenant_registry', $companyId) SET
              companyId = $companyId,
              lastSeen = time::now(),
-             updatedAt = time::now()`,
+             updatedAt = time::now()
+           RETURN status`,
           { companyId },
         );
+        const status = (rows as Array<{ status?: string }> | undefined)?.[0]?.status;
+        // No echoed status (an older server shape, a stub) → the tenant is
+        // not admitted on this pod until a refresh reads its row: fail
+        // closed on membership, the write still recorded the activity.
+        if (status !== undefined) this.noteStatus(companyId, status);
       })
       .catch((e) => this.logger.warn(`touch(${companyId}) write failed: ${(e as Error).message}`));
+  }
+
+  /**
+   * The one place membership is decided: remember the status, and derive
+   * the active roster from it. Anything that is not 'active' (suspended,
+   * provisioning, or an unexpected value) is out.
+   */
+  private noteStatus(companyId: string, status: string): void {
+    const known: TenantStatus =
+      status === 'active' || status === 'suspended' || status === 'provisioning'
+        ? status
+        : 'suspended';
+    this.knownStatus.set(companyId, known);
+    if (known === 'active') this.activeCache.add(companyId);
+    else this.activeCache.delete(companyId);
   }
 
   /**
@@ -311,12 +367,18 @@ export class TenantRegistryService implements OnModuleInit, OnModuleDestroy {
     }
   }
 
-  /** Replace the cache with the current active roster; keep old on failure. */
+  /**
+   * Replace the cache with the current roster; keep old on failure. Reads
+   * EVERY row, not only the active ones: a suspension written by another
+   * pod has to be learned here, or a touch() on this pod would keep the
+   * tenant's status unknown and its lastSeen writes would decide.
+   */
   private async refresh(): Promise<void> {
     try {
-      const active = await this.readActive();
+      const roster = await this.readRoster();
       this.activeCache.clear();
-      for (const id of active) this.activeCache.add(id);
+      this.knownStatus.clear();
+      for (const row of roster) this.noteStatus(row.companyId, row.status);
     } catch (e) {
       // Transient DB error — keep the last-known-good cache rather than
       // wiping the roster (which would starve fan-out).
@@ -325,13 +387,22 @@ export class TenantRegistryService implements OnModuleInit, OnModuleDestroy {
   }
 
   private async readActive(): Promise<string[]> {
+    return (await this.readRoster()).filter((r) => r.status === 'active').map((r) => r.companyId);
+  }
+
+  /** Every registry row with its status, deduped by companyId. */
+  private async readRoster(): Promise<Array<{ companyId: string; status: string }>> {
     if (!this.surreal) return [];
     return this.surreal.withAdminDb(async (db) => {
-      const rows = await queryRows<TenantRow>(
-        db,
-        `SELECT companyId FROM tenant_registry WHERE status = 'active'`,
-      );
-      return [...new Set(rows.map((r) => r.companyId).filter((id): id is string => Boolean(id)))];
+      const rows = await queryRows<RosterRow>(db, `SELECT companyId, status FROM tenant_registry`);
+      const byId = new Map<string, string>();
+      for (const r of rows) {
+        if (!r.companyId) continue;
+        // The column is SCHEMAFULL with DEFAULT 'active'; a missing value
+        // can only come from a stub, and reads as the default it would have.
+        byId.set(r.companyId, r.status ?? 'active');
+      }
+      return [...byId].map(([companyId, status]) => ({ companyId, status }));
     });
   }
 }

--- a/src/feedback/feedback.service.ts
+++ b/src/feedback/feedback.service.ts
@@ -1,8 +1,9 @@
 import { Injectable, Logger, Optional } from '@nestjs/common';
 import type { BrainScope } from '../auth/api-key.types';
 import { FactsService } from '../facts/facts.service';
-import { StringRecordId } from 'surrealdb';
-import { SurrealService } from '../db/surreal.service';
+import { StringRecordId, type Surreal } from 'surrealdb';
+import { SurrealService, runTransaction } from '../db/surreal.service';
+import { retryOnUniqueViolation } from '../db/surreal-retry';
 import { MetricsService } from '../metrics/metrics.service';
 import { idTailOf } from '../ingest/ingest-utils';
 import {
@@ -53,6 +54,65 @@ const OUTCOME_BUCKET: Record<FeedbackVerdict, OutcomeCounter | null> = {
   not_helpful: null,
 };
 
+/** The RETURN slot of the vote transaction: the verdict the vote replaced. */
+interface CastVoteRow {
+  prior?: FeedbackVerdict | null;
+}
+
+/**
+ * Cast one standing vote and learn what it replaced — in ONE transaction.
+ *
+ * The prior verdict and the write used to be two round-trips (a SELECT,
+ * then an INSERT … ON DUPLICATE KEY UPDATE). Two concurrent votes from the
+ * same actor both saw "no prior vote" in the gap: the UNIQUE index kept one
+ * row, but each request then emitted its own `+1` rollup delta, and the
+ * fact's confirmedCount counted one standing vote twice (audit 2026-09-06,
+ * F8). Reading the prior INSIDE the transaction that writes the vote makes
+ * the delta a function of what the database actually replaced: under
+ * contention the server serialises the two — the second one sees the
+ * first's row as its prior (a same-verdict replacement, net zero) — or
+ * aborts it with a write conflict, which the retry re-runs against the
+ * committed row. Either way exactly one vote stands and exactly one `+1`
+ * is emitted.
+ *
+ * Returns the replaced verdict, or undefined for a first vote.
+ */
+export async function castVote(
+  db: Surreal,
+  v: {
+    fact: StringRecordId;
+    verdict: FeedbackVerdict;
+    actor: string;
+    reason: string | undefined;
+  },
+): Promise<FeedbackVerdict | undefined> {
+  return retryOnUniqueViolation(async () => {
+    const row = await runTransaction<CastVoteRow | null | undefined>(db, (tx) => {
+      tx.add(
+        `LET $prior = (SELECT VALUE verdict FROM retrieval_feedback
+            WHERE factId = $fact AND actor = $actor LIMIT 1)[0]`,
+      )
+        // One standing vote per (fact, actor): the UNIQUE index routes a
+        // repeat into the UPDATE branch — verdict replaced, not stacked.
+        .add(
+          `INSERT INTO retrieval_feedback {
+             factId: $fact, verdict: $verdict, actor: $actor,
+             reason: $reason, createdAt: time::now()
+           } ON DUPLICATE KEY UPDATE
+             verdict = $verdict, reason = $reason, createdAt = time::now()`,
+        )
+        .add(`RETURN { prior: $prior }`)
+        .bind('fact', v.fact)
+        .bind('verdict', v.verdict)
+        .bind('actor', v.actor)
+        // undefined → NONE on the wire; option<string> rejects NULL.
+        .bind('reason', v.reason);
+    });
+    const prior = row?.prior;
+    return prior === null || prior === undefined ? undefined : prior;
+  });
+}
+
 @Injectable()
 export class FeedbackService {
   private readonly logger = new Logger(FeedbackService.name);
@@ -83,32 +143,15 @@ export class FeedbackService {
     await this.facts.getFact({ companyId: p.companyId, factId: p.factId, scopes: p.scopes });
     return this.surreal.withCompany(p.companyId, async (db) => {
       const fact = new StringRecordId(`knowledge_fact:${idTailOf(p.factId)}`);
-      // One standing vote per (fact, actor): the UNIQUE index routes a
-      // repeat into the UPDATE branch — verdict replaced, not stacked.
-      // The prior verdict is read alongside so the 0107 rollup can move
-      // the replaced vote out of its old bucket (−1 old / +1 new).
-      const [existing] = await db.query<[Array<{ id: unknown; verdict: FeedbackVerdict }>]>(
-        `SELECT id, verdict FROM retrieval_feedback WHERE factId = $fact AND actor = $actor`,
-        { fact, actor: p.actor },
-      );
-      const prior = ((existing as Array<{ id: unknown; verdict: FeedbackVerdict }>) ?? [])[0];
+      const prior = await castVote(db, {
+        fact,
+        verdict: p.verdict,
+        actor: p.actor,
+        reason: p.reason,
+      });
       const replaced = prior !== undefined;
-      await db.query(
-        `INSERT INTO retrieval_feedback {
-           factId: $fact, verdict: $verdict, actor: $actor,
-           reason: $reason, createdAt: time::now()
-         } ON DUPLICATE KEY UPDATE
-           verdict = $verdict, reason = $reason, createdAt = time::now()`,
-        {
-          fact,
-          verdict: p.verdict,
-          actor: p.actor,
-          // undefined → NONE on the wire; option<string> rejects NULL.
-          reason: p.reason,
-        },
-      );
       this.metrics?.countFeedback(p.verdict);
-      this.emitOutcome(p.companyId, String(fact), p.verdict, prior?.verdict, p.actor);
+      this.emitOutcome(p.companyId, String(fact), p.verdict, prior, p.actor);
       this.logger.log(
         `feedback ${p.companyId}: ${String(fact)} ${p.verdict}${replaced ? ' (replaced)' : ''}`,
       );

--- a/test/feedback-atomic-vote.e2e-spec.ts
+++ b/test/feedback-atomic-vote.e2e-spec.ts
@@ -1,0 +1,152 @@
+/**
+ * F8 (audit 2026-09-06) against a REAL SurrealDB: two concurrent votes from
+ * the same caller key leave one standing vote AND one `+1` in the 0107
+ * rollup. Before, the prior vote was read in a separate round-trip from
+ * the write, so both requests saw "no prior vote", the UNIQUE index kept
+ * one row, and `memory_outcome_stat.confirmedCount` counted it twice.
+ */
+import { AppFixture, createApp } from './app-fixture';
+import { SurrealService } from '../src/db/surreal.service';
+
+interface StatRow {
+  confirmedCount: number;
+  rejectedCount: number;
+}
+
+describe('feedback: one standing vote, one rollup delta (real SurrealDB)', () => {
+  let f: AppFixture;
+  const auth = () => ({ Authorization: `Bearer ${f.apiKey}` });
+
+  beforeAll(async () => {
+    f = await createApp({ companyId: 'co_feedback_atomic_e2e' });
+    process.env.OUTCOME_TELEMETRY_ENABLED = '1';
+  });
+
+  afterAll(async () => {
+    delete process.env.OUTCOME_TELEMETRY_ENABLED;
+    if (f) await f.close();
+  });
+
+  const tail = (factId: string) => factId.split(':')[1];
+
+  const statFor = async (factId: string): Promise<StatRow | null> => {
+    const surreal = f.app.get(SurrealService);
+    return surreal.withCompany(f.companyId, async (db) => {
+      const [rows] = await db.query<[StatRow[]]>(
+        `SELECT confirmedCount, rejectedCount FROM memory_outcome_stat
+          WHERE subjectId = type::record('knowledge_fact', $tail)`,
+        { tail: tail(factId) },
+      );
+      return (rows as StatRow[])?.[0] ?? null;
+    });
+  };
+
+  const standingVotes = async (factId: string): Promise<string[]> => {
+    const surreal = f.app.get(SurrealService);
+    return surreal.withCompany(f.companyId, async (db) => {
+      const [rows] = await db.query<[Array<{ verdict: string }>]>(
+        `SELECT verdict FROM retrieval_feedback
+          WHERE factId = type::record('knowledge_fact', $tail)`,
+        { tail: tail(factId) },
+      );
+      return ((rows as Array<{ verdict: string }>) ?? []).map((r) => r.verdict);
+    });
+  };
+
+  /** The rollup write is fire-and-forget — poll until it has landed. */
+  const settle = async (
+    probe: () => Promise<StatRow | null>,
+    ok: (s: StatRow | null) => boolean,
+  ) => {
+    let last = await probe();
+    for (let i = 0; i < 50 && !ok(last); i++) {
+      await new Promise((r) => setTimeout(r, 100));
+      last = await probe();
+    }
+    return last;
+  };
+
+  async function ingestFact(id: string): Promise<string> {
+    const r = await f.http
+      .post('/v1/ingest/fact')
+      .set(auth())
+      .send({
+        entityRef: { vertical: 'rent', id },
+        predicate: 'tier',
+        object: 'gold',
+        validFrom: '2026-01-01',
+        confidence: 0.9,
+        source: { vertical: 'rent', recorder: 'fb_bot' },
+      });
+    expect([200, 201]).toContain(r.status);
+    return r.body.factId as string;
+  }
+
+  it('two concurrent helpful votes from one key: one row, confirmedCount 1', async () => {
+    const factId = await ingestFact('fb_atomic_subject');
+    const [a, b] = await Promise.all([
+      f.http.post('/v1/feedback').set(auth()).send({ factId, verdict: 'helpful' }),
+      f.http.post('/v1/feedback').set(auth()).send({ factId, verdict: 'helpful' }),
+    ]);
+    expect(a.status).toBe(201);
+    expect(b.status).toBe(201);
+    // Exactly one of the two saw the other's vote as its prior.
+    expect([a.body.replaced, b.body.replaced].sort()).toEqual([false, true]);
+    expect(await standingVotes(factId)).toEqual(['helpful']);
+    // Give a wrong second delta every chance to land before asserting.
+    const stat = await settle(
+      () => statFor(factId),
+      (s) => (s?.confirmedCount ?? 0) >= 1,
+    );
+    await new Promise((r) => setTimeout(r, 300));
+    expect(await statFor(factId)).toMatchObject({ confirmedCount: 1, rejectedCount: 0 });
+    expect(stat).not.toBeNull();
+  });
+
+  it('helpful → incorrect moves the standing vote between buckets, never stacks', async () => {
+    const factId = await ingestFact('fb_atomic_flip');
+    const first = await f.http
+      .post('/v1/feedback')
+      .set(auth())
+      .send({ factId, verdict: 'helpful' });
+    expect(first.body.replaced).toBe(false);
+    await settle(
+      () => statFor(factId),
+      (s) => (s?.confirmedCount ?? 0) >= 1,
+    );
+    const second = await f.http
+      .post('/v1/feedback')
+      .set(auth())
+      .send({ factId, verdict: 'incorrect', reason: 'tier is silver' });
+    expect(second.status).toBe(201);
+    expect(second.body.replaced).toBe(true);
+    const flipped = await settle(
+      () => statFor(factId),
+      (s) => (s?.rejectedCount ?? 0) >= 1 && (s?.confirmedCount ?? 1) === 0,
+    );
+    expect(flipped).toMatchObject({ confirmedCount: 0, rejectedCount: 1 });
+    expect(await standingVotes(factId)).toEqual(['incorrect']);
+  });
+
+  it('concurrent helpful + incorrect from one key: one standing vote, one bucket at 1', async () => {
+    const factId = await ingestFact('fb_atomic_mixed');
+    const [a, b] = await Promise.all([
+      f.http.post('/v1/feedback').set(auth()).send({ factId, verdict: 'helpful' }),
+      f.http.post('/v1/feedback').set(auth()).send({ factId, verdict: 'incorrect' }),
+    ]);
+    expect(a.status).toBe(201);
+    expect(b.status).toBe(201);
+    const votes = await standingVotes(factId);
+    expect(votes).toHaveLength(1);
+    const stat = await settle(
+      () => statFor(factId),
+      (s) => (s?.confirmedCount ?? 0) + (s?.rejectedCount ?? 0) >= 1,
+    );
+    await new Promise((r) => setTimeout(r, 300));
+    const final = await statFor(factId);
+    expect(stat).not.toBeNull();
+    expect((final?.confirmedCount ?? 0) + (final?.rejectedCount ?? 0)).toBe(1);
+    // The rollup agrees with whichever vote stands.
+    expect(votes[0] === 'helpful' ? final?.confirmedCount : final?.rejectedCount).toBe(1);
+  });
+});

--- a/test/feedback-atomic-vote.unit-spec.ts
+++ b/test/feedback-atomic-vote.unit-spec.ts
@@ -1,0 +1,168 @@
+/**
+ * F8 (audit 2026-09-06): the prior vote and the new vote used to be two
+ * round-trips, so two concurrent votes from ONE actor both read "no prior
+ * vote" and each emitted `+1 confirmedCount` — one standing vote counted
+ * twice in the rollup. The vote is now cast and its prior read in ONE
+ * transaction, and the rollup delta is derived from what the database
+ * actually replaced.
+ *
+ * The fake here emulates a serialisable store at the transaction level:
+ * each vote transaction takes a snapshot of the standing vote, is held at
+ * a barrier until BOTH concurrent transactions have started (the audit's
+ * interleaving), and then commits — unless another transaction committed
+ * after its snapshot, in which case it aborts with the server's write
+ * conflict and the service's retry re-runs it against the committed row.
+ */
+import { FeedbackService } from '../src/feedback/feedback.service';
+import type { SurrealService } from '../src/db/surreal.service';
+import type { FactsService } from '../src/facts/facts.service';
+import type { MemoryOutcomeService, StatDelta } from '../src/outcomes/memory-outcome.service';
+
+interface Recorded {
+  events: Array<{ event: string }>;
+  statDeltas: StatDelta[];
+}
+
+function makeStore(opts: { barrier: number }) {
+  let standing: string | undefined;
+  let commits = 0;
+  let started = 0;
+  const waiters: Array<() => void> = [];
+  const transactions: Array<{ prior: string | undefined; attempt: number }> = [];
+  const attemptsByVerdict = new Map<string, number>();
+
+  const query = async (sql: string, vars?: Record<string, unknown>) => {
+    if (!sql.startsWith('BEGIN TRANSACTION') || !sql.includes('retrieval_feedback')) return [[]];
+    const verdict = String(vars?.verdict);
+    const attempt = (attemptsByVerdict.get(verdict) ?? 0) + 1;
+    attemptsByVerdict.set(verdict, attempt);
+    const snapshot = standing;
+    const commitsAtSnapshot = commits;
+    // Barrier: the first N transactions all read their snapshot before any
+    // of them commits — the exact window the two-round-trip code raced in.
+    started++;
+    if (started <= opts.barrier) {
+      await new Promise<void>((resolve) => {
+        waiters.push(resolve);
+        if (waiters.length === opts.barrier) for (const w of waiters.splice(0)) w();
+      });
+    }
+    if (commits > commitsAtSnapshot) {
+      throw new Error(
+        'Transaction conflict: Write conflict, retry the transaction. This transaction can be retried',
+      );
+    }
+    standing = verdict;
+    commits++;
+    transactions.push({ prior: snapshot, attempt });
+    // 3.x slot shape: BEGIN, LET, INSERT, RETURN, COMMIT.
+    return [null, null, [{ verdict }], { prior: snapshot ?? null }, null];
+  };
+  return {
+    query,
+    transactions,
+    standingVote: () => standing,
+    attempts: (verdict: string) => attemptsByVerdict.get(verdict) ?? 0,
+  };
+}
+
+function makeService(store: ReturnType<typeof makeStore>) {
+  const recorded: Recorded[] = [];
+  const surreal = {
+    withCompany: async <T>(_c: string, fn: (db: unknown) => Promise<T>) =>
+      fn({ query: store.query }),
+  } as unknown as SurrealService;
+  const facts = { getFact: async () => ({}) } as unknown as FactsService;
+  const outcomes = {
+    recordOutcomes: (o: Recorded) => recorded.push(o),
+  } as unknown as MemoryOutcomeService;
+  const svc = new FeedbackService(surreal, facts, undefined, outcomes);
+  return { svc, recorded };
+}
+
+const sum = (recorded: Recorded[], counter: string) =>
+  recorded
+    .flatMap((r) => r.statDeltas)
+    .filter((d) => d.counter === counter)
+    .reduce((n, d) => n + d.delta, 0);
+
+describe('feedback — one standing vote, one rollup delta, under concurrency (F8)', () => {
+  const vote = (verdict: 'helpful' | 'incorrect') => ({
+    companyId: 'co_a',
+    factId: 'knowledge_fact:f',
+    verdict,
+    actor: 'same_actor',
+    scopes: ['brain:read', 'brain:write'] as const,
+  });
+
+  beforeEach(() => {
+    process.env.OUTCOME_TELEMETRY_ENABLED = '1';
+  });
+  afterEach(() => {
+    delete process.env.OUTCOME_TELEMETRY_ENABLED;
+  });
+
+  it('two concurrent helpful votes from one actor net exactly +1 confirmedCount', async () => {
+    const store = makeStore({ barrier: 2 });
+    const { svc, recorded } = makeService(store);
+    const [a, b] = await Promise.all([svc.record(vote('helpful')), svc.record(vote('helpful'))]);
+    // Exactly one of the two saw the other's row as its prior.
+    expect([a.replaced, b.replaced].sort()).toEqual([false, true]);
+    expect(store.standingVote()).toBe('helpful');
+    // The loser aborted on the conflict and was re-run against the
+    // committed row — its retry is what makes the delta correct.
+    expect(store.attempts('helpful')).toBe(3);
+    expect(store.transactions.map((t) => t.prior)).toEqual([undefined, 'helpful']);
+    // Rollup: +1 once. The same-verdict replacement nets zero (no delta).
+    expect(sum(recorded, 'confirmedCount')).toBe(1);
+    // Raw audit trail: both votes are appended as events, by contract.
+    expect(recorded.flatMap((r) => r.events).map((e) => e.event)).toEqual([
+      'user_confirmed',
+      'user_confirmed',
+    ]);
+  });
+
+  it('a concurrent helpful + incorrect from one actor leaves exactly one bucket at 1', async () => {
+    const store = makeStore({ barrier: 2 });
+    const { svc, recorded } = makeService(store);
+    await Promise.all([svc.record(vote('helpful')), svc.record(vote('incorrect'))]);
+    const confirmed = sum(recorded, 'confirmedCount');
+    const rejected = sum(recorded, 'rejectedCount');
+    // Whichever verdict stands, the rollup agrees with the standing vote.
+    expect(confirmed + rejected).toBe(1);
+    expect(store.standingVote() === 'helpful' ? confirmed : rejected).toBe(1);
+  });
+
+  it('a sequential helpful → incorrect replacement moves the vote between buckets', async () => {
+    const store = makeStore({ barrier: 0 });
+    const { svc, recorded } = makeService(store);
+    expect((await svc.record(vote('helpful'))).replaced).toBe(false);
+    expect((await svc.record(vote('incorrect'))).replaced).toBe(true);
+    expect(sum(recorded, 'confirmedCount')).toBe(0);
+    expect(sum(recorded, 'rejectedCount')).toBe(1);
+  });
+
+  it('the prior is read inside the same transaction that writes the vote', async () => {
+    const seen: string[] = [];
+    const surreal = {
+      withCompany: async <T>(_c: string, fn: (db: unknown) => Promise<T>) =>
+        fn({
+          query: async (sql: string) => {
+            seen.push(sql);
+            return [null, null, [], { prior: null }, null];
+          },
+        }),
+    } as unknown as SurrealService;
+    const facts = { getFact: async () => ({}) } as unknown as FactsService;
+    const svc = new FeedbackService(surreal, facts);
+    await svc.record(vote('helpful'));
+    expect(seen).toHaveLength(1);
+    const [sql] = seen;
+    expect(sql).toMatch(/^BEGIN TRANSACTION;/);
+    expect(sql).toContain('LET $prior = (SELECT VALUE verdict FROM retrieval_feedback');
+    expect(sql).toContain('INSERT INTO retrieval_feedback');
+    expect(sql).toContain('ON DUPLICATE KEY UPDATE');
+    expect(sql).toContain('RETURN { prior: $prior }');
+    expect(sql).toMatch(/COMMIT TRANSACTION;$/);
+  });
+});

--- a/test/tenant-registry-suspended.e2e-spec.ts
+++ b/test/tenant-registry-suspended.e2e-spec.ts
@@ -1,0 +1,106 @@
+/**
+ * F9 (audit 2026-09-06) against a REAL SurrealDB: a suspended tenant whose
+ * credential is still valid keeps authenticating, and every request used to
+ * put it straight back into the synchronous active roster (touch() added
+ * to the cache before anything else) until the next refresh dropped it —
+ * a suspended tenant in and out of background fan-out by the minute.
+ *
+ * Membership now follows the registry STATUS, never the activity: the
+ * tenant stays out synchronously, after its lastSeen write, and across a
+ * roster refresh; lastSeen is still recorded.
+ */
+import { AppFixture, createApp } from './app-fixture';
+import { SurrealService } from '../src/db/surreal.service';
+import { TenantRegistryService } from '../src/auth/tenant-registry.service';
+import { ApiKeyService } from '../src/auth/api-key.service';
+
+describe('tenant registry: suspension survives activity (real SurrealDB)', () => {
+  let f: AppFixture;
+  const auth = () => ({ Authorization: `Bearer ${f.apiKey}` });
+  const settle = () => new Promise((r) => setTimeout(r, 250));
+
+  beforeAll(async () => {
+    f = await createApp({ companyId: 'co_suspended_roster_e2e' });
+  });
+
+  afterAll(async () => {
+    if (f) await f.close();
+  });
+
+  const registry = () => f.app.get(TenantRegistryService);
+
+  const rowFor = async (companyId: string) => {
+    const surreal = f.app.get(SurrealService);
+    return surreal.withAdminDb(async (db) => {
+      const [rows] = await db.query<[Array<{ status: string; lastSeen: unknown }>]>(
+        `SELECT status, lastSeen FROM type::record('tenant_registry', $id)`,
+        { id: companyId },
+      );
+      return (rows as Array<{ status: string; lastSeen: unknown }>)?.[0];
+    });
+  };
+
+  it('an active tenant enters the roster through the credential path', async () => {
+    await registry().register(f.companyId, { status: 'active' });
+    const r = await f.http.get('/v1/facts/knowledge_fact:nope').set(auth());
+    expect(r.status).not.toBe(401);
+    await settle();
+    expect(registry().activeCompanyIds()).toContain(f.companyId);
+    expect(f.app.get(ApiKeyService).knownCompanyIds()).toContain(f.companyId);
+  });
+
+  it('a suspended tenant with a valid credential stays OUT of the roster, even transiently', async () => {
+    await registry().register(f.companyId, { status: 'suspended' });
+    expect(registry().activeCompanyIds()).not.toContain(f.companyId);
+    const before = await rowFor(f.companyId);
+
+    // The real hot path: an authenticated request resolves the tenant and
+    // the credential resolver calls touch() on it.
+    const r = await f.http.get('/v1/facts/knowledge_fact:nope').set(auth());
+    expect(r.status).not.toBe(401);
+    // Synchronously — the old code added the tenant right here.
+    expect(registry().activeCompanyIds()).not.toContain(f.companyId);
+    await settle();
+    // After the lastSeen write echoed the row's status back.
+    expect(registry().activeCompanyIds()).not.toContain(f.companyId);
+
+    // The status was not touched. (register() wrote lastSeen a moment ago,
+    // so this touch is inside the write throttle — the lastSeen write path
+    // for a tenant unknown to this pod is exercised by the next test.)
+    const after = await rowFor(f.companyId);
+    expect(after?.status).toBe('suspended');
+    expect(after?.lastSeen).toBeDefined();
+    expect(before?.status).toBe('suspended');
+
+    // And across a roster refresh from the registry (what other pods do).
+    await (registry() as unknown as { refresh(): Promise<void> }).refresh();
+    expect(registry().activeCompanyIds()).not.toContain(f.companyId);
+    expect(await registry().listActive()).not.toContain(f.companyId);
+  });
+
+  it('a tenant unknown to this pod but suspended in the registry is not admitted by touch()', async () => {
+    const other = 'co_suspended_elsewhere_e2e';
+    // Written as another pod would: straight into the registry, so THIS
+    // pod's cache has never heard of it.
+    const surreal = f.app.get(SurrealService);
+    await surreal.withAdminDb(async (db) => {
+      await db.query(
+        `UPSERT type::record('tenant_registry', $id) SET
+           companyId = $id, status = 'suspended', lastSeen = time::now(), updatedAt = time::now()`,
+        { id: other },
+      );
+    });
+    registry().touch(other);
+    expect(registry().activeCompanyIds()).not.toContain(other);
+    await settle();
+    expect(registry().activeCompanyIds()).not.toContain(other);
+    expect((await rowFor(other))?.status).toBe('suspended');
+  });
+
+  it('re-registering as active restores membership', async () => {
+    await registry().register(f.companyId, { status: 'active' });
+    expect(registry().activeCompanyIds()).toContain(f.companyId);
+    await (registry() as unknown as { refresh(): Promise<void> }).refresh();
+    expect(registry().activeCompanyIds()).toContain(f.companyId);
+  });
+});

--- a/test/tenant-registry.service.unit-spec.ts
+++ b/test/tenant-registry.service.unit-spec.ts
@@ -47,17 +47,27 @@ interface RecordedQuery {
 
 function makeFakeSurreal() {
   const queries: RecordedQuery[] = [];
-  let activeRows: Array<{ companyId: string }> = [];
+  let rosterRows: Array<{ companyId: string; status: string }> = [];
   let stateRows: Array<Record<string, unknown>> = [];
+  /** What the registry row's status reads as when a touch() write echoes it. */
+  const statusInDb = new Map<string, string>();
   const surreal = {
     async withAdminDb<T>(fn: (db: unknown) => Promise<T>): Promise<T> {
       const db = {
         async query<R>(sql: string, vars?: Record<string, unknown>): Promise<R> {
           queries.push({ sql, vars });
-          if (sql.includes('SELECT companyId FROM tenant_registry')) {
-            return [activeRows] as unknown as R;
+          if (sql.includes('SELECT companyId, status FROM tenant_registry')) {
+            return [rosterRows] as unknown as R;
           }
           if (sql.includes('indexState')) return [stateRows] as unknown as R;
+          if (sql.includes('RETURN status')) {
+            // The real UPSERT creates a missing row with DEFAULT 'active'
+            // and leaves an existing row's status alone.
+            const id = String(vars?.companyId);
+            const status = statusInDb.get(id) ?? 'active';
+            statusInDb.set(id, status);
+            return [[{ status }]] as unknown as R;
+          }
           return [[]] as unknown as R;
         },
       };
@@ -68,7 +78,13 @@ function makeFakeSurreal() {
     surreal,
     queries,
     setActive(rows: string[]) {
-      activeRows = rows.map((companyId) => ({ companyId }));
+      rosterRows = rows.map((companyId) => ({ companyId, status: 'active' }));
+    },
+    setRoster(rows: Array<{ companyId: string; status: string }>) {
+      rosterRows = rows;
+    },
+    setStatusInDb(companyId: string, status: string) {
+      statusInDb.set(companyId, status);
     },
     setStateRows(rows: Array<Record<string, unknown>>) {
       stateRows = rows;
@@ -182,20 +198,99 @@ describe('TenantRegistryService', () => {
     svc.onModuleDestroy();
   });
 
-  it('touch() adds to the cache synchronously and writes lastSeen once (throttled)', async () => {
+  it('touch() on an unknown tenant admits it once the write echoes an active row, and throttles', async () => {
     const { surreal, queries } = makeFakeSurreal();
     const svc = new TenantRegistryService(surreal);
     svc.touch('co_z');
-    // Synchronous cache update — visible immediately, before any DB round-trip.
-    expect(svc.activeCompanyIds()).toEqual(['co_z']);
+    // Not before the registry has answered: this pod does not know the
+    // tenant's status, and a suspended row must never be admitted, even
+    // for the length of a round-trip.
+    expect(svc.activeCompanyIds()).toEqual([]);
     await flush();
+    expect(svc.activeCompanyIds()).toEqual(['co_z']);
     const writes = () => queries.filter((q) => q.sql.includes('UPSERT'));
     expect(writes()).toHaveLength(1);
+    expect(writes()[0]!.sql).toContain('RETURN status');
+    expect(writes()[0]!.sql).not.toContain('status =');
     expect(writes()[0]!.vars).toMatchObject({ companyId: 'co_z' });
-    // Second touch within the throttle window issues no new write.
+    // Second touch within the throttle window issues no new write — and
+    // a tenant this pod knows to be active is visible synchronously.
     svc.touch('co_z');
+    expect(svc.activeCompanyIds()).toEqual(['co_z']);
     await flush();
     expect(writes()).toHaveLength(1);
+    svc.onModuleDestroy();
+  });
+
+  it('touch() never lifts a suspension this pod knows about — not even transiently (F9)', async () => {
+    const { surreal, queries } = makeFakeSurreal();
+    const svc = new TenantRegistryService(surreal);
+    await svc.register('co_a', { status: 'suspended' });
+    expect(svc.activeCompanyIds()).toEqual([]);
+    svc.touch('co_a');
+    // The old code added the tenant right here, before the throttle.
+    expect(svc.activeCompanyIds()).toEqual([]);
+    await flush();
+    expect(svc.activeCompanyIds()).toEqual([]);
+    // register() wrote lastSeen just now, so the touch is throttled: the
+    // activity is not lost (it was recorded a moment ago), and no write
+    // means nothing could have changed the status either.
+    expect(queries.filter((q) => q.sql.includes('RETURN status'))).toHaveLength(0);
+    svc.onModuleDestroy();
+  });
+
+  it('touch() on a tenant suspended in the registry (unknown to this pod) is not admitted (F9)', async () => {
+    const { surreal, setStatusInDb } = makeFakeSurreal();
+    setStatusInDb('co_s', 'suspended');
+    const svc = new TenantRegistryService(surreal);
+    svc.touch('co_s');
+    expect(svc.activeCompanyIds()).toEqual([]);
+    await flush();
+    // The write echoed 'suspended' — lastSeen was bumped, membership not.
+    expect(svc.activeCompanyIds()).toEqual([]);
+    // Known now: a second touch stays out synchronously too.
+    svc.touch('co_s');
+    expect(svc.activeCompanyIds()).toEqual([]);
+    svc.onModuleDestroy();
+  });
+
+  it('touch() without an echoed status fails closed on membership', async () => {
+    // A write that does not say what the row's status is (a stub, an older
+    // server shape) records the activity and admits nothing.
+    const svc = new TenantRegistryService({
+      withAdminDb: async <T>(fn: (db: unknown) => Promise<T>) => fn({ query: async () => [[]] }),
+    } as unknown as SurrealService);
+    svc.touch('co_q');
+    await flush();
+    expect(svc.activeCompanyIds()).toEqual([]);
+    svc.onModuleDestroy();
+  });
+
+  it('a refresh learns a suspension written by another pod and drops the tenant', async () => {
+    const { surreal, setRoster } = makeFakeSurreal();
+    const svc = new TenantRegistryService(surreal);
+    await svc.register('co_a', { status: 'active' });
+    expect(svc.activeCompanyIds()).toEqual(['co_a']);
+    setRoster([
+      { companyId: 'co_a', status: 'suspended' },
+      { companyId: 'co_b', status: 'active' },
+      { companyId: 'co_p', status: 'provisioning' },
+    ]);
+    svc.onModuleInit(); // kicks a refresh
+    await flush();
+    expect(svc.activeCompanyIds()).toEqual(['co_b']);
+    // And the learned status governs the next touch.
+    svc.touch('co_a');
+    expect(svc.activeCompanyIds()).toEqual(['co_b']);
+    svc.onModuleDestroy();
+  });
+
+  it('in-memory mode: register(suspended) is remembered, touch() does not lift it', async () => {
+    const svc = new TenantRegistryService();
+    await svc.register('co_a', { status: 'suspended' });
+    expect(svc.activeCompanyIds()).toEqual([]);
+    svc.touch('co_a');
+    expect(svc.activeCompanyIds()).toEqual([]);
     svc.onModuleDestroy();
   });
 


### PR DESCRIPTION
Two findings from the 2026-09-06 current-state audit, one commit each.

## F8 — `fix(feedback)`: cast a vote and read the vote it replaces in one transaction
Two concurrent votes from the same actor each read "no prior vote" in the gap between the SELECT and the `INSERT … ON DUPLICATE KEY UPDATE`. The UNIQUE index kept one standing row, but each request emitted its own `+1` on the 0107 rollup, so `confirmedCount` counted one vote twice.

The prior verdict is now read **inside** the transaction that writes the vote (`LET $prior …; INSERT … ON DUPLICATE KEY UPDATE …; RETURN { prior }` via `runTransaction`), so the delta is a function of what the database actually replaced. Under contention the server serialises the two (the second sees the first's row as its prior — a same-verdict replacement, net zero) or aborts with a write conflict, which `retryOnUniqueViolation` re-runs against the committed row. Either way one vote stands and one `+1` is emitted; the raw event trail still records both votes, by contract. Probed on SurrealDB 3.2.4 first: the transaction returns the prior, and two racing first votes come back as `{prior: null}` / `{prior: "helpful"}` with one row.

## F9 — `fix(auth)`: a suspended tenant's activity never puts it back on the active roster
`touch()` added the tenant to the synchronous roster before anything else, so a suspended tenant whose credential still verified re-entered background fan-out on every request and dropped out on the next refresh. Membership now follows the registry **status** the pod knows, never the activity: known-active → visible synchronously as before; known-suspended/provisioning → stays out; unknown → admitted only after the lastSeen write echoes the row's status back (`RETURN status`; a new row gets the DEFAULT `active`, an existing row keeps its status); no echoed status admits nothing. `refresh()` now reads every row's status, so a suspension written by another pod governs the next touch here too. lastSeen is still recorded.

## Proof
- **Unit** `test/feedback-atomic-vote.unit-spec.ts`: a fake serialisable store (snapshot, barrier, conflict-on-stale-commit) — two concurrent helpful votes net exactly `+1`, the loser retries once; a concurrent helpful/incorrect pair leaves exactly one bucket at 1; sequential helpful→incorrect moves the vote; the SQL is one `BEGIN … COMMIT` block.
- **Unit** `test/tenant-registry.service.unit-spec.ts` (+6): register(suspended) → touch() → still out synchronously and after the write; suspended-in-registry-but-unknown-here is not admitted; no echoed status fails closed; a refresh learns a suspension written elsewhere; in-memory mode remembers a suspension.
- **Real SurrealDB** `test/feedback-atomic-vote.e2e-spec.ts`: two concurrent `POST /v1/feedback` helpful → both 201, exactly one `replaced: true`, one standing row, `confirmedCount 1 / rejectedCount 0` after the fire-and-forget rollup settles; helpful→incorrect flips the buckets; concurrent helpful+incorrect leaves one standing vote and the rollup agreeing with it.
- **Real SurrealDB** `test/tenant-registry-suspended.e2e-spec.ts`: a suspended tenant with a valid key makes an authenticated request and stays out of `activeCompanyIds()` synchronously, after the write, and across `refresh()`/`listActive()`; a tenant suspended by "another pod" is not admitted by `touch()`; re-registering as active restores membership.
- Both e2e suites fail on the previous code (F8: the two concurrent cases; F9: the two suspension cases) and pass with the fix. Existing `feedback.e2e` and `memory-outcome.e2e` still green (20/20 across the four suites). tsc app + spec, eslint, prettier clean.

Not in scope: F8's sibling race on other outcome writers (the audit only named feedback), and any rollup *reconciliation* from standing votes — the delta path is now exact, so none is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhrQxeisXJZEt4sg3PGyU6