### PR TITLE
fix(beliefs): two clocks per revision, a full-chain fold on targeted runs, and a compare-and-set revision write

### DIFF
--- a/src/admin/belief-promotion.service.ts
+++ b/src/admin/belief-promotion.service.ts
@@ -1,8 +1,7 @@
-import { createHash } from 'node:crypto';
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import type OpenAI from 'openai';
-import { RecordId, StringRecordId } from 'surrealdb';
+import { StringRecordId } from 'surrealdb';
 import { SurrealService } from '../db/surreal.service';
 import { chatCallParams, createOpenAiClient } from '../ai/openai-client';
 import {
@@ -19,15 +18,21 @@ import { supportEdgesEnabled } from '../common/provenance-flags';
 import { buildSupportEdgeBatches } from '../common/support-edges';
 import { absorbFoldableOrphans, resolveFieldFold } from './belief-field-fold';
 import {
+  admitScenes,
   beliefPromoterVersion,
   buildPromotableScenesQuery,
   promoterVersionFor,
-  sceneSingleUser,
   type PromotableSceneHead,
 } from './belief-scene-selection';
-import { formatValueDims, sceneValueVerdict } from './belief-value-gate';
 import { stampSupersededFrom } from './scene-baseline-ref';
 import { SceneVersionService } from './scene-version';
+import {
+  beliefRecordString,
+  commitRevision,
+  corroborateBelief,
+  epochMs,
+  type ActiveBeliefRow,
+} from './belief-revision';
 
 // The lexical fold rule lives in belief-field-fold.ts, the scene
 // selection / row shape / #387 fence / world stamping in
@@ -47,6 +52,7 @@ export {
   sceneSingleUser,
 } from './belief-scene-selection';
 export type { PromotableSceneHead } from './belief-scene-selection';
+export { beliefIdTail } from './belief-revision';
 
 /**
  * Belief promotion (Belief-A, SCENES_BELIEF_PROMOTION — default off):
@@ -153,15 +159,37 @@ export type { PromotableSceneHead } from './belief-scene-selection';
  * CONFLICT GUARD (built-in, no flag): a group whose latest timestamp is
  * shared by two DIFFERENT values has no deterministic winner — the whole
  * (subject, field) group is SKIPPED LOUDLY with a warn. Same for a
- * batch whose winner is not newer than the active belief's validFrom
- * (stale/ambiguous re-promotion — skipped loudly, never flip-flopped).
+ * differing candidate whose own latest evidence is not past the active
+ * belief's WATERMARK (stale re-promotion — skipped loudly, never
+ * flip-flopped).
+ *
+ * TWO CLOCKS (audit 2026-09-06 F6). A revision carries `validFrom` —
+ * when the state BEGAN, the opener of the trailing same-value run of
+ * its evidence — and `latestEvidenceAt` (0137) — the WATERMARK, the
+ * latest scene it has processed. A confirmation advances the watermark
+ * and leaves the beginning alone; a differing value is judged against
+ * the watermark, so evidence older than what the belief already saw
+ * cannot revise it in ANY arrival order (A on Jan 1, A again on Mar 1,
+ * then B dated Feb 1 arriving late stays a skip). A TARGETED run
+ * (conversationId) therefore folds the affected users' WHOLE promotable
+ * chain, not the one conversation, and promotes only the keys that
+ * conversation touched — a late scene lands at its place in the chain.
+ * The verdict is a function of the evidence, not of the order the runs
+ * saw it: every permutation converges to the same active row
+ * (belief-revision-chain.e2e-spec).
  *
  * REVISIONS: supersede chain in code, NEVER in-place for values. A new
  * value creates revision N+1 and stamps the old row status='superseded'
- * + validUntil + supersededBy; in-place UPDATE is allowed ONLY for the
- * corroboration counters (sourceSceneIds / conversationIds /
- * corroborationCount / conversationCount / updatedAt). fn::resolve_fact
- * reuse was REJECTED (claim-specific — 0120 header).
+ * + validUntil + supersededBy — the two in ONE compare-and-set
+ * transaction (commitRevision), so a head that moved under the run, or
+ * a revision slot another run filled with a different value, aborts
+ * cleanly instead of leaving two active heads. In-place UPDATE is
+ * allowed ONLY for the corroboration counters (sourceSceneIds /
+ * conversationIds / corroborationCount / conversationCount / updatedAt),
+ * the watermark, and the two chain-derived corrections that change no
+ * value: validFrom (when the same value began) and a missing priorValue
+ * (what it displaced). fn::resolve_fact reuse was REJECTED
+ * (claim-specific — 0120 header).
  *
  * PROVENANCE: sourceSceneIds is the inline canonical trail (survives
  * flag-off); when PROVENANCE_SUPPORT_EDGES is on, the pass additionally
@@ -260,11 +288,50 @@ export interface FoldedBelief {
   subject: string;
   field: string;
   value: string;
-  /** The winner delta's `from` ('' when unknown). */
+  /**
+   * The value the current state displaced: the chain's previous distinct
+   * value when the winning run does not open the chain, else the
+   * run-opening delta's own `from` ('' when unknown).
+   */
   priorValue: string;
+  /**
+   * The chain's previous distinct value alone ('' when the winning run
+   * opens the chain) — what a corroboration may backfill onto a head that
+   * records no priorValue. Unlike priorValue it never falls back to a
+   * delta's self-reported `from`.
+   */
+  displacedValue: string;
+  /** When the chain last held displacedValue — undefined with it. */
+  displacedAt?: Date;
+  /**
+   * When the current state BEGAN — the earliest contribution of the
+   * trailing same-value run, never the latest confirmation (audit
+   * 2026-09-06 F6). A re-confirmation on a later day leaves it where it
+   * is; an interlude of another value moves it to the run that followed.
+   */
   validFrom: Date;
+  /**
+   * The latest evidence behind the winning value — the run's last
+   * contribution — i.e. the revision WATERMARK. A differing candidate
+   * whose own evidenceAt is not past the active belief's watermark is
+   * stale: the belief has already processed later evidence.
+   */
+  evidenceAt: Date;
+  /**
+   * Every contribution time of the trailing run, ascending — validFrom
+   * is the first, evidenceAt the last. A revision that follows a head
+   * whose watermark falls inside the run begins at the first of these
+   * past that watermark.
+   */
+  runEvidenceAt: Date[];
   /** Scenes contributing the WINNING value (distinct, emission order). */
   sceneIds: string[];
+  /**
+   * EVERY scene that contributed to this key, winning value or not
+   * (distinct). A targeted run uses it to tell which keys the folded
+   * conversation actually touched.
+   */
+  allSceneIds: string[];
   /** Distinct conversations behind those scenes — the floor unit. */
   conversationIds: string[];
   confidence: number;
@@ -281,7 +348,14 @@ export interface FoldedBelief {
 export interface BeliefFold {
   folded: FoldedBelief[];
   /** Groups the conflict guard refused (ambiguous latest value). */
-  conflicts: Array<{ userId: string; subject: string; field: string; values: string[] }>;
+  conflicts: Array<{
+    userId: string;
+    subject: string;
+    field: string;
+    values: string[];
+    /** Every contributing scene — the targeted-run touch test. */
+    allSceneIds: string[];
+  }>;
   /** SCENES_BELIEF_FIELD_FOLD: incoming names folded onto existing ones. */
   fieldFolds: Array<{ userId: string; subject: string; from: string; to: string }>;
   /** Field-fold ambiguity guard: >1 existing candidates — NOT folded. */
@@ -481,6 +555,7 @@ function foldGroupVerdict(group: {
   const ambiguous = ordered.some(
     (c) => c.occurredAt === winner.occurredAt && c.value !== winner.value,
   );
+  const allSceneIds = [...new Set(ordered.map((c) => c.sceneId))];
   if (ambiguous) {
     return {
       conflict: {
@@ -488,11 +563,23 @@ function foldGroupVerdict(group: {
         subject: group.subject,
         field: group.field,
         values: [...new Set(ordered.map((c) => c.value))].sort(),
+        allSceneIds,
       },
     };
   }
   const corroborating = ordered.filter((c) => c.value === winner.value);
   const sceneIds = [...new Set(corroborating.map((c) => c.sceneId))];
+  // The trailing same-value run: walk back from the winner while the
+  // value holds. Its opener is when the current state BEGAN; the winner
+  // is the latest evidence for it (the watermark). Confirmations that sit
+  // BEFORE an interlude of another value still corroborate — they are
+  // evidence for the value — but they do not pull the beginning back past
+  // the interlude: the state was interrupted and began again.
+  let runStart = ordered.length - 1;
+  while (runStart > 0 && ordered[runStart - 1]!.value === winner.value) runStart -= 1;
+  const opener = ordered[runStart]!;
+  const displaced = runStart > 0 ? ordered[runStart - 1]!.value : '';
+  const priorValue = displaced !== '' ? displaced : opener.priorValue;
   const conversationIds = [
     ...new Set(corroborating.map((c) => c.conversationId).filter((c) => c !== '')),
   ];
@@ -511,9 +598,14 @@ function foldGroupVerdict(group: {
       subject: group.subject,
       field: group.field,
       value: winner.value,
-      priorValue: winner.priorValue,
-      validFrom: new Date(winner.occurredAt),
+      priorValue,
+      displacedValue: displaced,
+      ...(runStart > 0 ? { displacedAt: new Date(ordered[runStart - 1]!.occurredAt) } : {}),
+      validFrom: new Date(opener.occurredAt),
+      evidenceAt: new Date(winner.occurredAt),
+      runEvidenceAt: ordered.slice(runStart).map((c) => new Date(c.occurredAt)),
       sceneIds,
+      allSceneIds,
       conversationIds,
       confidence: Math.round(confidence * 10000) / 10000,
       // Distinct worlds behind the winning value (sorted = deterministic).
@@ -586,23 +678,6 @@ export function renderBeliefStatement(f: {
   return withPrior.slice(0, STATEMENT_MAX_CHARS);
 }
 
-/**
- * Pure: deterministic record-id tail over (userId|subject|field|
- * revision) — the composer's sceneIdTail idiom. Paired with INSERT
- * IGNORE it makes every create replay-idempotent, and it enforces
- * (userId, subject, field, revision) uniqueness in CODE — a compound
- * UNIQUE index is exactly the 3.2.4 planner trap 0120 avoids.
- */
-export function beliefIdTail(
-  key: { userId: string; subject: string; field: string },
-  revision: number,
-): string {
-  return createHash('sha256')
-    .update(`${key.userId}\x00${key.subject}\x00${key.field}\x00${revision}`)
-    .digest('hex')
-    .slice(0, 24);
-}
-
 export interface BeliefPromotionResult {
   /** Enriched scenes of the current version seen by the pass. */
   scenes: number;
@@ -631,18 +706,21 @@ export interface BeliefPromotionResult {
   beliefsCreated: number;
   beliefsCorroborated: number;
   beliefsRevised: number;
+  /**
+   * Active beliefs whose validFrom / priorValue were corrected from the
+   * full evidence chain without a value change (a late-arriving scene
+   * showed the state began at a different time, or what it displaced).
+   */
+  beliefsRealigned: number;
+  /**
+   * Revisions this run lost to a concurrent writer of the same key: the
+   * compare-and-set transaction found the head already superseded, or
+   * the revision slot already holding another value. Nothing was
+   * written; the next run recomputes the key from its evidence.
+   */
+  skippedContended: number;
   /** memory_support rows written (0 unless PROVENANCE_SUPPORT_EDGES). */
   supportEdges: number;
-}
-
-/** Active-belief head read back for the upsert decision. */
-interface ActiveBeliefRow {
-  id: unknown;
-  revision: number;
-  value: string;
-  validFrom: unknown;
-  sourceSceneIds?: unknown;
-  conversationIds?: unknown;
 }
 
 export interface BeliefDb {
@@ -700,6 +778,8 @@ export class BeliefPromotionService {
       beliefsCreated: 0,
       beliefsCorroborated: 0,
       beliefsRevised: 0,
+      beliefsRealigned: 0,
+      skippedContended: 0,
       supportEdges: 0,
     };
     // Defense in depth: the controller already 404s with the flag off; a
@@ -726,38 +806,56 @@ export class BeliefPromotionService {
         valueGate,
       });
       const [scenes] = await db.query<[PromotableSceneHead[]]>(selection.sql, selection.params);
-      const eligible: Array<{ scene: PromotableSceneHead; userId: string }> = [];
-      for (const scene of scenes ?? []) {
-        result.scenes += 1;
-        const userId = sceneSingleUser(scene);
-        if (userId === null) {
-          // #387 fail-closed: mixed-user, tenant-global or legacy
-          // (pre-0117 userIds) scenes never feed a belief.
-          result.skippedMixedUser += 1;
+      const gate = { valueGate, valueGateMin };
+      const eligible = admitScenes({
+        scenes: scenes ?? [],
+        gate,
+        count: result,
+        logger: this.logger,
+      });
+
+      // FULL-CHAIN RECOMPUTE (audit 2026-09-06 F6). A targeted run selects
+      // ONE conversation's scenes, but a belief is the verdict of ALL the
+      // evidence for its key, in time order — a late-arriving scene must
+      // land at its place in the chain, not be judged against the head
+      // alone (which is how a stale value dated between two confirmations
+      // used to displace the confirmed one). So the scenes the run folds
+      // are the affected users' whole promotable world; the batch only
+      // decides WHICH keys this run is about (the ones its scenes touch)
+      // and what the run summary counts. A full run already reads the
+      // whole world — nothing to add there.
+      const batchSceneIds = new Set(eligible.map((e) => String(e.scene.id)));
+      let foldInput = eligible;
+      if (opts.conversationId !== undefined && eligible.length > 0) {
+        const chainSelection = buildPromotableScenesQuery({
+          version,
+          packDeltas,
+          valueGate,
+          userIds: [...new Set(eligible.map((e) => e.userId))],
+        });
+        const [chainScenes] = await db.query<[PromotableSceneHead[]]>(
+          chainSelection.sql,
+          chainSelection.params,
+        );
+        foldInput = admitScenes({
+          scenes: chainScenes ?? [],
+          gate,
+          count: null,
+          logger: this.logger,
+        });
+        // The batch's scenes are part of the chain by construction (same
+        // users, no conversation filter); a chain read that somehow
+        // lacks one falls back to folding the batch alone rather than
+        // silently dropping the run's own evidence.
+        if (
+          !eligible.every((e) => foldInput.some((c) => String(c.scene.id) === String(e.scene.id)))
+        ) {
           this.logger.warn(
-            `belief promotion skipped scene ${String(scene.id)}: not single-user ` +
-              `(userIds=${JSON.stringify(scene.userIds ?? null)}) — #387 fence`,
+            `belief promotion: chain read for ${opts.conversationId} missed batch scenes — ` +
+              `folding the batch alone`,
           );
-          continue;
+          foldInput = eligible;
         }
-        // MEMORY-VALUE GATE: the value vector's first consumer. Runs
-        // AFTER the #387 fence (a security fence is never traded against
-        // a quality one) and BEFORE the fold, so a refused scene
-        // contributes no delta at all. Off ⇒ not even evaluated.
-        if (valueGate) {
-          const verdict = sceneValueVerdict(scene, valueGateMin);
-          if (!verdict.promote) {
-            result.skippedLowValue += 1;
-            this.logger.log(
-              `belief promotion value gate: scene ${String(scene.id)} skipped as noise ` +
-                `(${formatValueDims(verdict.dims)}; all < ${valueGateMin}) — ` +
-                `SCENES_VALUE_GATE_ENABLED`,
-            );
-            continue;
-          }
-        }
-        result.eligibleScenes += 1;
-        eligible.push({ scene, userId });
       }
 
       // #135 seam 2: fold candidates are the existing ACTIVE belief
@@ -765,8 +863,8 @@ export class BeliefPromotionService {
       // the 3.2.4 planner; the DELETE-WHERE trap does not apply to
       // reads). Flag off ⇒ zero extra queries.
       let existingFields: Map<string, string[]> | undefined;
-      if (fieldFoldOn && eligible.length > 0) {
-        const userIds = [...new Set(eligible.map((e) => e.userId))];
+      if (fieldFoldOn && foldInput.length > 0) {
+        const userIds = [...new Set(foldInput.map((e) => e.userId))];
         const [rows] = await db.query<
           [Array<{ userId: unknown; subject: unknown; field: unknown }>]
         >(
@@ -787,10 +885,18 @@ export class BeliefPromotionService {
         }
       }
 
-      const { folded, conflicts, fieldFolds, fieldFoldAmbiguities } = foldBeliefGroups(eligible, {
+      const chainFold = foldBeliefGroups(foldInput, {
         negationDeltas,
         ...(existingFields !== undefined ? { existingFields } : {}),
       });
+      // A targeted run promotes only the keys its own scenes touch — the
+      // rest of the users' chain was context for the fold, not this run's
+      // business (its verdicts are unchanged and would only re-stamp).
+      const touched = (g: { allSceneIds: string[] }) =>
+        foldInput === eligible || g.allSceneIds.some((s) => batchSceneIds.has(s));
+      const folded = chainFold.folded.filter(touched);
+      const conflicts = chainFold.conflicts.filter(touched);
+      const { fieldFolds, fieldFoldAmbiguities } = chainFold;
       result.skippedConflict = conflicts.length;
       result.fieldFolds = fieldFolds.length;
       result.fieldFoldAmbiguous = fieldFoldAmbiguities.length;
@@ -847,12 +953,34 @@ export class BeliefPromotionService {
         `fieldFolds=${result.fieldFolds} foldAmbiguous=${result.fieldFoldAmbiguous} ` +
         `orphansAbsorbed=${result.fieldOrphansAbsorbed} ` +
         `orphanAmbiguous=${result.fieldOrphanAmbiguous} ` +
-        `floor=${result.skippedFloor} stale=${result.skippedStale} edges=${result.supportEdges})`,
+        `floor=${result.skippedFloor} stale=${result.skippedStale} ` +
+        `realigned=${result.beliefsRealigned} contended=${result.skippedContended} ` +
+        `edges=${result.supportEdges})`,
     );
     return result;
   }
 
-  /** One (userId, subject, field) verdict: create / corroborate / revise. */
+  /**
+   * One (userId, subject, field) verdict: create / corroborate / revise.
+   *
+   * Every write that changes what the belief SAYS goes through ONE
+   * compare-and-set transaction (commitRevision, belief-revision.ts): the
+   * new revision row and the supersede stamp on the head land together or
+   * not at all, and a head that moved under this run — another pod
+   * revised the same key first — aborts the transaction instead of
+   * leaving two active revisions or a revision slot silently holding
+   * someone else's value. The stamps that follow (consolidatedInto,
+   * baselineRef, support edges) are replay-idempotent and re-asserted on
+   * every run, so a crash between the transaction and the stamps heals on
+   * the next pass.
+   *
+   * TWO CLOCKS (audit 2026-09-06 F6). `validFrom` is when the current
+   * state BEGAN; `latestEvidenceAt` (0137) is the WATERMARK — the latest
+   * scene the belief has processed for its value. A confirmation advances
+   * the watermark and leaves the beginning alone; a differing candidate
+   * is measured against the watermark, so evidence older than what the
+   * belief already saw can never revise it, whatever order it arrived in.
+   */
   private async upsertBelief({
     db,
     belief,
@@ -870,15 +998,18 @@ export class BeliefPromotionService {
     // came wholly out of ONE pack world (promoterVersionFor).
     const promoterVersion = promoterVersionFor(belief, runPromoterVersion);
     const [actives] = await db.query<[ActiveBeliefRow[]]>(
-      `SELECT id, revision, value, validFrom, sourceSceneIds, conversationIds
+      `SELECT id, revision, value, priorValue, validFrom, latestEvidenceAt,
+              sourceSceneIds, conversationIds
          FROM semantic_belief
         WHERE userId = $u AND subject = $s AND field = $f AND status = 'active'
         ORDER BY revision DESC`,
       { u: belief.userId, s: belief.subject, f: belief.field },
     );
     const head = (actives ?? [])[0];
-    // Self-heal a crash window (revision created, supersede stamp lost):
-    // every active row below the highest revision is stamped superseded.
+    // Self-heal a pre-0137 crash window (revision created, supersede
+    // stamp lost — impossible since the two became one transaction, but
+    // rows written before that can still carry it): every active row
+    // below the highest revision is stamped superseded.
     for (const dangling of (actives ?? []).slice(1)) {
       this.logger.warn(
         `belief promotion: repairing dangling active revision ${dangling.revision} ` +
@@ -896,7 +1027,18 @@ export class BeliefPromotionService {
     }
 
     if (!head) {
-      await this.createRevision({ db, belief, revision: 1, promoterVersion });
+      const committed = await commitRevision({
+        db,
+        belief,
+        revision: 1,
+        promoterVersion,
+        statement: await this.composeStatement(belief),
+        logger: this.logger,
+      });
+      if (!committed) {
+        result.skippedContended += 1;
+        return;
+      }
       await this.stampScenes(db, belief.sceneIds, beliefRecordString(belief, 1));
       if (edgesOn) {
         result.supportEdges += await this.writeEdges(db, promoterVersion, [
@@ -911,40 +1053,24 @@ export class BeliefPromotionService {
     }
 
     const headId = String(head.id);
-    // The WS driver returns datetimes as Date instances — never round-trip
-    // through String(Date) (the query_arc lesson).
-    const headValidFrom =
-      head.validFrom instanceof Date
-        ? head.validFrom.getTime()
-        : new Date(String(head.validFrom)).getTime();
+    const headValidFrom = epochMs(head.validFrom);
+    // The watermark. A legacy row (pre-0137) carries none: validFrom is
+    // then the comparison point — exactly the pre-0137 rule — and the
+    // row is stamped on its next corroboration.
+    const storedWatermark = epochMs(head.latestEvidenceAt);
+    const headWatermark = Number.isFinite(storedWatermark) ? storedWatermark : headValidFrom;
 
     if (head.value === belief.value) {
-      // CORROBORATION — the only in-place update the substrate allows:
-      // counters + provenance union, never value/statement/validFrom.
-      const knownScenes = (Array.isArray(head.sourceSceneIds) ? head.sourceSceneIds : []).map(
-        String,
-      );
-      const knownConvs = (Array.isArray(head.conversationIds) ? head.conversationIds : []).map(
-        String,
-      );
-      const mergedScenes = [...new Set([...knownScenes, ...belief.sceneIds])];
-      const mergedConvs = [...new Set([...knownConvs, ...belief.conversationIds])];
-      const newScenes = belief.sceneIds.filter((s) => !knownScenes.includes(s));
-      if (newScenes.length > 0) {
-        await db.query(
-          `UPDATE $id SET sourceSceneIds = $scenes, conversationIds = $convs,
-                          corroborationCount = $n, conversationCount = $m,
-                          updatedAt = time::now()`,
-          {
-            id: new StringRecordId(headId),
-            scenes: mergedScenes.map((s) => new StringRecordId(s)),
-            convs: mergedConvs,
-            n: mergedScenes.length,
-            m: mergedConvs.length,
-          },
-        );
-        result.beliefsCorroborated += 1;
-      }
+      await corroborateBelief({
+        db,
+        head,
+        headId,
+        headValidFrom,
+        headWatermark,
+        belief,
+        result,
+        logger: this.logger,
+      });
       // Stamps + edges are replay-idempotent (array::union / INSERT
       // IGNORE) and always re-asserted so a crash between the belief
       // write and the stamps heals on the next run.
@@ -960,39 +1086,61 @@ export class BeliefPromotionService {
       return;
     }
 
-    // Stale/ambiguous batch: never revise BACKWARD in valid time — a
-    // re-promotion of an older world must not flip-flop the chain.
-    if (!Number.isFinite(headValidFrom) || belief.validFrom.getTime() <= headValidFrom) {
+    // STALE GUARD against the WATERMARK, not the beginning: a differing
+    // value whose own latest evidence is not past what the belief has
+    // already processed is older news — A on Jan 1, A again on Mar 1,
+    // then B dated Feb 1 arriving late must not displace A. Never revise
+    // backward in valid time either (a re-promotion of an older world
+    // must not flip-flop the chain).
+    if (!Number.isFinite(headWatermark) || belief.evidenceAt.getTime() <= headWatermark) {
       result.skippedStale += 1;
       this.logger.warn(
         `belief promotion stale guard: (${belief.subject}, ${belief.field}) candidate ` +
-          `'${belief.value}' at ${belief.validFrom.toISOString()} is not newer than the ` +
-          `active revision ${head.revision} ('${head.value}') — group skipped`,
+          `'${belief.value}' with evidence at ${belief.evidenceAt.toISOString()} is not past ` +
+          `the active revision ${head.revision} ('${head.value}') watermark ` +
+          `${new Date(headWatermark).toISOString()} — group skipped`,
+      );
+      return;
+    }
+    // The new state began at the first contribution of its run that is
+    // past the head's watermark: a run that started before the head's
+    // latest evidence was interrupted by it, and only resumed after.
+    const revisionValidFrom =
+      belief.runEvidenceAt.find((t) => t.getTime() > headWatermark) ?? belief.evidenceAt;
+    if (!Number.isFinite(headValidFrom) || revisionValidFrom.getTime() <= headValidFrom) {
+      result.skippedStale += 1;
+      this.logger.warn(
+        `belief promotion stale guard: (${belief.subject}, ${belief.field}) candidate ` +
+          `'${belief.value}' would begin at ${revisionValidFrom.toISOString()}, not after the ` +
+          `active revision ${head.revision} ('${head.value}') began — group skipped`,
       );
       return;
     }
 
     // REVISION — supersede chain in code, never in-place: revision N+1
     // holds the new value; the displaced row gets status/validUntil/
-    // supersededBy stamped. The ACTUAL displaced value beats the delta's
-    // claimed `from` as priorValue.
+    // supersededBy stamped in the SAME transaction. The ACTUAL displaced
+    // value beats the chain's reading as priorValue.
     const revision = head.revision + 1;
     const newId = beliefRecordString(belief, revision);
-    await this.createRevision({
+    const revised: FoldedBelief = {
+      ...belief,
+      priorValue: head.value,
+      validFrom: revisionValidFrom,
+    };
+    const committed = await commitRevision({
       db,
-      belief: { ...belief, priorValue: head.value },
+      belief: revised,
       revision,
       promoterVersion,
+      statement: await this.composeStatement(revised),
+      displaced: { id: headId, revision: head.revision, until: revisionValidFrom },
+      logger: this.logger,
     });
-    await db.query(
-      `UPDATE $id SET status = 'superseded', supersededBy = $new,
-                      validUntil = $until, updatedAt = time::now()`,
-      {
-        id: new StringRecordId(headId),
-        new: new StringRecordId(newId),
-        until: belief.validFrom,
-      },
-    );
+    if (!committed) {
+      result.skippedContended += 1;
+      return;
+    }
     await this.stampScenes(db, belief.sceneIds, newId);
     // The 0106 baselineRef contract, NAMESPACED: the belief revision the
     // delta was applied against lands in `baselineRef.supersededFrom`
@@ -1022,44 +1170,6 @@ export class BeliefPromotionService {
       ]);
     }
     result.beliefsRevised += 1;
-  }
-
-  /** INSERT IGNORE one revision row (deterministic id — replay-safe). */
-  private async createRevision({
-    db,
-    belief,
-    revision,
-    promoterVersion,
-  }: {
-    db: BeliefDb;
-    belief: FoldedBelief;
-    revision: number;
-    promoterVersion: string;
-  }): Promise<void> {
-    const statement = await this.composeStatement(belief);
-    await db.query(`INSERT IGNORE INTO semantic_belief $rows`, {
-      rows: [
-        {
-          id: new RecordId('semantic_belief', beliefIdTail(belief, revision)),
-          userId: belief.userId,
-          subject: belief.subject,
-          field: belief.field,
-          value: belief.value,
-          ...(belief.priorValue !== '' ? { priorValue: belief.priorValue } : {}),
-          statement: statement.text,
-          statementSource: statement.source,
-          confidence: belief.confidence,
-          revision,
-          status: 'active',
-          validFrom: belief.validFrom,
-          sourceSceneIds: belief.sceneIds.map((s) => new StringRecordId(s)),
-          conversationIds: belief.conversationIds,
-          corroborationCount: belief.sceneIds.length,
-          conversationCount: belief.conversationIds.length,
-          promoterVersion,
-        },
-      ],
-    });
   }
 
   /** consolidatedInto ∪= [belief] on the consumed scenes (idempotent). */
@@ -1178,12 +1288,4 @@ export class BeliefPromotionService {
       return { text: template, source: 'template' };
     }
   }
-}
-
-/** Full record-id string for a folded belief at a given revision. */
-function beliefRecordString(
-  belief: Pick<FoldedBelief, 'userId' | 'subject' | 'field'>,
-  revision: number,
-): string {
-  return `semantic_belief:${beliefIdTail(belief, revision)}`;
 }

--- a/src/admin/belief-revision.ts
+++ b/src/admin/belief-revision.ts
@@ -1,0 +1,256 @@
+import { createHash } from 'node:crypto';
+import type { Logger } from '@nestjs/common';
+import { RecordId, StringRecordId, type Surreal } from 'surrealdb';
+import { runTransaction } from '../db/surreal.service';
+import type { BeliefDb, BeliefPromotionResult, FoldedBelief } from './belief-promotion.service';
+
+/**
+ * The belief WRITE path — what belief-promotion.service.ts does once the
+ * fold has a verdict and the active head is known (god-file split, the
+ * 800-line ceiling): the deterministic revision ids, the corroboration
+ * update (counters, watermark, chain-derived corrections) and the
+ * compare-and-set revision transaction. The decision of WHICH path a
+ * verdict takes (create / corroborate / stale / revise) stays with
+ * `upsertBelief` in the service; this module is the two writes it ends
+ * in. Pure of flags and of the fold.
+ */
+
+/**
+ * A stored datetime as epoch ms, or NaN when absent / unparseable. The WS
+ * driver hands datetimes over as Date instances; fixtures may hand ISO
+ * strings — both accepted, never String(Date) (the query_arc lesson).
+ */
+export function epochMs(v: unknown): number {
+  if (v instanceof Date) return v.getTime();
+  if (v === undefined || v === null || v === '') return Number.NaN;
+  return new Date(String(v)).getTime();
+}
+
+/**
+ * Pure: deterministic record-id tail over (userId|subject|field|
+ * revision) — the composer's sceneIdTail idiom. Paired with INSERT
+ * IGNORE it makes every create replay-idempotent, and it enforces
+ * (userId, subject, field, revision) uniqueness in CODE — a compound
+ * UNIQUE index is exactly the 3.2.4 planner trap 0120 avoids.
+ */
+export function beliefIdTail(
+  key: { userId: string; subject: string; field: string },
+  revision: number,
+): string {
+  return createHash('sha256')
+    .update(`${key.userId}\x00${key.subject}\x00${key.field}\x00${revision}`)
+    .digest('hex')
+    .slice(0, 24);
+}
+
+/** Full record-id string for a folded belief at a given revision. */
+export function beliefRecordString(
+  belief: Pick<FoldedBelief, 'userId' | 'subject' | 'field'>,
+  revision: number,
+): string {
+  return `semantic_belief:${beliefIdTail(belief, revision)}`;
+}
+
+/** Active-belief head read back for the upsert decision. */
+export interface ActiveBeliefRow {
+  id: unknown;
+  revision: number;
+  value: string;
+  priorValue?: unknown;
+  validFrom: unknown;
+  /** 0137 evidence watermark; NONE on a legacy row (falls back to validFrom). */
+  latestEvidenceAt?: unknown;
+  sourceSceneIds?: unknown;
+  conversationIds?: unknown;
+}
+
+const str = (v: unknown): string => (typeof v === 'string' ? v.trim() : '');
+
+/**
+ * CORROBORATION — the only in-place update the substrate allows:
+ * provenance union + counters, the watermark (advanced, never rewound),
+ * and — from the full evidence chain — the two corrections that do not
+ * change what the belief says: when the same value BEGAN, and what it
+ * displaced. Never value / statement.
+ *
+ * validFrom moves FORWARD only on the strength of an interlude the head
+ * never saw: another value held AFTER the recorded beginning, so the
+ * state was interrupted and began again at the chain's run (a chain that
+ * merely starts later says nothing about the beginning — kept). It moves
+ * BACKWARD only while the row is revision 1: with a predecessor, that
+ * predecessor's validUntil bounds this row — kept, at debug.
+ */
+export async function corroborateBelief({
+  db,
+  head,
+  headId,
+  headValidFrom,
+  headWatermark,
+  belief,
+  result,
+  logger,
+}: {
+  db: BeliefDb;
+  head: ActiveBeliefRow;
+  headId: string;
+  headValidFrom: number;
+  headWatermark: number;
+  belief: FoldedBelief;
+  result: BeliefPromotionResult;
+  logger: Logger;
+}): Promise<void> {
+  const knownScenes = (Array.isArray(head.sourceSceneIds) ? head.sourceSceneIds : []).map(String);
+  const knownConvs = (Array.isArray(head.conversationIds) ? head.conversationIds : []).map(String);
+  const mergedScenes = [...new Set([...knownScenes, ...belief.sceneIds])];
+  const mergedConvs = [...new Set([...knownConvs, ...belief.conversationIds])];
+  const newScenes = belief.sceneIds.filter((s) => !knownScenes.includes(s));
+  const set: string[] = [];
+  const params: Record<string, unknown> = { id: new StringRecordId(headId) };
+  if (newScenes.length > 0) {
+    set.push(
+      'sourceSceneIds = $scenes',
+      'conversationIds = $convs',
+      'corroborationCount = $n',
+      'conversationCount = $m',
+    );
+    params.scenes = mergedScenes.map((s) => new StringRecordId(s));
+    params.convs = mergedConvs;
+    params.n = mergedScenes.length;
+    params.m = mergedConvs.length;
+  }
+  // The watermark advances to the latest evidence seen; a legacy row
+  // without one is stamped at max(validFrom, this evidence).
+  const nextWatermark = Math.max(
+    Number.isFinite(headWatermark) ? headWatermark : 0,
+    belief.evidenceAt.getTime(),
+  );
+  if (!Number.isFinite(epochMs(head.latestEvidenceAt)) || nextWatermark > headWatermark) {
+    set.push('latestEvidenceAt = $evidenceAt');
+    params.evidenceAt = new Date(nextWatermark);
+  }
+  let realigned = false;
+  const chainBegan = belief.validFrom.getTime();
+  if (Number.isFinite(headValidFrom) && chainBegan !== headValidFrom) {
+    const interludeAfterHead =
+      belief.displacedAt !== undefined && belief.displacedAt.getTime() > headValidFrom;
+    const earlierAndUnbounded = chainBegan < headValidFrom && head.revision === 1;
+    if ((chainBegan > headValidFrom && interludeAfterHead) || earlierAndUnbounded) {
+      set.push('validFrom = $validFrom');
+      params.validFrom = belief.validFrom;
+      realigned = true;
+    } else {
+      logger.debug(
+        `belief promotion: (${belief.subject}, ${belief.field}) chain begins ` +
+          `${belief.validFrom.toISOString()} against revision ${head.revision}'s ` +
+          `${new Date(headValidFrom).toISOString()} — no interlude after it / ` +
+          `predecessor bounds it, kept`,
+      );
+    }
+  }
+  // What the state displaced, from the chain ALONE (an interlude the
+  // head never recorded) — never a delta's self-reported `from`, and
+  // never over a priorValue the row already has.
+  const headPrior = str(head.priorValue);
+  if (belief.displacedValue !== '' && belief.displacedValue !== belief.value && headPrior === '') {
+    set.push('priorValue = $prior');
+    params.prior = belief.displacedValue;
+    realigned = true;
+  }
+  if (set.length === 0) return;
+  await db.query(`UPDATE $id SET ${set.join(', ')}, updatedAt = time::now()`, params);
+  if (newScenes.length > 0) result.beliefsCorroborated += 1;
+  if (realigned) result.beliefsRealigned += 1;
+}
+
+/**
+ * The ONE write that changes what a belief says, as a compare-and-set
+ * transaction (BEGIN … COMMIT, runTransaction):
+ *   1. the revision SLOT is read — deterministic id over (key,
+ *      revision) — and a row already there with ANOTHER value aborts
+ *      (a concurrent run took this number first; INSERT IGNORE alone
+ *      would have let this run believe it wrote its value);
+ *   2. INSERT IGNORE the revision (a replay of the SAME value no-ops);
+ *   3. on a revise, the displaced head is stamped superseded ONLY IF it
+ *      is still the active head at the revision this run read
+ *      (`WHERE status = 'active' AND revision = $headRevision`); zero
+ *      rows stamped means the head moved under us — abort, which also
+ *      rolls the INSERT back (verified on 3.2.4: THROW inside the
+ *      transaction cancels every prior statement).
+ * The statement text is composed by the caller BEFORE this call (the
+ * optional LLM call must not sit inside a database transaction).
+ *
+ * Returns false when the transaction was lost — nothing written, the
+ * next run recomputes the key from its evidence. Any other failure is
+ * reported the same way: the caller's contract is "did my revision
+ * land", and it did not.
+ */
+export async function commitRevision({
+  db,
+  belief,
+  revision,
+  promoterVersion,
+  statement,
+  displaced,
+  logger,
+}: {
+  db: BeliefDb;
+  belief: FoldedBelief;
+  revision: number;
+  promoterVersion: string;
+  statement: { text: string; source: 'template' | 'llm' };
+  displaced?: { id: string; revision: number; until: Date } | undefined;
+  logger: Logger;
+}): Promise<boolean> {
+  const newId = new RecordId('semantic_belief', beliefIdTail(belief, revision));
+  const row = {
+    id: newId,
+    userId: belief.userId,
+    subject: belief.subject,
+    field: belief.field,
+    value: belief.value,
+    ...(belief.priorValue !== '' ? { priorValue: belief.priorValue } : {}),
+    statement: statement.text,
+    statementSource: statement.source,
+    confidence: belief.confidence,
+    revision,
+    status: 'active',
+    validFrom: belief.validFrom,
+    latestEvidenceAt: belief.evidenceAt,
+    sourceSceneIds: belief.sceneIds.map((s) => new StringRecordId(s)),
+    conversationIds: belief.conversationIds,
+    corroborationCount: belief.sceneIds.length,
+    conversationCount: belief.conversationIds.length,
+    promoterVersion,
+  };
+  try {
+    await runTransaction(db as unknown as Surreal, (tx) => {
+      tx.bind('newId', newId).bind('value', belief.value).bind('rows', [row]);
+      tx.add(`LET $held = (SELECT id, value AS held FROM $newId)`);
+      tx.add(
+        `IF array::len($held) > 0 AND $held[0].held != $value ` +
+          `{ THROW 'belief revision slot already holds another value' }`,
+      );
+      tx.add(`INSERT IGNORE INTO semantic_belief $rows`);
+      if (displaced) {
+        tx.bind('headId', new StringRecordId(displaced.id))
+          .bind('headRevision', displaced.revision)
+          .bind('until', displaced.until);
+        tx.add(
+          `LET $stamped = (UPDATE $headId SET status = 'superseded', supersededBy = $newId, ` +
+            `validUntil = $until, updatedAt = time::now() ` +
+            `WHERE status = 'active' AND revision = $headRevision RETURN AFTER)`,
+        );
+        tx.add(`IF array::len($stamped) = 0 { THROW 'belief head moved' }`);
+      }
+      tx.add(`RETURN true`);
+    });
+    return true;
+  } catch (e) {
+    logger.warn(
+      `belief promotion contended: (${belief.subject}, ${belief.field}) revision ${revision} ` +
+        `for user ${belief.userId} lost to a concurrent writer — nothing written, the next ` +
+        `run recomputes the key (${(e as Error).message?.slice(0, 160)})`,
+    );
+    return false;
+  }
+}

--- a/src/admin/belief-scene-selection.ts
+++ b/src/admin/belief-scene-selection.ts
@@ -1,3 +1,7 @@
+import type { Logger } from '@nestjs/common';
+import type { BeliefPromotionResult } from './belief-promotion.service';
+import { formatValueDims, sceneValueVerdict } from './belief-value-gate';
+
 /**
  * Which scenes the belief promotion pass reads, and which world stamp a
  * promoted belief carries (the god-file split off
@@ -129,12 +133,22 @@ export function buildPromotableScenesQuery(p: {
   conversationId?: string | undefined;
   packDeltas: boolean;
   valueGate?: boolean;
+  /**
+   * The full-chain read of a targeted run (F6): every promotable scene
+   * that involves these users, whatever conversation it came from, so a
+   * late-arriving scene is folded at its place in the whole chain rather
+   * than judged against the head alone. Undefined ⇒ no user clause —
+   * the SQL is byte-identical to the historical selection.
+   */
+  userIds?: readonly string[] | undefined;
 }): { sql: string; params: Record<string, unknown> } {
   const conv = p.conversationId !== undefined ? ` AND conversationIds CONTAINS $conv` : '';
+  const users = p.userIds !== undefined ? ` AND userIds CONTAINSANY $users` : '';
   const gate = p.valueGate === true;
   const params: Record<string, unknown> = {
     v: p.version,
     ...(p.conversationId !== undefined ? { conv: p.conversationId } : {}),
+    ...(p.userIds !== undefined ? { users: [...p.userIds] } : {}),
   };
   if (!p.packDeltas) {
     const dims = valueDimProjections(gate, ' '.repeat(16));
@@ -143,7 +157,9 @@ export function buildPromotableScenesQuery(p: {
         `SELECT id, userId, userIds, conversationIds, occurredTo, stateDeltas,
                 enrichedMemoryValue.explicitness AS explicitness${dims}
            FROM memory_episode
-          WHERE segmenterVersion = $v AND enrichmentVersion IS NOT NONE` + conv,
+          WHERE segmenterVersion = $v AND enrichmentVersion IS NOT NONE` +
+        conv +
+        users,
       params,
     };
   }
@@ -155,7 +171,9 @@ export function buildPromotableScenesQuery(p: {
          FROM memory_episode
         WHERE ((segmenterVersion = $v AND enrichmentVersion IS NOT NONE)
             OR (string::starts_with(segmenterVersion, $packPrefix)
-                AND stateDeltas IS NOT NONE AND array::len(stateDeltas) > 0))` + conv,
+                AND stateDeltas IS NOT NONE AND array::len(stateDeltas) > 0))` +
+      conv +
+      users,
     params: { ...params, packPrefix: PACK_SCENE_WORLD_PREFIX },
   };
 }
@@ -184,4 +202,62 @@ export function promoterVersionFor(
   return only !== undefined && isPackSceneWorld(only)
     ? beliefPromoterVersion(only)
     : runPromoterVersion;
+}
+
+/**
+ * The per-scene admission fences, in order: #387 single-user (a security
+ * fence is never traded against a quality one), then the memory-value
+ * gate. `count` is the run summary for the batch being promoted; null
+ * when the same fences are applied to the evidence chain a targeted run
+ * re-reads (that chain is context, not this run's scenes — its skips
+ * must not inflate the batch's counters).
+ */
+export function admitScenes({
+  scenes,
+  gate,
+  count,
+  logger,
+}: {
+  scenes: readonly PromotableSceneHead[];
+  gate: { valueGate: boolean; valueGateMin: number };
+  count: BeliefPromotionResult | null;
+  logger: Logger;
+}): Array<{ scene: PromotableSceneHead; userId: string }> {
+  const eligible: Array<{ scene: PromotableSceneHead; userId: string }> = [];
+  for (const scene of scenes) {
+    if (count) count.scenes += 1;
+    const userId = sceneSingleUser(scene);
+    if (userId === null) {
+      // #387 fail-closed: mixed-user, tenant-global or legacy (pre-0117
+      // userIds) scenes never feed a belief.
+      if (count) {
+        count.skippedMixedUser += 1;
+        logger.warn(
+          `belief promotion skipped scene ${String(scene.id)}: not single-user ` +
+            `(userIds=${JSON.stringify(scene.userIds ?? null)}) — #387 fence`,
+        );
+      }
+      continue;
+    }
+    // MEMORY-VALUE GATE: the value vector's first consumer. Runs AFTER the
+    // #387 fence and BEFORE the fold, so a refused scene contributes no
+    // delta at all. Off ⇒ not even evaluated.
+    if (gate.valueGate) {
+      const verdict = sceneValueVerdict(scene, gate.valueGateMin);
+      if (!verdict.promote) {
+        if (count) {
+          count.skippedLowValue += 1;
+          logger.log(
+            `belief promotion value gate: scene ${String(scene.id)} skipped as noise ` +
+              `(${formatValueDims(verdict.dims)}; all < ${gate.valueGateMin}) — ` +
+              `SCENES_VALUE_GATE_ENABLED`,
+          );
+        }
+        continue;
+      }
+    }
+    if (count) count.eligibleScenes += 1;
+    eligible.push({ scene, userId });
+  }
+  return eligible;
 }

--- a/src/compaction/promotion-runner.service.ts
+++ b/src/compaction/promotion-runner.service.ts
@@ -272,16 +272,10 @@ export class PromotionRunnerService {
 
     // Corroboration floor (COMPACTION_PROMOTION_MIN_EPISODES > 0): a
     // summary must consolidate INDEPENDENT evidence, so the floor counts
-    // distinct evidence contexts — the union of the members' grounding
-    // episode ids and conversation ids — not member rows. Five facts
-    // from ONE conversation are one witness, not five.
+    // distinct evidence contexts — not member rows. Five facts from ONE
+    // conversation are one witness, not five (distinctEvidenceContexts).
     if (schedule.minEpisodes > 0) {
-      const distinct = new Set<string>(unionEpisodeIds(members.map((m) => m.eps)));
-      for (const m of members) {
-        if (typeof m.conversationId === 'string' && m.conversationId.length > 0) {
-          distinct.add(m.conversationId);
-        }
-      }
+      const distinct = distinctEvidenceContexts(members);
       if (distinct.size < schedule.minEpisodes) {
         this.logger.debug(
           `promotion skipped (corroboration floor): ${String(group.entityId)}/${group.predicate} ` +
@@ -506,4 +500,38 @@ function scopeFilterFor(group: { userId?: string | null }): {
     scopeClause: group.userId ? 'AND userId = $scopeUser' : 'AND userId IS NONE',
     scopeParams: group.userId ? { scopeUser: group.userId } : {},
   };
+}
+
+/**
+ * Pure: the distinct evidence CONTEXTS behind a promotable group — the
+ * unit the corroboration floor counts (audit 2026-09-06 F10).
+ *
+ * ONE level of independence: a member's context is its conversation.
+ * Every reply of one conversation is the same witness, however many
+ * scene/episode stamps it carries — the union of episode ids AND
+ * conversation ids that used to be counted here made one reply from one
+ * conversation two witnesses and five replies up to six. Episode ids are
+ * the FALLBACK for a member whose conversation is unknown (legacy rows,
+ * document-derived facts), and even then an episode a conversation-known
+ * member already claims is not a second witness. A member with neither
+ * says nothing about independence and contributes no context.
+ */
+export function distinctEvidenceContexts(
+  members: ReadonlyArray<{ eps?: unknown; conversationId?: unknown }>,
+): Set<string> {
+  const contexts = new Set<string>();
+  const claimedEpisodes = new Set<string>();
+  const orphans: unknown[] = [];
+  for (const m of members) {
+    if (typeof m.conversationId === 'string' && m.conversationId.length > 0) {
+      contexts.add(`conversation:${m.conversationId}`);
+      for (const ep of unionEpisodeIds([m.eps])) claimedEpisodes.add(ep);
+    } else {
+      orphans.push(m.eps);
+    }
+  }
+  for (const ep of unionEpisodeIds(orphans)) {
+    if (!claimedEpisodes.has(ep)) contexts.add(ep);
+  }
+  return contexts;
 }

--- a/src/db/migrations/0137_belief_evidence_watermark.surql
+++ b/src/db/migrations/0137_belief_evidence_watermark.surql
@@ -1,0 +1,27 @@
+-- 0137: semantic_belief.latestEvidenceAt — the evidence watermark of a
+-- belief revision, kept SEPARATE from validFrom.
+--
+-- WHY. validFrom is "when the current state BEGAN" (the earliest scene of
+-- the trailing same-value run); the promotion pass used to derive it from
+-- the LATEST corroborating scene and then compared a differing candidate
+-- against it. Two consequences (audit 2026-09-06, F6): a confirmation
+-- moved the state's beginning forward, and a stale differing value could
+-- displace a state that later evidence had already re-confirmed — A on
+-- Jan 1, A again on Mar 1, then B dated Feb 1 arriving late made B the
+-- active belief although the latest evidence said A.
+--
+-- latestEvidenceAt is the occurredTo of the latest scene that contributed
+-- to the ACTIVE value: written on create and on revise, advanced (never
+-- rewound) by a corroboration. The stale guard compares a differing
+-- candidate's own latest evidence against THIS column, so evidence older
+-- than what the belief has already processed can never revise it. Legacy
+-- rows (NONE) fall back to validFrom — exactly the pre-0137 comparison —
+-- and are stamped on their next corroboration.
+--
+-- In-place writes remain limited to the corroboration counters plus this
+-- watermark, and to validFrom ONLY as a correction of when the same value
+-- began (a full-chain recompute finding the run's true start) — a value
+-- change still creates revision N+1 (the 0120 doctrine). No index: the
+-- column is read on a row the pass already selected by (userId, subject,
+-- field, status), never as a filter.
+DEFINE FIELD IF NOT EXISTS latestEvidenceAt ON semantic_belief TYPE option<datetime>;

--- a/test/belief-promotion.unit-spec.ts
+++ b/test/belief-promotion.unit-spec.ts
@@ -126,11 +126,50 @@ describe('foldBeliefGroups', () => {
     expect(folded).toHaveLength(1);
     expect(folded[0]).toMatchObject({
       value: 'lisbon',
-      priorValue: '',
+      // The chain's previous distinct value — what the current state
+      // displaced — not the winner delta's own (empty) `from`.
+      priorValue: 'porto',
       sceneIds: ['memory_episode:s2', 'memory_episode:s3'],
+      allSceneIds: ['memory_episode:s1', 'memory_episode:s2', 'memory_episode:s3'],
       conversationIds: ['conv:b', 'conv:c'],
     });
-    expect(folded[0]!.validFrom.toISOString()).toBe('2026-03-03T10:00:00.000Z');
+    // TWO CLOCKS (F6): the state BEGAN with the run's opener (s2) — a
+    // later confirmation (s3) is the evidence watermark, not the start.
+    expect(folded[0]!.validFrom.toISOString()).toBe('2026-03-02T10:00:00.000Z');
+    expect(folded[0]!.evidenceAt.toISOString()).toBe('2026-03-03T10:00:00.000Z');
+    expect(folded[0]!.runEvidenceAt.map((d) => d.toISOString())).toEqual([
+      '2026-03-02T10:00:00.000Z',
+      '2026-03-03T10:00:00.000Z',
+    ]);
+  });
+
+  it('an interlude of another value restarts the state: validFrom is the run AFTER it', () => {
+    // A on Jan 1, B on Feb 1, A on Mar 1: the current state is A since
+    // MARCH — the January A corroborates the value but the beginning
+    // does not reach back past the February interlude.
+    const at = (id: string, day: string, value: string, from = '') => ({
+      userId: 'u1',
+      scene: scene({
+        id: `memory_episode:${id}`,
+        conversationIds: [`conv:${id}`],
+        occurredTo: `2026-${day}T00:00:00.000Z`,
+        stateDeltas: [delta('alice', 'city', value, from)],
+      }),
+    });
+    const { folded } = foldBeliefGroups([
+      at('t3', '03-01', 'A'),
+      at('t1', '01-01', 'A'),
+      at('t2', '02-01', 'B'),
+    ]);
+    expect(folded).toHaveLength(1);
+    expect(folded[0]).toMatchObject({
+      value: 'A',
+      priorValue: 'B',
+      sceneIds: ['memory_episode:t1', 'memory_episode:t3'],
+    });
+    expect(folded[0]!.validFrom.toISOString()).toBe('2026-03-01T00:00:00.000Z');
+    expect(folded[0]!.evidenceAt.toISOString()).toBe('2026-03-01T00:00:00.000Z');
+    expect(folded[0]!.runEvidenceAt).toHaveLength(1);
   });
 
   it('conflict guard: two different values at the winning timestamp skip the whole group', () => {
@@ -152,7 +191,13 @@ describe('foldBeliefGroups', () => {
     ]);
     expect(folded).toEqual([]);
     expect(conflicts).toEqual([
-      { userId: 'u1', subject: 'mika', field: 'job.title', values: ['designer', 'engineer'] },
+      {
+        userId: 'u1',
+        subject: 'mika',
+        field: 'job.title',
+        values: ['designer', 'engineer'],
+        allSceneIds: ['memory_episode:s1', 'memory_episode:s2'],
+      },
     ]);
   });
 
@@ -391,7 +436,10 @@ describe('foldBeliefGroups: field fold (#135 seam 2)', () => {
       subject: 'Mikhail',
       field: 'car',
       value: BELIEF_NEGATION_VALUE,
-      priorValue: 'Compass',
+      // The chain's ACTUAL displaced value ('Jeep Compass', from s1) beats
+      // the negation delta's own claimed `from` ('Compass') — the same
+      // rule the revise path applies against a stored head.
+      priorValue: 'Jeep Compass',
       sceneIds: ['memory_episode:s2'],
     });
     expect(fieldFolds).toEqual([
@@ -455,6 +503,8 @@ describe('orphan absorb (SCENES_BELIEF_FIELD_FOLD — run()-level, fake db)', ()
     supersededBy?: string;
     validFrom: unknown;
     validUntil?: unknown;
+    /** 0137 evidence watermark. */
+    latestEvidenceAt?: unknown;
     sourceSceneIds: string[];
     conversationIds: string[];
   }
@@ -469,6 +519,8 @@ describe('orphan absorb (SCENES_BELIEF_FIELD_FOLD — run()-level, fake db)', ()
     rows: FakeBeliefRow[] = [];
     sceneHeads: PromotableSceneHead[] = [];
     sql: string[] = [];
+    /** Runs right before a commitRevision transaction — a concurrent writer's move. */
+    beforeTransaction?: () => void;
 
     async query(sqlText: string, params: Record<string, unknown> = {}): Promise<unknown> {
       this.sql.push(sqlText);
@@ -501,24 +553,35 @@ describe('orphan absorb (SCENES_BELIEF_FIELD_FOLD — run()-level, fake db)', ()
             .map((r) => ({ ...r })),
         ];
       }
-      if (sqlText.startsWith('INSERT IGNORE INTO semantic_belief')) {
-        for (const raw of p.rows as Array<Record<string, unknown>>) {
-          const id = String(raw.id);
-          if (this.rows.some((r) => r.id === id)) continue;
-          this.rows.push({
-            id,
-            userId: String(raw.userId),
-            subject: String(raw.subject),
-            field: String(raw.field),
-            value: String(raw.value),
-            ...(raw.priorValue !== undefined ? { priorValue: String(raw.priorValue) } : {}),
-            revision: raw.revision as number,
-            status: String(raw.status),
-            validFrom: raw.validFrom,
-            sourceSceneIds: (raw.sourceSceneIds as unknown[]).map(String),
-            conversationIds: [...(raw.conversationIds as string[])],
-          });
+      // commitRevision: the compare-and-set transaction (BEGIN … COMMIT).
+      // Modelled statement by statement: the revision-slot check, the
+      // INSERT IGNORE, and — on a revise — the guarded supersede stamp
+      // whose miss aborts the whole transaction (the real server rolls
+      // the INSERT back on THROW; here nothing was inserted yet when the
+      // stamp is checked first, which is observably the same).
+      if (sqlText.startsWith('BEGIN TRANSACTION')) {
+        // A concurrent writer's move, injected between the run's head read
+        // and its transaction — the contention seam the CAS exists for.
+        this.beforeTransaction?.();
+        const newId = String(p.newId);
+        const held = this.rows.find((r) => r.id === newId);
+        if (held !== undefined && held.value !== String(p.value)) {
+          throw new Error('The query was not executed due to a failed transaction');
         }
+        if (p.headId !== undefined) {
+          const head = this.rows.find((r) => r.id === String(p.headId));
+          if (head === undefined || head.status !== 'active' || head.revision !== p.headRevision) {
+            throw new Error('The query was not executed due to a failed transaction');
+          }
+          head.status = 'superseded';
+          head.supersededBy = newId;
+          head.validUntil = p.until;
+        }
+        this.insertIgnore(p.rows as Array<Record<string, unknown>>);
+        return [true];
+      }
+      if (sqlText.startsWith('INSERT IGNORE INTO semantic_belief')) {
+        this.insertIgnore(p.rows as Array<Record<string, unknown>>);
         return [];
       }
       if (sqlText.includes(`SET status = 'superseded'`)) {
@@ -528,14 +591,15 @@ describe('orphan absorb (SCENES_BELIEF_FIELD_FOLD — run()-level, fake db)', ()
         row.validUntil = p.until;
         return [];
       }
-      if (sqlText.includes('SET priorValue = $prior')) {
-        this.byId(String(p.id)).priorValue = String(p.prior);
-        return [];
-      }
-      if (sqlText.includes('SET sourceSceneIds')) {
+      // The in-place corroboration UPDATE: whichever of the counters /
+      // watermark / realignment assignments the service composed.
+      if (sqlText.startsWith('UPDATE $id SET')) {
         const row = this.byId(String(p.id));
-        row.sourceSceneIds = (p.scenes as unknown[]).map(String);
-        row.conversationIds = [...(p.convs as string[])];
+        if (p.scenes !== undefined) row.sourceSceneIds = (p.scenes as unknown[]).map(String);
+        if (p.convs !== undefined) row.conversationIds = [...(p.convs as string[])];
+        if (p.evidenceAt !== undefined) row.latestEvidenceAt = p.evidenceAt;
+        if (p.validFrom !== undefined) row.validFrom = p.validFrom;
+        if (p.prior !== undefined) row.priorValue = String(p.prior);
         return [];
       }
       // Scene stamps are no-ops here (pinned by their own e2e), including
@@ -550,6 +614,27 @@ describe('orphan absorb (SCENES_BELIEF_FIELD_FOLD — run()-level, fake db)', ()
       const row = this.rows.find((r) => r.id === id);
       if (row === undefined) throw new Error(`FakeBeliefDb: no row ${id}`);
       return row;
+    }
+
+    private insertIgnore(rows: Array<Record<string, unknown>>): void {
+      for (const raw of rows) {
+        const id = String(raw.id);
+        if (this.rows.some((r) => r.id === id)) continue;
+        this.rows.push({
+          id,
+          userId: String(raw.userId),
+          subject: String(raw.subject),
+          field: String(raw.field),
+          value: String(raw.value),
+          ...(raw.priorValue !== undefined ? { priorValue: String(raw.priorValue) } : {}),
+          revision: raw.revision as number,
+          status: String(raw.status),
+          validFrom: raw.validFrom,
+          ...(raw.latestEvidenceAt !== undefined ? { latestEvidenceAt: raw.latestEvidenceAt } : {}),
+          sourceSceneIds: (raw.sourceSceneIds as unknown[]).map(String),
+          conversationIds: [...(raw.conversationIds as string[])],
+        });
+      }
     }
 
     active(field: string, subject = 'Sasha', userId = 'u1'): FakeBeliefRow | undefined {
@@ -710,7 +795,8 @@ describe('orphan absorb (SCENES_BELIEF_FIELD_FOLD — run()-level, fake db)', ()
 
     const first = await svc.run('co_test');
     expect(first.fieldOrphansAbsorbed).toBe(1);
-    const after = JSON.parse(JSON.stringify(db.rows)) as FakeBeliefRow[];
+    // structuredClone, not a JSON round-trip: the 0137 watermark is a Date.
+    const after = structuredClone(db.rows);
 
     const second = await svc.run('co_test');
     expect(second.fieldOrphansAbsorbed).toBe(0);
@@ -820,6 +906,124 @@ describe('orphan absorb (SCENES_BELIEF_FIELD_FOLD — run()-level, fake db)', ()
     expect(res.fieldOrphanAmbiguous).toBe(0);
     expect(db.active('car', 'Mikhail')).toBeDefined();
     expect(db.active('car ownership', 'Mikhail')).toBeDefined();
+  });
+  describe('two clocks + compare-and-set (audit 2026-09-06 F6, fake db)', () => {
+    const at = (day: string) => `2026-${day}T00:00:00.000Z`;
+    const evidence = (tail: string, day: string, value: string, from = ''): PromotableSceneHead =>
+      scene({
+        id: `memory_episode:${tail}`,
+        conversationIds: [`conv:${tail}`],
+        occurredTo: at(day),
+        stateDeltas: [{ subject: 'alice', field: 'city', from, to: value }],
+      });
+    const headA = (over: Partial<FakeBeliefRow> = {}): FakeBeliefRow =>
+      belief({
+        id: 'semantic_belief:city1',
+        subject: 'alice',
+        field: 'city',
+        value: 'A',
+        validFrom: at('01-01'),
+        sourceSceneIds: ['memory_episode:t1'],
+        conversationIds: ['conv:t1'],
+        ...over,
+      });
+
+    it('stale guard against the WATERMARK: a differing value dated between two confirmations is a skip', async () => {
+      // The audit's repro judged against the head ALONE: A began Jan 1,
+      // was confirmed Mar 1, and B dated Feb 1 arrives late.
+      const db = new FakeBeliefDb();
+      db.rows = [
+        headA({
+          latestEvidenceAt: at('03-01'),
+          sourceSceneIds: ['memory_episode:t1', 'memory_episode:t3'],
+          conversationIds: ['conv:t1', 'conv:t3'],
+        }),
+      ];
+      db.sceneHeads = [evidence('t2', '02-01', 'B')];
+      const res = await makeRunService(db).run('co_test');
+      expect(res).toMatchObject({ skippedStale: 1, beliefsRevised: 0, beliefsCreated: 0 });
+      expect(db.rows).toHaveLength(1);
+      expect(db.rows[0]).toMatchObject({ value: 'A', status: 'active', revision: 1 });
+      expect(db.sql.some((s) => s.startsWith('BEGIN TRANSACTION'))).toBe(false);
+    });
+
+    it('a confirmation advances the watermark and leaves the beginning alone; a legacy row is stamped', async () => {
+      const db = new FakeBeliefDb();
+      db.rows = [headA()]; // pre-0137: no watermark at all
+      db.sceneHeads = [evidence('t3', '03-01', 'A')];
+      const res = await makeRunService(db).run('co_test');
+      expect(res).toMatchObject({ beliefsCorroborated: 1, beliefsRevised: 0, beliefsRealigned: 0 });
+      const head = db.active('city', 'alice')!;
+      expect(head.validFrom).toBe(at('01-01'));
+      expect(head.latestEvidenceAt).toEqual(new Date(at('03-01')));
+      expect(head.sourceSceneIds).toEqual(['memory_episode:t1', 'memory_episode:t3']);
+    });
+
+    it('a targeted run folds the WHOLE chain: the late B realigns the beginning to the run after it', async () => {
+      // Same world, but the run is targeted at the late conversation and
+      // the chain read (the fake answers every scene query with the whole
+      // world) shows A · B · A: the current A began in MARCH, displacing B.
+      const db = new FakeBeliefDb();
+      db.rows = [
+        headA({
+          latestEvidenceAt: at('03-01'),
+          sourceSceneIds: ['memory_episode:t1', 'memory_episode:t3'],
+          conversationIds: ['conv:t1', 'conv:t3'],
+        }),
+      ];
+      db.sceneHeads = [
+        evidence('t1', '01-01', 'A'),
+        evidence('t2', '02-01', 'B'),
+        evidence('t3', '03-01', 'A'),
+      ];
+      const res = await makeRunService(db).run('co_test', { conversationId: 'conv:t2' });
+      expect(res).toMatchObject({
+        beliefsRealigned: 1,
+        beliefsRevised: 0,
+        beliefsCreated: 0,
+        skippedStale: 0,
+      });
+      const head = db.active('city', 'alice')!;
+      expect(head).toMatchObject({ value: 'A', priorValue: 'B', revision: 1, status: 'active' });
+      expect(head.validFrom).toEqual(new Date(at('03-01')));
+      expect(db.rows).toHaveLength(1);
+      // The chain was read with the affected users as the filter.
+      expect(db.sql.some((s) => s.includes('userIds CONTAINSANY $users'))).toBe(true);
+    });
+
+    it('a revision is one compare-and-set transaction; a head that moved under the run is not revised twice', async () => {
+      const db = new FakeBeliefDb();
+      db.rows = [headA({ latestEvidenceAt: at('01-01') })];
+      db.sceneHeads = [evidence('t2', '02-01', 'B', 'A')];
+      // Another writer supersedes the head between this run's read and
+      // its transaction — the guarded stamp matches zero rows and the
+      // whole write (INSERT included) is abandoned.
+      db.beforeTransaction = () => {
+        db.rows[0]!.status = 'superseded';
+      };
+      const res = await makeRunService(db).run('co_test');
+      expect(res).toMatchObject({ skippedContended: 1, beliefsRevised: 0, beliefsCreated: 0 });
+      expect(db.rows).toHaveLength(1);
+      expect(db.sql.filter((s) => s.startsWith('BEGIN TRANSACTION'))).toHaveLength(1);
+    });
+
+    it('the revise transaction carries the new row AND the guarded supersede stamp together', async () => {
+      const db = new FakeBeliefDb();
+      db.rows = [headA({ latestEvidenceAt: at('01-01') })];
+      db.sceneHeads = [evidence('t2', '02-01', 'B', 'A')];
+      const res = await makeRunService(db).run('co_test');
+      expect(res).toMatchObject({ beliefsRevised: 1, skippedContended: 0 });
+      const tx = db.sql.find((s) => s.startsWith('BEGIN TRANSACTION'))!;
+      expect(tx).toContain('INSERT IGNORE INTO semantic_belief $rows');
+      expect(tx).toContain("WHERE status = 'active' AND revision = $headRevision RETURN AFTER");
+      expect(tx).toContain("THROW 'belief head moved'");
+      expect(tx).toContain('COMMIT TRANSACTION');
+      const [rev1, rev2] = [...db.rows].sort((a, b) => a.revision - b.revision);
+      expect(rev1).toMatchObject({ status: 'superseded', supersededBy: rev2!.id });
+      expect(rev2).toMatchObject({ value: 'B', priorValue: 'A', status: 'active', revision: 2 });
+      expect(rev2!.validFrom).toEqual(new Date(at('02-01')));
+      expect(rev2!.latestEvidenceAt).toEqual(new Date(at('02-01')));
+    });
   });
 });
 
@@ -1001,6 +1205,8 @@ describe('OFF-state hard guarantee (byte-identical prod)', () => {
       beliefsCreated: 0,
       beliefsCorroborated: 0,
       beliefsRevised: 0,
+      beliefsRealigned: 0,
+      skippedContended: 0,
       supportEdges: 0,
     });
   });

--- a/test/belief-revision-chain.e2e-spec.ts
+++ b/test/belief-revision-chain.e2e-spec.ts
@@ -1,0 +1,302 @@
+/**
+ * Belief revision chain against a REAL SurrealDB — the two clocks of a
+ * belief (audit 2026-09-06 F6) and the compare-and-set revision write.
+ *
+ * validFrom is when the state BEGAN; latestEvidenceAt (0137) is the
+ * WATERMARK — the latest scene the belief has processed. Targeted
+ * promotion by conversation, one scene per run, in EVERY order of
+ * {A on Jan 1, B on Feb 1, A on Mar 1}: the active row must come out
+ * the same — A since March, displacing B — whatever order the runs saw
+ * the scenes. Before the fix the order A, A, B ended with B active (the
+ * audit's repro): the stale guard compared B's date against the state's
+ * beginning (Jan 1) instead of the latest evidence (Mar 1).
+ *
+ * Concurrency: two runs revising one key at once leave exactly one
+ * active head, and a revision slot another writer filled with a
+ * different value is never overwritten — the loser writes nothing.
+ *
+ * Scene rows are seeded directly (the belief-promotion.e2e precedent):
+ * hand-seeded rows make the chain deterministic.
+ */
+import type { AppFixture } from './app-fixture';
+import { createApp } from './app-fixture';
+import { SurrealService } from '../src/db/surreal.service';
+import { Logger } from '@nestjs/common';
+import {
+  BeliefPromotionService,
+  beliefIdTail,
+  type FoldedBelief,
+} from '../src/admin/belief-promotion.service';
+import { commitRevision } from '../src/admin/belief-revision';
+
+interface BeliefRow {
+  id: unknown;
+  userId: string;
+  subject: string;
+  field: string;
+  value: string;
+  priorValue?: string;
+  revision: number;
+  status: string;
+  supersededBy?: unknown;
+  validFrom?: unknown;
+  validUntil?: unknown;
+  latestEvidenceAt?: unknown;
+  corroborationCount?: number;
+}
+
+const iso = (v: unknown): string =>
+  v instanceof Date ? v.toISOString() : new Date(String(v)).toISOString();
+
+const JAN = '2026-01-01T00:00:00.000Z';
+const FEB = '2026-02-01T00:00:00.000Z';
+const MAR = '2026-03-01T00:00:00.000Z';
+const APR = '2026-04-01T00:00:00.000Z';
+
+interface Evt {
+  tag: string;
+  at: string;
+  value: string;
+}
+const EVENTS: Evt[] = [
+  { tag: 'a1', at: JAN, value: 'A' },
+  { tag: 'b2', at: FEB, value: 'B' },
+  { tag: 'a3', at: MAR, value: 'A' },
+];
+function permutations<T>(items: T[]): T[][] {
+  if (items.length <= 1) return [items];
+  return items.flatMap((x, i) =>
+    permutations([...items.slice(0, i), ...items.slice(i + 1)]).map((rest) => [x, ...rest]),
+  );
+}
+
+describe('belief revision chain: two clocks + compare-and-set (e2e)', () => {
+  let f: AppFixture;
+  const saved: Record<string, string | undefined> = {};
+  const FLAGS = [
+    'SCENES_SEGMENTATION_ENABLED',
+    'SCENES_BELIEF_PROMOTION',
+    'SCENES_BELIEF_MIN_SCENES',
+    'SCENES_BELIEF_LLM_SYNTHESIS',
+    'SCENES_BELIEF_NEGATION_DELTAS',
+    'SCENES_BELIEF_FIELD_FOLD',
+    'SCENES_VALUE_GATE_ENABLED',
+    'PROVENANCE_SUPPORT_EDGES',
+  ];
+
+  const db = <T>(
+    fn: (d: { query: <Q>(sql: string, p?: Record<string, unknown>) => Promise<Q> }) => Promise<T>,
+  ): Promise<T> => f.app.get(SurrealService).withCompany(f.companyId, fn);
+
+  const seedScene = async (o: {
+    tail: string;
+    user: string;
+    conv: string;
+    at: string;
+    value: string;
+    from?: string;
+  }): Promise<void> => {
+    await db(async (d) => {
+      await d.query(
+        `CREATE type::record('memory_episode', $tail) CONTENT {
+           userId: $user, userIds: [$user], scope: [], sceneLabel: 'seed',
+           conversationIds: [$conv], occurredFrom: <datetime>$at, occurredTo: <datetime>$at,
+           gist: 'seed gist', confidence: 1,
+           stateDeltas: [{ subject: 'alice', field: 'city', from: $from, to: $value }],
+           segmenterVersion: 'scene-segmenter-v1', generation: 'seed-gen',
+           source: { recorder: 'test-seed' },
+           enrichmentVersion: 'seed-enrich-v1', enrichedMemoryValue: { explicitness: 0.8 }
+         }`,
+        {
+          tail: o.tail,
+          user: o.user,
+          conv: o.conv,
+          at: o.at,
+          value: o.value,
+          from: o.from ?? '',
+        },
+      );
+    });
+  };
+
+  const promoteConv = (conv: string) =>
+    f.app.get(BeliefPromotionService).run(f.companyId, { conversationId: conv });
+
+  const chainOf = (user: string): Promise<BeliefRow[]> =>
+    db(async (d) => {
+      const [rows] = await d.query<[BeliefRow[]]>(
+        `SELECT * FROM semantic_belief WHERE userId = $u ORDER BY revision ASC`,
+        { u: user },
+      );
+      return rows ?? [];
+    });
+
+  beforeAll(async () => {
+    for (const k of FLAGS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+    process.env.SCENES_SEGMENTATION_ENABLED = '1';
+    process.env.SCENES_BELIEF_PROMOTION = '1';
+    f = await createApp({ companyId: 'co_belief_chain_e2e' });
+  }, 120000);
+
+  afterAll(async () => {
+    for (const [k, v] of Object.entries(saved)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+    if (f) await f.close();
+  });
+
+  it.each(permutations(EVENTS).map((order) => [order.map((e) => e.tag).join(','), order]))(
+    'arrival order %s converges to A since March, displacing B',
+    async (label, order) => {
+      const user = `perm_${(label as string).replace(/,/g, '_')}`;
+      for (const e of order as Evt[]) {
+        const conv = `${user}:${e.tag}`;
+        await seedScene({ tail: `${user}_${e.tag}`, user, conv, at: e.at, value: e.value });
+        await promoteConv(conv);
+      }
+      const chain = await chainOf(user);
+      const active = chain.filter((r) => r.status === 'active');
+      expect(active).toHaveLength(1);
+      expect(active[0]).toMatchObject({ value: 'A', priorValue: 'B' });
+      expect(iso(active[0]!.validFrom)).toBe(MAR);
+      expect(iso(active[0]!.latestEvidenceAt)).toBe(MAR);
+      // The chain is 1..n without gaps and every displaced row points forward.
+      expect(chain.map((r) => r.revision)).toEqual(chain.map((_, i) => i + 1));
+      for (const r of chain.filter((r) => r.status === 'superseded')) {
+        expect(r.supersededBy).toBeDefined();
+        expect(r.validUntil).toBeDefined();
+      }
+    },
+  );
+
+  it('a confirmation advances the watermark and leaves the beginning alone; the late B is not a revision', async () => {
+    const user = 'wm_user';
+    await seedScene({ tail: 'wm_a1', user, conv: 'wm:c1', at: JAN, value: 'A' });
+    expect(await promoteConv('wm:c1')).toMatchObject({ beliefsCreated: 1 });
+    await seedScene({ tail: 'wm_a3', user, conv: 'wm:c3', at: MAR, value: 'A' });
+    expect(await promoteConv('wm:c3')).toMatchObject({ beliefsCorroborated: 1, beliefsRevised: 0 });
+    let [head] = await chainOf(user);
+    expect(head).toMatchObject({ value: 'A', revision: 1, corroborationCount: 2 });
+    expect(iso(head!.validFrom)).toBe(JAN); // the beginning stays
+    expect(iso(head!.latestEvidenceAt)).toBe(MAR); // the watermark moved
+
+    // B dated between the two confirmations arrives last: no revision —
+    // the chain reads A · B · A, so A holds and merely began again in March.
+    await seedScene({ tail: 'wm_b2', user, conv: 'wm:c2', at: FEB, value: 'B' });
+    const late = await promoteConv('wm:c2');
+    expect(late).toMatchObject({ beliefsRevised: 0, beliefsCreated: 0, beliefsRealigned: 1 });
+    const chain = await chainOf(user);
+    expect(chain).toHaveLength(1);
+    [head] = chain;
+    expect(head).toMatchObject({ value: 'A', priorValue: 'B', status: 'active' });
+    expect(iso(head!.validFrom)).toBe(MAR);
+  });
+
+  it('a legacy row without a watermark is judged by its validFrom, then stamped on its next corroboration', async () => {
+    const user = 'legacy_user';
+    // A pre-0137 revision: validFrom only, no latestEvidenceAt.
+    await db(async (d) => {
+      await d.query(
+        `CREATE type::record('semantic_belief', $tail) CONTENT {
+           userId: $u, subject: 'alice', field: 'city', value: 'A',
+           statement: 'alice — city: A', statementSource: 'template', confidence: 0.8,
+           revision: 1, status: 'active', validFrom: <datetime>$from,
+           sourceSceneIds: [], conversationIds: [], corroborationCount: 1, conversationCount: 1,
+           promoterVersion: 'belief-promotion-v1'
+         }`,
+        {
+          tail: beliefIdTail({ userId: user, subject: 'alice', field: 'city' }, 1),
+          u: user,
+          from: MAR,
+        },
+      );
+    });
+    await seedScene({ tail: 'lg_b2', user, conv: 'lg:c2', at: FEB, value: 'B' });
+    expect(await promoteConv('lg:c2')).toMatchObject({ skippedStale: 1, beliefsRevised: 0 });
+    expect(await chainOf(user)).toHaveLength(1);
+
+    await seedScene({ tail: 'lg_a4', user, conv: 'lg:c4', at: APR, value: 'A' });
+    expect(await promoteConv('lg:c4')).toMatchObject({ beliefsCorroborated: 1 });
+    const [head] = await chainOf(user);
+    expect(iso(head!.latestEvidenceAt)).toBe(APR);
+    expect(iso(head!.validFrom)).toBe(MAR); // no interlude after March — kept
+  });
+
+  it('two concurrent runs revising one key leave exactly one active head', async () => {
+    const user = 'race_user';
+    await seedScene({ tail: 'rc_a', user, conv: 'rc:c0', at: JAN, value: 'A' });
+    expect(await promoteConv('rc:c0')).toMatchObject({ beliefsCreated: 1 });
+    await seedScene({ tail: 'rc_b', user, conv: 'rc:c1', at: FEB, value: 'B' });
+    await seedScene({ tail: 'rc_c', user, conv: 'rc:c2', at: MAR, value: 'C' });
+    const results = await Promise.all([promoteConv('rc:c1'), promoteConv('rc:c2')]);
+    // Both runs fold the same chain (A · B · C) and race for revision 2 = C:
+    // exactly one lands it; the other either loses the compare-and-set
+    // (contended) or, having run second, finds the head already at C.
+    expect(results.reduce((n, r) => n + r.beliefsRevised, 0)).toBe(1);
+    const chain = await chainOf(user);
+    expect(chain.map((r) => `${r.revision}:${r.value}:${r.status}`)).toEqual([
+      '1:A:superseded',
+      '2:C:active',
+    ]);
+    expect(String(chain[0]!.supersededBy)).toBe(String(chain[1]!.id));
+  });
+
+  it('a revision slot another writer filled with a different value is never overwritten', async () => {
+    const user = 'slot_user';
+    await seedScene({ tail: 'sl_a', user, conv: 'sl:c0', at: JAN, value: 'A' });
+    expect(await promoteConv('sl:c0')).toMatchObject({ beliefsCreated: 1 });
+    const [head] = await chainOf(user);
+    const key = { userId: user, subject: 'alice', field: 'city' };
+    const candidate = (value: string): FoldedBelief => ({
+      ...key,
+      value,
+      priorValue: 'A',
+      displacedValue: 'A',
+      displacedAt: new Date(JAN),
+      validFrom: new Date(FEB),
+      evidenceAt: new Date(FEB),
+      runEvidenceAt: [new Date(FEB)],
+      sceneIds: [],
+      allSceneIds: [],
+      conversationIds: [],
+      confidence: 0.8,
+      worlds: [],
+    });
+    // The compare-and-set, driven directly: two writers, two values, one
+    // revision slot — on two separate pool connections.
+    const logger = new Logger('belief-revision-chain.e2e');
+    const displaced = { id: String(head!.id), revision: 1, until: new Date(FEB) };
+    const commit = (value: string) =>
+      db((d) =>
+        commitRevision({
+          db: d,
+          belief: candidate(value),
+          revision: 2,
+          promoterVersion: 'belief-promotion-v1',
+          statement: { text: `alice — city: ${value} (was: A)`, source: 'template' },
+          displaced,
+          logger,
+        }),
+      );
+    const [x, y] = await Promise.all([commit('X'), commit('Y')]);
+    expect([x, y].filter(Boolean)).toHaveLength(1);
+    const chain = await chainOf(user);
+    expect(chain).toHaveLength(2);
+    expect(chain[0]).toMatchObject({ revision: 1, status: 'superseded' });
+    expect(chain[1]).toMatchObject({ revision: 2, status: 'active' });
+    const winner = chain[1]!.value;
+    expect(['X', 'Y']).toContain(winner);
+    // The loser, retried after the fact, still writes nothing: the slot
+    // holds another value and the head is no longer active.
+    const loser = winner === 'X' ? 'Y' : 'X';
+    expect(await commit(loser)).toBe(false);
+    expect((await chainOf(user)).map((r) => `${r.revision}:${r.value}:${r.status}`)).toEqual([
+      '1:A:superseded',
+      `2:${winner}:active`,
+    ]);
+  });
+});

--- a/test/belief-value-gate.unit-spec.ts
+++ b/test/belief-value-gate.unit-spec.ts
@@ -206,9 +206,12 @@ describe('the gate through run() (fake db)', () => {
         return [this.sceneHeads];
       }
       if (sqlText.includes('field = $f')) return [[]];
-      if (sqlText.startsWith('INSERT IGNORE INTO semantic_belief')) {
+      // The revision lands through the compare-and-set transaction
+      // (commitRevision); with no head there is nothing to stamp — only
+      // the INSERT IGNORE inside it matters here.
+      if (sqlText.startsWith('BEGIN TRANSACTION')) {
         this.inserted.push(...(params.rows as Array<Record<string, unknown>>));
-        return [];
+        return [true];
       }
       if (sqlText.includes('UPDATE memory_episode')) return [];
       throw new Error(`FakeDb: unhandled SQL: ${sqlText}`);

--- a/test/promotion-gate.unit-spec.ts
+++ b/test/promotion-gate.unit-spec.ts
@@ -5,8 +5,9 @@
  *
  *   - corroboration floor (COMPACTION_PROMOTION_MIN_EPISODES): a group
  *     folds only when its members span enough DISTINCT evidence contexts
- *     (union of member source.episodeIds + source.conversationId) — five
- *     facts from ONE conversation are one witness, not five;
+ *     (source.conversationId; source.episodeIds only as the fallback for
+ *     a member whose conversation is unknown — distinctEvidenceContexts)
+ *     — five facts from ONE conversation are one witness, not five;
  *   - conflict guard (COMPACTION_PROMOTION_CONFLICT_GUARD): sibling
  *     COMPETING rows abort the group loudly;
  *   - both off/unset → promotion byte-identical to today (pinned);
@@ -14,7 +15,10 @@
  */
 import { Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { PromotionRunnerService } from '../src/compaction/promotion-runner.service';
+import {
+  PromotionRunnerService,
+  distinctEvidenceContexts,
+} from '../src/compaction/promotion-runner.service';
 import type { EmbedderService } from '../src/ai/embedder.service';
 import type { SurrealService } from '../src/db/surreal.service';
 
@@ -161,22 +165,83 @@ describe('PromotionRunnerService — corroboration floor', () => {
     expect(created[0]!.predicate).toBe('summary_said');
   });
 
-  it('counts episode stamps and conversation ids into ONE distinct-context set', async () => {
-    // One conversation only, but two members carry distinct episode
-    // stamps: contexts = {episode:e1, episode:e2, conv_1} = 3.
+  it('one conversation is ONE witness however many episode stamps its replies carry (F10)', async () => {
+    // One conversation only; two members carry distinct episode stamps.
+    // The pre-fix union counted {episode:e1, episode:e2, conv_1} = 3 and
+    // promoted at floor 3 — contradicting the floor's own doctrine. The
+    // context is the conversation: one witness, floor 2 not met.
+    const debug = jest.spyOn(Logger.prototype, 'debug').mockImplementation(() => undefined);
     const seeds = ONE_CONVERSATION.map((s, i) => ({
       ...s,
       ...(i === 0 ? { eps: ['episode:e1'] } : {}),
       ...(i === 1 ? { eps: ['episode:e2'] } : {}),
     }));
     const { runner, created } = makePromotionStack(seeds, {
-      COMPACTION_PROMOTION_MIN_EPISODES: '3',
+      COMPACTION_PROMOTION_MIN_EPISODES: '2',
+    });
+    const stats = await runner.promoteCompany('co_a');
+    expect(stats.groupsPromoted).toBe(0);
+    expect(created).toHaveLength(0);
+    expect(debug).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'promotion skipped (corroboration floor): knowledge_entity:e1/said distinct=1 < 2',
+      ),
+    );
+  });
+
+  it('episode stamps are the fallback witness only for members whose conversation is unknown', async () => {
+    // Three members without a conversation, each grounded in its own
+    // episode, plus two from conv_1: contexts = {conv_1, e1, e2, e3} = 4.
+    const seeds = ONE_CONVERSATION.map((s, i) =>
+      i < 3
+        ? { id: s.id, object: s.object, validFrom: s.validFrom, eps: [`episode:e${i + 1}`] }
+        : s,
+    );
+    const { runner, created } = makePromotionStack(seeds, {
+      COMPACTION_PROMOTION_MIN_EPISODES: '4',
     });
     const stats = await runner.promoteCompany('co_a');
     expect(stats.groupsPromoted).toBe(1);
     expect(created).toHaveLength(1);
   });
+});
 
+describe('distinctEvidenceContexts (pure)', () => {
+  it('several episodes of one conversation are one witness', () => {
+    const contexts = distinctEvidenceContexts([
+      { conversationId: 'c1', eps: ['episode:e1'] },
+      { conversationId: 'c1', eps: ['episode:e2'] },
+      { conversationId: 'c1', eps: ['episode:e3', 'episode:e4'] },
+    ]);
+    expect([...contexts]).toEqual(['conversation:c1']);
+  });
+
+  it('one member carrying both references is one witness', () => {
+    expect([...distinctEvidenceContexts([{ conversationId: 'c1', eps: ['episode:e1'] }])]).toEqual([
+      'conversation:c1',
+    ]);
+  });
+
+  it('two conversations are two witnesses', () => {
+    const contexts = distinctEvidenceContexts([
+      { conversationId: 'c1', eps: ['episode:e1'] },
+      { conversationId: 'c2', eps: ['episode:e1'] },
+    ]);
+    expect([...contexts].sort()).toEqual(['conversation:c1', 'conversation:c2']);
+  });
+
+  it('a context-less member falls back to its episodes, minus those a conversation already claims', () => {
+    const contexts = distinctEvidenceContexts([
+      { conversationId: 'c1', eps: ['episode:e1'] },
+      { eps: ['episode:e1', 'episode:e9'] },
+      { eps: ['episode:e9'] },
+      {},
+    ]);
+    expect([...contexts].sort()).toEqual(['conversation:c1', 'episode:e9']);
+  });
+});
+
+describe('PromotionRunnerService — corroboration floor (member SELECT)', () => {
   it('the member SELECT carries the evidence-context column', async () => {
     const { runner, calls } = makePromotionStack(TWO_CONVERSATIONS, {});
     await runner.promoteCompany('co_a');


### PR DESCRIPTION
Three items from the 2026-09-06 current-state audit: **F6** (P1, belief evidence watermark), **F10** (P2, corroboration floor counts one conversation as many witnesses), and additional note 1 (belief revision is not atomic). One commit per finding.

## F6 — two clocks per revision (P1)
Confirming a belief's value kept no watermark of the latest evidence, and a differing value was judged against the state's *original* `validFrom`. Targeted promotion by conversation — A on Jan 1, A again on Mar 1, then B dated Feb 1 arriving late — made **B** active although the latest evidence said A (the audit's real-DB repro).

- `validFrom` is now **when the state began** — the opener of the trailing same-value run of its evidence — never the latest confirmation. New column `latestEvidenceAt` (**migration 0137**, `option<datetime>`; renumbered after #536 took 0136) is the **watermark**: the latest scene the belief has processed. A confirmation advances the watermark and leaves the beginning alone; a differing candidate is measured against the watermark, so evidence older than what the belief already saw cannot revise it. A legacy row without a watermark is judged by its `validFrom` (the pre-0137 rule) and stamped on its next corroboration.
- **Full-chain fold on targeted runs.** A run scoped to one conversation now folds the affected users' *whole* promotable chain (`buildPromotableScenesQuery` gains a `userIds` clause; the flag-off SQL is byte-identical, pinned) and promotes only the keys that conversation touched. A late scene lands at its place in the chain: an interlude of another value after the recorded beginning moves `validFrom` forward to the run that followed and backfills the displaced value as `priorValue`; earlier evidence of the same value moves it back only while the row has no predecessor. Counted as `beliefsRealigned`.
- The verdict is a function of the evidence, not of arrival order: **every permutation** of {A Jan, B Feb, A Mar} ends with the same active row (A since March, displacing B, watermark March).

## F10 — one conversation is one witness (P2)
The floor unioned the members' episode ids *with* their conversation ids, so one reply from one conversation counted as two witnesses and five replies as up to six — contradicting the comment above the code. `distinctEvidenceContexts` (pure, exported) counts one level of independence: the conversation; episode ids only as the fallback for a member whose conversation is unknown, and never an episode a conversation-known member already claims. The unit test that pinned the union now pins the doctrine.

## Atomic revision (additional note 1)
`upsertBelief` read the head, `INSERT IGNORE`d revision N+1, then superseded the old row in separate queries. `commitRevision` is one `BEGIN…COMMIT`: the revision slot is read and a row already holding another value aborts; `INSERT IGNORE`; on a revise the head is superseded **only if** it is still the active head at the revision this run read, and zero rows stamped aborts — which rolls the INSERT back (verified on SurrealDB 3.2.4). A lost transaction is counted (`skippedContended`), written nowhere, and recomputed by the next run.

## Layout
The write path (`commitRevision`, the corroboration update, the deterministic id helpers) now lives in `src/admin/belief-revision.ts` and the per-scene admission fences in `belief-scene-selection.ts` — the god-file split that keeps `belief-promotion.service.ts` under its 800-line ceiling. `beliefIdTail` is re-exported from the service, so the historical import surface is unchanged.

## Proof
- **Unit** (`belief-promotion.unit-spec`, `promotion-gate.unit-spec`, `belief-value-gate.unit-spec`): the fold's two clocks and interlude rule; the watermark stale guard; a confirmation advancing the watermark with a legacy row stamped; the targeted full-chain realignment; a head moved under the run → no second revision, nothing inserted; the transaction's shape; F10's three cases plus the fallback.
- **Real SurrealDB** (`test/belief-revision-chain.e2e-spec.ts`, 10 tests): all six arrival orders converge; watermark vs beginning; the legacy row; two concurrent runs revising one key leave exactly one active head with a gapless chain; two writers racing for one revision slot — one lands, the loser writes nothing, then and on retry.
- Existing `belief-promotion` / `belief-serving` / `beliefs-api` / `scene-prediction-baseline` / `promotion` / migration-ledger / `answer-cache-dependencies` e2e suites pass unchanged on this branch; tsc (app + spec), eslint, prettier clean.

Semantics changed on purpose (and re-pinned): a fold's `priorValue` is the chain's actual displaced value rather than the winning delta's self-reported `from`; `BeliefPromotionResult` gains `beliefsRealigned` and `skippedContended`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhrQxeisXJZEt4sg3PGyU6