### PR TITLE
fix(vectors): width-gate every cosine scan, census the corpus, and repair it on boot and nightly

### DIFF
--- a/src/admin/admin-embedding-space.controller.ts
+++ b/src/admin/admin-embedding-space.controller.ts
@@ -13,6 +13,11 @@ import { AuthenticatedRequest } from '../auth/api-key.types';
 import { ApiKeyService } from '../auth/api-key.service';
 import { resolvePlatformTenant } from '../auth/tenant-scope';
 import {
+  VectorCorpusService,
+  type VectorCorpusInventory,
+  type VectorCorpusRepairResult,
+} from './vector-corpus.service';
+import {
   EmbeddingSpaceService,
   type EmbeddingSpaceState,
 } from '../ai/embedder/embedding-space.service';
@@ -58,6 +63,7 @@ export class AdminEmbeddingSpaceController {
   constructor(
     private readonly spaces: EmbeddingSpaceService,
     private readonly apiKeys: ApiKeyService,
+    private readonly corpus: VectorCorpusService,
   ) {}
 
   private tenant(req: AuthenticatedRequest, requested?: string): string {
@@ -74,6 +80,34 @@ export class AdminEmbeddingSpaceController {
     @Query('tenant') tenant?: string,
   ): Promise<EmbeddingSpaceState> {
     return this.spaces.getState(this.tenant(req, tenant));
+  }
+
+  /**
+   * Read-only census: every vector column counted by stored width and
+   * space against the primary embedder. A non-zero `nonConforming` is
+   * memory that dense retrieval cannot reach (the width gate skips it);
+   * `repairable` is what POST repair (or the nightly pass) re-embeds.
+   */
+  @Get('inventory')
+  @RequireScopes('brain:admin')
+  async inventory(
+    @Req() req: AuthenticatedRequest,
+    @Query('tenant') tenant?: string,
+  ): Promise<VectorCorpusInventory> {
+    return this.corpus.inventory(this.tenant(req, tenant));
+  }
+
+  /**
+   * Census, then re-embed every repairable row with the primary embedder
+   * (the same sweep the nightly pass runs), recorded as a reindex job run.
+   */
+  @Post('repair')
+  @RequireScopes('brain:admin')
+  async repair(
+    @Req() req: AuthenticatedRequest,
+    @Body() body: { tenant?: string } = {},
+  ): Promise<VectorCorpusRepairResult> {
+    return this.corpus.reconcileTenant(this.tenant(req, body.tenant), 'manual');
   }
 
   /** Phase 1 — arm shadow dual-write into the target space. */

--- a/src/admin/admin.module.ts
+++ b/src/admin/admin.module.ts
@@ -55,6 +55,7 @@ import { SceneVersionService } from './scene-version';
 import { SceneGistEmbeddingService } from './scene-gist-embedding.service';
 import { HnswMaintenanceService } from './hnsw-maintenance.service';
 import { HnswProvisionService } from './hnsw-provision.service';
+import { VectorCorpusService } from './vector-corpus.service';
 import { CodeMemoryModule } from '../code-memory/code-memory.module';
 import { RegistryModule } from '../registry/registry.module';
 import { IndexersModule } from '../indexers/indexers.module';
@@ -127,6 +128,7 @@ import { ConfigInspectorService } from './config-inspector.service';
     AdminService,
     HnswMaintenanceService,
     HnswProvisionService,
+    VectorCorpusService,
     AggregateComposerService,
     ArcComposerService,
     WindowDeriverService,

--- a/src/admin/vector-corpus.service.ts
+++ b/src/admin/vector-corpus.service.ts
@@ -1,0 +1,352 @@
+import { Injectable, Logger, OnModuleInit, Optional } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import type { Surreal } from 'surrealdb';
+import { ApiKeyService } from '../auth/api-key.service';
+import { TenantRegistryService } from '../auth/tenant-registry.service';
+import { SurrealService } from '../db/surreal.service';
+import { EmbedderService } from '../ai/embedder.service';
+import { VECTOR_COLUMNS } from '../ai/embedder/embedding-space';
+import { ReindexEmbeddingsService } from '../ai/embedder/reindex-embeddings.service';
+import { REINDEX_SWEPT_COLUMNS } from '../ai/embedder/reindex-engine.service';
+import { JobRunService } from '../jobs/job-run.service';
+import { MetricsService } from '../metrics/metrics.service';
+import { DistributedLeaseGuard } from '../common/distributed-lease.guard';
+import { InFlightGuard } from '../common/in-flight-guard';
+
+/** One vector column of one tenant, counted by stored width and space. */
+export interface VectorColumnCensus {
+  table: string;
+  field: string;
+  /** `reindex` — the reindex sweep re-embeds this column from stored text;
+   *  `producer` — the vector is derived by its own pass (summaries,
+   *  triggers, admin-supplied centroids) and only that pass can rewrite it. */
+  repair: 'reindex' | 'producer';
+  /** Rows holding a vector at all. */
+  rows: number;
+  byWidth: Array<{ width: number; spaceId: string | null; count: number }>;
+  conforming: number;
+  nonConforming: number;
+}
+
+export interface VectorCorpusInventory {
+  companyId: string;
+  /** The primary space every conforming row must be in. */
+  spaceId: string;
+  dimension: number;
+  columns: VectorColumnCensus[];
+  nonConforming: number;
+  /** Non-conforming rows the reindex sweep can repair. */
+  repairable: number;
+  /** Non-conforming rows only their producer can rewrite. */
+  producerOwned: number;
+}
+
+export interface VectorCorpusRepairResult {
+  companyId: string;
+  before: VectorCorpusInventory;
+  after: VectorCorpusInventory | null;
+  /** `repaired` — a sweep ran; `nothing_to_repair`; `embedder_not_ready` —
+   *  deferred (the next hook or nightly pass retries); `failed`. */
+  outcome: 'repaired' | 'nothing_to_repair' | 'embedder_not_ready' | 'failed';
+  error?: string;
+}
+
+interface CensusRow {
+  count?: number | bigint;
+  width?: number | bigint | null;
+  spaceId?: string | null;
+}
+
+const LOCK_KEY = 'vector-corpus-reconcile';
+const LEASE_TTL_SECONDS = 30 * 60;
+/** One operator-facing line per tenant per hour about a corpus that is still
+ *  non-conforming; the metric carries the number continuously. */
+const WARN_EVERY_MS = 60 * 60_000;
+
+/**
+ * Corpus census and self-repair for the thirteen vector columns.
+ *
+ * WHY. Every vector column is `option<array<float>>` — the store accepts a
+ * vector of any width — and the embedder that serves a deployment is chosen
+ * by EMBEDDER_PROVIDER. Change the provider (or boot with the fallback warm
+ * while the primary is not) and the corpus and the queries disagree on width.
+ * On the read side that used to be a table-wide error per query; the width
+ * gate (src/db/vector-width.ts, migration 0138) turned it into "the row is
+ * invisible". Invisible is safe, and it is still wrong: the tenant has memory
+ * that no dense query can reach. This service is the actuator that makes it
+ * right again, and the census that says how far from right it is.
+ *
+ * HOW. On every tenant's schema-ready hook and once a night, count each
+ * column by `array::len(vector)` and `embeddingSpaceId`. Rows whose width is
+ * not the primary embedder's are non-conforming. For the columns the reindex
+ * sweep owns (knowledge facts, entities, predicates, episodes, segments,
+ * scene gists, strategies — REINDEX_SWEPT_COLUMNS) the repair is the sweep
+ * itself, run for that tenant, recorded as a `reindex_embeddings` job run so
+ * it is visible where every other reindex is. Producer-owned columns
+ * (community summaries, procedural triggers, admin-supplied lens centroids,
+ * beliefs, fragments) are reported and counted; only their own pass can
+ * rewrite them. Nothing here is behind a flag: a corpus the serving model
+ * cannot read is a bug, not a configuration.
+ *
+ * The repair re-embeds from stored text with the PRIMARY embedder, so it is
+ * deferred (not skipped) while the primary is still warming — the fallback
+ * would only write the wrong width again.
+ */
+@Injectable()
+export class VectorCorpusService implements OnModuleInit {
+  private readonly logger = new Logger(VectorCorpusService.name);
+  private readonly local = new InFlightGuard();
+  private readonly pending = new Set<string>();
+  private readonly seen = new Set<string>();
+  private readonly warnedAt = new Map<string, number>();
+  private draining = false;
+
+  // eslint-disable-next-line max-params
+  constructor(
+    private readonly surreal: SurrealService,
+    private readonly embedder: EmbedderService,
+    private readonly reindex: ReindexEmbeddingsService,
+    private readonly apiKeys: ApiKeyService,
+    @Optional() private readonly jobs?: JobRunService,
+    @Optional() private readonly registry?: TenantRegistryService,
+    @Optional() private readonly metrics?: MetricsService,
+    @Optional() private readonly guard?: DistributedLeaseGuard,
+  ) {}
+
+  onModuleInit(): void {
+    this.surreal.onTenantSchemaReady((companyId) => this.noteTenant(companyId));
+  }
+
+  /** A tenant whose schema just became ready gets one census (and repair). */
+  noteTenant(companyId: string): void {
+    if (this.seen.has(companyId) || this.pending.has(companyId)) return;
+    this.pending.add(companyId);
+    void this.drain();
+  }
+
+  private async drain(): Promise<void> {
+    if (this.draining) return;
+    this.draining = true;
+    try {
+      for (const companyId of this.pending) {
+        this.pending.delete(companyId);
+        this.seen.add(companyId);
+        try {
+          await this.reconcileTenant(companyId, 'startup');
+        } catch (e) {
+          this.logger.warn(`vector corpus census failed for ${companyId}: ${(e as Error).message}`);
+        }
+      }
+    } finally {
+      this.draining = false;
+    }
+  }
+
+  /** 05:40 UTC — after the HNSW provisioning sweep (05:10). */
+  @Cron('40 5 * * *', { timeZone: 'UTC' })
+  async runNightly(): Promise<VectorCorpusRepairResult[]> {
+    const run = this.guard
+      ? await this.guard.run(LOCK_KEY, () => this.reconcileAll('cron'), LEASE_TTL_SECONDS)
+      : await this.local.run(LOCK_KEY, () => this.reconcileAll('cron'));
+    if (run === null) {
+      this.logger.warn('vector corpus reconcile skipped — a previous run is still in flight');
+      return [];
+    }
+    return run;
+  }
+
+  async reconcileAll(trigger: 'cron' | 'manual' = 'manual'): Promise<VectorCorpusRepairResult[]> {
+    const results: VectorCorpusRepairResult[] = [];
+    const totals = new Map<string, number>();
+    let tenantsNonConforming = 0;
+    for (const companyId of this.roster()) {
+      try {
+        const r = await this.reconcileTenant(companyId, trigger);
+        results.push(r);
+        const final = r.after ?? r.before;
+        if (final.nonConforming > 0) tenantsNonConforming++;
+        for (const c of final.columns) {
+          const key = `${c.table}.${c.field}`;
+          totals.set(key, (totals.get(key) ?? 0) + c.nonConforming);
+        }
+      } catch (e) {
+        this.logger.warn(
+          `vector corpus reconcile failed for ${companyId}: ${(e as Error).message}`,
+        );
+      }
+    }
+    if (this.metrics) {
+      for (const col of VECTOR_COLUMNS) {
+        this.metrics.setVectorCorpusNonconforming(
+          col.table,
+          col.field,
+          totals.get(`${col.table}.${col.field}`) ?? 0,
+        );
+      }
+      this.metrics.setVectorCorpusTenantsNonconforming(tenantsNonConforming);
+    }
+    return results;
+  }
+
+  /**
+   * Census, then repair what the sweep can repair. The census runs on the
+   * root pool: it reads counts, never rows, and is the operator's view.
+   */
+  async reconcileTenant(
+    companyId: string,
+    trigger: 'startup' | 'cron' | 'manual',
+  ): Promise<VectorCorpusRepairResult> {
+    const before = await this.inventory(companyId);
+    if (before.nonConforming === 0) {
+      return { companyId, before, after: null, outcome: 'nothing_to_repair' };
+    }
+    this.warnOnce(companyId, before);
+    if (before.repairable === 0) {
+      return { companyId, before, after: null, outcome: 'nothing_to_repair' };
+    }
+    if (!this.embedder.isReady()) {
+      this.logger.warn(
+        `vector corpus repair for ${companyId} deferred: ${before.repairable} row(s) need the ` +
+          `primary embedder (${before.spaceId}) and it is not ready yet; retried on the next pass`,
+      );
+      this.metrics?.countVectorCorpusRepair('deferred');
+      return { companyId, before, after: null, outcome: 'embedder_not_ready' };
+    }
+    const run = await this.jobs?.start({
+      jobType: 'reindex_embeddings',
+      companyId,
+      triggeredBy: trigger === 'manual' ? 'manual' : trigger,
+      initialProgress: {
+        reason: 'vector_corpus_repair',
+        tenantFilter: companyId,
+        nonConforming: before.nonConforming,
+        repairable: before.repairable,
+      },
+    });
+    try {
+      const sweep = await this.reindex.run({ tenant: companyId, allTables: true });
+      const after = await this.inventory(companyId);
+      await this.jobs?.finish(run!, {
+        status: 'succeeded',
+        result: {
+          factsScanned: sweep.factsScanned,
+          factsUpdated: sweep.factsUpdated,
+          tables: sweep.tables ?? [],
+          nonConformingBefore: before.nonConforming,
+          nonConformingAfter: after.nonConforming,
+        },
+      });
+      this.metrics?.countVectorCorpusRepair(after.repairable === 0 ? 'repaired' : 'partial');
+      this.logger.log(
+        `vector corpus repair for ${companyId}: ${before.repairable} non-conforming row(s) ` +
+          `re-embedded into ${before.spaceId}; ${after.nonConforming} remain` +
+          `${after.producerOwned > 0 ? ` (${after.producerOwned} producer-owned)` : ''}`,
+      );
+      return { companyId, before, after, outcome: 'repaired' };
+    } catch (e) {
+      const message = (e as Error).message;
+      await this.jobs?.finish(run!, {
+        status: 'failed',
+        error: { message, name: (e as Error).name },
+      });
+      this.metrics?.countVectorCorpusRepair('failed');
+      this.logger.error(`vector corpus repair for ${companyId} failed: ${message}`);
+      return { companyId, before, after: null, outcome: 'failed', error: message };
+    }
+  }
+
+  /** Read-only census of every vector column. */
+  async inventory(companyId: string): Promise<VectorCorpusInventory> {
+    const dimension = this.embedder.primaryDimensions();
+    const spaceId = this.embedder.primarySpaceId();
+    const columns = await this.surreal.withCompany(companyId, async (db) => {
+      const out: VectorColumnCensus[] = [];
+      for (const col of VECTOR_COLUMNS) {
+        out.push(await this.censusColumn(db, col, dimension));
+      }
+      return out;
+    });
+    const nonConforming = columns.reduce((n, c) => n + c.nonConforming, 0);
+    const repairable = columns
+      .filter((c) => c.repair === 'reindex')
+      .reduce((n, c) => n + c.nonConforming, 0);
+    return {
+      companyId,
+      spaceId,
+      dimension,
+      columns,
+      nonConforming,
+      repairable,
+      producerOwned: nonConforming - repairable,
+    };
+  }
+
+  private async censusColumn(
+    db: Surreal,
+    col: { table: string; field: string },
+    dimension: number,
+  ): Promise<VectorColumnCensus> {
+    const { table, field } = col;
+    // `table`/`field` come from VECTOR_COLUMNS, never from a caller.
+    // embeddingSpaceId is NONE on tables that never got the column (0101
+    // added it to the swept tables, 0132 to lens_suppression) — the width is
+    // what decides conformance; the space id is reported for the operator.
+    const [rows] = await db.query<[CensusRow[]]>(
+      `SELECT count() AS count, array::len(${field}) AS width, embeddingSpaceId AS spaceId
+         FROM ${table}
+        WHERE ${field} != NONE
+        GROUP BY width, spaceId`,
+    );
+    const byWidth = ((rows as CensusRow[]) ?? [])
+      .map((r) => ({
+        width: Number(r.width ?? 0),
+        spaceId: typeof r.spaceId === 'string' ? r.spaceId : null,
+        count: Number(r.count ?? 0),
+      }))
+      .sort((a, b) => a.width - b.width || (a.spaceId ?? '').localeCompare(b.spaceId ?? ''));
+    const total = byWidth.reduce((n, r) => n + r.count, 0);
+    const conforming = byWidth
+      .filter((r) => r.width === dimension)
+      .reduce((n, r) => n + r.count, 0);
+    const repair = REINDEX_SWEPT_COLUMNS.some((c) => c.table === table && c.field === field)
+      ? 'reindex'
+      : 'producer';
+    return {
+      table,
+      field,
+      repair,
+      rows: total,
+      byWidth,
+      conforming,
+      nonConforming: total - conforming,
+    };
+  }
+
+  private warnOnce(companyId: string, inv: VectorCorpusInventory): void {
+    const last = this.warnedAt.get(companyId) ?? 0;
+    if (Date.now() - last < WARN_EVERY_MS) return;
+    this.warnedAt.set(companyId, Date.now());
+    const detail = inv.columns
+      .filter((c) => c.nonConforming > 0)
+      .map(
+        (c) =>
+          `${c.table}.${c.field}=${c.nonConforming}` +
+          `[${c.byWidth
+            .filter((w) => w.width !== inv.dimension)
+            .map((w) => `${w.width}${w.spaceId ? `@${w.spaceId}` : ''}×${w.count}`)
+            .join(',')}]`,
+      )
+      .join(' ');
+    this.logger.warn(
+      `vector corpus for ${companyId} has ${inv.nonConforming} row(s) not in the primary space ` +
+        `${inv.spaceId} (${inv.dimension}-wide): ${detail}. They are invisible to dense retrieval ` +
+        `until re-embedded; ${inv.repairable} repairable by the reindex sweep, ` +
+        `${inv.producerOwned} producer-owned.`,
+    );
+  }
+
+  private roster(): readonly string[] {
+    const active = this.registry?.activeCompanyIds() ?? [];
+    return active.length > 0 ? active : this.apiKeys.knownCompanyIds();
+  }
+}

--- a/src/agent-qa/agent-qa.service.ts
+++ b/src/agent-qa/agent-qa.service.ts
@@ -398,7 +398,7 @@ export class AgentQaService {
           `SELECT predicate, object, validFrom,
                     vector::similarity::cosine(embedding, $q) AS score
                FROM knowledge_fact
-              WHERE status = 'active' AND embedding != NONE ${versionClause}
+              WHERE status = 'active' AND embedding != NONE AND array::len(embedding) = array::len($q) ${versionClause}
               ORDER BY score DESC
               LIMIT 40`,
           { q: vec, dv: version },

--- a/src/ai/embedder/reindex-engine.service.ts
+++ b/src/ai/embedder/reindex-engine.service.ts
@@ -104,6 +104,17 @@ const ADDITIONAL_TABLE_SPECS: ReindexTableSpec[] = [
   },
 ];
 
+/**
+ * Every (table, field) the reindex sweep rewrites — knowledge_fact's main
+ * column plus ADDITIONAL_TABLE_SPECS. The corpus census (VectorCorpusService)
+ * classifies a non-conforming row as repairable exactly when its column is
+ * here; every other vector column is producer-owned.
+ */
+export const REINDEX_SWEPT_COLUMNS: ReadonlyArray<{ table: string; field: string }> = [
+  { table: 'knowledge_fact', field: 'embedding' },
+  ...ADDITIONAL_TABLE_SPECS.map((t) => ({ table: t.table, field: t.vectorField })),
+];
+
 /** Per-table row of the opt-in all-tables sweep, surfaced for operator audit. */
 export interface TableReindexCount {
   table: string;

--- a/src/code-memory/code-memory-search.service.ts
+++ b/src/code-memory/code-memory-search.service.ts
@@ -76,7 +76,7 @@ export class CodeMemorySearchService {
            WHERE predicate >= $prefix AND predicate < $prefixEnd
              AND status = 'active'
              AND retractedAt IS NONE
-             AND embedding != NONE
+             AND embedding != NONE AND array::len(embedding) = array::len($embedding)
              AND validFrom <= time::now()
              AND (validUntil IS NONE OR validUntil > time::now())
            ORDER BY score DESC

--- a/src/db/migrations/0138_resolve_fact_width_gate.surql
+++ b/src/db/migrations/0138_resolve_fact_width_gate.surql
@@ -13,8 +13,9 @@
 -- application code (see src/db/vector-width.ts and the truth test
 -- test/embedding-space-truth.unit-spec.ts).
 --
--- fn::resolve_facts (the batch mapper, 0129) calls fn::resolve_fact by name
--- and is unchanged.
+-- fn::resolve_facts (the batch mapper) is copied verbatim too: the positional
+-- contract lives beside the function it calls, and the doctrine test reads
+-- both from the latest file that defines fn::resolve_fact.
 
 DEFINE FUNCTION OVERWRITE fn::resolve_fact(
     $entity_id: record<knowledge_entity>,
@@ -559,4 +560,24 @@ DEFINE FUNCTION OVERWRITE fn::resolve_fact(
         bestOpponentId: $best_opp.id,
         reason: NONE
     };
+};
+
+-- Batch mapper stays in lockstep with the 27-arg signature (positional
+-- contract lives HERE, beside the function it calls — see 0071/0084).
+-- $cfg.tiebreak_window_ms / $f.update_cue are absent-tolerant: a caller
+-- that never sets them maps to NONE and the tiebreaker stays off — the
+-- batch path only carries append_only / bitemporal_event rows today,
+-- neither of which the 'bitemporal'-gated tiebreaker can touch.
+DEFINE FUNCTION OVERWRITE fn::resolve_facts($facts: array, $cfg: object) {
+    RETURN $facts.map(|$f| fn::resolve_fact(
+        type::record('knowledge_entity', $f.eid),
+        $f.predicate, $f.object, $f.object_meta, $f.embedding,
+        $f.confidence, $f.valid_from, $f.valid_until, $f.source,
+        $f.source_trust, $f.semantics, $cfg.similarity_threshold,
+        $cfg.w_confidence, $cfg.w_source_trust, $cfg.w_recency, $cfg.w_authority,
+        $cfg.reject_threshold, $cfg.margin_for_supersede,
+        $f.lang, $f.script, $f.entropy, $f.user_id, $f.derived_version,
+        $f.predicate_alias, $cfg.slot_similarity,
+        $cfg.tiebreak_window_ms, $f.update_cue
+    ));
 };

--- a/src/db/migrations/0138_resolve_fact_width_gate.surql
+++ b/src/db/migrations/0138_resolve_fact_width_gate.surql
@@ -1,0 +1,562 @@
+-- 0138: width-gate the dedup cosine inside fn::resolve_fact.
+--
+-- fn::resolve_fact is copied VERBATIM from 0129 (its latest revision) with
+-- ONE change in the $competing selection: a candidate row whose stored
+-- vector has a different width from the incoming $embedding is skipped
+-- BEFORE the cosine. On SurrealDB 3.2.4 `vector::similarity::cosine` on two
+-- vectors of different width is an error for the whole statement, and the
+-- statement here is the write path of every fact — so a single row embedded
+-- under another model (a 1536-wide OpenAI vector in a bge-m3 1024 corpus,
+-- which is exactly what the preprod tenant holds) failed every subsequent
+-- write of that entity's aspect. `AND` short-circuits (measured), so the
+-- gate is enough; the same gate now guards every cosine scan in the
+-- application code (see src/db/vector-width.ts and the truth test
+-- test/embedding-space-truth.unit-spec.ts).
+--
+-- fn::resolve_facts (the batch mapper, 0129) calls fn::resolve_fact by name
+-- and is unchanged.
+
+DEFINE FUNCTION OVERWRITE fn::resolve_fact(
+    $entity_id: record<knowledge_entity>,
+    $predicate: string,
+    $object: string,
+    $object_meta: option<object>,
+    $embedding: array<float>,
+    $confidence: float,
+    $valid_from: datetime,
+    $valid_until: option<datetime>,
+    $source: object,
+    $source_trust: float,
+    $semantics: string,
+    $similarity_threshold: float,
+    $w_confidence: float,
+    $w_source_trust: float,
+    $w_recency: float,
+    $w_authority: float,
+    $reject_threshold: float,
+    $margin_for_supersede: float,
+    $lang: option<string>,
+    $script: option<string>,
+    $entropy: option<float>,
+    $user_id: option<string>,
+    $derived_version: option<string>,
+    $predicate_alias: option<string>,
+    $slot_similarity: option<float>,
+    -- 0129: ambiguity window (ms) for the succession tiebreaker; NONE
+    -- (the flag-off / non-mention default) disables the tiebreaker.
+    $tiebreak_window_ms: option<number>,
+    -- 0129: caller-attested succession cue on the incoming object
+    -- (deterministic marker regex, computed TS-side on the mention
+    -- path only). Anything but true leaves the doctrine untouched.
+    $update_cue: option<bool>
+) {
+    -- Source key + declared authority (migration 0046): computed up front
+    -- because authority now participates in the winner's score, not just
+    -- the trust snapshot.
+    LET $src_key = fn::source_key_of($source);
+    LET $src_authority = fn::source_authority_of($src_key);
+    -- 0050: origin identity — the document (or, absent one, the source key).
+    LET $origin_key = fn::origin_key_of($source);
+
+    -- 0084: the slot gate — bitemporal_event uses its own (stricter)
+    -- cosine threshold when the caller supplies one; every other
+    -- semantics keeps the shared threshold untouched.
+    LET $eff_similarity = IF $semantics = 'bitemporal_event' THEN
+        ($slot_similarity ?? $similarity_threshold)
+    ELSE
+        $similarity_threshold
+    END;
+
+    -- 0083: event-time recency for bitemporal_event — the new row's
+    -- recency decays from ITS validFrom exactly like the incumbents'
+    -- below, so two rows of one batch derive compare by event date, not
+    -- by the shared wall-clock write moment.
+    LET $new_recency = IF $semantics = 'bitemporal_event' THEN
+        math::pow(math::E, - duration::secs(time::now() - $valid_from) / 31536000)
+    ELSE
+        1.0
+    END;
+
+    LET $new_score =
+        $w_confidence * $confidence
+        + $w_source_trust * $source_trust
+        + $w_recency * $new_recency
+        + $w_authority * $src_authority;
+
+    -- 0083: the reject gate covers both bitemporal forms (derived rows
+    -- score ~0.65 with the deriver's constants — comfortably above the
+    -- 0.30 default, so lifecycle-on derive is not dead-letter-prone).
+    IF ($semantics = 'bitemporal' OR $semantics = 'bitemporal_event') AND $new_score < $reject_threshold {
+        CREATE ingest_dead_letter CONTENT {
+            payload: { entityId: $entity_id, predicate: $predicate, object: $object, source: $source },
+            reason: 'low_score: ' + <string>$new_score
+        };
+        RETURN { outcome: 'REJECTED', factId: NONE, reason: 'low_score' };
+    };
+
+    LET $candidates = SELECT
+        id, predicate, predicateAlias, object, confidence, recordedAt, source,
+        embedding, validFrom, validUntil
+    FROM knowledge_fact
+    WHERE entityId = $entity_id
+      -- 0082: resolution keys on the CANONICAL predicate — a coined
+      -- predicate meets every other coinage of the same canon. Rows and
+      -- calls without an alias reduce to the old `predicate = $predicate`.
+      AND (predicateAlias ?? predicate) = ($predicate_alias ?? $predicate)
+      -- 0085 (F3): bitemporal_event re-admits COMPETING rows — a stuck
+      -- same-day pair must be closable by the next strictly-later-day
+      -- update; 0084's 'active'-only pool left the slot broken forever
+      -- (both contested rows invisible, the update inserted plainly).
+      -- 0129: the SAME F3 doctrine for an ARMED, cue-bearing
+      -- 'bitemporal' resolve — measured live (memfit-tb-1): a competing
+      -- pair in a promoted slot was PERMANENT ("package manager is
+      -- pnpm" ↔ "…queue backend is Redis Streams" stayed competing
+      -- forever, every later update INSERTED past it on an empty pool,
+      -- and serving kept abstaining on the queue value). Re-admission
+      -- is gated on window+cue, so a flag-off / no-cue / direct-path
+      -- call sees the byte-identical active-only pool.
+      AND (status = 'active'
+           OR (status = 'competing' AND $semantics = 'bitemporal_event')
+           OR (status = 'competing' AND $semantics = 'bitemporal'
+               AND $tiebreak_window_ms != NONE AND $update_cue = true))
+      AND retractedAt IS NONE
+      -- 0055: conflict resolution is scope-local. A personal fact only
+      -- ever meets facts of the SAME user; a tenant-global fact only
+      -- meets tenant-global ones.
+      AND (IF $user_id IS NONE THEN userId IS NONE ELSE userId = $user_id END)
+      -- 0079: conflict resolution is namespace-local. A derived fact only
+      -- ever meets facts of the SAME derivedVersion; a live-world fact
+      -- only meets live-world ones — a re-derivation cannot supersede,
+      -- compete with, or corroborate the incumbent world.
+      AND (IF $derived_version IS NONE THEN derivedVersion IS NONE ELSE derivedVersion = $derived_version END);
+
+    -- 0083: bitemporal_event takes the same similarity+interval-gated
+    -- pool as bitemporal (the ELSE branch) — the gate is what keeps
+    -- aspect CLASSES from colliding.
+    -- 0084: gated on the EFFECTIVE threshold (slot-specific for
+    -- bitemporal_event, shared for everything else).
+    LET $competing = IF $semantics = 'append_only' THEN
+        []
+    ELSE IF $semantics = 'single_active' THEN
+        $candidates
+    ELSE
+        (SELECT * FROM $candidates
+            WHERE embedding != NONE
+              -- 0138: a competitor of another width is not a competitor.
+              -- vector::similarity::cosine aborts the WHOLE statement when the
+              -- two vectors differ in width, so one foreign-width row in the
+              -- candidate set used to fail every write for that entity; AND
+              -- short-circuits, so the cosine never sees such a row now.
+              AND array::len(embedding) = array::len($embedding)
+              AND vector::similarity::cosine(embedding, $embedding) >= $eff_similarity
+              AND fn::intervals_overlap(validFrom, validUntil, $valid_from, $valid_until))
+    END;
+
+    -- Trust snapshot (migration 0044): what the resolver believes about this
+    -- source RIGHT NOW, frozen onto the fact. learnedTrust is read before
+    -- any nightly refit can overwrite the source_trust row. Scoped lookup
+    -- since migration 0045; declared authority since 0046; originKey since
+    -- 0050.
+    LET $new = CREATE ONLY knowledge_fact CONTENT {
+        entityId: $entity_id,
+        predicate: $predicate,
+        predicateAlias: $predicate_alias,
+        object: $object,
+        objectMeta: $object_meta,
+        confidence: $confidence,
+        validFrom: $valid_from,
+        validUntil: $valid_until,
+        source: $source,
+        embedding: $embedding,
+        status: 'active',
+        userId: $user_id,
+        derivedVersion: $derived_version,
+        trustSnapshot: {
+            sourceKey: $src_key,
+            originKey: $origin_key,
+            domain: $predicate,
+            declaredTrust: $source_trust,
+            learnedTrust: fn::source_trust_scoped($src_key, $predicate),
+            authority: $src_authority,
+            calculatedAt: time::now()
+        }
+    };
+
+    -- 0083: the create-returned-NONE fence (V9 phase 0). Every branch
+    -- below dereferences $new.id; when the CREATE evaluates to NONE the
+    -- old body died on the first UPDATE with "Cannot execute UPDATE
+    -- statement using value: NONE" and took the whole fn::resolve_facts
+    -- batch (= one conversation of derive) with it. Fail the ROW, keep
+    -- the batch.
+    IF $new = NONE OR $new.id = NONE {
+        CREATE ingest_dead_letter CONTENT {
+            payload: { entityId: $entity_id, predicate: $predicate, object: $object, source: $source },
+            reason: 'create_returned_none'
+        };
+        RETURN { outcome: 'REJECTED', factId: NONE, reason: 'create_returned_none' };
+    };
+
+    -- Corroboration (migration 0047): the SAME claim from a DIFFERENT
+    -- source is independent confirmation, not a duel. Keep the new row as
+    -- the audit record of the second claim; strengthen the incumbent.
+    -- Runs before the backdated guard — claim identity beats date order.
+    -- 0050: independence is decided by ORIGIN, not recorder — two indexers
+    -- reading one document are the same origin and must not corroborate.
+    -- 0082: append_only pools over $candidates ($competing is [] by
+    -- definition, which used to make corroboration unreachable for the
+    -- open-vocabulary bulk); other semantics keep the $competing pool.
+    LET $corr_pool = IF $semantics = 'append_only' THEN $candidates ELSE $competing END;
+    LET $corroborated = (SELECT id, recordedAt FROM $corr_pool
+        WHERE object = $object
+          AND fn::origin_key_of(source) != $origin_key
+        ORDER BY recordedAt DESC LIMIT 1)[0];
+
+    IF $corroborated != NONE {
+        UPDATE $new.id SET
+            status = 'corroborating',
+            corroborates = $corroborated.id;
+        UPDATE $corroborated.id SET corroboration = {
+            -- 0051: count is the number of DISTINCT corroborating origins,
+            -- derived from the deduped set — a repeated origin leaves both
+            -- the union and the count unchanged.
+            count: array::len(array::union(
+                IF corroboration IS NONE OR corroboration.originKeys IS NONE THEN [] ELSE corroboration.originKeys END,
+                [$origin_key]
+            )),
+            sourceKeys: array::union(
+                IF corroboration IS NONE THEN [] ELSE corroboration.sourceKeys END,
+                [$src_key]
+            ),
+            originKeys: array::union(
+                IF corroboration IS NONE OR corroboration.originKeys IS NONE THEN [] ELSE corroboration.originKeys END,
+                [$origin_key]
+            ),
+            lastAt: time::now()
+        };
+        RETURN {
+            outcome: 'CORROBORATED',
+            factId: $new.id,
+            corroboratedFactId: $corroborated.id,
+            reason: NONE
+        };
+    };
+
+    -- 0129: restatement dedup for ARMED 'bitemporal' resolves. The
+    -- corroboration branch above deliberately requires a DIFFERENT
+    -- origin (0050), so a same-origin repeat of the SAME object falls
+    -- through to the margin doctrine and — at the batch-shaped ~0
+    -- margin — lands a COMPETING pair of two IDENTICAL values
+    -- (measured live: (ledger-sync, name) = "ledger-sync" twice, both
+    -- competing), and that phantom conflict noise feeds serving
+    -- abstention. A restatement is neither an update nor a
+    -- contradiction: keep the incumbent untouched (NO corroboration
+    -- count/keys update — 0051's distinct-origin inflation guard
+    -- stands) and close the new row as corroborating it. Gated on the
+    -- armed-call marker ($tiebreak_window_ms bound ⇒ flag on + mention
+    -- path), cue NOT required — a restatement rarely carries one.
+    IF $semantics = 'bitemporal' AND $tiebreak_window_ms != NONE {
+        LET $restated = (SELECT id, recordedAt FROM $competing
+            WHERE object = $object
+              AND fn::origin_key_of(source) = $origin_key
+            ORDER BY recordedAt DESC LIMIT 1)[0];
+        IF $restated != NONE {
+            UPDATE $new.id SET
+                status = 'corroborating',
+                corroborates = $restated.id;
+            RETURN {
+                outcome: 'CORROBORATED',
+                factId: $new.id,
+                corroboratedFactId: $restated.id,
+                reason: 'restated'
+            };
+        };
+    };
+
+    IF array::len($competing) = 0 {
+        -- Locale + entropy folded in from the caller (migration 0039). Applied
+        -- on INSERTED only, matching the old post-call UPDATE gate.
+        IF $lang != NONE {
+            UPDATE $new.id SET lang = $lang, script = $script;
+        };
+        IF $entropy != NONE {
+            UPDATE $new.id SET extractionEntropy = $entropy;
+        };
+        RETURN { outcome: 'INSERTED', factId: $new.id, reason: NONE };
+    };
+
+    -- Backdated guard (migration 0043): a candidate with a STRICTLY NEWER
+    -- validFrom means the incoming fact is history. Slot it before the
+    -- next-newer decision as an already-superseded row; the active
+    -- timeline stays exactly as if events had arrived in order.
+    -- 0083: extended to bitemporal_event — its pool is similarity+interval
+    -- gated, so "history of the same claim" is exactly what a newer
+    -- candidate there means (a re-derived old session must not pollute
+    -- current-value reads).
+    -- 0084: bitemporal_event compares at DAY granularity — a same-day
+    -- incumbent with a later time-of-day must not turn the incoming row
+    -- into history (the event data carries day precision only).
+    LET $next_after = IF $semantics = 'single_active' THEN
+        (SELECT id, validFrom FROM $competing
+            WHERE validFrom > $valid_from
+            ORDER BY validFrom ASC LIMIT 1)[0]
+    ELSE IF $semantics = 'bitemporal_event' THEN
+        (SELECT id, validFrom FROM $competing
+            WHERE time::floor(validFrom, 1d) > time::floor($valid_from, 1d)
+            ORDER BY validFrom ASC LIMIT 1)[0]
+    ELSE
+        NONE
+    END;
+
+    IF $next_after != NONE {
+        -- Same sentinel shape as a natural supersede (no retractedAt —
+        -- migration 0014; retractionReason 'superseded' feeds revive +
+        -- calibration).
+        UPDATE $new.id SET
+            status = 'superseded',
+            retractionReason = 'superseded',
+            retractedBy = 'system',
+            supersededBy = $next_after.id,
+            priorValidUntil = $valid_until,
+            validUntil = $next_after.validFrom;
+        RETURN {
+            outcome: 'INSERTED_HISTORICAL',
+            factId: $new.id,
+            supersededByFactId: $next_after.id,
+            reason: 'backdated'
+        };
+    };
+
+    LET $scored = SELECT
+        id,
+        confidence,
+        source,
+        validFrom,
+        object,
+        predicate,
+        $w_confidence * confidence AS sc_confidence,
+        $w_source_trust * fn::source_trust_scoped(fn::source_key_of(source), $predicate) AS sc_source_trust,
+        -- 0083: incumbents decay from validFrom under bitemporal_event
+        -- (event-time recency); every other semantics keeps recordedAt.
+        $w_recency * math::pow(math::E, - duration::secs(time::now() - (IF $semantics = 'bitemporal_event' THEN validFrom ELSE recordedAt END)) / 31536000) AS sc_recency,
+        $w_authority * fn::source_authority_of(fn::source_key_of(source)) AS sc_authority,
+        ($w_confidence * confidence
+         + $w_source_trust * fn::source_trust_scoped(fn::source_key_of(source), $predicate)
+         + $w_recency * math::pow(math::E, - duration::secs(time::now() - (IF $semantics = 'bitemporal_event' THEN validFrom ELSE recordedAt END)) / 31536000)
+         + $w_authority * fn::source_authority_of(fn::source_key_of(source))
+        ) AS score
+    FROM $competing;
+
+    LET $best_opp_score = math::max($scored.score);
+    LET $best_opp = (SELECT * FROM $scored WHERE score = $best_opp_score LIMIT 1)[0];
+
+    LET $winner_components = {
+        confidence: $w_confidence * $confidence,
+        sourceTrust: $w_source_trust * $source_trust,
+        -- 0083: honest breakdown — the winner's recency term is the
+        -- event-time value actually used in $new_score.
+        recency: $w_recency * $new_recency,
+        authority: $w_authority * $src_authority
+    };
+    LET $loser_components = {
+        confidence: $best_opp.sc_confidence,
+        sourceTrust: $best_opp.sc_source_trust,
+        recency: $best_opp.sc_recency,
+        authority: $best_opp.sc_authority
+    };
+
+    LET $abs_conf = math::abs($winner_components.confidence - $loser_components.confidence);
+    LET $abs_st   = math::abs($winner_components.sourceTrust - $loser_components.sourceTrust);
+    LET $abs_rec  = math::abs($winner_components.recency - $loser_components.recency);
+    LET $abs_auth = math::abs($winner_components.authority - $loser_components.authority);
+    LET $max_abs  = math::max([$abs_conf, $abs_st, $abs_rec, $abs_auth]);
+
+    LET $dominant_dim = IF $max_abs = $abs_conf THEN 'confidence'
+                       ELSE IF $max_abs = $abs_st THEN 'source_trust'
+                       ELSE IF $max_abs = $abs_rec THEN 'recency'
+                       ELSE 'authority'
+                       END;
+
+    LET $slot_delta = {
+        predicate: ($best_opp.predicate != $predicate),
+        object: ($best_opp.object != $object),
+        validFrom: ($best_opp.validFrom != $valid_from),
+        source: ($best_opp.source != $source)
+    };
+
+    LET $score_breakdown = {
+        winner: {
+            total: $new_score,
+            confidence: $winner_components.confidence,
+            sourceTrust: $winner_components.sourceTrust,
+            recency: $winner_components.recency,
+            authority: $winner_components.authority
+        },
+        loser: {
+            total: $best_opp_score,
+            confidence: $loser_components.confidence,
+            sourceTrust: $loser_components.sourceTrust,
+            recency: $loser_components.recency,
+            authority: $loser_components.authority
+        },
+        margin: $new_score - $best_opp_score
+    };
+
+    -- 0129: the succession tiebreaker. Armed ONLY when (a) semantics is
+    -- 'bitemporal' (the promoted-slot / open-slot margin doctrine —
+    -- bitemporal_event has its own event-order doctrine above, and
+    -- single_active supersedes unconditionally), (b) the margin did NOT
+    -- already produce a clear winner (a clear winner keeps today's
+    -- pool-wide close), (c) the caller bound an ambiguity window, and
+    -- (d) the caller attested a succession cue on the incoming object.
+    -- Losers are the pool members whose event time is strictly earlier
+    -- than the incoming validFrom by MORE than the window; everyone
+    -- else (same report moment, within-window, missing validFrom) keeps
+    -- the close-margin → COMPETING flip, 0085-F1-partition style.
+    LET $margin_win = $semantics != 'bitemporal_event'
+        AND $new_score >= $best_opp_score + $margin_for_supersede;
+    LET $tb_losers = IF $semantics = 'bitemporal'
+        AND $margin_win = false
+        AND $tiebreak_window_ms != NONE
+        AND $update_cue = true
+    THEN
+        (SELECT * FROM $competing
+            WHERE validFrom != NONE
+              AND validFrom + duration::from_millis(<int> $tiebreak_window_ms) < $valid_from
+              -- 0129: an incumbent citing an EXTERNAL ARTIFACT
+              -- (document/url evidence) is a standing independent
+              -- voice — mere recency never closes it (the D6
+              -- payout-cutoff doctrine); it stays a peer and flips
+              -- COMPETING. Rows without evidence arrays (the mention
+              -- bulk) reduce to [] and pass untouched.
+              AND 'document' NOT IN (source.evidence.kind ?? [])
+              AND 'url' NOT IN (source.evidence.kind ?? []))
+    ELSE
+        []
+    END;
+    LET $tb_fire = array::len($tb_losers) > 0;
+
+    -- 0083: bitemporal_event supersedes by EVENT ORDER — a strictly
+    -- later validFrom is a knowledge update and wins decisively (the
+    -- score margin cannot express this: batch derive gives every row
+    -- the same confidence/trust/authority, so margins sit near 0 and
+    -- recordedAt-scoring left every update COMPETING forever).
+    -- 0084: the order is DAY-granular — the event data carries day
+    -- precision, so a same-day pair is genuine ambiguity and stays
+    -- COMPETING for the contradiction lane (the time-of-day asymmetry
+    -- between occurred_on T00:00 and the hh:mm sessionDate fallback
+    -- must not fabricate an update).
+    -- 0085 (F1): the 0084 decision was PAIRWISE ($best_opp) while the
+    -- action was POOL-WIDE. With a multi-row pool (cosine similarity is
+    -- not transitive, so two rows each ≥gate to the incoming update can
+    -- sit <gate to each other and both stay active) that meant: best_opp
+    -- = the earlier row → a SAME-DAY paraphrase closed as history;
+    -- best_opp = the same-day row → the strictly-older value silently
+    -- flipped to COMPETING instead of closing. bitemporal_event now
+    -- PARTITIONS the pool by day and decides per member — event order
+    -- is the whole doctrine (0083), and the margin path was declared
+    -- unreachable for batch-derived rows by 0084's own rationale, so it
+    -- no longer applies to this semantics. Strictly-earlier-DAY members
+    -- close; same-day members flip to COMPETING (the backdated guard
+    -- already returned for any strictly-later member). The pairwise
+    -- day comparison survives only inside $score_breakdown/$slot_delta
+    -- reporting.
+    -- 0129: when the succession tiebreaker fires, 'bitemporal' takes
+    -- the same partitioned shape — beyond-window-older members close,
+    -- the rest flip to COMPETING.
+    LET $losers = IF $semantics = 'bitemporal_event' THEN
+        (SELECT * FROM $competing
+            WHERE time::floor(validFrom, 1d) < time::floor($valid_from, 1d))
+    ELSE IF $tb_fire THEN
+        $tb_losers
+    ELSE
+        $competing
+    END;
+    LET $day_peers = IF $semantics = 'bitemporal_event' THEN
+        (SELECT * FROM $competing
+            WHERE time::floor(validFrom, 1d) >= time::floor($valid_from, 1d))
+    ELSE IF $tb_fire THEN
+        (SELECT * FROM $competing WHERE id NOT IN $tb_losers.id)
+    ELSE
+        []
+    END;
+
+    LET $supersede =
+        $semantics = 'single_active'
+        OR ($semantics = 'bitemporal_event' AND array::len($losers) > 0)
+        OR ($semantics != 'bitemporal_event' AND $new_score >= $best_opp_score + $margin_for_supersede)
+        -- 0129: succession beats a flat margin — the incoming claim
+        -- narrates the update of a strictly-earlier state.
+        OR $tb_fire;
+
+    LET $loser_ids = $competing.id;
+
+    IF $supersede {
+        -- NO `retractedAt = time::now()` — a natural supersede is not a
+        -- retraction (migration 0014). Keep the retractionReason +
+        -- retractedBy sentinel that revive + calibration depend on.
+        FOR $loser IN $losers {
+            UPDATE $loser.id SET
+                status = 'superseded',
+                retractionReason = 'superseded',
+                retractedBy = 'system',
+                supersededBy = $new.id,
+                priorValidUntil = $loser.validUntil,
+                validUntil = $valid_from;
+        };
+        -- 0085 (F1): contested same/later-day members stay OPEN but
+        -- flagged — same flip the COMPETING branch applies to losers.
+        UPDATE knowledge_fact SET status = 'competing' WHERE id IN $day_peers.id;
+        -- Conflict trace (migration 0044): persist the decision the fn just
+        -- computed — the fact remembers WHY it won.
+        UPDATE $new.id SET conflictTrace = {
+            scoreBreakdown: $score_breakdown,
+            dominantDimension: $dominant_dim,
+            slotDelta: $slot_delta,
+            bestOpponentId: $best_opp.id,
+            decidedAt: time::now()
+        };
+        -- 0129: the tiebreak decision is auditable on the winner —
+        -- flag-off calls never reach here ($tb_fire false), so the
+        -- trace shape is unchanged for them.
+        IF $tb_fire {
+            UPDATE $new.id SET conflictTrace.temporalTiebreak = {
+                windowMs: $tiebreak_window_ms,
+                updateCue: true,
+                decidedBy: 'event_order'
+            };
+        };
+        RETURN {
+            outcome: 'SUPERSEDED',
+            factId: $new.id,
+            -- 0085: only the members actually closed.
+            supersededFactIds: $losers.id,
+            competingFactIds: $day_peers.id,
+            scoreBreakdown: $score_breakdown,
+            dominantDimension: $dominant_dim,
+            slotDelta: $slot_delta,
+            bestOpponentId: $best_opp.id,
+            reason: IF $tb_fire THEN 'temporal_tiebreak' ELSE NONE END
+        };
+    };
+
+    UPDATE $new.id SET
+        status = 'competing',
+        conflictTrace = {
+            scoreBreakdown: $score_breakdown,
+            dominantDimension: $dominant_dim,
+            slotDelta: $slot_delta,
+            bestOpponentId: $best_opp.id,
+            decidedAt: time::now()
+        };
+    UPDATE knowledge_fact SET status = 'competing' WHERE id IN $loser_ids;
+    RETURN {
+        outcome: 'COMPETING',
+        factId: $new.id,
+        competingFactIds: $loser_ids,
+        scoreBreakdown: $score_breakdown,
+        dominantDimension: $dominant_dim,
+        slotDelta: $slot_delta,
+        bestOpponentId: $best_opp.id,
+        reason: NONE
+    };
+};

--- a/src/db/vector-width.ts
+++ b/src/db/vector-width.ts
@@ -1,0 +1,34 @@
+/**
+ * The width gate every cosine scan carries.
+ *
+ * `vector::similarity::cosine(col, $q)` is not a per-row miss when one row's
+ * vector has a different width from the query — on SurrealDB 3.2.4 it is an
+ * error for the WHOLE statement (measured; see test/embedding-space.e2e-spec).
+ * So one row embedded under another model — a 1536-wide OpenAI vector in a
+ * bge-m3 1024 corpus, which is exactly what the preprod tenant held on
+ * 2026-09-09 — takes dense retrieval down for every row of the table, and
+ * on the write path (fn::resolve_fact's dedup gate) fails every write of the
+ * entity's aspect.
+ *
+ * The gate is one clause, placed right after the `!= NONE` guard that every
+ * scan already has:
+ *
+ *     WHERE col != NONE AND array::len(col) = array::len($q)
+ *
+ * `AND` short-circuits (measured), so the cosine never sees a foreign-width
+ * row; such a row is simply not a candidate. It is invisible, not fatal —
+ * which is the right degradation: the census (VectorCorpusService) reports
+ * it, the metric counts it, and the reindex repairs it.
+ *
+ * A truth test (test/embedding-space-truth.unit-spec.ts) fails the build when
+ * a cosine scan appears anywhere in src/ without this clause in the same
+ * statement, so the next scan site cannot forget it.
+ */
+export function sameWidthGate(field: string, param = 'q'): string {
+  return `${field} != NONE AND array::len(${field}) = array::len($${param})`;
+}
+
+/** The exact clause the truth test looks for next to a cosine on `field`. */
+export function widthGateClause(field: string, param = 'q'): string {
+  return `array::len(${field}) = array::len($${param})`;
+}

--- a/src/dreams/dedup.service.ts
+++ b/src/dreams/dedup.service.ts
@@ -272,7 +272,8 @@ export class DreamsDedupService {
       `LET $q = (SELECT VALUE embedding FROM ONLY type::record($fid));
        SELECT entityId, vector::similarity::cosine(embedding, $q) AS sim
          FROM knowledge_fact
-        WHERE ${filters}
+        WHERE array::len(embedding) = array::len($q)
+          AND ${filters}
         ORDER BY sim DESC
         LIMIT 5;`,
       { fid: seedFactId, ...fence.params },

--- a/src/ingest/entity-resolver.service.ts
+++ b/src/ingest/entity-resolver.service.ts
@@ -260,7 +260,7 @@ export class EntityResolverService {
          WHERE predicate = 'name'
            AND status = 'active'
            AND retractedAt IS NONE
-           AND embedding != NONE
+           AND embedding != NONE AND array::len(embedding) = array::len($q)
            AND userId IS NONE
            AND entityId.mergedInto IS NONE
          ORDER BY sim DESC

--- a/src/metrics/metrics.service.ts
+++ b/src/metrics/metrics.service.ts
@@ -326,6 +326,28 @@ export class MetricsService implements OnModuleInit {
     registers: [this.registry],
   });
 
+  // Vector rows whose width is not the primary embedder's, summed over every
+  // tenant at the last nightly census (VectorCorpusService). Non-zero means
+  // memory that dense retrieval cannot reach; `repairs` says what the
+  // actuator did about it.
+  readonly vectorCorpusNonconforming = new Gauge({
+    name: 'brain_vector_corpus_nonconforming_rows',
+    help: 'Vector rows not in the primary embedding space, by column, at the last census',
+    labelNames: ['table', 'field'] as const,
+    registers: [this.registry],
+  });
+  readonly vectorCorpusTenantsNonconforming = new Gauge({
+    name: 'brain_vector_corpus_tenants_nonconforming',
+    help: 'Tenants with at least one vector row outside the primary embedding space',
+    registers: [this.registry],
+  });
+  readonly vectorCorpusRepairs = new Counter({
+    name: 'brain_vector_corpus_repairs_total',
+    help: 'Corpus repair attempts by outcome (repaired, partial, deferred, failed)',
+    labelNames: ['outcome'] as const,
+    registers: [this.registry],
+  });
+
   // What the sweep saw, by kind:
   //   scanned — blobs the store offered
   //   orphan  — unreferenced past the grace window (what a real run
@@ -1186,6 +1208,18 @@ export class MetricsService implements OnModuleInit {
 
   setHnswIndexTenants(state: string, n: number): void {
     this.hnswIndexTenants.set({ state } as LabelValues<'state'>, n);
+  }
+
+  setVectorCorpusNonconforming(table: string, field: string, n: number): void {
+    this.vectorCorpusNonconforming.set({ table, field } as LabelValues<'table' | 'field'>, n);
+  }
+
+  setVectorCorpusTenantsNonconforming(n: number): void {
+    this.vectorCorpusTenantsNonconforming.set(n);
+  }
+
+  countVectorCorpusRepair(outcome: 'repaired' | 'partial' | 'deferred' | 'failed'): void {
+    this.vectorCorpusRepairs.inc({ outcome } as LabelValues<'outcome'>);
   }
 
   countEvidenceOrphanBlobs(kind: 'scanned' | 'orphan' | 'deleted' | 'failed', n = 1): void {

--- a/src/search/internals/insight-leg.ts
+++ b/src/search/internals/insight-leg.ts
@@ -146,7 +146,7 @@ export async function runInsightLegs({
                   source, trustSnapshot, corroboration, userId,
                   vector::similarity::cosine(embedding, $q) AS score
              FROM knowledge_fact
-            WHERE embedding != NONE ${insightGate} ${piiGate} ${userGate} ${worldGate}
+            WHERE embedding != NONE AND array::len(embedding) = array::len($q) ${insightGate} ${piiGate} ${userGate} ${worldGate}
             ORDER BY score DESC
             LIMIT $k`,
           { q: queryVector, k: fetchK, ...shared },

--- a/src/search/internals/legs.ts
+++ b/src/search/internals/legs.ts
@@ -107,7 +107,7 @@ export async function runVectorLeg({
         ${combinedGraphProjection(tuning.combinedVectorGraph, edgeFence)}
         vector::similarity::cosine(embedding, $q) AS simScore
       FROM knowledge_fact
-      WHERE embedding != NONE
+      WHERE embedding != NONE AND array::len(embedding) = array::len($q)
         ${baseWhere.sql}
       ORDER BY simScore DESC
       LIMIT $k

--- a/src/search/internals/segment-leg.ts
+++ b/src/search/internals/segment-leg.ts
@@ -127,7 +127,7 @@ export async function runSegmentLegs({
           `SELECT id, conversationId, text, occurredAt,
                   vector::similarity::cosine(embedding, $q) AS score
              FROM episode_segment
-            WHERE embedding != NONE ${piiGate} ${gate.clause}
+            WHERE embedding != NONE AND array::len(embedding) = array::len($q) ${piiGate} ${gate.clause}
             ORDER BY score DESC
             LIMIT $k`,
           { q: queryVector, k: fetchK, ...gate.params },

--- a/src/synthesize/belief-lane.service.ts
+++ b/src/synthesize/belief-lane.service.ts
@@ -136,7 +136,7 @@ export class BeliefLaneService {
               `SELECT ${select},
                     vector::similarity::cosine(embedding, $q) AS score
                FROM semantic_belief
-              WHERE embedding != NONE AND ${where}
+              WHERE embedding != NONE AND array::len(embedding) = array::len($q) AND ${where}
               ORDER BY score DESC
               LIMIT $k`,
               { q: queryVector, k: fetchK, u: userId },

--- a/src/synthesize/fragment-lane.service.ts
+++ b/src/synthesize/fragment-lane.service.ts
@@ -144,7 +144,7 @@ export class FragmentLaneService {
               `SELECT ${select},
                     vector::similarity::cosine(embedding, $q) AS score
                FROM derived_representation
-              WHERE embedding != NONE AND ${where}
+              WHERE embedding != NONE AND array::len(embedding) = array::len($q) AND ${where}
               ORDER BY score DESC
               LIMIT $k`,
               { q: queryVector, k: fetchK, ...userFence.params },

--- a/src/synthesize/scan-leg.ts
+++ b/src/synthesize/scan-leg.ts
@@ -139,7 +139,7 @@ async function runBrute<Row>(req: DenseScanLegRequest): Promise<Row[]> {
     `SELECT ${req.projection},
         vector::similarity::cosine(embedding, $q) AS score
    FROM ${req.table}
-  WHERE embedding != NONE ${req.gates}
+  WHERE embedding != NONE AND array::len(embedding) = array::len($q) ${req.gates}
   ORDER BY score DESC
   LIMIT $k`,
     req.params,

--- a/src/synthesize/scene-lane.service.ts
+++ b/src/synthesize/scene-lane.service.ts
@@ -225,7 +225,7 @@ export class SceneLaneService {
               `SELECT ${select},
                       vector::similarity::cosine(gistEmbedding, $q) AS score
                  FROM memory_episode
-                WHERE gistEmbedding != NONE
+                WHERE gistEmbedding != NONE AND array::len(gistEmbedding) = array::len($q)
                   ${fences}
                 ORDER BY score DESC
                 LIMIT $k`,

--- a/src/synthesize/segment-lane.service.ts
+++ b/src/synthesize/segment-lane.service.ts
@@ -76,7 +76,7 @@ export class SegmentLaneService {
           `SELECT id, text, occurredAt,
                     vector::similarity::cosine(embedding, $q) AS score
                FROM episode_segment
-              WHERE embedding != NONE ${piiGate} ${gate.clause}
+              WHERE embedding != NONE AND array::len(embedding) = array::len($q) ${piiGate} ${gate.clause}
               ORDER BY score DESC
               LIMIT $k`,
           { q: queryVector, k: fetchK, ...gate.params },
@@ -138,7 +138,7 @@ export class SegmentLaneService {
           `SELECT id, conversationId, occurredAt,
                     vector::similarity::cosine(embedding, $q) AS score
                FROM episode_segment
-              WHERE embedding != NONE ${piiGate} ${gate.clause}
+              WHERE embedding != NONE AND array::len(embedding) = array::len($q) ${piiGate} ${gate.clause}
               ORDER BY score DESC
               LIMIT $k`,
           { q: queryVector, k: opts.limit, ...gate.params },

--- a/test/embedding-space-truth.unit-spec.ts
+++ b/test/embedding-space-truth.unit-spec.ts
@@ -9,6 +9,7 @@ import {
   declaredSpace,
   providerIdOf,
 } from '../src/ai/embedder/embedding-space';
+import { widthGateClause } from '../src/db/vector-width';
 
 /**
  * Embedding-space truth gate.
@@ -86,6 +87,45 @@ describe('embedding-space truth — the schema cannot hold an unclassified vecto
       t.vectorFields.map((f) => `${t.table}.${f}`),
     ).sort();
     expect(swept.filter((c) => !vectors.has(c))).toEqual([]);
+  });
+});
+
+describe('embedding-space truth — every cosine scan carries the width gate', () => {
+  // vector::similarity::cosine over one foreign-width row aborts the WHOLE
+  // statement (SurrealDB 3.2.4). Every scan in src/ must skip such rows with
+  // `array::len(col) = array::len($q)` in the same statement (see
+  // src/db/vector-width.ts); this is what keeps the next scan site honest.
+  const COSINE = /vector::similarity::cosine\(\s*([A-Za-z_.]+)\s*,\s*\$([A-Za-z_]+)\s*\)/g;
+
+  it('in application code: each statement with a cosine has the gate for that column', () => {
+    const offenders: string[] = [];
+    for (const f of TS_FILES) {
+      const text = stripComments(readFileSync(f, 'utf8'));
+      // One template literal is one statement (or one shared filter string).
+      for (const lit of text.match(/`[^`]*`/gs) ?? []) {
+        for (const m of lit.matchAll(COSINE)) {
+          const [, field, param] = m as unknown as [string, string, string];
+          if (!lit.includes(widthGateClause(field, param))) {
+            offenders.push(`${f.slice(ROOT.length + 1)}: cosine(${field}, $${param}) without gate`);
+          }
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it('in the store: the latest fn::resolve_fact revision gates its dedup cosine', () => {
+    // The dedup gate inside resolve_fact is copied into every revision; only
+    // the highest-numbered file is what a tenant runs.
+    const defining = SURQL_FILES.filter((f) =>
+      /DEFINE FUNCTION (OVERWRITE |IF NOT EXISTS )?fn::resolve_fact\(/.test(
+        readFileSync(f, 'utf8'),
+      ),
+    ).sort();
+    const latest = defining[defining.length - 1]!;
+    const body = readFileSync(latest, 'utf8');
+    expect(body).toMatch(/array::len\(embedding\) = array::len\(\$embedding\)/);
+    expect(body).toMatch(/vector::similarity::cosine\(embedding, \$embedding\)/);
   });
 });
 

--- a/test/test-doubles.ts
+++ b/test/test-doubles.ts
@@ -22,6 +22,7 @@ export class StubEmbedder implements Pick<
   | 'embedManyForWrite'
   | 'getDimensions'
   | 'primaryDimensions'
+  | 'isReady'
   | 'primarySpaceId'
   | 'activeSpaceId'
 > {
@@ -67,6 +68,12 @@ export class StubEmbedder implements Pick<
 
   getDimensions(): number {
     return this.dimensions;
+  }
+
+  /** The stub is always warm: readiness must see a ready embedder, so the
+   *  probes it answers (`/ready`) exercise the database, not a model load. */
+  isReady(): boolean {
+    return true;
   }
 
   primaryDimensions(): number {

--- a/test/vector-corpus-width.e2e-spec.ts
+++ b/test/vector-corpus-width.e2e-spec.ts
@@ -1,0 +1,106 @@
+/**
+ * A vector of the wrong width in a tenant's corpus — the preprod state on
+ * 2026-09-09: 39 OpenAI 1536-wide fact vectors under a bge-m3 (1024) embedder.
+ * Before the width gate, one such row made every cosine scan of the table an
+ * error (dense retrieval down for every row) and every write of the entity's
+ * aspect fail inside fn::resolve_fact. Now such a row is invisible to dense
+ * retrieval, the census reports it, and the repair re-embeds it.
+ *
+ * The fixture's stub embedder is 1536-wide, so here the FOREIGN width is
+ * 1024 — same class, mirrored.
+ */
+import { AppFixture, createApp } from './app-fixture';
+import { SurrealService } from '../src/db/surreal.service';
+
+describe('vector corpus width: gate, census, repair (real SurrealDB)', () => {
+  let f: AppFixture;
+  const auth = () => ({ Authorization: `Bearer ${f.apiKey}` });
+  const FOREIGN = 1024;
+  const vec = (w: number) => Array.from({ length: w }, (_, i) => (i % 7) / 7);
+
+  beforeAll(async () => {
+    f = await createApp({ companyId: 'co_vector_width_e2e' });
+  });
+
+  afterAll(async () => {
+    if (f) await f.close();
+  });
+
+  const ingest = async (object: string, entity = 'width_subject') => {
+    const res = await f.http
+      .post('/v1/ingest/fact')
+      .set(auth())
+      .send({
+        entityRef: { vertical: 'rent', id: entity },
+        predicate: 'complained_about',
+        object,
+        validFrom: '2026-01-01',
+        confidence: 0.9,
+        source: { vertical: 'rent', recorder: 'bot' },
+      });
+    return res;
+  };
+
+  const inventory = async () => {
+    const r = await f.http.get('/v1/admin/embedding-space/inventory').set(auth());
+    expect(r.status).toBe(200);
+    return r.body as {
+      dimension: number;
+      nonConforming: number;
+      repairable: number;
+      columns: Array<{ table: string; field: string; rows: number; nonConforming: number }>;
+    };
+  };
+
+  it('a foreign-width row neither breaks dense search nor the write path, is counted, and is repaired', async () => {
+    const first = await ingest('the elevator is broken again');
+    expect([200, 201]).toContain(first.status);
+
+    // Poison: a vector of another model's width on the same table.
+    const surreal = f.app.get(SurrealService);
+    await surreal.withCompany(f.companyId, async (db) => {
+      await db.query(
+        `UPDATE knowledge_fact SET embedding = $v, embeddingSpaceId = 'other:model:1024'
+          WHERE predicate = 'complained_about' AND object = 'the elevator is broken again'`,
+        { v: vec(FOREIGN) },
+      );
+    });
+
+    // Read side: dense search over a table holding a foreign-width row.
+    const search = await f.http
+      .post('/v1/search')
+      .set(auth())
+      .send({ query: 'elevator broken', limit: 5 });
+    expect(search.status).toBe(201);
+
+    // Write side: fn::resolve_fact's dedup gate compares the new vector with
+    // every candidate of the aspect — the poisoned row is among them.
+    const second = await ingest('the elevator is broken, third week');
+    expect([200, 201]).toContain(second.status);
+
+    // Census sees exactly the poisoned row, as repairable.
+    const before = await inventory();
+    const facts = before.columns.find(
+      (c) => c.table === 'knowledge_fact' && c.field === 'embedding',
+    )!;
+    expect(before.dimension).toBe(1536);
+    expect(facts.nonConforming).toBe(1);
+    expect(before.repairable).toBeGreaterThanOrEqual(1);
+
+    // Repair: the sweep re-embeds with the primary (stub, 1536).
+    const repair = await f.http.post('/v1/admin/embedding-space/repair').set(auth()).send({});
+    expect(repair.status).toBe(201);
+    expect(repair.body.outcome).toBe('repaired');
+    expect(repair.body.after.nonConforming).toBe(0);
+
+    const after = await inventory();
+    expect(after.nonConforming).toBe(0);
+    const widths = await surreal.withCompany(f.companyId, async (db) => {
+      const [rows] = await db.query<[Array<{ w: number }>]>(
+        `SELECT array::len(embedding) AS w FROM knowledge_fact WHERE embedding != NONE`,
+      );
+      return new Set((rows as Array<{ w: number }>).map((r) => Number(r.w)));
+    });
+    expect([...widths]).toEqual([1536]);
+  });
+});

--- a/test/vector-corpus.unit-spec.ts
+++ b/test/vector-corpus.unit-spec.ts
@@ -1,0 +1,216 @@
+import { VectorCorpusService } from '../src/admin/vector-corpus.service';
+import { VECTOR_COLUMNS } from '../src/ai/embedder/embedding-space';
+
+/**
+ * The census classifies and counts; the reconcile decides. Both are pinned
+ * here on a stub store so the rules are explicit:
+ *   - a row is non-conforming when its width is not the primary embedder's,
+ *     whatever its embeddingSpaceId says;
+ *   - only columns the reindex sweep owns are repairable, the rest are
+ *     producer-owned and reported;
+ *   - repair runs the sweep once per tenant, records a job run, and is
+ *     deferred (not skipped) while the primary embedder is still warming.
+ */
+describe('VectorCorpusService', () => {
+  type Census = Record<string, Array<{ width: number; spaceId?: string | null; count: number }>>;
+
+  function make(opts: {
+    census: Census;
+    ready?: boolean;
+    afterRepair?: Census;
+    dimension?: number;
+  }) {
+    let census = opts.census;
+    const queries: string[] = [];
+    const db = {
+      query: async (sql: string) => {
+        queries.push(sql);
+        const m = /FROM (\w+)\s+WHERE (\w+) != NONE/.exec(sql);
+        if (!m) return [[]];
+        const rows = census[`${m[1]}.${m[2]}`] ?? [];
+        return [rows.map((r) => ({ count: r.count, width: r.width, spaceId: r.spaceId ?? null }))];
+      },
+    };
+    const surreal = {
+      withCompany: (_c: string, fn: (d: unknown) => Promise<unknown>) => fn(db),
+      onTenantSchemaReady: jest.fn(),
+    };
+    const embedder = {
+      primaryDimensions: () => opts.dimension ?? 1024,
+      primarySpaceId: () => 'bge-m3:Xenova/bge-m3:1024',
+      isReady: () => opts.ready ?? true,
+    };
+    const reindex = {
+      run: jest.fn(async () => {
+        if (opts.afterRepair) census = opts.afterRepair;
+        return { factsScanned: 40, factsUpdated: 39, tables: [] };
+      }),
+    };
+    const jobs = {
+      start: jest.fn(async (input: unknown) => ({ runId: 'r1', ...(input as object) })),
+      finish: jest.fn(async () => undefined),
+    };
+    const metrics = {
+      setVectorCorpusNonconforming: jest.fn(),
+      setVectorCorpusTenantsNonconforming: jest.fn(),
+      countVectorCorpusRepair: jest.fn(),
+    };
+    const apiKeys = { knownCompanyIds: () => ['co_x'] };
+    const svc = new VectorCorpusService(
+      surreal as never,
+      embedder as never,
+      reindex as never,
+      apiKeys as never,
+      jobs as never,
+      undefined,
+      metrics as never,
+    );
+    return { svc, reindex, jobs, metrics, queries };
+  }
+
+  it('counts every declared column, by width and space, against the primary width', async () => {
+    const { svc, queries } = make({
+      census: {
+        'knowledge_fact.embedding': [
+          { width: 1536, spaceId: null, count: 39 },
+          { width: 1024, spaceId: 'bge-m3:Xenova/bge-m3:1024', count: 3 },
+        ],
+        'lens_suppression.centroid': [{ width: 1536, spaceId: 'openai:x:1536', count: 2 }],
+      },
+    });
+    const inv = await svc.inventory('co_x');
+    expect(inv.columns).toHaveLength(VECTOR_COLUMNS.length);
+    expect(queries).toHaveLength(VECTOR_COLUMNS.length);
+    const facts = inv.columns.find((c) => c.table === 'knowledge_fact' && c.field === 'embedding')!;
+    expect(facts).toMatchObject({ repair: 'reindex', rows: 42, conforming: 3, nonConforming: 39 });
+    expect(facts.byWidth).toEqual([
+      { width: 1024, spaceId: 'bge-m3:Xenova/bge-m3:1024', count: 3 },
+      { width: 1536, spaceId: null, count: 39 },
+    ]);
+    const centroid = inv.columns.find((c) => c.table === 'lens_suppression')!;
+    expect(centroid).toMatchObject({ repair: 'producer', nonConforming: 2 });
+    expect(inv).toMatchObject({
+      dimension: 1024,
+      nonConforming: 41,
+      repairable: 39,
+      producerOwned: 2,
+    });
+  });
+
+  it('a row in the right width is conforming even without a space stamp; a stamped row of the wrong width is not', async () => {
+    const { svc } = make({
+      census: {
+        'knowledge_entity.embedding': [
+          { width: 1024, spaceId: null, count: 5 },
+          { width: 1024, spaceId: 'openai:text-embedding-3-small:1536', count: 1 },
+          { width: 1536, spaceId: 'bge-m3:Xenova/bge-m3:1024', count: 1 },
+        ],
+      },
+    });
+    const inv = await svc.inventory('co_x');
+    const ent = inv.columns.find((c) => c.table === 'knowledge_entity')!;
+    // Width is the contract the cosine enforces; the stamp is bookkeeping.
+    expect(ent).toMatchObject({ conforming: 6, nonConforming: 1 });
+  });
+
+  it('repairs a repairable corpus with one sweep for that tenant, recorded as a reindex job run', async () => {
+    const { svc, reindex, jobs, metrics } = make({
+      census: { 'knowledge_fact.embedding': [{ width: 1536, count: 39 }] },
+      afterRepair: { 'knowledge_fact.embedding': [{ width: 1024, count: 39 }] },
+    });
+    const r = await svc.reconcileTenant('co_x', 'startup');
+    expect(r.outcome).toBe('repaired');
+    expect(reindex.run).toHaveBeenCalledTimes(1);
+    expect(reindex.run).toHaveBeenCalledWith({ tenant: 'co_x', allTables: true });
+    expect(jobs.start).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jobType: 'reindex_embeddings',
+        companyId: 'co_x',
+        triggeredBy: 'startup',
+        initialProgress: expect.objectContaining({
+          reason: 'vector_corpus_repair',
+          repairable: 39,
+        }),
+      }),
+    );
+    expect(jobs.finish).toHaveBeenCalledWith(
+      expect.objectContaining({ runId: 'r1' }),
+      expect.objectContaining({
+        status: 'succeeded',
+        result: expect.objectContaining({ nonConformingBefore: 39, nonConformingAfter: 0 }),
+      }),
+    );
+    expect(r.after?.nonConforming).toBe(0);
+    expect(metrics.countVectorCorpusRepair).toHaveBeenCalledWith('repaired');
+  });
+
+  it('does not sweep for producer-owned rows alone — they are reported, not re-embedded', async () => {
+    const { svc, reindex, jobs } = make({
+      census: { 'community_node.summaryEmbedding': [{ width: 1536, count: 4 }] },
+    });
+    const r = await svc.reconcileTenant('co_x', 'cron');
+    expect(r.outcome).toBe('nothing_to_repair');
+    expect(r.before.producerOwned).toBe(4);
+    expect(reindex.run).not.toHaveBeenCalled();
+    expect(jobs.start).not.toHaveBeenCalled();
+  });
+
+  it('defers, never skips, while the primary embedder is not ready — the fallback would write the wrong width', async () => {
+    const { svc, reindex, metrics } = make({
+      census: { 'knowledge_fact.embedding': [{ width: 1536, count: 39 }] },
+      ready: false,
+    });
+    const r = await svc.reconcileTenant('co_x', 'startup');
+    expect(r.outcome).toBe('embedder_not_ready');
+    expect(reindex.run).not.toHaveBeenCalled();
+    expect(metrics.countVectorCorpusRepair).toHaveBeenCalledWith('deferred');
+  });
+
+  it('a conforming corpus is a no-op: no sweep, no job run', async () => {
+    const { svc, reindex, jobs } = make({
+      census: { 'knowledge_fact.embedding': [{ width: 1024, count: 40 }] },
+    });
+    const r = await svc.reconcileTenant('co_x', 'cron');
+    expect(r.outcome).toBe('nothing_to_repair');
+    expect(reindex.run).not.toHaveBeenCalled();
+    expect(jobs.start).not.toHaveBeenCalled();
+  });
+
+  it('a failed sweep is recorded as a failed job run and reported, not thrown', async () => {
+    const { svc, jobs, metrics } = make({
+      census: { 'knowledge_fact.embedding': [{ width: 1536, count: 39 }] },
+    });
+    const boom = new Error('embedder exploded');
+    (svc as unknown as { reindex: { run: jest.Mock } }).reindex.run.mockRejectedValueOnce(boom);
+    const r = await svc.reconcileTenant('co_x', 'manual');
+    expect(r.outcome).toBe('failed');
+    expect(r.error).toBe('embedder exploded');
+    expect(jobs.finish).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        status: 'failed',
+        error: expect.objectContaining({ message: 'embedder exploded' }),
+      }),
+    );
+    expect(metrics.countVectorCorpusRepair).toHaveBeenCalledWith('failed');
+  });
+
+  it('the nightly pass publishes per-column totals and the tenant count', async () => {
+    const { svc, metrics } = make({
+      census: { 'knowledge_fact.embedding': [{ width: 1536, count: 2 }] },
+      ready: false,
+    });
+    await svc.reconcileAll('cron');
+    expect(metrics.setVectorCorpusNonconforming).toHaveBeenCalledWith(
+      'knowledge_fact',
+      'embedding',
+      2,
+    );
+    expect(metrics.setVectorCorpusNonconforming).toHaveBeenCalledWith(
+      'knowledge_entity',
+      'embedding',
+      0,
+    );
+    expect(metrics.setVectorCorpusTenantsNonconforming).toHaveBeenCalledWith(1);
+  });
+});


### PR DESCRIPTION
V-2 from the #501-wave review, closed structurally. Measured on the box today: the registered tenant holds 39 `knowledge_fact` vectors 1536 wide (OpenAI, May) under a bge-m3 (1024) embedder, `embeddingSpaceId` null, no `embedding_space_state` row. On SurrealDB 3.2.4 one such row makes `vector::similarity::cosine` fail for the **whole statement** — every dense search of the table, and every write of an entity's aspect through `fn::resolve_fact`'s dedup gate.

## Read + write side — the width gate
- Every cosine scan in `src/` (13 statements, 12 files: fact/segment/insight/scan legs, segment/scene/fragment/belief lanes, agent-qa, code-memory, entity-resolver, dedup) carries `AND array::len(col) = array::len($q)` beside its existing `!= NONE` guard. `AND` short-circuits (measured), so a foreign-width row is **invisible, not fatal**. `src/db/vector-width.ts` documents the clause.
- `test/embedding-space-truth.unit-spec.ts` gains two gates: every template literal in `src/` with a cosine must contain the clause for that column, and the highest-numbered `fn::resolve_fact` revision must gate its dedup cosine — the next scan site cannot forget it.
- Migration `0138_resolve_fact_width_gate.surql`: `fn::resolve_fact` copied verbatim from 0129 with the gate in the `$competing` selection (`fn::resolve_facts` calls it by name, unchanged).

## Census + actuator — `VectorCorpusService`
- Counts each of the 13 `VECTOR_COLUMNS` by stored width and `embeddingSpaceId` against the primary embedder; a row is non-conforming when its width is not the primary's, whatever its stamp says. Columns the reindex sweep owns (`REINDEX_SWEPT_COLUMNS`, now exported by the engine) are `repairable`; the rest (community summaries, procedural triggers, lens centroids, beliefs, fragments) are `producer`-owned and reported.
- Runs on every tenant's schema-ready hook and nightly at 05:40 UTC under the lease guard; publishes `brain_vector_corpus_nonconforming_rows{table,field}`, `brain_vector_corpus_tenants_nonconforming`, `brain_vector_corpus_repairs_total{outcome}`; warns once per tenant per hour with the per-column breakdown.
- Repair = the existing reindex sweep for that tenant (`allTables`), recorded as a `reindex_embeddings` job run with the reason and counts. **Deferred, not skipped**, while the primary embedder is still warming (the fallback would write the wrong width again). No flag.
- Routes: `GET /v1/admin/embedding-space/inventory?tenant=` and `POST /v1/admin/embedding-space/repair {tenant}` (brain:admin, platform tenant resolution as the other embedding-space routes).

On preprod this means the first boot after deploy censuses `co_admin`, finds the 39 rows, and re-embeds them with bge-m3 — no operator, no key.

## Proof
- Unit `test/vector-corpus.unit-spec.ts` (8): classification by width vs stamp, repairable vs producer-owned, one sweep per tenant + job run, deferral when not ready, failure recorded not thrown, nightly metrics.
- E2E `test/vector-corpus-width.e2e-spec.ts` (real SurrealDB): a foreign-width row on `knowledge_fact` — `POST /v1/search` still 201, a second fact for the same aspect still writes (0138), the inventory counts exactly that row as repairable, `POST repair` → `repaired`, corpus back to one width. `embedding-space.e2e` (the raw-SurrealDB truth) and `hnsw.e2e` unchanged and green.
- tsc app + spec, eslint, prettier clean. `StubEmbedder.isReady()` added (same one-liner as #535 / #539 — trivial to resolve on whichever lands second).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhrQxeisXJZEt4sg3PGyU6