### PR TITLE
fix(health): one readiness vocabulary for /ready, the admin grid and the capability probe

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -734,6 +734,29 @@ session serves every tenant on the pod, so the canary tenant proves the
 property for all of them and the scraper's `instance` label already pins
 *which pod*. The tenant is named in the log line.
 
+**The canary tenant** is the first (sorted) id of the tenant registry's
+*active* roster — the same roster provisioning and every sweep should use;
+the static `BRAIN_API_KEYS` set stands in only where the registry knows
+nothing (dev, a fresh install). `CAPABILITY_PROBE_TENANT` pins one, and it
+**must name a tenant the process already knows**: the scoped path provisions
+the database it is handed, so a typo used to create `co_<typo>` with the full
+migration set on every boot. An unknown or suspended override is refused
+before any connection is taken and reported as a conclusive `error` — it
+pages, on purpose, as a configuration error.
+
+**`degraded` is reachable both ways.** With the strict space guard on (the
+default) a not-warm primary never returns a wrong-width vector — the
+embedder refuses the call with its "embedding space strict-guard" 503, and
+the probe reads that refusal as `degraded`. With the guard off the fallback
+answers in its own space and the width measurement catches it.
+
+**The admin cockpit shows the same thing.** `/v1/admin/health/components`
+reads the readiness report `/ready` answers from (database, scoped pool with
+its own row, embedder with the warmup bookkeeping — attempts, last error,
+next retry) and annotates each row with the probe's last outcome (`probe
+serving 12s ago`). It does not probe on its own, so the grid, `/ready` and
+the alert cannot disagree.
+
 Rules in `monitoring/grafana/provisioning/alerting/rules.yaml`:
 
 - **ScopedReadCapabilityDead** (critical, `for: 5m`) — `min(brain_capability_probe_ok{capability="scoped_read"}) < 1`. Five consecutive conclusive failures at the default cadence. A lapsed session is no longer sticky (the pool re-signs on the next acquire), so five failures in a row mean the pool cannot sign in at all; the wait buys immunity from a single-tick blip.

--- a/src/admin/admin-infra.controller.ts
+++ b/src/admin/admin-infra.controller.ts
@@ -38,15 +38,15 @@ export class AdminInfraController {
   /**
    * Per-component health grid. Each component reports status (ok |
    * warming | degraded | disabled | unreachable) + latency (when
-   * cheap) + a short message. Distinct from /health which is the
-   * binary up/down for k8s.
+   * cheap) + a short message. The database, scoped-pool and embedder rows
+   * come from the same readiness report /ready answers from, annotated
+   * with the capability probe's last outcome — one vocabulary, not a
+   * second set of probes.
    */
   @Get('health/components')
   @RequireScopes('brain:admin')
   async healthComponentsView(): Promise<HealthComponentsResponse> {
-    const dbStart = Date.now();
-    const dbOk = await this.adminInfra.pingDb();
-    return this.healthComponents.build(dbOk, Date.now() - dbStart);
+    return this.healthComponents.build();
   }
 
   /**

--- a/src/admin/health-components.service.ts
+++ b/src/admin/health-components.service.ts
@@ -1,78 +1,159 @@
 import { Injectable } from '@nestjs/common';
 import { envFlagNotDisabled } from '../common/env-validation';
+import { HealthService, type ReadinessReport } from '../common/health.service';
 import { EmbedderService } from '../ai/embedder.service';
+import { CapabilityProbeService, type LastProbeReport } from '../metrics/capability-probe.service';
+import { isConclusive } from '../metrics/capability-probe';
 import { IntentClassifierService } from './intent-classifier.service';
 import { ChangefeedConsumerService } from '../audit/changefeed-consumer.service';
-import type { HealthComponentsResponse } from '../contracts/admin/health-components.schema';
-
-type ComponentStatus = 'ok' | 'warming' | 'degraded' | 'disabled' | 'unreachable';
+import type {
+  HealthComponent,
+  HealthComponentsResponse,
+} from '../contracts/admin/health-components.schema';
 
 /**
- * HealthComponentsService — builds the per-component health grid for the
- * admin cockpit (/v1/admin/health/components). Probes the embedder,
- * intent classifier, and changefeed consumer; the DB-liveness result is
- * passed in by the controller (which owns AdminInfraService.pingDb).
- * Extracted from AdminInfraController so the controller keeps ≤3 deps and
- * holds no business logic.
+ * HealthComponentsService — the per-component grid for the admin cockpit
+ * (/v1/admin/health/components).
+ *
+ * The database, scoped-pool and embedder rows are READ from
+ * `HealthService.readiness()` — the same report `/ready` answers from — and
+ * annotated with the capability probe's last outcome. Nothing here probes
+ * on its own. The cockpit used to ping the root pool and ask `isReady()`:
+ * it could show a green embedder while `/ready` said "warming", and it had
+ * no scoped-pool row at all — the state #502 and #511 were written for was
+ * invisible on the one surface an operator looks at. One vocabulary, three
+ * surfaces: `/ready`, this grid, and the probe's metrics agree by
+ * construction.
  */
 @Injectable()
 export class HealthComponentsService {
+  // eslint-disable-next-line max-params -- Nest DI constructor; each param is an injection token
   constructor(
+    private readonly health: HealthService,
+    private readonly probe: CapabilityProbeService,
     private readonly embedder: EmbedderService,
     private readonly intent: IntentClassifierService,
     private readonly changefeed: ChangefeedConsumerService,
   ) {}
 
-  build(dbOk: boolean, dbLatencyMs: number): HealthComponentsResponse {
-    const components: Array<{
-      name: string;
-      status: ComponentStatus;
-      latencyMs?: number;
-      message?: string;
-    }> = [];
+  async build(): Promise<HealthComponentsResponse> {
+    const readiness = await this.health.readiness();
+    const last = this.probe.lastReports();
+    const components: HealthComponent[] = [
+      this.database(readiness),
+      this.scopedPool(readiness, last.scoped_read),
+      this.embedderRow(readiness, last.embed),
+      this.intentRow(),
+      this.openAiKeyRow(),
+      this.changefeedRow(),
+      this.calibrationRow(),
+    ];
+    return {
+      generatedAt: new Date().toISOString(),
+      components,
+    } satisfies HealthComponentsResponse;
+  }
 
-    // SurrealDB (probed by the caller)
-    components.push({
+  private database(r: ReadinessReport): HealthComponent {
+    return {
       name: 'surrealdb',
-      status: dbOk ? 'ok' : 'unreachable',
-      latencyMs: dbLatencyMs,
-    });
+      status: r.dbOk ? 'ok' : 'unreachable',
+      latencyMs: r.detail.dbLatencyMs,
+      ...(r.dbOk ? {} : { message: 'liveness ping failed — the same signal /health reports' }),
+    };
+  }
 
-    // Embedder (BGE-M3 or OpenAI proxy — service exposes isReady)
-    const embedderReady = this.embedder.isReady();
-    const embedderProvider = this.embedder.cacheStats().provider;
-    components.push({
-      name: `embedder (${embedderProvider})`,
-      status: embedderReady ? 'ok' : 'warming',
-      message: embedderReady
-        ? `cache size ${this.embedder.cacheStats().size}`
-        : this.embedder.isServingDegraded()
-          ? `loading model weights — serving cross-space on the ${embedderProvider} ` +
-            `fallback; vector writes are refused until the primary is ready`
-          : 'downloading model weights',
-    });
+  /**
+   * The caller-facing read path. `disabled` is honest, not green: with no
+   * scoped credentials reads run root-authorized and `scopedOk` is
+   * vacuously true. `degraded` (not `unreachable`) when the socket is fine
+   * but the session cannot authorize — the failure /ready used to miss.
+   */
+  private scopedPool(r: ReadinessReport, probe: LastProbeReport | undefined): HealthComponent {
+    const name = 'scoped pool (brain_caller)';
+    if (!r.detail.scopedEnabled) {
+      return {
+        name,
+        status: 'disabled',
+        message:
+          'SURREALDB_SCOPED_USER/PASS unset — reads run root-authorized; the DB-level ' +
+          'fence is inert',
+      };
+    }
+    if (!r.dbOk) return { name, status: 'unreachable', message: 'database unreachable' };
+    const probeFailed =
+      probe !== undefined && isConclusive(probe.outcome) && probe.outcome !== 'serving';
+    return {
+      name,
+      status: r.scopedOk && !probeFailed ? 'ok' : 'degraded',
+      latencyMs: r.detail.scopedLatencyMs,
+      message: joinParts(
+        r.scopedOk ? 'authorizes reads' : 'cannot authorize reads — unauthorized (see /ready)',
+        probeSummary(probe),
+      ),
+    };
+  }
 
-    // Intent classifier
+  /**
+   * "Ready" here is `/ready`'s definition — the next embed answers in the
+   * configured space — and the message carries the warmup bookkeeping
+   * (#518) instead of a guess about what the provider is doing.
+   */
+  private embedderRow(r: ReadinessReport, probe: LastProbeReport | undefined): HealthComponent {
+    const stats = this.embedder.cacheStats();
+    const name = `embedder (${stats.provider})`;
+    const w = r.detail.embedder;
+    if (!r.embedderReady) {
+      const attempt = w.failures > 0 ? `warmup failed ${w.failures}×` : 'warming up';
+      const detail = w.lastError ? ` (last error: ${w.lastError})` : '';
+      const next = w.inFlight
+        ? 'attempt in flight'
+        : w.nextRetryAt
+          ? `next attempt at ${w.nextRetryAt}`
+          : 'the next readiness poll re-arms an attempt';
+      return {
+        name,
+        status: w.failures > 0 ? 'degraded' : 'warming',
+        message: joinParts(
+          `${attempt}${detail}; ${next}. Queries that need the configured space are refused ` +
+            `(503) until the primary is ready; hybrid search answers lexical-only`,
+          probeSummary(probe),
+        ),
+      };
+    }
+    const probeFailed =
+      probe !== undefined && isConclusive(probe.outcome) && probe.outcome !== 'serving';
+    return {
+      name,
+      status: probeFailed ? 'degraded' : 'ok',
+      message: joinParts(`cache size ${stats.size}`, probeSummary(probe)),
+    };
+  }
+
+  private intentRow(): HealthComponent {
     const intentStats = this.intent.stats();
-    components.push({
+    return {
       name: 'intent classifier',
       status: !intentStats.enabled ? 'disabled' : intentStats.ready ? 'ok' : 'warming',
       message: intentStats.enabled
         ? `model=${intentStats.model} cache=${intentStats.cacheSize}`
         : 'CHAT_ROUTE_NLI_ENABLED=0',
-    });
+    };
+  }
 
-    // OpenAI key presence (we don't ping — that would burn tokens)
+  /** Presence only — a ping would burn tokens. */
+  private openAiKeyRow(): HealthComponent {
     const hasOpenAI = !!process.env.OPENAI_API_KEY;
-    components.push({
+    return {
       name: 'openai key',
       status: hasOpenAI ? 'ok' : 'disabled',
       message: hasOpenAI ? 'present (not pinged)' : 'OPENAI_API_KEY unset',
-    });
+    };
+  }
 
-    // Changefeed consumer
+  private changefeedRow(): HealthComponent {
     const cf = this.changefeed.stats();
-    components.push({
+    return {
       name: 'changefeed consumer',
       status: !cf.enabled
         ? 'disabled'
@@ -84,18 +165,27 @@ export class HealthComponentsService {
       message: cf.enabled
         ? `${cf.lastPendingRemaining} pending · ${cf.tickCount} ticks`
         : 'AUDIT_CHANGEFEED_ENABLED=0',
-    });
+    };
+  }
 
-    // Calibration source
-    components.push({
+  private calibrationRow(): HealthComponent {
+    return {
       name: 'calibration',
       status: envFlagNotDisabled(process.env.CALIBRATION_USE_GOLD_SET) ? 'ok' : 'disabled',
       message: 'see /admin/calibration for ECE + version history',
-    });
-
-    return {
-      generatedAt: new Date().toISOString(),
-      components,
-    } satisfies HealthComponentsResponse;
+    };
   }
+}
+
+/** `probe serving 12s ago`, or the failure with its detail when conclusive. */
+function probeSummary(report: LastProbeReport | undefined): string | undefined {
+  if (!report) return undefined;
+  const ageS = Math.max(0, Math.round((Date.now() - Date.parse(report.at)) / 1000));
+  const head = `probe ${report.outcome} ${ageS}s ago`;
+  const failed = isConclusive(report.outcome) && report.outcome !== 'serving';
+  return failed && report.detail ? `${head}: ${report.detail}` : head;
+}
+
+function joinParts(...parts: Array<string | undefined>): string {
+  return parts.filter((p): p is string => typeof p === 'string' && p.length > 0).join(' · ');
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,7 +5,6 @@ import { ScheduleModule } from '@nestjs/schedule';
 import { APP_GUARD } from '@nestjs/core';
 import { CommonModule } from './common/common.module';
 import { HealthController } from './common/health.controller';
-import { HealthService } from './common/health.service';
 import { TenantThrottlerGuard } from './common/tenant-throttler.guard';
 import { SurrealModule } from './db/surreal.module';
 import { LiveModule } from './live/live.module';
@@ -112,7 +111,6 @@ import { MriModule } from './mri/mri.module';
   ],
   controllers: [HealthController],
   providers: [
-    HealthService,
     {
       provide: APP_GUARD,
       useClass: TenantThrottlerGuard,

--- a/src/common/common.module.ts
+++ b/src/common/common.module.ts
@@ -3,6 +3,7 @@ import { APP_INTERCEPTOR } from '@nestjs/core';
 import { DebugTraceInterceptor, TraceBufferService } from './debug-trace';
 import { ActivityTrackerService } from './activity-tracker.service';
 import { InFlightInterceptor } from './in-flight.interceptor';
+import { HealthService } from './health.service';
 
 @Global()
 @Module({
@@ -11,7 +12,10 @@ import { InFlightInterceptor } from './in-flight.interceptor';
     { provide: APP_INTERCEPTOR, useClass: DebugTraceInterceptor },
     ActivityTrackerService,
     { provide: APP_INTERCEPTOR, useClass: InFlightInterceptor },
+    // The one readiness definition — exported so the admin cockpit reads the
+    // same report /ready answers from, instead of probing on its own.
+    HealthService,
   ],
-  exports: [TraceBufferService, ActivityTrackerService],
+  exports: [TraceBufferService, ActivityTrackerService, HealthService],
 })
 export class CommonModule {}

--- a/src/common/health.service.ts
+++ b/src/common/health.service.ts
@@ -1,17 +1,51 @@
 import { Injectable } from '@nestjs/common';
 import { SurrealService } from '../db/surreal.service';
-import { EmbedderService } from '../ai/embedder.service';
+import { EmbedderService, type EmbedderWarmupStatus } from '../ai/embedder.service';
 
 export interface LivenessReport {
   dbOk: boolean;
+  /** Round-trip of the liveness ping, for the cockpit's latency column. */
+  dbLatencyMs: number;
 }
 
-export interface ReadinessReport {
+/**
+ * The checks `/ready` gates on. Each one has a CONTINUOUS counterpart in the
+ * capability probe (`CAPABILITY_COVERAGE` is typed on these keys, and a
+ * source-level gate in the probe's spec catches a check added without one)
+ * — a readiness check that is polled only at deploy time is the blindness
+ * #502 produced.
+ */
+export interface ReadinessChecks {
   dbOk: boolean;
   /** The caller-facing read path (scoped pool) can still authorize a query. */
   scopedOk: boolean;
   embedderReady: boolean;
+}
+
+/** Measurements behind the checks — what the cockpit shows next to them. */
+export interface ReadinessDetail {
+  dbLatencyMs: number;
+  /**
+   * The scoped (`brain_caller`) pool is configured. When false, reads route
+   * to root and `scopedOk` is vacuously true — a surface must say
+   * "disabled", not "ok", for that case.
+   */
+  scopedEnabled: boolean;
+  scopedLatencyMs: number;
+  /** Warmup bookkeeping behind `embedderReady`: attempts, last error, next retry. */
+  embedder: EmbedderWarmupStatus;
+}
+
+/**
+ * THE readiness vocabulary. `/ready`, the admin cockpit
+ * (/v1/admin/health/components) and the capability probe all read this one
+ * report, so "embedder ready" and "scoped reads work" cannot mean three
+ * different things on three surfaces (they did: the cockpit pinged root and
+ * asked `isReady()`, and never showed the scoped pool at all).
+ */
+export interface ReadinessReport extends ReadinessChecks {
   ready: boolean;
+  detail: ReadinessDetail;
 }
 
 /**
@@ -29,8 +63,9 @@ export class HealthService {
 
   /** Liveness — is the DB connection reachable right now. */
   async liveness(): Promise<LivenessReport> {
+    const started = Date.now();
     const dbOk = await this.surreal.ping().catch(() => false);
-    return { dbOk };
+    return { dbOk, dbLatencyMs: Date.now() - started };
   }
 
   /**
@@ -46,9 +81,19 @@ export class HealthService {
    * checks and readiness-aware balancers can detect a broken read path.
    */
   async readiness(): Promise<ReadinessReport> {
-    const dbOk = await this.surreal.ping().catch(() => false);
+    const { dbOk, dbLatencyMs } = await this.liveness();
+    const scopedEnabled = this.surreal.scopedPoolEnabled();
+    const scopedStarted = Date.now();
     const scopedOk = dbOk ? await this.surreal.pingScoped().catch(() => false) : false;
+    const scopedLatencyMs = Date.now() - scopedStarted;
     const embedderReady = this.embedder.isReady();
-    return { dbOk, scopedOk, embedderReady, ready: dbOk && scopedOk && embedderReady };
+    const embedder = this.embedder.warmupStatus();
+    return {
+      dbOk,
+      scopedOk,
+      embedderReady,
+      ready: dbOk && scopedOk && embedderReady,
+      detail: { dbLatencyMs, scopedEnabled, scopedLatencyMs, embedder },
+    };
   }
 }

--- a/src/db/surreal.service.ts
+++ b/src/db/surreal.service.ts
@@ -341,6 +341,16 @@ export class SurrealService implements OnModuleInit, OnApplicationShutdown {
    * question here is "can the read path authorize", not "is it idle".
    * Returns true when the scoped pool is disabled (`ping()` covers root).
    */
+  /**
+   * Whether the caller-facing read path runs on the scoped (`brain_caller`)
+   * pool at all. False = SURREALDB_SCOPED_USER/PASS unset, reads route to
+   * root and `pingScoped()` answers true vacuously — the health surfaces
+   * show that as "disabled" rather than as a healthy fence.
+   */
+  scopedPoolEnabled(): boolean {
+    return this.scopedEnabled;
+  }
+
   async pingScoped(): Promise<boolean> {
     if (!this.scopedEnabled) return true;
     // Time only the queue, not authentication. An available slot whose

--- a/src/metrics/capability-probe.service.ts
+++ b/src/metrics/capability-probe.service.ts
@@ -7,6 +7,7 @@ import {
 } from '@nestjs/common';
 import { SurrealService } from '../db/surreal.service';
 import { ApiKeyService } from '../auth/api-key.service';
+import { TenantRegistryService } from '../auth/tenant-registry.service';
 import { EmbedderService } from '../ai/embedder.service';
 import { MetricsService } from './metrics.service';
 import { envFlagNotDisabled } from '../common/env-validation';
@@ -15,8 +16,15 @@ import {
   classifyProbeFailure,
   isConclusive,
   probeErrorDetail,
+  type CapabilityName,
   type ProbeReport,
 } from './capability-probe';
+
+/** The last thing the probe saw for one capability, for the health surfaces. */
+export interface LastProbeReport extends ProbeReport {
+  /** ISO time the report was published. */
+  at: string;
+}
 
 /** Default probe cadence. One minute is the detection latency floor. */
 const DEFAULT_INTERVAL_MS = 60_000;
@@ -28,6 +36,13 @@ const MIN_INTERVAL_MS = 5_000;
  * short enough that a wedged capability cannot hold the tick past the next.
  */
 const PROBE_DEADLINE_MS = 15_000;
+/**
+ * How long shutdown waits for a tick that is mid-flight. A probe holds a
+ * pool connection and a pending query; tearing the pool down underneath it
+ * lands an error on a closing SurrealService. Bounded by the probe's own
+ * deadline plus slack, so a hung capability cannot hold the process open.
+ */
+const SHUTDOWN_DRAIN_MS = PROBE_DEADLINE_MS + 1_000;
 
 /**
  * The cheapest statement that exercises the WHOLE scoped read path:
@@ -97,6 +112,9 @@ export class CapabilityProbeService implements OnApplicationBootstrap, OnApplica
   private readonly tenantOverride = process.env.CAPABILITY_PROBE_TENANT?.trim() || undefined;
   private timer: NodeJS.Timeout | undefined;
   private running = false;
+  /** The tick in progress, so shutdown can wait for it. */
+  private inFlight: Promise<void> | undefined;
+  private readonly last = new Map<CapabilityName, LastProbeReport>();
 
   // eslint-disable-next-line max-params -- Nest DI constructor; each param is an injection token and cannot be folded into an options object without breaking DI
   constructor(
@@ -107,6 +125,9 @@ export class CapabilityProbeService implements OnApplicationBootstrap, OnApplica
     // unit fixture) still gets the scoped-read probe; the embed probe then
     // reports `skipped` rather than pretending to have run.
     @Optional() private readonly embedder?: EmbedderService,
+    // The production roster. Optional for the same unit fixtures; without
+    // it the canary comes from the static key set alone.
+    @Optional() private readonly registry?: TenantRegistryService,
   ) {}
 
   onApplicationBootstrap(): void {
@@ -117,13 +138,40 @@ export class CapabilityProbeService implements OnApplicationBootstrap, OnApplica
     this.timer.unref();
     this.logger.log(
       `capability probe armed: [${CAPABILITY_NAMES.join(', ')}] every ${this.intervalMs}ms ` +
-        `(tenant=${this.probeTenant() ?? 'none yet'})`,
+        `(tenant=${this.probeTenant().tenant ?? 'none yet'})`,
     );
   }
 
-  onApplicationShutdown(): void {
+  /**
+   * Stop the timer, then let a tick that is mid-flight finish (bounded).
+   * Nest tears the pools down right after this hook; a probe still holding
+   * a scoped connection would otherwise fail on a closing service and log
+   * an error that is not a capability failure.
+   */
+  async onApplicationShutdown(): Promise<void> {
     if (this.timer) clearInterval(this.timer);
     this.timer = undefined;
+    const pending = this.inFlight;
+    if (!pending) return;
+    let drain: NodeJS.Timeout | undefined;
+    await Promise.race([
+      pending,
+      new Promise<void>((resolve) => {
+        drain = setTimeout(resolve, SHUTDOWN_DRAIN_MS);
+      }),
+    ]).finally(() => {
+      if (drain) clearTimeout(drain);
+    });
+  }
+
+  /**
+   * What the probe last saw, per capability — the health surfaces show it
+   * next to the readiness report so the cockpit and the alert agree.
+   */
+  lastReports(): Partial<Record<CapabilityName, LastProbeReport>> {
+    const out: Partial<Record<CapabilityName, LastProbeReport>> = {};
+    for (const [capability, report] of this.last) out[capability] = report;
+    return out;
   }
 
   /**
@@ -148,18 +196,23 @@ export class CapabilityProbeService implements OnApplicationBootstrap, OnApplica
       return;
     }
     this.running = true;
-    try {
-      await this.runOnce();
-    } catch (e) {
-      // runOnce swallows per-capability failures; reaching here means the
-      // prober itself broke, which must not kill the timer.
-      this.logger.error(`capability probe tick failed: ${probeErrorDetail(e)}`);
-    } finally {
-      this.running = false;
-    }
+    this.inFlight = (async () => {
+      try {
+        await this.runOnce();
+      } catch (e) {
+        // runOnce swallows per-capability failures; reaching here means the
+        // prober itself broke, which must not kill the timer.
+        this.logger.error(`capability probe tick failed: ${probeErrorDetail(e)}`);
+      } finally {
+        this.running = false;
+        this.inFlight = undefined;
+      }
+    })();
+    await this.inFlight;
   }
 
   private publish(report: ProbeReport): void {
+    this.last.set(report.capability, { ...report, at: new Date().toISOString() });
     this.metrics.recordCapabilityProbe(report.capability, report.outcome);
     if (report.outcome === 'serving') return;
     const line = `capability '${report.capability}' is ${report.outcome}: ${report.detail ?? '—'}`;
@@ -168,28 +221,62 @@ export class CapabilityProbeService implements OnApplicationBootstrap, OnApplica
   }
 
   /**
-   * The canary tenant. Explicit override first, else the first id of the
-   * known roster (static keys before registry ids — a stable ordering, so
-   * the probe hits the same database every tick and its cost is bounded).
+   * The canary tenant, or why there is none.
+   *
+   * The registry's ACTIVE roster is the source: it is what production
+   * provisions from and what a suspension removes a tenant from. The static
+   * key set (BRAIN_API_KEYS) only stands in where the registry knows nothing
+   * — dev, unit fixtures, a fresh install. Sorted, so the probe hits the
+   * same database every tick and its cost is bounded.
+   *
+   * An explicit CAPABILITY_PROBE_TENANT must name a tenant the process
+   * already knows. `withScopedCompany` provisions the database it is given
+   * — a typo or a deleted id would silently create `co_<typo>` with the
+   * full migration set on every boot — so an unknown override is refused
+   * here, before any connection is taken, and reported as a conclusive
+   * `error` so it pages instead of quietly probing the wrong thing.
    *
    * One tenant, not all of them: the scoped session is shared by every
    * tenant on the pod, so a per-tenant sweep would multiply series and DB
    * load by the roster size to re-answer the same question.
    */
-  private probeTenant(): string | undefined {
-    if (this.tenantOverride) return this.tenantOverride;
-    return this.apiKeys.knownCompanyIds()[0];
-  }
-
-  private async probeScopedRead(): Promise<ProbeReport> {
-    const tenant = this.probeTenant();
-    if (!tenant) {
+  private probeTenant(): { tenant: string } | { tenant?: undefined; reason: ProbeReport } {
+    const known = this.knownRoster();
+    if (this.tenantOverride) {
+      if (known.includes(this.tenantOverride)) return { tenant: this.tenantOverride };
       return {
+        reason: {
+          capability: 'scoped_read',
+          outcome: 'error',
+          detail:
+            `CAPABILITY_PROBE_TENANT='${this.tenantOverride}' is not a known tenant ` +
+            `(registry active roster or BRAIN_API_KEYS); refusing to probe it — it would ` +
+            `create co_${this.tenantOverride}. Known: [${known.join(', ') || 'none'}]`,
+        },
+      };
+    }
+    const tenant = known[0];
+    if (tenant) return { tenant };
+    return {
+      reason: {
         capability: 'scoped_read',
         outcome: 'skipped',
         detail: 'no tenant in the roster to probe (set CAPABILITY_PROBE_TENANT to pin one)',
-      };
-    }
+      },
+    };
+  }
+
+  /** Registry-active first, static keys only when the registry is silent. */
+  private knownRoster(): string[] {
+    const active = this.registry?.activeCompanyIds() ?? [];
+    const roster = active.length > 0 ? active : this.apiKeys.knownCompanyIds();
+    return [...new Set(roster)].sort();
+  }
+
+  private async probeScopedRead(): Promise<ProbeReport> {
+    const pick = this.probeTenant();
+    if (pick.tenant === undefined) return pick.reason;
+    const { tenant } = pick;
     try {
       await withDeadline(
         this.surreal.withScopedCompany(tenant, PROBE_SCOPES, (db) =>
@@ -222,6 +309,14 @@ export class CapabilityProbeService implements OnApplicationBootstrap, OnApplica
    * asks the same question as the thing it monitors inherits its bugs.
    * `embedUncached` for the same reason — a cached answer proves only that
    * the cache works.
+   *
+   * Two roads lead to `degraded`. With the strict space guard on (the
+   * default) a not-warm primary never answers: `serveProvider` refuses the
+   * call with its "embedding space strict-guard" 503, which
+   * `classifyProbeFailure` reads as `degraded` — that refusal IS the
+   * wrong-width condition. With the guard off the fallback answers in its
+   * own space and the width measurement below catches it. Same outcome,
+   * same operator meaning, whichever way the flag is set.
    */
   private async probeEmbed(): Promise<ProbeReport> {
     const embedder = this.embedder;
@@ -251,10 +346,16 @@ export class CapabilityProbeService implements OnApplicationBootstrap, OnApplica
       }
       return { capability: 'embed', outcome: 'serving' };
     } catch (e) {
+      const outcome = classifyProbeFailure(e);
       return {
         capability: 'embed',
-        outcome: classifyProbeFailure(e),
-        detail: `embedder: ${probeErrorDetail(e)}`,
+        outcome,
+        detail:
+          outcome === 'degraded'
+            ? `embedder refused to answer outside the configured space: ${probeErrorDetail(e)}. ` +
+              `The primary is not warm (see its warmup status on /ready and the admin health ` +
+              `grid); it retries on its own`
+            : `embedder: ${probeErrorDetail(e)}`,
       };
     }
   }

--- a/src/metrics/capability-probe.ts
+++ b/src/metrics/capability-probe.ts
@@ -1,4 +1,4 @@
-import type { ReadinessReport } from '../common/health.service';
+import type { ReadinessChecks } from '../common/health.service';
 
 /**
  * Capability probes — the ACTIVE half of "is this capability alive".
@@ -47,7 +47,7 @@ import type { ReadinessReport } from '../common/health.service';
  */
 
 /** The checks `/ready` reports, minus its own roll-up field. */
-export type ReadinessCheck = Exclude<keyof ReadinessReport, 'ready'>;
+export type ReadinessCheck = keyof ReadinessChecks;
 
 export const CAPABILITY_NAMES = ['scoped_read', 'embed'] as const;
 export type CapabilityName = (typeof CAPABILITY_NAMES)[number];
@@ -132,10 +132,23 @@ const UNAUTHORIZED =
  * could have authorized — reporting it as a failure is how a load spike
  * turns into a page.
  */
-export function classifyProbeFailure(error: unknown): 'unauthorized' | 'busy' | 'error' {
+/**
+ * The embedder's own refusal to answer from a space other than the
+ * configured one (`EmbedderService.serveProvider`, on by default). Under
+ * that guard a not-warm primary never returns a wrong-width vector — the
+ * call is refused first — so this message IS the wrong-width condition,
+ * and it classifies as `degraded`, the same outcome the width measurement
+ * reports when the guard is off.
+ */
+const SPACE_GUARD = /embedding space strict-guard/i;
+
+export function classifyProbeFailure(
+  error: unknown,
+): 'unauthorized' | 'busy' | 'degraded' | 'error' {
   const message = error instanceof Error ? error.message : String(error);
   if (BUSY.test(message)) return 'busy';
   if (UNAUTHORIZED.test(message)) return 'unauthorized';
+  if (SPACE_GUARD.test(message)) return 'degraded';
   return 'error';
 }
 

--- a/test/admin-health-components.e2e-spec.ts
+++ b/test/admin-health-components.e2e-spec.ts
@@ -1,0 +1,68 @@
+/**
+ * The admin cockpit's health grid against a REAL SurrealDB, with the scoped
+ * pool configured (migration 0005's `brain_caller`).
+ *
+ * What this pins: the grid has a row for the scoped read path, and the
+ * grid, `/ready` and the capability probe say the same thing about the
+ * same moment — the grid does not run its own probes, it reads the
+ * readiness report and the probe's last outcome.
+ */
+import { AppFixture, createApp } from './app-fixture';
+import { CapabilityProbeService } from '../src/metrics/capability-probe.service';
+import { HealthComponentsResponseSchema } from '../src/contracts/admin/health-components.schema';
+
+describe('GET /v1/admin/health/components (real SurrealDB, scoped pool on)', () => {
+  let f: AppFixture;
+  const auth = () => ({ Authorization: `Bearer ${f.apiKey}` });
+
+  beforeAll(async () => {
+    f = await createApp({ companyId: 'co_health_grid_e2e', enableScopedPool: true });
+  });
+
+  afterAll(async () => {
+    if (f) await f.close();
+  });
+
+  it('shows the scoped pool as its own row, agreeing with /ready', async () => {
+    const ready = await f.http.get('/ready');
+    expect(ready.status).toBe(200);
+    expect(ready.body.checks).toMatchObject({ surrealdb: 'ok', scopedPool: 'ok' });
+
+    const res = await f.http.get('/v1/admin/health/components').set(auth());
+    expect(res.status).toBe(200);
+    const parsed = HealthComponentsResponseSchema.safeParse(res.body);
+    expect(parsed.success).toBe(true);
+
+    type Row = { name: string; status: string; message?: string; latencyMs?: number };
+    const rows = res.body.components as Row[];
+    const byName = new Map<string, Row>(rows.map((c) => [c.name, c]));
+    expect(byName.get('surrealdb')).toMatchObject({ status: 'ok' });
+    expect(typeof byName.get('surrealdb')?.latencyMs).toBe('number');
+    // The row the cockpit never had: the caller-facing read path, authorized.
+    expect(byName.get('scoped pool (brain_caller)')).toMatchObject({ status: 'ok' });
+    expect(byName.get('scoped pool (brain_caller)')?.message).toContain('authorizes reads');
+    // The embedder row is named by provider and reads /ready's definition.
+    const embedder = [...byName.keys()].find((n) => n.startsWith('embedder ('));
+    expect(embedder).toBeDefined();
+    expect(byName.get(embedder!)).toMatchObject({ status: 'ok' });
+  });
+
+  it("annotates the rows with the probe's last outcome once the probe has run", async () => {
+    const probe = f.app.get(CapabilityProbeService);
+    const reports = await probe.runOnce();
+    // The scoped read went through the real tenant database; the embed is
+    // the fixture's stub, which answers in the configured space.
+    expect(reports.find((r) => r.capability === 'scoped_read')?.outcome).toBe('serving');
+
+    const res = await f.http.get('/v1/admin/health/components').set(auth());
+    const scoped = res.body.components.find(
+      (c: { name: string }) => c.name === 'scoped pool (brain_caller)',
+    ) as { status: string; message: string };
+    expect(scoped.status).toBe('ok');
+    expect(scoped.message).toMatch(/probe serving \d+s ago/);
+  });
+
+  it('is admin-only', async () => {
+    expect((await f.http.get('/v1/admin/health/components')).status).toBe(401);
+  });
+});

--- a/test/capability-probe.unit-spec.ts
+++ b/test/capability-probe.unit-spec.ts
@@ -29,6 +29,8 @@ type Stubs = {
   surreal: { withScopedCompany: jest.Mock };
   apiKeys: { knownCompanyIds: jest.Mock };
   embedder: { primaryDimensions: jest.Mock; embedUncached: jest.Mock; activeSpaceId: jest.Mock };
+  /** The registry's active roster; absent = the process has no registry wired. */
+  registry?: { activeCompanyIds: jest.Mock };
 };
 
 function makeStubs(overrides: Partial<Stubs> = {}): Stubs {
@@ -51,9 +53,15 @@ function build(stubs: Stubs): { svc: CapabilityProbeService; metrics: MetricsSer
     stubs.apiKeys as any,
     metrics,
     stubs.embedder as any,
+    stubs.registry as any,
   );
   return { svc, metrics };
 }
+
+const STRICT_GUARD_503 =
+  "embedding space strict-guard: refusing to serve a query in 'openai:text-embedding-3-small:1536' " +
+  "against rows in 'bge-m3:Xenova/bge-m3:1024' (different width). The primary embedder is not " +
+  'ready; retry once warmup completes.';
 
 /** Current value of a labelled gauge/counter series, or undefined. */
 async function series(
@@ -204,16 +212,81 @@ describe('capability probe — scoped read', () => {
     expect(await ok(metrics, 'scoped_read')).toBeUndefined();
   });
 
-  it('honours CAPABILITY_PROBE_TENANT over the roster', async () => {
+  it('honours CAPABILITY_PROBE_TENANT over the roster when it names a known tenant', async () => {
     process.env.CAPABILITY_PROBE_TENANT = 'canary';
     try {
       const stubs = makeStubs();
+      stubs.apiKeys.knownCompanyIds.mockReturnValue(['acme', 'canary']);
       const { svc } = build(stubs);
       await svc.runOnce();
       expect(stubs.surreal.withScopedCompany.mock.calls[0][0]).toBe('canary');
     } finally {
       delete process.env.CAPABILITY_PROBE_TENANT;
     }
+  });
+
+  it('refuses an UNKNOWN CAPABILITY_PROBE_TENANT loudly, without touching the database', async () => {
+    // withScopedCompany provisions the database it is handed. A typo in the
+    // override used to create co_<typo> with the full migration set on
+    // every boot — silently, while the probe reported that tenant healthy.
+    process.env.CAPABILITY_PROBE_TENANT = 'typo';
+    try {
+      const stubs = makeStubs();
+      const { svc, metrics } = build(stubs);
+      const [scoped] = await svc.runOnce();
+      expect(scoped?.outcome).toBe('error');
+      expect(scoped?.detail).toContain("CAPABILITY_PROBE_TENANT='typo'");
+      expect(scoped?.detail).toContain('co_typo');
+      expect(stubs.surreal.withScopedCompany).not.toHaveBeenCalled();
+      // Conclusive: the up-gauge goes to 0 and the alert pages the config error.
+      expect(await ok(metrics, 'scoped_read')).toBe(0);
+    } finally {
+      delete process.env.CAPABILITY_PROBE_TENANT;
+    }
+  });
+
+  it("picks the canary from the registry's ACTIVE roster before the static key set", async () => {
+    const stubs = makeStubs({
+      registry: { activeCompanyIds: jest.fn().mockReturnValue(['zed', 'beta']) },
+    });
+    const { svc } = build(stubs);
+    await svc.runOnce();
+    // Sorted for a stable canary; the static 'acme' is not consulted.
+    expect(stubs.surreal.withScopedCompany.mock.calls[0][0]).toBe('beta');
+  });
+
+  it('falls back to the static key set only when the registry knows nothing', async () => {
+    const stubs = makeStubs({ registry: { activeCompanyIds: jest.fn().mockReturnValue([]) } });
+    const { svc } = build(stubs);
+    await svc.runOnce();
+    expect(stubs.surreal.withScopedCompany.mock.calls[0][0]).toBe('acme');
+  });
+
+  it('a suspended tenant named by the override is not known — it is refused, not probed', async () => {
+    process.env.CAPABILITY_PROBE_TENANT = 'sleeper';
+    try {
+      const stubs = makeStubs({
+        registry: { activeCompanyIds: jest.fn().mockReturnValue(['acme']) },
+      });
+      const { svc } = build(stubs);
+      const [scoped] = await svc.runOnce();
+      expect(scoped?.outcome).toBe('error');
+      expect(stubs.surreal.withScopedCompany).not.toHaveBeenCalled();
+    } finally {
+      delete process.env.CAPABILITY_PROBE_TENANT;
+    }
+  });
+
+  it('remembers the last report per capability for the health surfaces', async () => {
+    const stubs = makeStubs();
+    stubs.surreal.withScopedCompany.mockRejectedValue(new Error(ANONYMOUS));
+    const { svc } = build(stubs);
+    expect(svc.lastReports()).toEqual({});
+    await svc.runOnce();
+    const last = svc.lastReports();
+    expect(last.scoped_read?.outcome).toBe('unauthorized');
+    expect(last.embed?.outcome).toBe('serving');
+    expect(Date.parse(last.scoped_read!.at)).toBeGreaterThan(0);
   });
 });
 
@@ -239,6 +312,23 @@ describe('capability probe — embed', () => {
     const { svc, metrics } = build(makeStubs());
     await svc.runOnce();
     expect(await ok(metrics, 'embed')).toBe(1);
+  });
+
+  it("reads the strict space guard's 503 as DEGRADED — the refusal is the wrong-width condition", async () => {
+    // With the guard on (the default) a not-warm primary never answers at
+    // all: serveProvider refuses first. That is the production path; the
+    // width measurement above is the flag-off path. Same outcome.
+    const stubs = makeStubs();
+    stubs.embedder.embedUncached.mockRejectedValue(new Error(STRICT_GUARD_503));
+    const { svc, metrics } = build(stubs);
+
+    const embed = (await svc.runOnce()).find((r) => r.capability === 'embed');
+
+    expect(embed?.outcome).toBe('degraded');
+    expect(embed?.detail).toContain('configured space');
+    expect(embed?.detail).toContain('strict-guard');
+    expect(await ok(metrics, 'embed')).toBe(0);
+    expect(classifyProbeFailure(new Error(STRICT_GUARD_503))).toBe('degraded');
   });
 
   it('never lets a cached answer stand in for a live one', async () => {
@@ -291,7 +381,7 @@ describe('capability probe — scheduling', () => {
     await jest.advanceTimersByTimeAsync(300_000);
 
     expect(stubs.surreal.withScopedCompany).not.toHaveBeenCalled();
-    svc.onApplicationShutdown();
+    await svc.onApplicationShutdown();
   });
 
   it('is armed by default — a forgotten flag must not recreate the blindness', async () => {
@@ -304,7 +394,7 @@ describe('capability probe — scheduling', () => {
     await jest.advanceTimersByTimeAsync(5_000);
 
     expect(stubs.surreal.withScopedCompany).toHaveBeenCalledTimes(1);
-    svc.onApplicationShutdown();
+    await svc.onApplicationShutdown();
   });
 
   it('probes on the configured interval once enabled', async () => {
@@ -315,10 +405,55 @@ describe('capability probe — scheduling', () => {
 
     svc.onApplicationBootstrap();
     await jest.advanceTimersByTimeAsync(11_000);
-    svc.onApplicationShutdown();
+    await svc.onApplicationShutdown();
 
     expect(stubs.surreal.withScopedCompany).toHaveBeenCalledTimes(2);
     expect(await ticks(metrics, 'scoped_read', 'serving')).toBe(2);
+  });
+
+  it('shutdown waits for the tick in flight instead of pulling the pool from under it', async () => {
+    setEnv('CAPABILITY_PROBE_ENABLED', '1');
+    setEnv('CAPABILITY_PROBE_INTERVAL_MS', '5000');
+    const stubs = makeStubs();
+    let release!: () => void;
+    stubs.surreal.withScopedCompany.mockReturnValue(
+      new Promise<unknown[]>((resolve) => {
+        release = () => resolve([[]]);
+      }),
+    );
+    const { svc } = build(stubs);
+
+    svc.onApplicationBootstrap();
+    await jest.advanceTimersByTimeAsync(5_000);
+    expect(stubs.surreal.withScopedCompany).toHaveBeenCalledTimes(1);
+
+    let shutDown = false;
+    const shutdown = svc.onApplicationShutdown().then(() => {
+      shutDown = true;
+    });
+    await jest.advanceTimersByTimeAsync(1_000);
+    expect(shutDown).toBe(false); // still waiting on the probe
+    release();
+    await shutdown;
+    expect(shutDown).toBe(true);
+  });
+
+  it('shutdown is bounded — a hung probe cannot hold the process open', async () => {
+    setEnv('CAPABILITY_PROBE_ENABLED', '1');
+    setEnv('CAPABILITY_PROBE_INTERVAL_MS', '5000');
+    const stubs = makeStubs();
+    stubs.surreal.withScopedCompany.mockReturnValue(new Promise(() => undefined));
+    const { svc } = build(stubs);
+
+    svc.onApplicationBootstrap();
+    await jest.advanceTimersByTimeAsync(5_000);
+    let shutDown = false;
+    const shutdown = svc.onApplicationShutdown().then(() => {
+      shutDown = true;
+    });
+    await jest.advanceTimersByTimeAsync(20_000);
+    await shutdown;
+    expect(shutDown).toBe(true);
   });
 
   it('does not stack ticks when a capability hangs', async () => {
@@ -331,7 +466,10 @@ describe('capability probe — scheduling', () => {
     svc.onApplicationBootstrap();
     // Two further ticks land inside the first probe's 15s deadline.
     await jest.advanceTimersByTimeAsync(14_000);
-    svc.onApplicationShutdown();
+    // Shutdown waits for the hung probe up to its (faked) drain bound.
+    const shutdown = svc.onApplicationShutdown();
+    await jest.advanceTimersByTimeAsync(20_000);
+    await shutdown;
 
     expect(stubs.surreal.withScopedCompany).toHaveBeenCalledTimes(1);
   });
@@ -344,7 +482,7 @@ describe('capability probe — scheduling', () => {
 
     svc.onApplicationBootstrap();
     await jest.advanceTimersByTimeAsync(6_000);
-    svc.onApplicationShutdown();
+    await svc.onApplicationShutdown();
     await jest.advanceTimersByTimeAsync(60_000);
 
     expect(stubs.surreal.withScopedCompany).toHaveBeenCalledTimes(1);
@@ -361,13 +499,15 @@ describe('capability coverage gate', () => {
    * so the next check to ship cannot quietly be deploy-time-only.
    *
    * Renaming a check is caught by the compiler instead (CAPABILITY_COVERAGE
-   * is typed on `keyof ReadinessReport`); this catches ADDING one.
+   * is typed on `keyof ReadinessChecks`); this catches ADDING one. The
+   * measurements next to the checks (`ReadinessDetail`) are not gates and
+   * are not enumerated here.
    */
   const health = readFileSync(join(__dirname, '..', 'src', 'common', 'health.service.ts'), 'utf8');
 
   function readinessChecks(): string[] {
-    const block = /export interface ReadinessReport \{([\s\S]*?)\n\}/.exec(health);
-    if (!block) throw new Error('ReadinessReport interface not found — the gate cannot run');
+    const block = /export interface ReadinessChecks \{([\s\S]*?)\n\}/.exec(health);
+    if (!block) throw new Error('ReadinessChecks interface not found — the gate cannot run');
     return [...block[1]!.matchAll(/^\s{2}(\w+)\??:/gm)]
       .map((m) => m[1]!)
       .filter((name) => name !== 'ready');

--- a/test/contracts-admin-health-components.unit-spec.ts
+++ b/test/contracts-admin-health-components.unit-spec.ts
@@ -8,6 +8,8 @@ import { AdminInfraService } from '../src/admin/admin-infra.service';
 import { HealthComponentsService } from '../src/admin/health-components.service';
 import type { SurrealService } from '../src/db/surreal.service';
 import type { EmbedderService } from '../src/ai/embedder.service';
+import type { HealthService } from '../src/common/health.service';
+import type { CapabilityProbeService } from '../src/metrics/capability-probe.service';
 import type { IntentClassifierService } from '../src/admin/intent-classifier.service';
 import type { ChangefeedConsumerService } from '../src/audit/changefeed-consumer.service';
 
@@ -16,9 +18,28 @@ function makeController(): AdminInfraController {
     ping: async () => true,
   } as unknown as SurrealService;
   const embedder = {
-    isReady: () => true,
     cacheStats: () => ({ provider: 'bge-m3', size: 100 }),
   } as unknown as EmbedderService;
+  const health = {
+    readiness: async () => ({
+      dbOk: true,
+      scopedOk: true,
+      embedderReady: true,
+      ready: true,
+      detail: {
+        dbLatencyMs: 1,
+        scopedEnabled: true,
+        scopedLatencyMs: 2,
+        embedder: { ready: true, failures: 0, inFlight: false },
+      },
+    }),
+  } as unknown as HealthService;
+  const probe = {
+    lastReports: () => ({
+      scoped_read: { capability: 'scoped_read', outcome: 'serving', at: new Date().toISOString() },
+      embed: { capability: 'embed', outcome: 'serving', at: new Date().toISOString() },
+    }),
+  } as unknown as CapabilityProbeService;
   const intent = {
     stats: () => ({ enabled: true, ready: true, model: 'mini', cacheSize: 0 }),
   } as unknown as IntentClassifierService;
@@ -36,7 +57,7 @@ function makeController(): AdminInfraController {
     }),
   } as unknown as ChangefeedConsumerService;
   const adminInfra = new AdminInfraService(surreal, undefined as never);
-  const healthComponents = new HealthComponentsService(embedder, intent, changefeed);
+  const healthComponents = new HealthComponentsService(health, probe, embedder, intent, changefeed);
   return makeAdminInfraController({ adminInfra, healthComponents });
 }
 

--- a/test/health-components.unit-spec.ts
+++ b/test/health-components.unit-spec.ts
@@ -1,0 +1,227 @@
+/**
+ * The admin health grid speaks /ready's vocabulary.
+ *
+ * Before: the cockpit pinged the root pool and asked `isReady()` on its own,
+ * had no scoped-pool row at all, and could show a green embedder while
+ * /ready said "warming". These tests pin that every row about the request
+ * path is DERIVED from HealthService.readiness() + the capability probe's
+ * last outcome, never probed a second way.
+ */
+import { HealthComponentsService } from '../src/admin/health-components.service';
+import { HealthComponentsResponseSchema } from '../src/contracts/admin/health-components.schema';
+import type { ReadinessReport } from '../src/common/health.service';
+import type { LastProbeReport } from '../src/metrics/capability-probe.service';
+import type { CapabilityName } from '../src/metrics/capability-probe';
+
+type LastReports = Partial<Record<CapabilityName, LastProbeReport>>;
+
+const READY: ReadinessReport = {
+  dbOk: true,
+  scopedOk: true,
+  embedderReady: true,
+  ready: true,
+  detail: {
+    dbLatencyMs: 3,
+    scopedEnabled: true,
+    scopedLatencyMs: 4,
+    embedder: { ready: true, failures: 0, inFlight: false },
+  },
+};
+
+type DetailOverrides = Partial<ReadinessReport['detail']>;
+
+const at = (secondsAgo: number) => new Date(Date.now() - secondsAgo * 1000).toISOString();
+
+function grid(
+  readiness: Partial<Omit<ReadinessReport, 'detail'>> & { detail?: DetailOverrides } = {},
+  last: LastReports = {},
+) {
+  const report: ReadinessReport = {
+    ...READY,
+    ...readiness,
+    detail: { ...READY.detail, ...(readiness.detail ?? {}) },
+  };
+  const svc = new HealthComponentsService(
+    { readiness: async () => report } as never,
+    { lastReports: () => last } as never,
+    { cacheStats: () => ({ provider: 'bge-m3', size: 7 }) } as never,
+    { stats: () => ({ enabled: true, ready: true, model: 'mini', cacheSize: 0 }) } as never,
+    {
+      stats: () => ({
+        enabled: false,
+        inFlight: false,
+        lastTickAt: null,
+        lastPendingRemaining: 0,
+        totalConsumed: 0,
+        tickCount: 0,
+        lastError: null,
+        sources: [],
+        perBatchLimit: 100,
+      }),
+    } as never,
+  );
+  return svc.build();
+}
+
+const row = async (name: string, ...args: Parameters<typeof grid>) => {
+  const res = await grid(...args);
+  const hit = res.components.find((c) => c.name === name);
+  if (!hit) throw new Error(`no row '${name}' in ${res.components.map((c) => c.name).join(', ')}`);
+  return hit;
+};
+
+describe('health grid — scoped pool row (the one the cockpit never had)', () => {
+  it('is ok when readiness says the read path authorizes and the probe last served', async () => {
+    const r = await row(
+      'scoped pool (brain_caller)',
+      {},
+      {
+        scoped_read: { capability: 'scoped_read', outcome: 'serving', at: at(12) },
+      },
+    );
+    expect(r.status).toBe('ok');
+    expect(r.latencyMs).toBe(4);
+    expect(r.message).toContain('authorizes reads');
+    expect(r.message).toMatch(/probe serving 1[12]s ago/);
+  });
+
+  it('is DISABLED, not ok, when the scoped pool is not configured (reads run root-authorized)', async () => {
+    // pingScoped() answers true vacuously in that state; a green row would
+    // present the absence of a fence as a healthy fence.
+    const r = await row('scoped pool (brain_caller)', { detail: { scopedEnabled: false } });
+    expect(r.status).toBe('disabled');
+    expect(r.message).toContain('SURREALDB_SCOPED_USER/PASS unset');
+  });
+
+  it('is degraded (socket fine, session cannot authorize) when readiness says scopedOk=false', async () => {
+    const r = await row('scoped pool (brain_caller)', { scopedOk: false, ready: false });
+    expect(r.status).toBe('degraded');
+    expect(r.message).toContain('unauthorized');
+  });
+
+  it("is degraded when the probe's last conclusive outcome was a failure, even if the ping just passed", async () => {
+    const r = await row(
+      'scoped pool (brain_caller)',
+      {},
+      {
+        scoped_read: {
+          capability: 'scoped_read',
+          outcome: 'unauthorized',
+          detail: 'Anonymous access not allowed',
+          at: at(30),
+        },
+      },
+    );
+    expect(r.status).toBe('degraded');
+    expect(r.message).toContain('probe unauthorized');
+    expect(r.message).toContain('Anonymous access not allowed');
+  });
+
+  it('a BUSY probe is not a failure — the row stays ok', async () => {
+    const r = await row(
+      'scoped pool (brain_caller)',
+      {},
+      {
+        scoped_read: { capability: 'scoped_read', outcome: 'busy', at: at(5) },
+      },
+    );
+    expect(r.status).toBe('ok');
+    expect(r.message).toContain('probe busy');
+  });
+
+  it('is unreachable when the database itself is down', async () => {
+    const r = await row('scoped pool (brain_caller)', {
+      dbOk: false,
+      scopedOk: false,
+      ready: false,
+    });
+    expect(r.status).toBe('unreachable');
+  });
+});
+
+describe('health grid — embedder row from the warmup bookkeeping', () => {
+  it('is ok with the cache size and the probe outcome when /ready says ready', async () => {
+    const r = await row(
+      'embedder (bge-m3)',
+      {},
+      {
+        embed: { capability: 'embed', outcome: 'serving', at: at(2) },
+      },
+    );
+    expect(r.status).toBe('ok');
+    expect(r.message).toContain('cache size 7');
+    expect(r.message).toMatch(/probe serving [0-3]s ago/);
+  });
+
+  it('is warming, with the attempt in flight, while the first warmup runs', async () => {
+    const r = await row('embedder (bge-m3)', {
+      embedderReady: false,
+      ready: false,
+      detail: { embedder: { ready: false, failures: 0, inFlight: true } },
+    });
+    expect(r.status).toBe('warming');
+    expect(r.message).toContain('attempt in flight');
+    expect(r.message).toContain('refused (503)');
+  });
+
+  it('is DEGRADED with the last error and the next retry once a warmup has failed', async () => {
+    const r = await row('embedder (bge-m3)', {
+      embedderReady: false,
+      ready: false,
+      detail: {
+        embedder: {
+          ready: false,
+          failures: 2,
+          inFlight: false,
+          lastError: 'HF 401 on tokenizer_config.json',
+          nextRetryAt: '2026-09-09T15:00:00.000Z',
+        },
+      },
+    });
+    expect(r.status).toBe('degraded');
+    expect(r.message).toContain('warmup failed 2×');
+    expect(r.message).toContain('HF 401 on tokenizer_config.json');
+    expect(r.message).toContain('next attempt at 2026-09-09T15:00:00.000Z');
+  });
+
+  it("is degraded when /ready says ready but the probe's last vector was outside the space", async () => {
+    const r = await row(
+      'embedder (bge-m3)',
+      {},
+      {
+        embed: {
+          capability: 'embed',
+          outcome: 'degraded',
+          detail: 'embedder answered 1536-wide, configured space is 1024-wide',
+          at: at(40),
+        },
+      },
+    );
+    expect(r.status).toBe('degraded');
+    expect(r.message).toContain('1536-wide');
+  });
+});
+
+describe('health grid — wire contract and provenance', () => {
+  it('matches the published schema with the new rows in place', async () => {
+    const res = await grid();
+    const parsed = HealthComponentsResponseSchema.safeParse(res);
+    expect(parsed.success).toBe(true);
+    expect(res.components.map((c) => c.name)).toEqual([
+      'surrealdb',
+      'scoped pool (brain_caller)',
+      'embedder (bge-m3)',
+      'intent classifier',
+      'openai key',
+      'changefeed consumer',
+      'calibration',
+    ]);
+  });
+
+  it('takes the database row from the readiness report, latency included — no second ping', async () => {
+    const r = await row('surrealdb', { detail: { dbLatencyMs: 9 } });
+    expect(r).toEqual({ name: 'surrealdb', status: 'ok', latencyMs: 9 });
+    const down = await row('surrealdb', { dbOk: false, scopedOk: false, ready: false });
+    expect(down.status).toBe('unreachable');
+  });
+});

--- a/test/health-ready.unit-spec.ts
+++ b/test/health-ready.unit-spec.ts
@@ -20,8 +20,12 @@ describe('HealthController', () => {
     const surreal = {
       ping: async () => opts.db,
       pingScoped: async () => opts.scoped ?? true,
+      scopedPoolEnabled: () => true,
     } as any;
-    const embedder = { isReady: () => opts.embedderReady } as any;
+    const embedder = {
+      isReady: () => opts.embedderReady,
+      warmupStatus: () => ({ ready: opts.embedderReady, failures: 0, inFlight: false }),
+    } as any;
     return new HealthController(new HealthService(surreal, embedder));
   }
 

--- a/test/test-doubles.ts
+++ b/test/test-doubles.ts
@@ -1,6 +1,6 @@
 import { createHash } from 'node:crypto';
 import type { INestApplication } from '@nestjs/common';
-import type { EmbedderService } from '../src/ai/embedder.service';
+import type { EmbedderService, EmbedderWarmupStatus } from '../src/ai/embedder.service';
 import type { ExtractorService, ExtractionResult } from '../src/ai/extractor.service';
 import type { LocalCrossEncoderProvider } from '../src/ai/cross-encoder/local-cross-encoder.provider';
 import { SynthesizeService } from '../src/synthesize/synthesize.service';
@@ -23,6 +23,9 @@ export class StubEmbedder implements Pick<
   | 'getDimensions'
   | 'primaryDimensions'
   | 'isReady'
+  | 'warmupStatus'
+  | 'cacheStats'
+  | 'embedUncached'
   | 'primarySpaceId'
   | 'activeSpaceId'
 > {
@@ -71,9 +74,24 @@ export class StubEmbedder implements Pick<
   }
 
   /** The stub is always warm: readiness must see a ready embedder, so the
-   *  probes it answers (`/ready`) exercise the database, not a model load. */
+   *  surfaces it feeds (`/ready`, the admin health grid) exercise the
+   *  database, not a model load. */
   isReady(): boolean {
     return true;
+  }
+
+  warmupStatus(): EmbedderWarmupStatus {
+    return { ready: true, failures: 0, inFlight: false };
+  }
+
+  /** What the admin health grid names the embedder row by. */
+  cacheStats(): { size: number; inFlight: number; waiting: number; provider: string } {
+    return { size: 0, inFlight: 0, waiting: 0, provider: 'stub' };
+  }
+
+  /** The capability probe's uncached call — the stub has no cache to bypass. */
+  async embedUncached(text: string): Promise<number[]> {
+    return this.embed(text);
   }
 
   primaryDimensions(): number {


### PR DESCRIPTION
Findings A-5, M-6, M-7, M-8, A-10 from the #501-wave review plan, on top of #518/#521/#522/#533.

## The problem
Three definitions of "healthy". `/ready` checked the scoped pool and the embedder; the admin cockpit (`/v1/admin/health/components`) pinged the **root** pool and asked `isReady()` on its own, with **no scoped-pool row at all** — the state #502 and #511 were written for was invisible on the one surface an operator looks at; the capability probe published to metrics only.

## Change
- **A-5** — `HealthService.readiness()` is THE report: the three gate checks (`ReadinessChecks`, which `CAPABILITY_COVERAGE` and the source-level gate in the probe spec key on) plus a `detail` block (latencies, whether the scoped pool is configured, the embedder's warmup bookkeeping from #518). `HealthComponentsService.build()` reads it — no second ping — and annotates the database / scoped-pool / embedder rows with the probe's last outcome (`probe serving 12s ago`, or the failure with its detail). A disabled scoped pool shows as `disabled`, not green; a session that cannot authorize shows as `degraded`. `HealthService` moves to the global `CommonModule`. **Wire shape unchanged** (same rows, same status enum): the landing's duplicate schema still parses it.
- **M-6** — with the strict space guard on (default) a not-warm primary is refused with its 503 before a wrong-width vector can exist, so `degraded` was unreachable in production. The refusal now classifies as `degraded` (`classifyProbeFailure`); the width measurement stays for the flag-off path. Same outcome either way.
- **M-7** — `CAPABILITY_PROBE_TENANT` must name a tenant the process knows (registry active roster or `BRAIN_API_KEYS`). `withScopedCompany` provisions the database it is handed, so a typo used to create `co_<typo>` with the full migration set on every boot. An unknown **or suspended** override is refused before any connection is taken and reported as a conclusive `error` — it pages as the configuration mistake it is.
- **M-8** — `onApplicationShutdown` waits (bounded, 16 s) for a tick in flight instead of letting Nest tear the pool down underneath it.
- **A-10** — the canary tenant comes from the tenant registry's ACTIVE roster (sorted); the static key set stands in only when the registry knows nothing. Other sweeps still iterate `apiKeys.knownCompanyIds()` — out of scope here, listed below.
- Runbook § Capability probes documents the canary source, the override rule, `degraded`'s two roads and the cockpit.
- `StubEmbedder` gains `isReady/warmupStatus/cacheStats/embedUncached`: `/ready` and the cockpit had never been exercised end to end against the stub, and both threw. (#535 adds `isReady` to the same stub — a one-line overlap to resolve on whichever lands second.)

## Proof
- `test/health-components.unit-spec.ts` (new, 12): scoped row ok / disabled / degraded / unreachable; the probe's conclusive failure folds into the row; `busy` is not a failure; embedder `warming` (attempt in flight) vs `degraded` (failed N×, last error, next retry); the row order and the published schema; the database row is the readiness report's, latency included.
- `test/capability-probe.unit-spec.ts` (+8): known override honoured; unknown override → `error`, no DB call, up-gauge 0; registry-active roster first, static fallback; suspended override refused; strict-guard 503 → `degraded`; `lastReports()`; shutdown waits for the in-flight tick and is bounded for a hung one.
- `test/admin-health-components.e2e-spec.ts` (new, real SurrealDB, scoped pool on): the grid parses against the schema, agrees with `/ready`, has the scoped-pool row `ok` with latency, the embedder row `ok`; after `runOnce()` the row carries `probe serving Ns ago`; admin-only (401).
- Existing `capability-probe.e2e-spec` still green. Unit 45/45, e2e 6/6, tsc app + spec, eslint, prettier clean.

## Left out
- Every other background sweep still reads `apiKeys.knownCompanyIds()` (calibration, compaction, changefeed, dreams, jobs, …) — the same two-roster issue, one shared change; not touched here.
- `config-catalog.data.ts` description of `CAPABILITY_PROBE_TENANT` (now "must be a known tenant") — another open PR owns that file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhrQxeisXJZEt4sg3PGyU6