### PR TITLE
fix(answer-cache): cache every dependency of an answer, and count usage only for what was served

### DIFF
--- a/src/answer-cache/answer-cache.service.ts
+++ b/src/answer-cache/answer-cache.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger, Optional } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { createHash } from 'node:crypto';
-import { StringRecordId } from 'surrealdb';
+import { StringRecordId, type Surreal } from 'surrealdb';
 import { SurrealService } from '../db/surreal.service';
 import { envFlagEnabled } from '../common/env-validation';
 import { pinUserScope } from '../auth/user-scope';
@@ -12,7 +12,7 @@ import { ReadPinService, type ReadPin } from '../episodes/read-pin.service';
 import { detectEnumerationShape } from '../synthesize/answer-router';
 import type { RetrievalProfile } from '../search/retrieval-profile';
 import type { SynthesizeDto } from '../synthesize/dto/synthesize.dto';
-import type { SynthesizeResult } from '../synthesize/synthesize.types';
+import type { EvidenceCitation, SynthesizeResult } from '../synthesize/synthesize.types';
 import type { Citation } from '../synthesize/fact-index';
 
 /**
@@ -21,20 +21,206 @@ import type { Citation } from '../synthesize/fact-index';
  * the evidence: a change to the generator system prompt, the fact-line
  * rendering, or the frame sections can change what the same facts
  * produce — and none of that is visible in the profile or the model
- * id. Bump this constant MANUALLY in the PR that changes prompt shape;
- * every existing entry then misses by key construction (no sweep
- * needed, TTL reaps the orphans).
+ * id. Bump this constant MANUALLY in the PR that changes prompt shape OR
+ * the stored-row contract; every existing entry then misses by key
+ * construction (no sweep needed, TTL reaps the orphans).
+ *
+ *   1 — 0091 shape.
+ *   2 — 0136: a row carries its typed non-fact `dependencies`; a pre-0136
+ *       row cannot be revalidated and must never be served.
  */
-export const ANSWER_CACHE_PROMPT_VERSION = 1;
+export const ANSWER_CACHE_PROMPT_VERSION = 2;
 
 /** Table + record-id namespace of the cache rows (migration 0091). */
 const TABLE = 'answer_cache';
 
-/** Mirrors the migration-0091/0097 ASSERT on answer_cache.invalidationCause.
- *  `newer_fact` (0097) = the additive-write freshness cause: a NEW active
- *  fact appeared on a cited entity after the answer was built. */
+/** Mirrors the migration-0091/0097/0136 ASSERT on
+ *  answer_cache.invalidationCause. `newer_fact` (0097) = the additive-write
+ *  freshness cause: a NEW active fact appeared on a cited entity after the
+ *  answer was built. `dependency_changed` (0136) = a non-fact dependency's
+ *  lifecycle stamp moved while its row stayed servable (a belief revised in
+ *  place, a scene recomposed, an asset's quarantine state changed). */
 export type InvalidationCause =
-  'superseded' | 'retracted' | 'expired_validity' | 'missing' | 'newer_fact';
+  'superseded' | 'retracted' | 'expired_validity' | 'missing' | 'newer_fact' | 'dependency_changed';
+
+/**
+ * The non-fact evidence a cached answer rests on (0136, audit F3) — one
+ * entry per EvidenceCitation arm, in the order the arms are declared.
+ * Every kind here is revalidated on EVERY read; an arm this list does not
+ * name is untrackable, and an answer citing one is never admitted.
+ */
+export type CachedDependencyKind = 'belief' | 'episode' | 'fragment' | 'scene';
+
+export interface CachedDependency {
+  kind: CachedDependencyKind;
+  /** Full record id — `semantic_belief:…`, `episode:…`,
+   *  `evidence_fragment:…`, `memory_episode:…`. */
+  id: string;
+  /**
+   * Lifecycle stamp observed at admission, compared byte-for-byte on
+   * read: a belief's `revision`, a scene's gist hash, a fragment's asset
+   * quarantine state; '' for an episode (immutable text — existence IS
+   * its lifecycle). A changed stamp is `dependency_changed`.
+   */
+  rev: string;
+}
+
+const DEPENDENCY_KINDS: readonly CachedDependencyKind[] = [
+  'belief',
+  'episode',
+  'fragment',
+  'scene',
+];
+
+/** A dependency row as the per-kind SELECT returns it (see dependencySelect). */
+interface DependencyRow {
+  id: unknown;
+  userId?: string | null;
+  revision?: number | string | null;
+  status?: string | null;
+  supersededBy?: unknown;
+  validUntil?: Date | string | null;
+  quarantineStatus?: string | null;
+  gist?: string | null;
+  enrichedGist?: string | null;
+}
+
+/**
+ * The typed dependency set of a result's evidence citations, or null when
+ * a citation carries no arm this cache can revalidate (the ONE-OF
+ * invariant means exactly one id is present on a well-formed citation;
+ * a malformed one is untrackable and blocks admission — fail closed).
+ * De-duplicated per (kind, id); kind order is the declared arm order.
+ */
+export function dependenciesOf(
+  evidenceCitations: EvidenceCitation[] | undefined,
+): Array<Pick<CachedDependency, 'kind' | 'id'>> | null {
+  const out: Array<Pick<CachedDependency, 'kind' | 'id'>> = [];
+  const seen = new Set<string>();
+  for (const c of evidenceCitations ?? []) {
+    const dep = dependencyArm(c);
+    if (!dep) return null;
+    const key = `${dep.kind}|${dep.id}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(dep);
+  }
+  return out.sort((a, b) => DEPENDENCY_KINDS.indexOf(a.kind) - DEPENDENCY_KINDS.indexOf(b.kind));
+}
+
+function dependencyArm(c: EvidenceCitation): Pick<CachedDependency, 'kind' | 'id'> | null {
+  if (isRecordId(c.beliefId)) return { kind: 'belief', id: c.beliefId };
+  if (isRecordId(c.episodeId)) return { kind: 'episode', id: c.episodeId };
+  if (isRecordId(c.fragmentId)) return { kind: 'fragment', id: c.fragmentId };
+  if (isRecordId(c.sceneId)) return { kind: 'scene', id: c.sceneId };
+  return null;
+}
+
+/** 3.x does not coerce string↔record: only a `table:key` string can be
+ *  bound as a record id, so anything else is untrackable. */
+function isRecordId(v: unknown): v is string {
+  return typeof v === 'string' && v.includes(':') && v.length > 2;
+}
+
+/** The id-only evidence citation a served hit returns for a dependency —
+ *  the arm the answer was admitted with, nothing rendered. */
+function citationOfDependency(dep: CachedDependency): EvidenceCitation {
+  switch (dep.kind) {
+    case 'belief':
+      return { beliefId: dep.id };
+    case 'episode':
+      return { episodeId: dep.id };
+    case 'fragment':
+      return { fragmentId: dep.id };
+    case 'scene':
+      return { sceneId: dep.id };
+  }
+}
+
+/** A stored dependency entry as the 0136 ASSERTs shape it; anything else
+ *  is a malformed row and fails closed on read. */
+function isCachedDependency(v: unknown): v is CachedDependency {
+  if (v === null || typeof v !== 'object') return false;
+  const d = v as Record<string, unknown>;
+  return (
+    typeof d.kind === 'string' &&
+    (DEPENDENCY_KINDS as readonly string[]).includes(d.kind) &&
+    isRecordId(d.id) &&
+    typeof d.rev === 'string'
+  );
+}
+
+/**
+ * One SELECT per kind, bound on `$<kind>` (a record-id array). The
+ * projection is exactly what `dependencyRev` and `dependencyLifecycle`
+ * read: existence, the user-scope fence column, the lifecycle state and
+ * the revision stamp — nothing content-bearing leaves the DB.
+ */
+function dependencySelect(kind: CachedDependencyKind): string {
+  switch (kind) {
+    case 'belief':
+      return `SELECT id, revision, status, supersededBy, validUntil, userId
+                FROM semantic_belief WHERE id INSIDE $belief`;
+    case 'episode':
+      return `SELECT id, userId FROM episode WHERE id INSIDE $episode`;
+    case 'fragment':
+      // The fragment row is immutable; its parent asset's quarantine
+      // state is the lifecycle (a rejected asset must not keep serving
+      // through a cached answer). A dangling asset link reads as NONE.
+      return `SELECT id, assetId.quarantineStatus AS quarantineStatus
+                FROM evidence_fragment WHERE id INSIDE $fragment`;
+    case 'scene':
+      return `SELECT id, gist, enrichedGist, userId FROM memory_episode WHERE id INSIDE $scene`;
+  }
+}
+
+/** The stamp that must not move for the cached answer to stay valid. */
+function dependencyRev(kind: CachedDependencyKind, row: DependencyRow): string {
+  switch (kind) {
+    case 'belief':
+      return String(row.revision ?? '');
+    case 'episode':
+      return '';
+    case 'fragment':
+      return String(row.quarantineStatus ?? '');
+    case 'scene':
+      return sha256(`${row.gist ?? ''}\n${row.enrichedGist ?? ''}`).slice(0, 16);
+  }
+}
+
+/**
+ * The lifecycle gate a dependency row must pass to be servable — the
+ * cited-fact gate's counterpart per kind. Null = servable. The user-scope
+ * fence is shared: a row bound to ANOTHER user is invisible (existence
+ * never leaks), so it reads as 'missing'.
+ */
+function dependencyLifecycle(
+  kind: CachedDependencyKind,
+  row: DependencyRow,
+  scopeUserId: string | undefined,
+): InvalidationCause | null {
+  if (
+    scopeUserId !== undefined &&
+    typeof row.userId === 'string' &&
+    row.userId.length > 0 &&
+    row.userId !== scopeUserId
+  ) {
+    return 'missing';
+  }
+  if (kind === 'belief') {
+    if (row.status === 'retracted') return 'retracted';
+    if (
+      row.status === 'superseded' ||
+      (row.supersededBy !== undefined && row.supersededBy !== null)
+    ) {
+      return 'superseded';
+    }
+    if (row.status !== 'active') return 'missing';
+    if (row.validUntil && toMs(row.validUntil) <= Date.now()) return 'expired_validity';
+  }
+  if (kind === 'fragment' && row.quarantineStatus === 'rejected') return 'missing';
+  return null;
+}
 
 /** Cap on freshness-probe candidate rows pulled per read. The probe only
  *  needs existence of ONE scope+policy-visible newer fact.
@@ -176,6 +362,9 @@ interface CacheRow {
   createdAt: Date | string;
   expiresAt: Date | string;
   invalidatedAt?: Date | string | null;
+  /** 0136 typed non-fact dependencies; absent on a pre-0136 row, which
+   *  therefore cannot be revalidated and fails closed. */
+  dependencies?: CachedDependency[] | null;
 }
 
 /** The two read fences the fact read path applies, threaded together
@@ -237,6 +426,16 @@ interface CitedFactRow {
  * verified grounded answers, per-user key partitioning (NDSS'26
  * semantic-cache poisoning + CacheAttack both exploit shared/unverified
  * admission).
+ *
+ * Every dependency, not only the facts (0136, audit F3): a mixed answer
+ * — facts plus belief / episode / fragment / scene citations — stores
+ * its non-fact arms as typed {kind, id, rev} entries stamped from the
+ * live rows at admission, and check-on-read revalidates each one under
+ * the same user-scope fence: missing or fenced ⇒ 'missing', a belief
+ * superseded / retracted / past validUntil ⇒ its lifecycle cause, a
+ * moved stamp (belief revision, scene gist, asset quarantine state) ⇒
+ * 'dependency_changed'. An answer whose evidence the cache cannot track
+ * is not admitted; a pre-0136 row (no dependency list) is never served.
  *
  * v2 (deferred by design): embedding-similarity candidates promoted to
  * servable only after async judge verification — never served
@@ -311,17 +510,18 @@ export class AnswerCacheService {
    * are never cached — an uncited answer is uninvalidatable, and a
    * non-supported one failed the grounding audit.
    *
-   * L3 evidence citations (FOVEA_L3_EPISODE_CITATIONS) are DELIBERATELY
-   * not admission-bearing: an episode-only-cited L3 answer (zero fact
-   * citations, ≥1 evidence citation) has citations.length 0 and is
-   * rejected by the gate below. Check-on-read revalidates cited FACT
-   * rows against the live substrate and cannot (yet) invalidate episode
-   * citations, so caching such an answer would make it uninvalidatable.
-   * The BELIEF arm (BELIEFS_SERVING_LANE) rides the same doctrine: a
-   * belief-only-cited current-state answer has citations.length 0 and
-   * is rejected here too — check-on-read cannot invalidate a belief
-   * citation against the supersede chain, so caching it would serve a
-   * stale current-state answer past the next revision.
+   * Evidence citations are admission-bearing ONLY as tracked dependencies
+   * (0136, audit F3). Fact citations remain the admission gate — an
+   * answer with zero fact citations (episode-only L3, belief-only
+   * current-state) has citations.length 0 and is rejected below, since
+   * the entity-scoped freshness probe has nothing to anchor on. A MIXED
+   * answer (≥1 fact plus belief / episode / fragment / scene citations)
+   * used to be admitted with only its fact half recorded, so a belief
+   * revision left the cached text serving until TTL; it is now admitted
+   * with every non-fact arm stored as {kind, id, rev} and revalidated on
+   * read, and it is NOT admitted at all when any arm is untrackable or
+   * already dead at admission time (fail closed — the answer is stale
+   * before it is stored).
    */
   async admit(
     ctx: AnswerCacheStoreContext,
@@ -334,6 +534,13 @@ export class AnswerCacheService {
       result.reason !== undefined ||
       result.citations.length === 0
     ) {
+      return;
+    }
+    const wanted = dependenciesOf(result.evidenceCitations);
+    if (wanted === null) {
+      // A citation with no trackable arm — the cache cannot promise to
+      // notice when it dies, so the answer is served fresh every time.
+      this.metrics?.countAnswerCache('not_admitted');
       return;
     }
     const answer = result.answer;
@@ -355,7 +562,14 @@ export class AnswerCacheService {
     const ttlHours = this.ttlHours(ctx.isEnumeration || broadAnswer);
     const expiresAt = new Date(Date.now() + ttlHours * 3_600_000);
     try {
-      await this.surreal.withCompany(ctx.companyId, async (db) => {
+      const stored = await this.surreal.withCompany(ctx.companyId, async (db) => {
+        // Stamp every non-fact dependency from its LIVE row first: the
+        // revision the answer was built against is what the read path
+        // compares to. A dependency that is already missing, fenced, or
+        // dead at admission means the answer is stale before it is
+        // stored — never written (fail closed).
+        const dependencies = await this.stampDependencies(db, wanted, ctx.userId);
+        if (dependencies === null) return false;
         // Record id = queryHash, so re-admission after invalidation or
         // TTL expiry REPLACES the row in place (the unique
         // (companyId, queryHash) index stays trivially consistent).
@@ -371,6 +585,7 @@ export class AnswerCacheService {
              reason: '',
              citedFactIds: $citedFactIds,
              entityIds: $entityIds,
+             dependencies: $dependencies,
              profileHash: $profileHash,
              modelId: $modelId,
              promptVersion: $promptVersion,
@@ -390,14 +605,16 @@ export class AnswerCacheService {
             answer,
             citedFactIds,
             entityIds,
+            dependencies,
             profileHash: ctx.profileHash,
             modelId: ctx.model,
             promptVersion: ANSWER_CACHE_PROMPT_VERSION,
             expiresAt,
           },
         );
+        return true;
       });
-      this.metrics?.countAnswerCache('stored');
+      this.metrics?.countAnswerCache(stored ? 'stored' : 'not_admitted');
     } catch (e) {
       this.logger.warn(
         `answer-cache store failed (companyId=${ctx.companyId}): ${(e as Error).message}`,
@@ -507,8 +724,8 @@ export class AnswerCacheService {
       // clause double-fences both (a user-scoped query must never hit
       // a global entry and vice versa).
       const [rows] = await db.query<[CacheRow[]]>(
-        `SELECT id, answer, citedFactIds, entityIds, createdAt, expiresAt,
-                invalidatedAt
+        `SELECT id, answer, citedFactIds, entityIds, dependencies, createdAt,
+                expiresAt, invalidatedAt
            FROM type::record($tb, $key)
           WHERE companyId = $companyId
             AND queryHash = $key
@@ -534,9 +751,15 @@ export class AnswerCacheService {
       return null;
     }
     await this.recordServe(ctx);
+    // 0136: the non-fact arms the answer rests on, just revalidated, come
+    // back as id-only evidence citations (the rendered excerpt is not
+    // stored); absent when there are none, per the SynthesizeResult
+    // contract.
+    const evidenceCitations = (row.dependencies ?? []).map(citationOfDependency);
     return {
       answer: row.answer,
       citations: verdict.citations,
+      ...(evidenceCitations.length > 0 ? { evidenceCitations } : {}),
       // A cached serve skipped retrieval — there is no hit list to
       // return; the citations above are rebuilt from the LIVE fact
       // rows the check-on-read just validated.
@@ -568,6 +791,11 @@ export class AnswerCacheService {
   ): Promise<{ cause: InvalidationCause } | { citations: Citation[] }> {
     const ids = row.citedFactIds ?? [];
     if (ids.length === 0) return { cause: 'missing' };
+    // 0136: a pre-0136 row carries no dependency list, so what it rests on
+    // beyond its cited facts is unknown — fail closed (the key-version
+    // bump already makes such a row miss; this is the belt to that brace).
+    const dependencies = row.dependencies;
+    if (!Array.isArray(dependencies)) return { cause: 'missing' };
     const entityIds = row.entityIds ?? [];
     const answerCreatedAt =
       row.createdAt instanceof Date ? row.createdAt : new Date(String(row.createdAt));
@@ -581,10 +809,13 @@ export class AnswerCacheService {
     const probeUserGate = ctx.userId
       ? 'AND (userId IS NONE OR userId = $probeScopeUserId)'
       : 'AND userId IS NONE';
-    const { facts, names, newer } = await this.surreal.withScopedCompany(
+    const { facts, names, newer, dependencyRows } = await this.surreal.withScopedCompany(
       ctx.companyId,
       callerScopes,
       async (db) => {
+        // 0136: the non-fact dependencies' live rows, on the SAME scoped
+        // connection (one extra round trip only when the row has any).
+        const dependencyRows = await this.fetchDependencyRows(db, dependencies);
         const [factRows, entityRows, newerRows] = await db.query<
           [CitedFactRow[], Array<{ id: unknown; canonicalName: string }>, CitedFactRow[]]
         >(
@@ -612,6 +843,7 @@ export class AnswerCacheService {
           facts: factRows ?? [],
           names: entityRows ?? [],
           newer: newerRows ?? [],
+          dependencyRows,
         };
       },
     );
@@ -627,19 +859,95 @@ export class AnswerCacheService {
     });
     const fences: ReadFences = { scopeUserId, rowPolicy };
     const cited = this.evaluateCitedFacts(ids, { byId, nameById }, fences);
-    // Additive-write freshness probe (audit F1) runs ONLY when every cited
-    // fact still validated — a more specific lifecycle cause
-    // (retracted/superseded/…) takes precedence over 'newer_fact' for
-    // observability. A newer visible fact on a cited entity means the
-    // store changed under this answer: fail closed to a fresh synthesis.
-    const result: { cause: InvalidationCause } | { citations: Citation[] } =
-      'cause' in cited
-        ? cited
-        : this.hasNewerVisibleFact(newer, fences)
-          ? { cause: 'newer_fact' }
-          : cited;
+    // Precedence, most specific first: a dead cited fact, then a dead or
+    // changed non-fact dependency (0136), then the additive-write freshness
+    // probe (audit F1) — which runs ONLY when everything the answer rests
+    // on still validated, so a lifecycle cause is never masked by
+    // 'newer_fact'. Any of them means the store changed under this
+    // answer: fail closed to a fresh synthesis.
+    let result: { cause: InvalidationCause } | { citations: Citation[] } = cited;
+    if (!('cause' in result)) {
+      const dependencyCause = this.evaluateDependencies(dependencies, dependencyRows, scopeUserId);
+      if (dependencyCause) result = { cause: dependencyCause };
+      else if (this.hasNewerVisibleFact(newer, fences)) result = { cause: 'newer_fact' };
+    }
     rowPolicy.finish();
     return result;
+  }
+
+  /**
+   * Admission-time stamping (0136): every wanted dependency's LIVE row,
+   * read on the connection the cache row is written with, so the stored
+   * `rev` is exactly the state the answer was built against. Null when
+   * any dependency is missing, fenced from the answer's user partition,
+   * or already dead — the answer is stale before it is stored and must
+   * not be.
+   */
+  private async stampDependencies(
+    db: Pick<Surreal, 'query'>,
+    wanted: ReadonlyArray<Pick<CachedDependency, 'kind' | 'id'>>,
+    scopeUserId: string | undefined,
+  ): Promise<CachedDependency[] | null> {
+    if (wanted.length === 0) return [];
+    const rows = await this.fetchDependencyRows(db, wanted);
+    const out: CachedDependency[] = [];
+    for (const dep of wanted) {
+      const row = rows.get(`${dep.kind}|${dep.id}`);
+      if (!row || dependencyLifecycle(dep.kind, row, scopeUserId) !== null) return null;
+      out.push({ kind: dep.kind, id: dep.id, rev: dependencyRev(dep.kind, row) });
+    }
+    return out;
+  }
+
+  /**
+   * The live rows behind a dependency set — one SELECT per kind present,
+   * one round trip, keyed `kind|id`. Empty input ⇒ no query at all, so a
+   * fact-only answer costs exactly what it did before 0136.
+   */
+  private async fetchDependencyRows(
+    db: Pick<Surreal, 'query'>,
+    deps: ReadonlyArray<Pick<CachedDependency, 'kind' | 'id'>>,
+  ): Promise<Map<string, DependencyRow>> {
+    const out = new Map<string, DependencyRow>();
+    const kinds = DEPENDENCY_KINDS.filter((k) => deps.some((d) => d.kind === k));
+    if (kinds.length === 0) return out;
+    const params: Record<string, StringRecordId[]> = {};
+    for (const k of kinds) {
+      params[k] = deps
+        .filter((d) => d.kind === k && isRecordId(d.id))
+        .map((d) => new StringRecordId(d.id));
+    }
+    const results = await db.query<DependencyRow[][]>(
+      kinds.map((k) => `${dependencySelect(k)};`).join('\n'),
+      params,
+    );
+    kinds.forEach((k, i) => {
+      for (const r of results[i] ?? []) out.set(`${k}|${String(r.id)}`, r);
+    });
+    return out;
+  }
+
+  /**
+   * Read-time gate over the stored dependency list (0136): every entry
+   * must still exist under the user-scope fence, pass its kind's lifecycle
+   * gate, and carry the SAME revision stamp it was admitted with. The
+   * FIRST failure returns its cause, fail-closed; a malformed stored
+   * entry reads as 'missing'.
+   */
+  private evaluateDependencies(
+    deps: ReadonlyArray<unknown>,
+    rows: ReadonlyMap<string, DependencyRow>,
+    scopeUserId: string | undefined,
+  ): InvalidationCause | null {
+    for (const raw of deps) {
+      if (!isCachedDependency(raw)) return 'missing';
+      const row = rows.get(`${raw.kind}|${raw.id}`);
+      if (!row) return 'missing';
+      const cause = dependencyLifecycle(raw.kind, row, scopeUserId);
+      if (cause) return cause;
+      if (dependencyRev(raw.kind, row) !== raw.rev) return 'dependency_changed';
+    }
+    return null;
   }
 
   /**

--- a/src/db/migrations/0136_answer_cache_dependencies.surql
+++ b/src/db/migrations/0136_answer_cache_dependencies.surql
@@ -1,0 +1,33 @@
+-- 0136: answer_cache carries EVERY dependency of a cached answer, not
+-- only its cited facts (audit 2026-09-06 F3).
+--
+-- 0091's admission stored the answer text plus `citedFactIds`, and the
+-- check-on-read revalidated exactly those. A mixed answer — one fact plus
+-- a belief / episode / fragment / scene citation — was admitted with the
+-- non-fact half of its grounding silently dropped, so a belief revision
+-- (the value the answer states is no longer the current state) left the
+-- cached text serving until TTL: the cited fact still validated, and
+-- nothing else was checked.
+--
+-- `dependencies` records the non-fact evidence arms as typed entries
+-- {kind, id, rev}: `rev` is the lifecycle stamp observed at admission (a
+-- belief's `revision`, a scene's gist hash, a fragment's asset quarantine
+-- state; an episode is immutable text, so existence is its lifecycle)
+-- and the read path fails closed on a missing row, a dead lifecycle
+-- state, or a changed stamp. Pre-0136 rows carry no `dependencies` and
+-- are treated as unverifiable (invalidated on their next read); the
+-- cache-key version bump in answer-cache.service.ts makes them miss by
+-- key construction anyway.
+--
+-- `dependency_changed` joins the invalidation causes: the stamp moved
+-- while the row stayed in a servable state (a belief revised in place, a
+-- scene recomposed, an asset's quarantine state changed).
+DEFINE FIELD IF NOT EXISTS dependencies ON answer_cache TYPE array DEFAULT [];
+DEFINE FIELD IF NOT EXISTS dependencies.* ON answer_cache TYPE object;
+DEFINE FIELD IF NOT EXISTS dependencies.*.kind ON answer_cache TYPE string
+  ASSERT $value INSIDE ['belief', 'episode', 'fragment', 'scene'];
+DEFINE FIELD IF NOT EXISTS dependencies.*.id ON answer_cache TYPE string;
+DEFINE FIELD IF NOT EXISTS dependencies.*.rev ON answer_cache TYPE string;
+DEFINE FIELD OVERWRITE invalidationCause ON answer_cache TYPE option<string>
+  ASSERT $value = NONE
+      OR $value INSIDE ['superseded', 'retracted', 'expired_validity', 'missing', 'newer_fact', 'dependency_changed'];

--- a/src/metrics/metrics.service.ts
+++ b/src/metrics/metrics.service.ts
@@ -379,6 +379,9 @@ export class MetricsService implements OnModuleInit {
   //                    exactly how much staleness the fact link caught.
   //   stored         — verified grounded answer admitted (write-through)
   //   bypass         — cache on but request ineligible (explain/empty)
+  //   not_admitted   — a supported answer refused at admission (0136):
+  //                    its evidence carries an arm the cache cannot
+  //                    revalidate, or a dependency was already dead
   readonly answerCacheCount = new Counter({
     name: 'brain_answer_cache_total',
     help: 'Answer-cache decisions by outcome',
@@ -1007,7 +1010,9 @@ export class MetricsService implements OnModuleInit {
     this.synthesizeCount.inc({ outcome } as LabelValues<'outcome'>);
   }
 
-  countAnswerCache(outcome: 'hit' | 'miss' | 'rejected_stale' | 'stored' | 'bypass'): void {
+  countAnswerCache(
+    outcome: 'hit' | 'miss' | 'rejected_stale' | 'stored' | 'bypass' | 'not_admitted',
+  ): void {
     this.answerCacheCount.inc({ outcome } as LabelValues<'outcome'>);
   }
 

--- a/src/synthesize/outcome-emit.ts
+++ b/src/synthesize/outcome-emit.ts
@@ -57,18 +57,21 @@ export function unverifiedServe(
  * The cited facts were used in the answer; on a `supported` verdict the
  * same ids additionally count as VERIFIED use (meta carries the verdict
  * string only — content-free). Called from BOTH finalizeAndAdmit
- * serving paths (primary + L3 flip) with the verdict, and from the
- * unverifiedReturn exit WITHOUT one — guardrails off/'answer' serve
- * citations with no verifier, which counts as use, never as verified
- * use. `companyId` is optional because bare-cache finalize callers may
- * not carry it — absent ⇒ no events.
+ * serving paths (primary + L3 flip) AFTER every serving gate, with the
+ * FINAL result's citations and the verdict only when that result is the
+ * supported ok-path (audit F7: a draft the gate downgraded records
+ * nothing, a lenient partial serve records use but never verified use);
+ * and from the unverifiedReturn exit WITHOUT a verdict — guardrails
+ * off/'answer' serve citations with no verifier, which counts as use,
+ * never as verified use. `companyId` is optional because bare-cache
+ * finalize callers may not carry it — absent ⇒ no events.
  */
 export function emitAnswerUse(
   outcomes: MemoryOutcomeService | undefined,
   opts: {
     companyId: string | undefined;
     citations: Citation[];
-    verdict?: VerifierOutput;
+    verdict?: VerifierOutput | undefined;
     /**
      * 0119: the request's primary decision id (abstain gate or L3
      * trigger), threaded by synthesize ONLY under
@@ -136,7 +139,7 @@ export function emitBeliefAnswerUse(
   opts: {
     companyId: string | undefined;
     evidenceCitations: EvidenceCitation[] | undefined;
-    verdict?: VerifierOutput;
+    verdict?: VerifierOutput | undefined;
     decisionId?: string | undefined;
   },
 ): void {

--- a/src/synthesize/synthesize.service.ts
+++ b/src/synthesize/synthesize.service.ts
@@ -751,23 +751,6 @@ export class SynthesizeService {
     verdict: VerifierOutput,
     args: Omit<Parameters<typeof finalizeVerdict>[1], 'verdict' | 'questionAnswered'>,
   ): Promise<SynthesizeResult> {
-    // 0107: cited facts were USED; a supported verdict ⇒ VERIFIED use.
-    // Both serving paths (primary + L3 flip) land here with companyId;
-    // the 0119 primary decision id (capture on) joins outcome → decision.
-    emitAnswerUse(this.outcomes, {
-      companyId: ctx.companyId,
-      citations: args.citations,
-      verdict,
-      decisionId: ctx.decisionId,
-    });
-    // 0107 belief arm (D7): cited beliefs count as use — and as VERIFIED
-    // use on a supported verdict — with the same decisionId threading.
-    emitBeliefAnswerUse(this.outcomes, {
-      companyId: ctx.companyId,
-      evidenceCitations: args.evidenceCitations,
-      verdict,
-      decisionId: ctx.decisionId,
-    });
     // The gate-resolution also folds in the evidence-capability flag
     // (FOVEA_EVIDENCE_CAPABILITY, 0113 — resolveEvidenceCapability, the
     // resolveAnswerIntegrity sibling in answer-integrity.ts): does the
@@ -784,6 +767,31 @@ export class SynthesizeService {
       questionAnswered: verdict.questionAnswered,
       ...args,
       ...gate,
+    });
+    // 0107: usage is what was actually SERVED — emitted AFTER every gate
+    // (answer-integrity Parts A + C, evidence capability, ungrounded
+    // support) from the FINAL result, never from the draft (audit F7). A
+    // supported draft the gate downgraded to an abstention carries
+    // citations: [] here and records nothing; a lenient partial/failed
+    // serve counts as use of its citations but never as VERIFIED use
+    // (the verdict rides along only on the supported ok-path). Both
+    // serving paths (primary + L3 flip) land here with companyId; the
+    // 0119 primary decision id (capture on) joins outcome → decision.
+    const servedVerdict = final.reason === undefined ? verdict : undefined;
+    emitAnswerUse(this.outcomes, {
+      companyId: ctx.companyId,
+      citations: final.citations,
+      verdict: servedVerdict,
+      decisionId: ctx.decisionId,
+    });
+    // 0107 belief arm (D7): the served answer's cited beliefs count as
+    // use — and as VERIFIED use on the supported ok-path — with the same
+    // decisionId threading.
+    emitBeliefAnswerUse(this.outcomes, {
+      companyId: ctx.companyId,
+      evidenceCitations: final.evidenceCitations,
+      verdict: servedVerdict,
+      decisionId: ctx.decisionId,
     });
     if (ctx.cache?.ctx) {
       await this.answerCache?.admit(ctx.cache.ctx, final, verdict.verdict);

--- a/test/answer-cache-dependencies.e2e-spec.ts
+++ b/test/answer-cache-dependencies.e2e-spec.ts
@@ -1,0 +1,255 @@
+/**
+ * 0136 answer-cache dependencies e2e (audit 2026-09-06 F3) over a real
+ * SurrealDB — the scenario the audit described, end to end:
+ *
+ *   a MIXED answer (one fact + one belief) is admitted; the fact stays
+ *   true ("works at Acme" — here: the Postgres decision) while the belief
+ *   is REVISED (the current database moves on). Before 0136 the cached
+ *   text kept serving until TTL because only the cited fact was
+ *   revalidated; now the belief is a stamped dependency, the revision
+ *   invalidates the entry (cause=superseded), and the next request
+ *   re-synthesizes and is re-admitted against the NEW revision.
+ *
+ * Substrate = the belief-serving e2e recipe: a tenant-global fact, an
+ * enriched scene with a stateDelta folded by the Belief-A promotion into
+ * an active belief for USER, then a SECOND, later scene whose delta
+ * supersedes it. Generator/verifier are scripted (mockSynthesizeOpenAi).
+ */
+import type { AppFixture } from './app-fixture';
+import { createApp } from './app-fixture';
+import { mockSynthesizeOpenAi } from './test-doubles';
+import { SurrealService } from '../src/db/surreal.service';
+
+const USER = 'cache_deps_u1';
+const QUERY = 'which database does the inventory service use, and what was decided first?';
+const VERIFY_SUPPORTED = JSON.stringify({ verdict: 'supported', unsupportedClaims: [] });
+const FLAG_KEYS = [
+  'SYNTHESIZE_ANSWER_CACHE',
+  'BELIEFS_SERVING_LANE',
+  'RETRIEVAL_ABSTENTION_CALIBRATION',
+  'SCENES_SEGMENTATION_ENABLED',
+  'SCENES_BELIEF_PROMOTION',
+] as const;
+
+interface BeliefRow {
+  id: unknown;
+  value: string;
+  status: string;
+  revision: number;
+  supersededBy?: unknown;
+}
+
+interface CacheRow {
+  answer: string;
+  hitCount: number;
+  invalidationCause?: string | null;
+  dependencies?: Array<{ kind: string; id: string; rev: string }> | null;
+}
+
+describe('0136 answer-cache dependencies e2e (a belief revision invalidates a mixed answer)', () => {
+  let f: AppFixture;
+  const auth = () => ({ Authorization: `Bearer ${f.apiKey}` });
+  const savedEnv: Record<string, string | undefined> = {};
+  let pgFactId: string;
+  let beliefV1: string;
+
+  const db = <T>(
+    fn: (d: { query: <Q>(sql: string, p?: Record<string, unknown>) => Promise<Q> }) => Promise<T>,
+  ): Promise<T> => f.app.get(SurrealService).withCompany(f.companyId, fn);
+
+  const synth = () =>
+    f.http.post('/v1/synthesize').set(auth()).send({ query: QUERY, userId: USER, limit: 5 });
+
+  const beliefs = () =>
+    db(async (d) => {
+      const [rows] = await d.query<[BeliefRow[]]>(
+        `SELECT id, value, status, revision, supersededBy FROM semantic_belief ORDER BY revision`,
+      );
+      return rows ?? [];
+    });
+
+  const cacheRows = () =>
+    db(async (d) => {
+      const [rows] = await d.query<[CacheRow[]]>(
+        `SELECT answer, hitCount, invalidationCause, dependencies FROM answer_cache`,
+      );
+      return rows ?? [];
+    });
+
+  /** Seed one enriched scene carrying a database stateDelta for USER. */
+  const seedScene = (id: string, from: string, to: string, at: string) =>
+    db(async (d) => {
+      await d.query(
+        `CREATE type::record('memory_episode', $id) CONTENT {
+           userId: $u, userIds: [$u], scope: [],
+           sceneLabel: 'db switch', conversationIds: [$conv],
+           occurredFrom: <datetime>$at, occurredTo: <datetime>$at,
+           gist: $gist, confidence: 1,
+           stateDeltas: [{ subject: 'inventory service', field: 'database',
+                           from: $from, to: $to }],
+           segmenterVersion: 'scene-segmenter-v1', generation: 'seed-gen',
+           source: { recorder: 'test-seed' },
+           enrichmentVersion: 'seed-enrich-v1',
+           enrichedMemoryValue: { explicitness: 0.8 } }`,
+        { id, u: USER, conv: `proj:${id}`, at, gist: `switched to ${to}`, from, to },
+      );
+    });
+
+  const promote = async () => {
+    process.env.SCENES_SEGMENTATION_ENABLED = '1';
+    process.env.SCENES_BELIEF_PROMOTION = '1';
+    try {
+      const res = await f.http.post('/v1/admin/maintenance/scenes/beliefs').set(auth()).send({});
+      expect(res.status).toBe(201);
+      return res.body as { beliefsCreated: number };
+    } finally {
+      delete process.env.SCENES_SEGMENTATION_ENABLED;
+      delete process.env.SCENES_BELIEF_PROMOTION;
+    }
+  };
+
+  /** One scripted generate+verify round citing the fact AND a belief. */
+  const mockMixedRound = (answer: string, beliefId: string) =>
+    mockSynthesizeOpenAi(f.app, [
+      JSON.stringify({ answer, citedFactIds: [pgFactId], citedBeliefIds: [beliefId] }),
+      VERIFY_SUPPORTED,
+    ]);
+
+  beforeAll(async () => {
+    for (const k of FLAG_KEYS) {
+      savedEnv[k] = process.env[k];
+      delete process.env[k];
+    }
+    process.env.RETRIEVAL_ABSTENTION_CALIBRATION = 'off';
+    process.env.BELIEFS_SERVING_LANE = '1';
+    process.env.SYNTHESIZE_ANSWER_CACHE = '1';
+    f = await createApp({ companyId: 'co_answer_cache_deps_e2e' });
+
+    const pg = await f.http
+      .post('/v1/ingest/fact')
+      .set(auth())
+      .send({
+        entityRef: { vertical: 'proj', id: 'postgresql' },
+        predicate: 'code_memory__decided',
+        object: 'we will use Postgres as the main database',
+        validFrom: new Date('2026-08-01').toISOString(),
+        confidence: 0.9,
+        source: { vertical: 'proj', recorder: 'bot' },
+      });
+    expect([200, 201]).toContain(pg.status);
+    pgFactId = pg.body.factId as string;
+
+    await seedScene('cachedeps1', 'PostgreSQL', 'SurrealDB', '2026-08-10T10:00:00.000Z');
+    expect(await promote()).toMatchObject({ beliefsCreated: 1 });
+    const rows = await beliefs();
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({ value: 'SurrealDB', status: 'active', revision: 1 });
+    beliefV1 = String(rows[0]!.id);
+  }, 120000);
+
+  afterAll(async () => {
+    for (const [k, v] of Object.entries(savedEnv)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+    if (f) await f.close();
+  });
+
+  it('admits the mixed answer WITH the belief as a stamped dependency, then serves it cached', async () => {
+    const answer = `Postgres was decided first [${pgFactId}]; the inventory service now uses SurrealDB [${beliefV1}].`;
+    const state1 = mockMixedRound(answer, beliefV1);
+    const res1 = await synth();
+    expect(res1.status).toBe(201);
+    expect(res1.body.answer).toBe(answer);
+    expect(res1.body.cached).toBeUndefined();
+    expect(res1.body.evidenceCitations).toHaveLength(1);
+    expect(res1.body.evidenceCitations[0]).toMatchObject({ beliefId: beliefV1 });
+    expect(state1.calls).toHaveLength(2);
+
+    // The stored row carries the belief — kind, id and the revision stamp
+    // the answer was built against. This is what 0091 dropped (audit F3).
+    const stored = await cacheRows();
+    expect(stored).toHaveLength(1);
+    expect(stored[0]!.dependencies).toEqual([{ kind: 'belief', id: beliefV1, rev: '1' }]);
+
+    // Served from the cache: no LLM call, the belief arm comes back as an
+    // id-only evidence citation, hitCount moves.
+    const state2 = mockMixedRound('A DIFFERENT answer that must not surface.', beliefV1);
+    const res2 = await synth();
+    expect(res2.status).toBe(201);
+    expect(res2.body.cached).toBe(true);
+    expect(res2.body.answer).toBe(answer);
+    expect(res2.body.citations?.[0]?.factId).toBe(pgFactId);
+    expect(res2.body.evidenceCitations).toEqual([{ beliefId: beliefV1 }]);
+    expect(state2.calls).toHaveLength(0);
+    expect((await cacheRows())[0]!.hitCount).toBe(1);
+  });
+
+  it('a belief revision invalidates the entry (cause=superseded) while the cited fact is untouched, and the fresh answer is re-admitted against the new revision', async () => {
+    // The current state moves on: a LATER scene folds into revision 2 and
+    // supersedes revision 1. The fact the answer also cites stays active.
+    await seedScene('cachedeps2', 'SurrealDB', 'DynamoDB', '2026-08-20T10:00:00.000Z');
+    // A later delta on an existing (subject, field) is a REVISION, not a
+    // new belief: revision 2 is created and revision 1 superseded.
+    expect(await promote()).toMatchObject({ beliefsRevised: 1 });
+    const rows = await beliefs();
+    expect(rows).toHaveLength(2);
+    const v1 = rows.find((r) => String(r.id) === beliefV1)!;
+    expect(v1.status).toBe('superseded');
+    const v2 = rows.find((r) => r.revision === 2)!;
+    expect(v2).toMatchObject({ value: 'DynamoDB', status: 'active' });
+    const beliefV2 = String(v2.id);
+
+    // Check-on-read: the fact still validates, the belief does not — the
+    // stale text must NOT surface, the LLM runs again, and the row records
+    // the belief's lifecycle cause.
+    const fresh = `Postgres was decided first [${pgFactId}]; the inventory service now uses DynamoDB [${beliefV2}].`;
+    const state3 = mockMixedRound(fresh, beliefV2);
+    const res3 = await synth();
+    expect(res3.status).toBe(201);
+    expect(res3.body.cached).toBeUndefined();
+    expect(res3.body.answer).toBe(fresh);
+    expect(state3.calls).toHaveLength(2);
+
+    // Re-admission REPLACES the row in place (same key): the invalidation
+    // stamp is gone and the dependency now points at revision 2.
+    const after = await cacheRows();
+    expect(after).toHaveLength(1);
+    expect(after[0]!.answer).toBe(fresh);
+    expect(after[0]!.invalidationCause ?? null).toBeNull();
+    expect(after[0]!.dependencies).toEqual([{ kind: 'belief', id: beliefV2, rev: '2' }]);
+
+    // …and the new entry serves.
+    const state4 = mockMixedRound('must not surface either', beliefV2);
+    const res4 = await synth();
+    expect(res4.body.cached).toBe(true);
+    expect(res4.body.answer).toBe(fresh);
+    expect(state4.calls).toHaveLength(0);
+  });
+
+  it('an in-place revision bump (same belief row) is dependency_changed, recorded on the row before re-admission replaces it', async () => {
+    // The stamp moves while the row stays active: the schema allows only
+    // 'active' | 'superseded' for status, so a value change always creates
+    // a new revision — but the `revision` counter itself is what the entry
+    // was admitted against, and a moved counter must not keep serving.
+    const rows = await beliefs();
+    const active = rows.find((r) => r.status === 'active')!;
+    await db(async (d) => {
+      await d.query(`UPDATE $id SET revision = revision + 1, updatedAt = time::now()`, {
+        id: active.id,
+      });
+    });
+    // A scripted round that ABSTAINS (no citations) is never admitted, so
+    // the invalidated row survives with its cause for inspection.
+    mockSynthesizeOpenAi(f.app, [
+      JSON.stringify({ answer: 'I do not know.', citedFactIds: [] }),
+      JSON.stringify({ verdict: 'unsupported', unsupportedClaims: ['all'] }),
+    ]);
+    const res = await synth();
+    expect(res.status).toBe(201);
+    expect(res.body.cached).toBeUndefined();
+    const after = await cacheRows();
+    expect(after).toHaveLength(1);
+    expect(after[0]!.invalidationCause).toBe('dependency_changed');
+  });
+});

--- a/test/answer-cache.unit-spec.ts
+++ b/test/answer-cache.unit-spec.ts
@@ -11,9 +11,11 @@ import {
   canonicalDerivedPin,
   computeCacheKey,
   computeProfileHash,
+  dependenciesOf,
   deterministicSerialize,
   normalizeQuery,
   type AnswerCacheStoreContext,
+  type CachedDependencyKind,
 } from '../src/answer-cache/answer-cache.service';
 
 /**
@@ -127,7 +129,9 @@ describe('computeCacheKey', () => {
   });
 
   it('bakes the prompt version in (a bump misses every old entry)', () => {
-    expect(ANSWER_CACHE_PROMPT_VERSION).toBe(1);
+    // 2 = 0136: a row carries its typed non-fact dependencies, so every
+    // pre-0136 entry (which cannot be revalidated) misses by key.
+    expect(ANSWER_CACHE_PROMPT_VERSION).toBe(2);
   });
 });
 
@@ -153,11 +157,29 @@ function makeHarness(opts: {
    *  — used to model DB rows that survive the SQL scope gate but are then
    *  discarded by the JS row-policy (the gap-1 cap-before-scope vector). */
   deniedPredicate?: string;
+  /** 0136: the live rows behind non-fact dependencies, per kind — what the
+   *  per-kind dependency SELECTs (one batch, kinds in declared order)
+   *  return at admission and on read. Absent kind ⇒ no rows ⇒ 'missing'. */
+  dependencyRows?: Partial<Record<CachedDependencyKind, Array<Record<string, unknown>>>>;
 }) {
   const calls: QueryCall[] = [];
+  const DEP_TABLES: Record<CachedDependencyKind, string> = {
+    belief: 'FROM semantic_belief',
+    episode: 'FROM episode ',
+    fragment: 'FROM evidence_fragment',
+    scene: 'FROM memory_episode',
+  };
   const db = {
     query: async (sql: string, params: Record<string, unknown> = {}) => {
       calls.push({ sql, params });
+      const depKinds = (Object.keys(DEP_TABLES) as CachedDependencyKind[]).filter((k) =>
+        sql.includes(DEP_TABLES[k]),
+      );
+      if (depKinds.length > 0) {
+        // One result slot per kind present, in the order the service emits
+        // the statements (the declared kind order).
+        return depKinds.map((k) => opts.dependencyRows?.[k] ?? []);
+      }
       if (/FROM knowledge_fact/.test(sql)) {
         // check-on-read batch: [cited facts, entity names, newer-fact probe].
         // Model the DB-side LIMIT on the probe so cap-before-scope behaves
@@ -233,6 +255,9 @@ function liveCacheRow(over: Record<string, unknown> = {}) {
     answer: 'Acme is gold tier.',
     citedFactIds: ['knowledge_fact:f1'],
     entityIds: ['knowledge_entity:e1'],
+    // 0136: a fact-only answer carries an EMPTY dependency list (an absent
+    // list is a pre-0136 row and fails closed — see the dependency block).
+    dependencies: [],
     createdAt: new Date(Date.now() - 3_600_000),
     expiresAt: new Date(Date.now() + 3_600_000),
     invalidatedAt: null,
@@ -708,4 +733,392 @@ describe('AnswerCacheService.admit — admission rules', () => {
       expect(h.outcomes).toEqual([]);
     },
   );
+});
+
+// ── 0136: every dependency, not only the facts (audit F3) ──────────
+
+describe('dependenciesOf — the typed dependency set of an answer', () => {
+  it('maps each evidence arm to its kind, de-duplicates, orders by declared kind', () => {
+    expect(
+      dependenciesOf([
+        { sceneId: 'memory_episode:s1' },
+        { beliefId: 'semantic_belief:b1', excerpt: 'x' },
+        { episodeId: 'episode:e1', conversationId: 'c1' },
+        { fragmentId: 'evidence_fragment:f1', assetId: 'evidence_asset:a1' },
+        { beliefId: 'semantic_belief:b1' },
+      ]),
+    ).toEqual([
+      { kind: 'belief', id: 'semantic_belief:b1' },
+      { kind: 'episode', id: 'episode:e1' },
+      { kind: 'fragment', id: 'evidence_fragment:f1' },
+      { kind: 'scene', id: 'memory_episode:s1' },
+    ]);
+  });
+
+  it('no evidence citations ⇒ an empty (trackable) set', () => {
+    expect(dependenciesOf(undefined)).toEqual([]);
+    expect(dependenciesOf([])).toEqual([]);
+  });
+
+  it('a citation with no trackable arm ⇒ null (untrackable, blocks admission)', () => {
+    expect(dependenciesOf([{ beliefId: 'semantic_belief:b1' }, {}])).toBeNull();
+    // Not a record id — 3.x cannot bind it, so it can never be revalidated.
+    expect(dependenciesOf([{ beliefId: 'b1' }])).toBeNull();
+  });
+});
+
+describe('AnswerCacheService.admit — dependencies are stamped, or the answer is not cached', () => {
+  const ctx: AnswerCacheStoreContext = {
+    key: 'b'.repeat(64),
+    companyId: 'co_test',
+    profileHash: 'ph',
+    model: 'gpt-4o-mini',
+    normalizedQuery: 'where does alice live and work',
+    isEnumeration: false,
+  };
+  /** The audit's repro: one fact (employer) plus one belief (residence). */
+  const mixed: SynthesizeResult = {
+    answer: 'Alice lives in A and works at Acme.',
+    citations: [
+      {
+        factId: 'knowledge_fact:f',
+        entityId: 'knowledge_entity:e',
+        canonicalName: 'Alice',
+        predicate: 'employer',
+        object: 'Acme',
+      },
+    ],
+    evidenceCitations: [{ beliefId: 'semantic_belief:old', excerpt: 'Alice — residence: A' }],
+    results: [],
+  };
+  const liveBelief = (over: Record<string, unknown> = {}) => ({
+    id: 'semantic_belief:old',
+    revision: 3,
+    status: 'active',
+    supersededBy: null,
+    validUntil: null,
+    userId: 'alice',
+    ...over,
+  });
+
+  it('audit F3 repro: a mixed fact+belief answer is admitted WITH the belief as a stamped dependency', async () => {
+    const h = makeHarness({ dependencyRows: { belief: [liveBelief()] } });
+    await h.svc.admit(ctx, mixed, 'supported');
+    // The belief row was read (its revision is the stamp)…
+    const lookup = h.calls.find((c) => /FROM semantic_belief/.test(c.sql));
+    expect(lookup).toBeDefined();
+    expect(JSON.stringify(lookup!.params)).toContain('semantic_belief:old');
+    // …and the stored row carries it — this is what 0091 dropped.
+    const upsert = h.calls.find((c) => /UPSERT/.test(c.sql))!;
+    expect(upsert.sql).toContain('dependencies: $dependencies');
+    expect(upsert.params.dependencies).toEqual([
+      { kind: 'belief', id: 'semantic_belief:old', rev: '3' },
+    ]);
+    expect(upsert.params.citedFactIds).toEqual(['knowledge_fact:f']);
+    expect(h.outcomes).toEqual(['stored']);
+  });
+
+  it('a fact-only answer stores an empty dependency list and issues no dependency query', async () => {
+    const h = makeHarness({});
+    await h.svc.admit(ctx, { ...mixed, evidenceCitations: [] }, 'supported');
+    expect(h.calls.some((c) => /FROM semantic_belief/.test(c.sql))).toBe(false);
+    const upsert = h.calls.find((c) => /UPSERT/.test(c.sql))!;
+    expect(upsert.params.dependencies).toEqual([]);
+    expect(h.outcomes).toEqual(['stored']);
+  });
+
+  it.each([
+    ['belief already superseded', liveBelief({ status: 'superseded' })],
+    ['belief already retracted', liveBelief({ status: 'retracted' })],
+    ['belief past validUntil', liveBelief({ validUntil: new Date(Date.now() - 1_000) })],
+    ['belief bound to another user (answer partition = bob)', liveBelief({ userId: 'alice' })],
+  ] as Array<[string, Record<string, unknown>]>)(
+    'not admitted when a dependency is already dead at admission: %s',
+    async (name, row) => {
+      const h = makeHarness({ dependencyRows: { belief: [row] } });
+      const scoped = name.includes('another user') ? { ...ctx, userId: 'bob' } : ctx;
+      await h.svc.admit(scoped, mixed, 'supported');
+      expect(h.calls.some((c) => /UPSERT/.test(c.sql))).toBe(false);
+      expect(h.outcomes).toEqual(['not_admitted']);
+    },
+  );
+
+  it('not admitted when a dependency row is missing', async () => {
+    const h = makeHarness({ dependencyRows: { belief: [] } });
+    await h.svc.admit(ctx, mixed, 'supported');
+    expect(h.calls.some((c) => /UPSERT/.test(c.sql))).toBe(false);
+    expect(h.outcomes).toEqual(['not_admitted']);
+  });
+
+  it('not admitted when a citation carries no trackable arm (no query at all)', async () => {
+    const h = makeHarness({ dependencyRows: { belief: [liveBelief()] } });
+    await h.svc.admit(
+      ctx,
+      { ...mixed, evidenceCitations: [{ beliefId: 'semantic_belief:old' }, {}] },
+      'supported',
+    );
+    expect(h.calls).toHaveLength(0);
+    expect(h.outcomes).toEqual(['not_admitted']);
+  });
+
+  it('stamps every arm with its own revision: episode (existence), fragment (asset quarantine), scene (gist hash)', async () => {
+    const h = makeHarness({
+      dependencyRows: {
+        episode: [{ id: 'episode:ep1', userId: null }],
+        fragment: [{ id: 'evidence_fragment:fr1', quarantineStatus: 'clean' }],
+        scene: [{ id: 'memory_episode:sc1', gist: 'moved to A', enrichedGist: null }],
+      },
+    });
+    await h.svc.admit(
+      ctx,
+      {
+        ...mixed,
+        evidenceCitations: [
+          { episodeId: 'episode:ep1', conversationId: 'c1' },
+          { fragmentId: 'evidence_fragment:fr1', assetId: 'evidence_asset:a1' },
+          { sceneId: 'memory_episode:sc1' },
+        ],
+      },
+      'supported',
+    );
+    const upsert = h.calls.find((c) => /UPSERT/.test(c.sql))!;
+    const deps = upsert.params.dependencies as Array<{ kind: string; id: string; rev: string }>;
+    expect(deps.map((d) => [d.kind, d.id])).toEqual([
+      ['episode', 'episode:ep1'],
+      ['fragment', 'evidence_fragment:fr1'],
+      ['scene', 'memory_episode:sc1'],
+    ]);
+    expect(deps[0]!.rev).toBe('');
+    expect(deps[1]!.rev).toBe('clean');
+    expect(deps[2]!.rev).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it('a fragment whose asset is quarantine-rejected is dead at admission', async () => {
+    const h = makeHarness({
+      dependencyRows: { fragment: [{ id: 'evidence_fragment:fr1', quarantineStatus: 'rejected' }] },
+    });
+    await h.svc.admit(
+      ctx,
+      { ...mixed, evidenceCitations: [{ fragmentId: 'evidence_fragment:fr1' }] },
+      'supported',
+    );
+    expect(h.calls.some((c) => /UPSERT/.test(c.sql))).toBe(false);
+    expect(h.outcomes).toEqual(['not_admitted']);
+  });
+});
+
+describe('AnswerCacheService.begin — dependency check-on-read (0136)', () => {
+  const beliefDep = { kind: 'belief', id: 'semantic_belief:b1', rev: '3' };
+  const liveBelief = (over: Record<string, unknown> = {}) => ({
+    id: 'semantic_belief:b1',
+    revision: 3,
+    status: 'active',
+    supersededBy: null,
+    validUntil: null,
+    userId: null,
+    ...over,
+  });
+  const args = () => beginArgs();
+
+  it('the audit scenario: the cited fact still validates, the belief was superseded → cause=superseded, miss', async () => {
+    const h = makeHarness({
+      cacheRow: liveCacheRow({ dependencies: [beliefDep] }),
+      factRows: [activeFact()],
+      dependencyRows: {
+        belief: [liveBelief({ status: 'superseded', supersededBy: 'semantic_belief:b2' })],
+      },
+    });
+    const out = await h.svc.begin(args());
+    expect(out?.hit).toBeUndefined();
+    expect(h.outcomes).toEqual(['rejected_stale']);
+    const inv = h.calls.find((c) => /invalidationCause/.test(c.sql))!;
+    expect(inv.params.cause).toBe('superseded');
+  });
+
+  it.each([
+    ['belief retracted → retracted', liveBelief({ status: 'retracted' }), 'retracted'],
+    [
+      'belief past validUntil → expired_validity',
+      liveBelief({ validUntil: new Date(Date.now() - 1_000) }),
+      'expired_validity',
+    ],
+    [
+      'belief revised in place (revision moved) → dependency_changed',
+      liveBelief({ revision: 4 }),
+      'dependency_changed',
+    ],
+    [
+      'belief left the servable lifecycle → missing',
+      liveBelief({ status: 'competing' }),
+      'missing',
+    ],
+  ] as Array<[string, Record<string, unknown>, string]>)('%s', async (_n, row, cause) => {
+    const h = makeHarness({
+      cacheRow: liveCacheRow({ dependencies: [beliefDep] }),
+      factRows: [activeFact()],
+      dependencyRows: { belief: [row] },
+    });
+    expect((await h.svc.begin(args()))?.hit).toBeUndefined();
+    expect(h.calls.find((c) => /invalidationCause/.test(c.sql))!.params.cause).toBe(cause);
+  });
+
+  it('a dependency row that is gone → missing (existence never leaks)', async () => {
+    const h = makeHarness({
+      cacheRow: liveCacheRow({ dependencies: [beliefDep] }),
+      factRows: [activeFact()],
+      dependencyRows: { belief: [] },
+    });
+    expect((await h.svc.begin(args()))?.hit).toBeUndefined();
+    expect(h.calls.find((c) => /invalidationCause/.test(c.sql))!.params.cause).toBe('missing');
+  });
+
+  it('scene gist recomposed → dependency_changed; unchanged gist → serves', async () => {
+    const admitted = makeHarness({
+      dependencyRows: {
+        scene: [{ id: 'memory_episode:s1', gist: 'moved to A', enrichedGist: null }],
+      },
+    });
+    await admitted.svc.admit(
+      {
+        key: 'c'.repeat(64),
+        companyId: 'co_test',
+        profileHash: 'ph',
+        model: 'm',
+        normalizedQuery: 'q',
+        isEnumeration: false,
+      },
+      {
+        answer: 'a',
+        citations: [
+          {
+            factId: 'knowledge_fact:f1',
+            entityId: 'knowledge_entity:e1',
+            canonicalName: 'E',
+            predicate: 'p',
+            object: 'o',
+          },
+        ],
+        evidenceCitations: [{ sceneId: 'memory_episode:s1' }],
+        results: [],
+      },
+      'supported',
+    );
+    const stored = admitted.calls.find((c) => /UPSERT/.test(c.sql))!.params.dependencies as Array<
+      Record<string, unknown>
+    >;
+
+    const changed = makeHarness({
+      cacheRow: liveCacheRow({ dependencies: stored }),
+      factRows: [activeFact()],
+      dependencyRows: {
+        scene: [{ id: 'memory_episode:s1', gist: 'moved to B', enrichedGist: null }],
+      },
+    });
+    expect((await changed.svc.begin(args()))?.hit).toBeUndefined();
+    expect(changed.calls.find((c) => /invalidationCause/.test(c.sql))!.params.cause).toBe(
+      'dependency_changed',
+    );
+
+    const same = makeHarness({
+      cacheRow: liveCacheRow({ dependencies: stored }),
+      factRows: [activeFact()],
+      dependencyRows: {
+        scene: [{ id: 'memory_episode:s1', gist: 'moved to A', enrichedGist: null }],
+      },
+    });
+    expect((await same.svc.begin(args()))?.hit?.cached).toBe(true);
+  });
+
+  it('fragment: asset quarantine state moved → dependency_changed; rejected → missing', async () => {
+    const dep = { kind: 'fragment', id: 'evidence_fragment:fr1', rev: 'clean' };
+    const moved = makeHarness({
+      cacheRow: liveCacheRow({ dependencies: [dep] }),
+      factRows: [activeFact()],
+      dependencyRows: { fragment: [{ id: 'evidence_fragment:fr1', quarantineStatus: 'pending' }] },
+    });
+    expect((await moved.svc.begin(args()))?.hit).toBeUndefined();
+    expect(moved.calls.find((c) => /invalidationCause/.test(c.sql))!.params.cause).toBe(
+      'dependency_changed',
+    );
+    const rejected = makeHarness({
+      cacheRow: liveCacheRow({ dependencies: [dep] }),
+      factRows: [activeFact()],
+      dependencyRows: { fragment: [{ id: 'evidence_fragment:fr1', quarantineStatus: 'rejected' }] },
+    });
+    expect((await rejected.svc.begin(args()))?.hit).toBeUndefined();
+    expect(rejected.calls.find((c) => /invalidationCause/.test(c.sql))!.params.cause).toBe(
+      'missing',
+    );
+  });
+
+  it('episode: the row exists → serves; forgotten → missing', async () => {
+    const dep = { kind: 'episode', id: 'episode:ep1', rev: '' };
+    const alive = makeHarness({
+      cacheRow: liveCacheRow({ dependencies: [dep] }),
+      factRows: [activeFact()],
+      dependencyRows: { episode: [{ id: 'episode:ep1', userId: null }] },
+    });
+    expect((await alive.svc.begin(args()))?.hit?.cached).toBe(true);
+    const gone = makeHarness({
+      cacheRow: liveCacheRow({ dependencies: [dep] }),
+      factRows: [activeFact()],
+      dependencyRows: { episode: [] },
+    });
+    expect((await gone.svc.begin(args()))?.hit).toBeUndefined();
+    expect(gone.calls.find((c) => /invalidationCause/.test(c.sql))!.params.cause).toBe('missing');
+  });
+
+  it('every dependency live → serves, and the additive-write probe still runs after them', async () => {
+    const served = makeHarness({
+      cacheRow: liveCacheRow({ dependencies: [beliefDep] }),
+      factRows: [activeFact()],
+      dependencyRows: { belief: [liveBelief()] },
+    });
+    const hit = await served.svc.begin(args());
+    expect(hit?.hit?.cached).toBe(true);
+    // The revalidated arm comes back as an id-only evidence citation.
+    expect(hit?.hit?.evidenceCitations).toEqual([{ beliefId: 'semantic_belief:b1' }]);
+    expect(served.outcomes).toEqual(['hit']);
+
+    const newer = makeHarness({
+      cacheRow: liveCacheRow({ dependencies: [beliefDep] }),
+      factRows: [activeFact()],
+      dependencyRows: { belief: [liveBelief()] },
+      probeRows: [newerFact()],
+    });
+    expect((await newer.svc.begin(args()))?.hit).toBeUndefined();
+    expect(newer.calls.find((c) => /invalidationCause/.test(c.sql))!.params.cause).toBe(
+      'newer_fact',
+    );
+  });
+
+  it('precedence: a dead cited fact wins over a dead dependency', async () => {
+    const h = makeHarness({
+      cacheRow: liveCacheRow({ dependencies: [beliefDep] }),
+      factRows: [activeFact({ status: 'retracted' })],
+      dependencyRows: { belief: [liveBelief({ status: 'superseded' })] },
+    });
+    expect((await h.svc.begin(args()))?.hit).toBeUndefined();
+    expect(h.calls.find((c) => /invalidationCause/.test(c.sql))!.params.cause).toBe('retracted');
+  });
+
+  it('a pre-0136 row (no dependency list) is never served — fail closed before any fact read', async () => {
+    const legacy = liveCacheRow();
+    delete (legacy as Record<string, unknown>).dependencies;
+    const h = makeHarness({ cacheRow: legacy, factRows: [activeFact()] });
+    expect((await h.svc.begin(args()))?.hit).toBeUndefined();
+    expect(h.calls.some((c) => /FROM knowledge_fact/.test(c.sql))).toBe(false);
+    expect(h.calls.find((c) => /invalidationCause/.test(c.sql))!.params.cause).toBe('missing');
+    expect(h.outcomes).toEqual(['rejected_stale']);
+  });
+
+  it('a malformed stored dependency entry fails closed as missing', async () => {
+    const h = makeHarness({
+      cacheRow: liveCacheRow({ dependencies: [{ kind: 'belief', id: 'nope', rev: '1' }] }),
+      factRows: [activeFact()],
+      dependencyRows: { belief: [liveBelief()] },
+    });
+    expect((await h.svc.begin(args()))?.hit).toBeUndefined();
+    expect(h.calls.find((c) => /invalidationCause/.test(c.sql))!.params.cause).toBe('missing');
+  });
 });

--- a/test/synthesize-outcome-writers.unit-spec.ts
+++ b/test/synthesize-outcome-writers.unit-spec.ts
@@ -28,6 +28,8 @@ import type {
   OutcomeEventInput,
 } from '../src/outcomes/memory-outcome.service';
 import type { DecisionInput, MemoryDecisionService } from '../src/outcomes/memory-decision.service';
+import type { SurrealService } from '../src/db/surreal.service';
+import type { AnswerCacheService } from '../src/answer-cache/answer-cache.service';
 
 interface RecordedCall {
   companyId: string;
@@ -64,7 +66,7 @@ function makeConfig(): ConfigService {
 
 /** Generator answers with a citation; the verifier (system prompt names
  *  the auditor role) returns the requested verdict. */
-function stubOpenAI(verdict: string) {
+function stubOpenAI(verdict: string, citedId = 'f1') {
   return {
     chat: {
       completions: {
@@ -76,7 +78,7 @@ function stubOpenAI(verdict: string) {
                 message: {
                   content: isVerifier
                     ? JSON.stringify({ verdict })
-                    : JSON.stringify({ answer: 'Maya [f1].', citedFactIds: ['f1'] }),
+                    : JSON.stringify({ answer: `Maya [${citedId}].`, citedFactIds: [citedId] }),
                 },
                 finish_reason: 'stop',
               },
@@ -99,6 +101,13 @@ function makeSvc(
     metrics?: MetricsService | undefined;
     decisionCalls?: DecisionCall[] | undefined;
     searchImpl?: (() => Promise<{ results: SearchHit[] }>) | undefined;
+    /** The hit's fact id (and what the generator cites); a `table:key` id
+     *  is needed for the 0115 grounding fetch to consider it at all. */
+    factId?: string | undefined;
+    /** 0115 grounding fetch port source — a stub whose withCompany
+     *  answers the `SELECT id, groundingStatus` read. */
+    surreal?: SurrealService | undefined;
+    answerCache?: AnswerCacheService | undefined;
   } = {},
 ): { svc: SynthesizeService; calls: RecordedCall[] } {
   const calls: RecordedCall[] = [];
@@ -115,25 +124,26 @@ function makeSvc(
         },
       } as unknown as MemoryDecisionService)
     : undefined;
+  const factId = opts.factId ?? 'f1';
   const search = {
-    search: opts.searchImpl ?? (async () => ({ results: [makeHit('cust_a', 'f1')] })),
+    search: opts.searchImpl ?? (async () => ({ results: [makeHit('cust_a', factId)] })),
   } as unknown as SearchService;
   const svc = new SynthesizeService(
     search,
     makeConfig(),
     opts.metrics, // metrics
     undefined, // evidenceCollector
-    undefined, // answerCache
+    opts.answerCache, // answerCache
     undefined, // l3
     undefined, // focusSignal
     undefined, // lensSuppression
     undefined, // laneClassifier
     outcomes,
     undefined, // predicateRegistry
-    undefined, // surreal (0115 grounding fetch)
+    opts.surreal, // surreal (0115 grounding fetch)
     decisions,
   );
-  (svc as unknown as { openai: unknown }).openai = stubOpenAI(verdict);
+  (svc as unknown as { openai: unknown }).openai = stubOpenAI(verdict, factId);
   return { svc, calls };
 }
 
@@ -175,16 +185,115 @@ describe('SynthesizeService — 0107 outcome writer seams', () => {
     expect(calls.every((c) => c.companyId === 'co_x')).toBe(true);
   });
 
-  it('strict + unsupported: used_in_answer still recorded at the finalize seam, NO verifier_supported', async () => {
+  it('strict + unsupported: nothing was served, so NO used_in_answer and NO verifier_supported (audit F7)', async () => {
+    // Strict fails closed on an unsupported verdict (answer: null,
+    // citations: []). Before F7 the finalize seam still recorded
+    // used_in_answer for the DRAFT's citations — a use that never reached
+    // the caller. Usage is now emitted from the FINAL result only.
     const { svc, calls } = makeSvc('unsupported');
-    await svc.synthesize({
+    const out = await svc.synthesize({
       companyId: 'co_x',
       dto: { ...baseDto, synthesisGuardrails: 'strict' },
       callerScopes: ['brain:read'],
     });
+    expect(out.answer).toBeNull();
     expect(named(calls, 'selected_for_context')).toHaveLength(1);
-    expect(named(calls, 'used_in_answer')).toHaveLength(1);
+    expect(named(calls, 'used_in_answer')).toHaveLength(0);
     expect(named(calls, 'verifier_supported')).toHaveLength(0);
+  });
+
+  it('lenient + partial: the answer IS served (reason-tagged) → used_in_answer, never verifier_supported', async () => {
+    // Abstention off: under 'verifier' calibration a lenient partial is the
+    // explicit decline (nothing served); with it off the lenient path serves
+    // the reason-tagged answer — the served-but-not-verified case.
+    process.env.RETRIEVAL_ABSTENTION_CALIBRATION = 'off';
+    try {
+      const { svc, calls } = makeSvc('partial');
+      const out = await svc.synthesize({
+        companyId: 'co_x',
+        dto: { ...baseDto, synthesisGuardrails: 'lenient' },
+        callerScopes: ['brain:read'],
+      });
+      expect(out.answer).toBe('Maya [f1].');
+      expect(out.reason).toBe('verifier_partial');
+      const used = named(calls, 'used_in_answer');
+      expect(used).toHaveLength(1);
+      expect(used[0]).toMatchObject({ subjectId: 'f1' });
+      expect(named(calls, 'verifier_supported')).toHaveLength(0);
+    } finally {
+      delete process.env.RETRIEVAL_ABSTENTION_CALIBRATION;
+    }
+  });
+
+  it('a supported draft the serving gate downgrades records NOTHING — no used_in_answer, no verifier_supported (audit F7)', async () => {
+    // EVIDENCE_UNGROUNDED_SERVING_GATE: every cited fact is ungrounded ⇒
+    // the supported verdict is downgraded to an abstention AFTER the
+    // verifier said 'supported'. The pre-F7 seam had already counted the
+    // draft's citations as verified use by then.
+    process.env.EVIDENCE_UNGROUNDED_SERVING_GATE = '1';
+    try {
+      const surreal = {
+        withCompany: async <T>(_c: string, fn: (db: unknown) => Promise<T>) =>
+          fn({
+            query: async () => [[{ id: 'knowledge_fact:f1', groundingStatus: 'ungrounded' }]],
+          }),
+      } as unknown as SurrealService;
+      const { svc, calls } = makeSvc('supported', { surreal, factId: 'knowledge_fact:f1' });
+      const out = await svc.synthesize({
+        companyId: 'co_x',
+        dto: { ...baseDto, synthesisGuardrails: 'strict' },
+        callerScopes: ['brain:read'],
+      });
+      expect(out.reason).toBe('ungrounded_evidence');
+      expect(out.citations).toEqual([]);
+      expect(named(calls, 'selected_for_context')).toHaveLength(1);
+      expect(named(calls, 'used_in_answer')).toHaveLength(0);
+      expect(named(calls, 'verifier_supported')).toHaveLength(0);
+    } finally {
+      delete process.env.EVIDENCE_UNGROUNDED_SERVING_GATE;
+    }
+  });
+
+  it('an answer-cache hit is served as-is: counted as ok, no outcome events (read-only accounting)', async () => {
+    const counted: string[] = [];
+    const metrics = new Proxy(
+      {},
+      {
+        get: (_t, prop) =>
+          prop === 'countSynthesize' ? (o: string) => counted.push(o) : () => undefined,
+      },
+    ) as unknown as MetricsService;
+    const answerCache = {
+      begin: async () => ({
+        hit: {
+          answer: 'Maya (cached).',
+          citations: [
+            {
+              factId: 'f1',
+              entityId: 'cust_a',
+              canonicalName: 'cust_a',
+              predicate: 'name',
+              object: 'Maya',
+            },
+          ],
+          results: [],
+          cached: true,
+        },
+      }),
+      admit: async () => undefined,
+    } as unknown as AnswerCacheService;
+    const { svc, calls } = makeSvc('supported', { metrics, answerCache });
+    const out = await svc.synthesize({
+      companyId: 'co_x',
+      dto: { ...baseDto, synthesisGuardrails: 'strict' },
+      callerScopes: ['brain:read'],
+    });
+    expect(out.cached).toBe(true);
+    expect(out.answer).toBe('Maya (cached).');
+    expect(counted).toEqual(['ok']);
+    // The hit's citations were already counted when the answer was first
+    // served and admitted; a re-serve from the cache records nothing.
+    expect(calls).toEqual([]);
   });
 
   it("'answer' guardrails (unverifiedReturn exit): used_in_answer, never verifier_supported", async () => {


### PR DESCRIPTION
Closes two findings of the 2026-09-06 current-state audit: **F3** (the answer cache loses the dependencies of a mixed answer) and **F7** (usage telemetry is emitted before the final serving gates).

## F3 — every dependency, not only the facts
Admission rejected only answers with **no** fact citations, so a mixed fact + belief (or episode / fragment / scene) answer was cached with its non-fact half dropped: check-on-read revalidated the cited facts and nothing else, and a belief revision left the cached text serving until TTL. The audit's own repro (one fact + `semantic_belief:old`) was admitted without the belief anywhere in the row.

- **Migration `0136`**: `answer_cache.dependencies` — a typed list of `{kind, id, rev}` (`kind` asserted to `belief | episode | fragment | scene`), and `dependency_changed` joins the `invalidationCause` set.
- **Admission** stamps each arm from its live row on the connection the row is written with: a belief's `revision`, a scene's gist hash, a fragment's parent-asset `quarantineStatus`, `''` for an immutable episode (existence is its lifecycle). An answer is **not admitted** when a citation carries no trackable arm, or when a dependency is already missing, fenced from the answer's user partition, superseded, retracted, expired, or quarantine-rejected — the answer is stale before it is stored. New metric outcome `not_admitted`.
- **Check-on-read** revalidates every entry on the same scoped connection, under the same user-scope fence as the cited facts, one extra round trip only when the row has any: missing/fenced → `missing`; belief superseded / retracted / past `validUntil` → its lifecycle cause; a moved stamp (belief revised in place, scene recomposed, quarantine state changed) → `dependency_changed`. Precedence: dead cited fact → dead/changed dependency → the additive-write probe.
- A served hit returns the arms as id-only `evidenceCitations` (the rendered excerpt is not stored).
- `ANSWER_CACHE_PROMPT_VERSION` 1 → 2 so every pre-0136 row misses by key construction; a row without a dependency list is additionally never served. Fact-only answers store `[]` and issue no extra query — byte-identical cost.

## F7 — usage is what was served
`finalizeAndAdmit` emitted `used_in_answer` / `verifier_supported` from the **draft**, before the answer-integrity (Parts A + C), evidence-capability and ungrounded-support gates ran — a supported draft the gate downgraded still bumped `verifiedUseCount`, and a strict fail-closed exit still counted as use. Both emissions now come **after** `finalizeVerdict`, from the final result: an abstention carries no citations and records nothing; a lenient partial/failed serve records use but never verified use; a cache hit stays read-only accounting (counted as `ok`, no events). Ranking/decay built on these counters now reads only real serves.

## Proof
- **Unit** (`answer-cache.unit-spec` 72/72, `synthesize-outcome-writers.unit-spec` 13/13): dependency derivation (arms, de-dup, untrackable → null); admission — the audit repro is stored with `dependencies: [{kind:'belief', id, rev:'3'}]`, refusal per dead arm, per-arm stamps; read-time matrix — superseded / retracted / expired / revision moved / gist moved / quarantine moved / gone / pre-0136 row / malformed entry / precedence over `newer_fact` / hit returns the arm; F7 — strict unsupported records nothing, lenient partial records use only, a supported draft downgraded by the ungrounded gate records nothing, a cache hit records nothing.
- **Real SurrealDB 3.2.4** (`test/answer-cache-dependencies.e2e-spec.ts`, 3/3): the audit scenario end to end — a mixed answer is admitted with the belief stamped (`rev:'1'`), served cached with the belief arm echoed, a later scene folds into revision 2 and **invalidates the entry (`cause=superseded`) while the cited fact is untouched**, the fresh answer is re-admitted against revision 2 and serves, and an in-place revision bump stamps `dependency_changed`. Neighbouring `answer-cache`, `belief-serving`, `memory-outcome` e2e suites: 19/19.
- tsc (app + spec), eslint, prettier clean.

## Notes for the reviewer
- Migration id `0136` is the next free number on `main` at this writing; `migrationId` is UNIQUE, so if another branch lands a `0136_*` first, this file must be renumbered before merge (a duplicate id silently never applies).
- Not in scope: rendering the belief excerpt on a cached hit (the hit carries ids only), and a sweep that reaps invalidated rows (TTL handles it, as before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhrQxeisXJZEt4sg3PGyU6