### PR TITLE
fix(vectors): build only the HNSW indexes a query consumes, and let the segment leg ride its index

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -180,17 +180,6 @@ SEARCH_RERANKER_SC_N=1
 # LRU cache size — same query maps to same predicate distribution,
 # so we don't pay per-LLM call repeatedly on hot UI patterns.
 
-# ── HyPE: Hypothetical Prompt Embeddings (optional, ingest-time) ─────────
-# At ingest, generate a hypothetical question the fact answers, embed
-# it, store as `altEmbedding`. Search vector leg takes
-# max(cos(main, q), cos(alt, q)) — closes the question→statement
-# embedding gap without paying an LLM call on the read path.
-#
-# Adds one gpt-4o-mini + one embedding call per fact ingest. On the
-# eval the standalone effect was neutral; combined with reranker
-# it sometimes hurts. Useful when your queries lean question-form
-# and you can't enable the read-path reranker.
-# 
 # ── Personalized PageRank entity prior (optional) ────────────────────────
 # HippoRAG-style: seed candidates by their match score, run 3 power
 # iterations over the typed-edge graph (mentioned_with, identity_of),

--- a/src/admin/hnsw-maintenance.service.ts
+++ b/src/admin/hnsw-maintenance.service.ts
@@ -43,12 +43,20 @@ import { probeHnswIndex, resetKnnIndexMemo } from '../db/knn-index';
  * /v1/admin/reindex/embeddings) BEFORE `create` — with no index present
  * the rewrites it must perform are not rejected.
  *
- * segment_embedding_hnsw (the coverage-scan leg, V11 §5) has a swap
- * caveat: reindex-embeddings rewrites knowledge_fact ONLY — segments
- * keep their old-size vectors. Segments are derived state (0075), so
- * the segment step of a swap is delete + re-segment the world;
- * entity_embedding_hnsw shares the same hole and today relies on entity
- * vectors being rewritten by their own ingest path.
+ * Two indexes, each with a consumer: fact_embedding_hnsw rides under the
+ * fact legs, the dedup seed and inline entity resolution (all `<|K,EF|>`
+ * over knowledge_fact.embedding); segment_embedding_hnsw rides under the
+ * segment legs, the segment lane and the coverage-scan lane
+ * (episode_segment.embedding). fact_alt_embedding_hnsw (a column with no
+ * writer since the HyPE experiment was reverted) and entity_embedding_hnsw
+ * (knowledge_entity.embedding has no KNN and no cosine consumer — entity
+ * resolution reads fact vectors) were retired by migration 0139: they were
+ * built, waited for and counted in readiness for nothing.
+ *
+ * segment_embedding_hnsw has a swap caveat: the reindex sweep re-embeds
+ * episode_segment along with the other swept tables (reindex-engine
+ * ADDITIONAL_TABLE_SPECS), and a segment world can also be rebuilt from
+ * its episodes (0075).
  *
  * ── Every build is CONCURRENTLY ────────────────────────────────────────
  *
@@ -62,7 +70,7 @@ import { probeHnswIndex, resetKnnIndexMemo } from '../db/knn-index';
  * default; a default that is a measured failure at exactly the corpus size
  * the index exists for is not a configuration, so there is one path now.
  *
- * `create` also emits one DEFINE per index rather than a four-index
+ * `create` also emits one DEFINE per index rather than a multi-index
  * super-statement: a concurrent build is per-index by nature (each has
  * its own `building` progress), and a single failing DEFINE inside a
  * multi-statement query takes its siblings with it.
@@ -80,7 +88,7 @@ import { probeHnswIndex, resetKnnIndexMemo } from '../db/knn-index';
  *
  * ── `ensure` — the idempotent action provisioning is allowed to call ──
  *
- * `create` RECREATES: it REMOVEs all four indexes and defines them again.
+ * `create` RECREATES: it REMOVEs both indexes and defines them again.
  * That is right for an operator repairing a width swap and catastrophic for
  * anything automatic — a provisioning hook that ran `create` on process
  * boot would drop a large tenant's working indexes and leave it serving
@@ -171,15 +179,11 @@ export interface HnswMaintenanceResult {
 }
 
 const FACT_MAIN = 'fact_embedding_hnsw';
-const FACT_ALT = 'fact_alt_embedding_hnsw';
-const ENTITY_MAIN = 'entity_embedding_hnsw';
 const SEGMENT_MAIN = 'segment_embedding_hnsw';
 
 /** Every index this service owns, with the table and column it rides. */
 const INDEX_SPECS = [
   { index: FACT_MAIN, table: 'knowledge_fact', field: 'embedding' },
-  { index: FACT_ALT, table: 'knowledge_fact', field: 'altEmbedding' },
-  { index: ENTITY_MAIN, table: 'knowledge_entity', field: 'embedding' },
   { index: SEGMENT_MAIN, table: 'episode_segment', field: 'embedding' },
 ] as const;
 
@@ -378,7 +382,7 @@ export class HnswMaintenanceService {
   /**
    * RECREATE at the declared width: remove first, then define each index
    * on its own statement, CONCURRENTLY, so one failure cannot take the
-   * other three with it and each build has its own progress row.
+   * other with it and each build has its own progress row.
    */
   private async create(db: Surreal, dimension: number): Promise<void> {
     // DIMENSION cannot be parameterised in DDL — `dimension` comes from
@@ -394,8 +398,6 @@ export class HnswMaintenanceService {
   private async drop(db: Surreal): Promise<void> {
     await db.query(
       `REMOVE INDEX IF EXISTS ${FACT_MAIN} ON knowledge_fact;
-           REMOVE INDEX IF EXISTS ${FACT_ALT} ON knowledge_fact;
-           REMOVE INDEX IF EXISTS ${ENTITY_MAIN} ON knowledge_entity;
            REMOVE INDEX IF EXISTS ${SEGMENT_MAIN} ON episode_segment;`,
     );
   }

--- a/src/admin/hnsw-provision.service.ts
+++ b/src/admin/hnsw-provision.service.ts
@@ -436,13 +436,14 @@ export class HnswProvisionService implements OnModuleInit {
 }
 
 /**
- * Fold four per-index states into the one word the roster carries.
+ * Fold the per-index states into the one word the roster carries.
  *
  * `mismatch` outranks everything: an index at a foreign width is worse than
  * a missing one (it also rejects writes), and no automatic action fixes it.
  * `partial` exists because a concurrent build finishes per index, and
- * because the four indexes serve different legs (entity resolution and the
- * dedup seed both ride fact_embedding_hnsw; the segment index serves the
+ * because the two indexes serve different legs (the fact legs, the dedup
+ * seed and inline entity resolution all ride fact_embedding_hnsw; the
+ * segment index serves the segment legs, the segment lane and the
  * coverage-scan lane), so one missing index degrades one lane, not all.
  */
 function foldState(r: HnswMaintenanceResult): HnswProvisionState {

--- a/src/ai/embedder/embedding-space.ts
+++ b/src/ai/embedder/embedding-space.ts
@@ -213,7 +213,6 @@ export const VECTOR_COLUMNS = [
   { table: 'episode', field: 'embedding' },
   { table: 'episode_segment', field: 'embedding' },
   { table: 'knowledge_entity', field: 'embedding' },
-  { table: 'knowledge_fact', field: 'altEmbedding' },
   { table: 'knowledge_fact', field: 'embedding' },
   { table: 'knowledge_predicate', field: 'embedding' },
   { table: 'lens_suppression', field: 'centroid' },
@@ -246,7 +245,7 @@ export const NON_EMBEDDING_FLOAT_COLUMNS = [
  * be swept for a column the schema does not declare.
  */
 export const EMBEDDING_TABLES = [
-  { table: 'knowledge_fact', vectorFields: ['embedding', 'altEmbedding'] },
+  { table: 'knowledge_fact', vectorFields: ['embedding'] },
   { table: 'knowledge_entity', vectorFields: ['embedding'] },
   { table: 'knowledge_predicate', vectorFields: ['embedding'] },
   { table: 'episode', vectorFields: ['embedding'] },

--- a/src/db/migrations/0139_retire_alt_and_entity_hnsw.surql
+++ b/src/db/migrations/0139_retire_alt_and_entity_hnsw.surql
@@ -1,0 +1,27 @@
+-- 0139: retire the two HNSW indexes no query consumes, and the column one
+-- of them rode.
+--
+-- Measured (2026-09-09): every `<|K,EF|>` in the application runs over
+-- knowledge_fact.embedding (the fact legs, the dedup seed, inline entity
+-- resolution) or episode_segment.embedding (the coverage-scan lane, and
+-- from this change the segment legs and the segment lane).
+--
+--   * knowledge_fact.altEmbedding — the HyPE experiment's column. Its writer
+--     was reverted; nothing reads it; it is empty on every deployment.
+--     fact_alt_embedding_hnsw was built, waited for and counted in readiness
+--     for a column that is never written. Both go.
+--   * knowledge_entity.embedding — has no KNN and no cosine consumer (entity
+--     resolution compares FACT vectors, not entity vectors), so
+--     entity_embedding_hnsw was likewise dead weight. The column stays: it
+--     is written by ingest and is part of the reindex sweep (a future
+--     entity-vector consumer wants it), only the index goes.
+--
+-- REMOVE FIELD on a column that holds no vector touches no data; the truth
+-- test (test/embedding-space-truth.unit-spec.ts) folds this removal into
+-- the schema it derives from the migrations, so the column is no longer
+-- expected in VECTOR_COLUMNS. HnswMaintenanceService's INDEX_SPECS drops
+-- both indexes in the same change, so `create`/`ensure` never bring them
+-- back.
+REMOVE INDEX IF EXISTS fact_alt_embedding_hnsw ON knowledge_fact;
+REMOVE INDEX IF EXISTS entity_embedding_hnsw ON knowledge_entity;
+REMOVE FIELD IF EXISTS altEmbedding ON knowledge_fact;

--- a/src/search/internals/scan-leg.ts
+++ b/src/search/internals/scan-leg.ts
@@ -1,6 +1,10 @@
 import type { Surreal } from 'surrealdb';
-import type { CoverageScanMode } from '../search/retrieval-profile';
-import { knnIndexKnownUnusable, knnOperatorDropped, noteKnnOperatorDropped } from '../db/knn-index';
+import type { CoverageScanMode } from '../retrieval-profile';
+import {
+  knnIndexKnownUnusable,
+  knnOperatorDropped,
+  noteKnnOperatorDropped,
+} from '../../db/knn-index';
 
 /** The HNSW index each coverage-scan table rides — for the diagnostic. */
 const SCAN_HNSW: Record<DenseScanLegRequest['table'], string> = {

--- a/src/search/internals/segment-leg.ts
+++ b/src/search/internals/segment-leg.ts
@@ -1,6 +1,8 @@
 import type { Surreal } from 'surrealdb';
 import { segmentUserGate } from '../../auth/segment-scope';
 import type { FactRow } from './types';
+import type { LegTuning } from './legs';
+import { runDenseScanLeg } from './scan-leg';
 
 /**
  * Verbatim fusion leg (audit W4 #18): episode_segment rows retrieved as
@@ -39,6 +41,8 @@ export interface SegmentLegOptions {
   callerScopes: string[];
   userId?: string | undefined;
   mode: 'hybrid' | 'vector' | 'lexical';
+  /** Resolved by the retrieval-profile bootstrap; absent → exact scan. */
+  tuning?: Pick<LegTuning, 'hnswEnabled' | 'hnswEf' | 'hnswOverfetch'> | undefined;
 }
 
 interface SegmentRow {
@@ -110,6 +114,7 @@ export async function runSegmentLegs({
   callerScopes,
   userId,
   mode,
+  tuning,
 }: SegmentLegOptions): Promise<{
   vectorRows: FactRow[];
   lexicalRows: FactRow[];
@@ -122,16 +127,23 @@ export async function runSegmentLegs({
   const gate = segmentUserGate(userId);
 
   const [denseRes, bm25Res] = await Promise.all([
+    // HNSW-first when the tenant has segment_embedding_hnsw (the same
+    // KNN → missing-index memo → exact-scan path the fact leg takes);
+    // the exact scan is byte-identical to the pre-HNSW query.
     mode !== 'lexical' && queryVector
-      ? db.query<[SegmentRow[]]>(
-          `SELECT id, conversationId, text, occurredAt,
-                  vector::similarity::cosine(embedding, $q) AS score
-             FROM episode_segment
-            WHERE embedding != NONE AND array::len(embedding) = array::len($q) ${piiGate} ${gate.clause}
-            ORDER BY score DESC
-            LIMIT $k`,
-          { q: queryVector, k: fetchK, ...gate.params },
-        )
+      ? runDenseScanLeg<SegmentRow>({
+          db,
+          table: 'episode_segment',
+          projection: 'id, conversationId, text, occurredAt',
+          gates: `${piiGate} ${gate.clause}`,
+          params: { q: queryVector, k: fetchK, ...gate.params },
+          k: fetchK,
+          tuning: {
+            mode: tuning?.hnswEnabled ? 'hnsw' : 'brute',
+            ef: tuning?.hnswEf ?? 100,
+            overfetch: tuning?.hnswOverfetch ?? 4,
+          },
+        }).then((rows) => [rows] as [SegmentRow[]])
       : Promise.resolve([[] as SegmentRow[]]),
     mode !== 'vector'
       ? db.query<[SegmentRow[]]>(

--- a/src/search/search-retrieval.service.ts
+++ b/src/search/search-retrieval.service.ts
@@ -179,6 +179,7 @@ export class SearchRetrievalService {
           callerScopes: ctx.callerScopes,
           userId: ctx.dto.userId,
           mode: ctx.mode,
+          tuning: ctx.tuning,
         });
         const fused = fuse(vectorRows, lexicalRows, ctx.mode);
         for (const r of fused) {

--- a/src/synthesize/evidence-collector.service.ts
+++ b/src/synthesize/evidence-collector.service.ts
@@ -27,7 +27,7 @@ import type { CitableFragment } from './fragment-citations';
 import type { CitableBelief } from './belief-citations';
 import type { CitableScene } from './scene-citations';
 import type { ZoomCandidate } from './fragment-zoom';
-import type { CoverageScanTuning } from './scan-leg';
+import type { CoverageScanTuning } from '../search/internals/scan-leg';
 
 /** Grounding anchors the raw-window lane expands (top evidence order). */
 const RAW_WINDOW_MAX_ANCHORS = 4;

--- a/src/synthesize/mention-scan.service.ts
+++ b/src/synthesize/mention-scan.service.ts
@@ -13,7 +13,7 @@ import {
   topicTerms,
   type ScanRow,
 } from './mention-scan';
-import { BRUTE_ONLY, runDenseScanLeg, type CoverageScanTuning } from './scan-leg';
+import { BRUTE_ONLY, runDenseScanLeg, type CoverageScanTuning } from '../search/internals/scan-leg';
 import { buildLexMatchLeg } from './lex-leg';
 import type { CoverageLexMode } from '../search/retrieval-profile';
 

--- a/src/synthesize/query-arc.service.ts
+++ b/src/synthesize/query-arc.service.ts
@@ -4,7 +4,7 @@ import { EmbedderService } from '../ai/embedder.service';
 import { ReadPinService, derivedVersionFence } from '../episodes/read-pin.service';
 import { filterMentions, LEX_MATCH_FLOOR, type ScanRow } from './mention-scan';
 import { extractArcTopic, pickArcBeats, renderArcLines, type ArcBeat } from './query-arc';
-import { BRUTE_ONLY, runDenseScanLeg, type CoverageScanTuning } from './scan-leg';
+import { BRUTE_ONLY, runDenseScanLeg, type CoverageScanTuning } from '../search/internals/scan-leg';
 import { buildLexMatchLeg } from './lex-leg';
 import type { CoverageLexMode } from '../search/retrieval-profile';
 import { makeRowPolicyFilter } from '../policy/row-filter';

--- a/src/synthesize/segment-lane.service.ts
+++ b/src/synthesize/segment-lane.service.ts
@@ -3,6 +3,8 @@ import { SurrealService } from '../db/surreal.service';
 import { EmbedderService } from '../ai/embedder.service';
 import { RerankerService } from '../ai/reranker.service';
 import { segmentUserGate } from '../auth/segment-scope';
+import { resolveSearchTuning } from '../search/retrieval-profile';
+import { runDenseScanLeg, type CoverageScanTuning } from '../search/internals/scan-leg';
 
 interface SegmentRow {
   id: unknown;
@@ -72,15 +74,16 @@ export class SegmentLaneService {
     try {
       const queryVector = await this.embedder.embed(opts.query);
       const fused = await this.surreal.withCompany(opts.companyId, async (db) => {
-        const [dense] = await db.query<[SegmentRow[]]>(
-          `SELECT id, text, occurredAt,
-                    vector::similarity::cosine(embedding, $q) AS score
-               FROM episode_segment
-              WHERE embedding != NONE AND array::len(embedding) = array::len($q) ${piiGate} ${gate.clause}
-              ORDER BY score DESC
-              LIMIT $k`,
-          { q: queryVector, k: fetchK, ...gate.params },
-        );
+        const dense = await runDenseScanLeg<SegmentRow>({
+          db,
+          table: 'episode_segment',
+          projection: 'id, text, occurredAt',
+          gates: `${piiGate} ${gate.clause}`,
+          params: { q: queryVector, k: fetchK, ...gate.params },
+          k: fetchK,
+          tuning: segmentScanTuning(),
+          logger: this.logger,
+        });
         const [bm25] = await db.query<[SegmentRow[]]>(
           `SELECT id, text, occurredAt, search::score(1) AS score
                FROM episode_segment
@@ -134,15 +137,16 @@ export class SegmentLaneService {
     try {
       const queryVector = await this.embedder.embed(opts.query);
       const fused = await this.surreal.withCompany(opts.companyId, async (db) => {
-        const [dense] = await db.query<[SegmentAnchorRow[]]>(
-          `SELECT id, conversationId, occurredAt,
-                    vector::similarity::cosine(embedding, $q) AS score
-               FROM episode_segment
-              WHERE embedding != NONE AND array::len(embedding) = array::len($q) ${piiGate} ${gate.clause}
-              ORDER BY score DESC
-              LIMIT $k`,
-          { q: queryVector, k: opts.limit, ...gate.params },
-        );
+        const dense = await runDenseScanLeg<SegmentAnchorRow>({
+          db,
+          table: 'episode_segment',
+          projection: 'id, conversationId, occurredAt',
+          gates: `${piiGate} ${gate.clause}`,
+          params: { q: queryVector, k: opts.limit, ...gate.params },
+          k: opts.limit,
+          tuning: segmentScanTuning(),
+          logger: this.logger,
+        });
         const [bm25] = await db.query<[SegmentAnchorRow[]]>(
           `SELECT id, conversationId, occurredAt, search::score(1) AS score
                FROM episode_segment
@@ -221,4 +225,19 @@ function rrfFuseScored<T extends { id: unknown }>(
     });
   }
   return [...scores.values()].sort((a, b) => b.score - a.score);
+}
+
+/**
+ * The segment lane rides segment_embedding_hnsw under the same flags as
+ * the search legs (SEARCH_HNSW_ENABLED / _EF / _OVERFETCH); with the flag
+ * off, or no index yet, the exact scan is byte-identical to the pre-HNSW
+ * query. Read per call so an operator flip needs no restart.
+ */
+function segmentScanTuning(): CoverageScanTuning {
+  const t = resolveSearchTuning();
+  return {
+    mode: t.hnswEnabled ? 'hnsw' : 'brute',
+    ef: t.hnswEf,
+    overfetch: t.hnswOverfetch,
+  };
 }

--- a/test/coverage-scan-leg.unit-spec.ts
+++ b/test/coverage-scan-leg.unit-spec.ts
@@ -1,4 +1,4 @@
-import { runDenseScanLeg, BRUTE_ONLY } from '../src/synthesize/scan-leg';
+import { runDenseScanLeg, BRUTE_ONLY } from '../src/search/internals/scan-leg';
 import {
   resolveRetrievalProfile,
   resolveRetrievalProfileFor,

--- a/test/embedding-space-truth.unit-spec.ts
+++ b/test/embedding-space-truth.unit-spec.ts
@@ -54,10 +54,15 @@ const stripComments = (text: string): string => text.replace(/\/\*[\s\S]*?\*\/|\
 function declaredFloatColumns(): Set<string> {
   const pattern =
     /DEFINE\s+FIELD\s+(?:IF\s+NOT\s+EXISTS\s+|OVERWRITE\s+)?(\w+)\s+ON\s+(?:TABLE\s+)?(\w+)\s+TYPE\s+(?:option<)?array<float>/gi;
+  // A later migration may retire a column (`REMOVE FIELD [IF EXISTS] f ON
+  // [TABLE] t`); the schema a tenant runs is the fold of the files in
+  // order, so a removal after the last definition takes the column out.
+  const removal = /REMOVE\s+FIELD\s+(?:IF\s+EXISTS\s+)?(\w+)\s+ON\s+(?:TABLE\s+)?(\w+)/gi;
   const found = new Set<string>();
-  for (const f of SURQL_FILES) {
+  for (const f of [...SURQL_FILES].sort()) {
     const text = readFileSync(f, 'utf8').replace(/\s+/g, ' ');
     for (const m of text.matchAll(pattern)) found.add(`${m[2]}.${m[1]}`);
+    for (const m of text.matchAll(removal)) found.delete(`${m[2]}.${m[1]}`);
   }
   return found;
 }

--- a/test/embedding-space.unit-spec.ts
+++ b/test/embedding-space.unit-spec.ts
@@ -128,6 +128,6 @@ describe('EMBEDDING_TABLES / field constant', () => {
       'procedural_memory',
     ]);
     const fact = EMBEDDING_TABLES.find((t) => t.table === 'knowledge_fact')!;
-    expect(fact.vectorFields).toEqual(['embedding', 'altEmbedding']);
+    expect(fact.vectorFields).toEqual(['embedding']);
   });
 });

--- a/test/hnsw-concurrent-build.unit-spec.ts
+++ b/test/hnsw-concurrent-build.unit-spec.ts
@@ -32,12 +32,7 @@ const INFO_TABLE = (indexes: string[]) => [
   },
 ];
 
-const ALL_INDEXES = [
-  'fact_embedding_hnsw',
-  'fact_alt_embedding_hnsw',
-  'entity_embedding_hnsw',
-  'segment_embedding_hnsw',
-];
+const ALL_INDEXES = ['fact_embedding_hnsw', 'segment_embedding_hnsw'];
 
 /**
  * A db that records every statement and answers the two INFO probes from
@@ -81,7 +76,7 @@ describe('hnsw create — always CONCURRENTLY', () => {
     // 1 REMOVE + 4 DEFINE. Not a super-statement: one failing DEFINE inside
     // a multi-statement query takes its siblings with it, and each
     // concurrent build has its own progress row.
-    expect(statements).toHaveLength(5);
+    expect(statements).toHaveLength(3);
     expect(statements[0]).toContain('REMOVE INDEX IF EXISTS');
     expect(statements[0]).not.toContain('DEFINE INDEX');
     for (const s of statements.slice(1)) {
@@ -100,7 +95,7 @@ describe('hnsw create — always CONCURRENTLY', () => {
     try {
       const db = fakeDb('ready');
       await service(db).apply('co1', 'create', { waitMs: 0 });
-      expect(ddl(db.calls)).toHaveLength(5);
+      expect(ddl(db.calls)).toHaveLength(3);
       expect(ddl(db.calls).every((s) => s.includes('CONCURRENTLY') || s.startsWith('REMOVE'))).toBe(
         true,
       );
@@ -115,12 +110,7 @@ describe('hnsw create — always CONCURRENTLY', () => {
     const db = fakeDb('indexing');
     const res = await service(db).apply('co1', 'create', { waitMs: 0 });
     expect(res.ready).toBe(false);
-    expect(res.builds.map((b) => b.state)).toEqual([
-      'building',
-      'building',
-      'building',
-      'building',
-    ]);
+    expect(res.builds.map((b) => b.state)).toEqual(['building', 'building']);
     // Progress is surfaced, not just a boolean.
     expect(res.builds[0]!.initial).toBe(20000);
     expect(res.builds[0]!.pending).toBe(0);
@@ -161,7 +151,7 @@ describe('waitMs — the request decides how long it holds', () => {
     const res = await pending;
     expect(res.ready).toBe(false);
     // One probe round (DDL + first probe), no polling.
-    expect(db.calls.filter((c) => c.startsWith('INFO FOR TABLE'))).toHaveLength(4);
+    expect(db.calls.filter((c) => c.startsWith('INFO FOR TABLE'))).toHaveLength(2);
   });
 });
 
@@ -178,13 +168,13 @@ describe('hnsw status / drop', () => {
   it("action:'status' on an un-indexed tenant reports absent, not ready", async () => {
     const db = fakeDb('absent');
     const res = await service(db).apply('co1', 'status');
-    expect(res.builds.map((b) => b.state)).toEqual(['absent', 'absent', 'absent', 'absent']);
+    expect(res.builds.map((b) => b.state)).toEqual(['absent', 'absent']);
     expect(res.ready).toBe(false);
     // INFO FOR INDEX throws on a missing index, so it must not be called.
     expect(db.calls.some((c) => c.startsWith('INFO FOR INDEX'))).toBe(false);
   });
 
-  it('drop removes the four indexes and never claims ready', async () => {
+  it('drop removes both indexes and never claims ready', async () => {
     const db = fakeDb('absent');
     const res = await service(db).apply('co1', 'drop');
     const statements = ddl(db.calls);
@@ -203,7 +193,7 @@ describe('hnsw status / drop', () => {
       }),
     };
     const res = await service(db as never).apply('co1', 'status');
-    expect(res.builds.map((b) => b.state)).toEqual(['unknown', 'unknown', 'unknown', 'unknown']);
+    expect(res.builds.map((b) => b.state)).toEqual(['unknown', 'unknown']);
     expect(res.ready).toBe(false);
   });
 

--- a/test/hnsw-provisioning.unit-spec.ts
+++ b/test/hnsw-provisioning.unit-spec.ts
@@ -25,12 +25,7 @@ import { HnswProvisionService } from '../src/admin/hnsw-provision.service';
  *                                            from the existence probe alone
  */
 
-const ALL = [
-  'fact_embedding_hnsw',
-  'fact_alt_embedding_hnsw',
-  'entity_embedding_hnsw',
-  'segment_embedding_hnsw',
-];
+const ALL = ['fact_embedding_hnsw', 'segment_embedding_hnsw'];
 
 type IndexState = { status: 'ready' | 'indexing'; dimension?: number };
 
@@ -82,7 +77,7 @@ describe('ensure — the idempotent action provisioning is allowed to call', () 
     const db = fakeDb({ fact_embedding_hnsw: { status: 'ready' } });
     const r = await maintenance(db).apply('co1', 'ensure');
     const emitted = ddl(db.calls);
-    expect(emitted).toHaveLength(3);
+    expect(emitted).toHaveLength(1);
     for (const stmt of emitted) {
       expect(stmt).toMatch(/^DEFINE INDEX/);
       expect(stmt).toContain('CONCURRENTLY');
@@ -92,11 +87,7 @@ describe('ensure — the idempotent action provisioning is allowed to call', () 
     // is never dropped, so there is no window where the tenant is served
     // unranked rows because maintenance was running.
     expect(emitted.some((s) => s.startsWith('REMOVE'))).toBe(false);
-    expect(r.created).toEqual([
-      'fact_alt_embedding_hnsw',
-      'entity_embedding_hnsw',
-      'segment_embedding_hnsw',
-    ]);
+    expect(r.created).toEqual(['segment_embedding_hnsw']);
     expect(r.concurrent).toBe(true);
   });
 
@@ -154,17 +145,17 @@ describe('width is part of readiness', () => {
     // wrong width is `ready` to the engine and rejects every write.
     const db = fakeDb({
       ...Object.fromEntries(ALL.map((n) => [n, { status: 'ready' as const }])),
-      entity_embedding_hnsw: { status: 'ready' as const, dimension: 1536 },
+      segment_embedding_hnsw: { status: 'ready' as const, dimension: 1536 },
     });
     const r = await maintenance(db, 1024).apply('co1', 'status');
-    expect(r.mismatched).toEqual(['entity_embedding_hnsw']);
+    expect(r.mismatched).toEqual(['segment_embedding_hnsw']);
     expect(r.ready).toBe(false);
   });
 
   it('ensure does not try to repair a mismatch — the repair is destructive', async () => {
     const db = fakeDb({
       ...Object.fromEntries(ALL.map((n) => [n, { status: 'ready' as const }])),
-      entity_embedding_hnsw: { status: 'ready' as const, dimension: 1536 },
+      segment_embedding_hnsw: { status: 'ready' as const, dimension: 1536 },
     });
     await maintenance(db, 1024).apply('co1', 'ensure');
     expect(ddl(db.calls)).toEqual([]);
@@ -196,7 +187,7 @@ function provision(opts: {
       ready: true,
       builds: ALL.map((index) => ({ index, table: 't', state: 'ready' as const })),
       mismatched: [],
-      created: action === 'ensure' ? ['entity_embedding_hnsw'] : [],
+      created: action === 'ensure' ? ['segment_embedding_hnsw'] : [],
     }));
   const registry = {
     // No registry roster in these fixtures: the sweep falls back to the static keys.
@@ -366,7 +357,7 @@ describe('HnswProvisionService — reconciliation', () => {
       concurrent: true,
       ready: false,
       builds: ALL.map((index) => ({ index, table: 't', state: 'ready' as const })),
-      mismatched: ['entity_embedding_hnsw'],
+      mismatched: ['segment_embedding_hnsw'],
       created: [],
     }));
     const { svc } = provision({ apply, recorded });

--- a/test/hnsw.e2e-spec.ts
+++ b/test/hnsw.e2e-spec.ts
@@ -112,12 +112,7 @@ describe('HNSW vector leg (real SurrealDB)', () => {
     // the default wait (60 s) is far more than a fixture-sized tenant needs.
     expect(create.body.concurrent).toBe(true);
     expect(create.body.ready).toBe(true);
-    expect(create.body.builds.map((b: { state: string }) => b.state)).toEqual([
-      'ready',
-      'ready',
-      'ready',
-      'ready',
-    ]);
+    expect(create.body.builds.map((b: { state: string }) => b.state)).toEqual(['ready', 'ready']);
 
     const baseline = await search('HNSW Probe Tenant');
 
@@ -148,7 +143,7 @@ describe('HNSW vector leg (real SurrealDB)', () => {
       expect(create.status).toBe(201);
       expect(create.body.concurrent).toBe(true);
       expect(create.body.ready).toBe(true);
-      expect(create.body.builds).toHaveLength(4);
+      expect(create.body.builds).toHaveLength(2);
       for (const b of create.body.builds as Array<{ index: string; state: string }>) {
         expect(b.state).toBe('ready');
       }
@@ -293,12 +288,7 @@ describe('HNSW provisioning + roster (real SurrealDB)', () => {
     const first = await ensure();
     // A fresh tenant has none of the four, so ensure defines all four —
     // always CONCURRENTLY, and without dropping anything.
-    expect(first.created.sort()).toEqual([
-      'entity_embedding_hnsw',
-      'fact_alt_embedding_hnsw',
-      'fact_embedding_hnsw',
-      'segment_embedding_hnsw',
-    ]);
+    expect(first.created.sort()).toEqual(['fact_embedding_hnsw', 'segment_embedding_hnsw']);
     expect(first.mismatched).toEqual([]);
 
     // Idempotence is the property that makes this safe to run on a
@@ -343,7 +333,7 @@ describe('HNSW provisioning + roster (real SurrealDB)', () => {
   it('a dry run records the state and emits no DDL', async () => {
     const surreal = f.app.get(SurrealService);
     await surreal.withCompany(f.companyId, async (db) => {
-      await db.query(`REMOVE INDEX IF EXISTS entity_embedding_hnsw ON knowledge_entity;`);
+      await db.query(`REMOVE INDEX IF EXISTS segment_embedding_hnsw ON episode_segment;`);
     });
     const dry = await f.http
       .post('/v1/admin/maintenance/hnsw/reconcile')
@@ -355,9 +345,9 @@ describe('HNSW provisioning + roster (real SurrealDB)', () => {
     // Still absent — a dry run reports, it does not repair.
     await surreal.withCompany(f.companyId, async (db) => {
       const [info] = await db.query<[{ indexes?: Record<string, string> }]>(
-        `INFO FOR TABLE knowledge_entity;`,
+        `INFO FOR TABLE episode_segment;`,
       );
-      expect((info as { indexes?: Record<string, string> })?.indexes?.entity_embedding_hnsw).toBe(
+      expect((info as { indexes?: Record<string, string> })?.indexes?.segment_embedding_hnsw).toBe(
         undefined,
       );
     });

--- a/test/knn-index-memo.unit-spec.ts
+++ b/test/knn-index-memo.unit-spec.ts
@@ -199,12 +199,10 @@ describe('hnsw maintenance and the memo', () => {
         state === 'absent'
           ? {}
           : Object.fromEntries(
-              [
-                'fact_embedding_hnsw',
-                'fact_alt_embedding_hnsw',
-                'entity_embedding_hnsw',
-                'segment_embedding_hnsw',
-              ].map((n) => [n, `DEFINE INDEX ${n} …`]),
+              ['fact_embedding_hnsw', 'segment_embedding_hnsw'].map((n) => [
+                n,
+                `DEFINE INDEX ${n} …`,
+              ]),
             ),
       lives: {},
       tables: {},

--- a/test/knn-missing-index.unit-spec.ts
+++ b/test/knn-missing-index.unit-spec.ts
@@ -1,5 +1,5 @@
 import { runVectorLeg } from '../src/search/internals/legs';
-import { runDenseScanLeg } from '../src/synthesize/scan-leg';
+import { runDenseScanLeg } from '../src/search/internals/scan-leg';
 import { hnswIndexState, knnDroppedMessage, knnOperatorDropped } from '../src/db/knn-index';
 
 /**

--- a/test/scan-hnsw.e2e-spec.ts
+++ b/test/scan-hnsw.e2e-spec.ts
@@ -11,7 +11,7 @@ import { SurrealService } from '../src/db/surreal.service';
 import { EmbedderService } from '../src/ai/embedder.service';
 import { MentionScanService } from '../src/synthesize/mention-scan.service';
 import { QueryArcService } from '../src/synthesize/query-arc.service';
-import type { CoverageScanTuning } from '../src/synthesize/scan-leg';
+import type { CoverageScanTuning } from '../src/search/internals/scan-leg';
 
 describe('coverage-scan HNSW parity (real SurrealDB)', () => {
   let f: AppFixture;

--- a/test/segment-hnsw.e2e-spec.ts
+++ b/test/segment-hnsw.e2e-spec.ts
@@ -1,0 +1,141 @@
+/**
+ * Two things migration 0139 and the segment-leg rewiring promise, checked on
+ * a real SurrealDB:
+ *
+ *  1. The retired column and indexes are gone from a migrated tenant and the
+ *     maintenance route builds exactly the two indexes a query consumes.
+ *  2. The segment leg rides segment_embedding_hnsw when the tenant has it
+ *     (the statement carries the KNN operator) and returns the same rows,
+ *     in the same order, from the exact scan when it does not — the index
+ *     is an accelerator, never a different answer.
+ */
+import type { Surreal } from 'surrealdb';
+import { AppFixture, createApp } from './app-fixture';
+import { SurrealService } from '../src/db/surreal.service';
+import { EmbedderService } from '../src/ai/embedder.service';
+import { runSegmentLegs } from '../src/search/internals/segment-leg';
+
+describe('segment HNSW index: retired indexes gone, segment leg rides the one that stays', () => {
+  let f: AppFixture;
+  const auth = () => ({ Authorization: `Bearer ${f.apiKey}` });
+  const TEXTS = [
+    'the boiler in flat 4 was replaced on tuesday',
+    'parking permits renew in march',
+    'the lift inspection certificate expired',
+  ];
+
+  beforeAll(async () => {
+    f = await createApp({ companyId: 'co_segment_hnsw_e2e' });
+    const embedder = f.app.get(EmbedderService);
+    const surreal = f.app.get(SurrealService);
+    const rows: Array<{
+      conversationId: string;
+      seq: number;
+      episodeIds: string[];
+      text: string;
+      occurredAt: Date;
+      recorder: string;
+      embedding: number[];
+    }> = [];
+    for (let i = 0; i < TEXTS.length; i += 1) {
+      const text = TEXTS[i]!;
+      rows.push({
+        conversationId: `conv_seg_${i}`,
+        seq: 0,
+        episodeIds: [],
+        text,
+        occurredAt: new Date(`2026-02-0${i + 1}T10:00:00Z`),
+        recorder: 'test-seeder',
+        embedding: await embedder.embed(text),
+      });
+    }
+    await surreal.withCompany(f.companyId, async (db) => {
+      await db.query(`INSERT INTO episode_segment $rows`, { rows });
+    });
+  });
+
+  afterAll(async () => {
+    if (f) await f.close();
+  });
+
+  it('0139: altEmbedding is not a field any more, and create builds only the two consumed indexes', async () => {
+    const surreal = f.app.get(SurrealService);
+    const fields = await surreal.withCompany(f.companyId, async (db) => {
+      const [info] = await db.query<[{ fields?: Record<string, string> }]>(
+        `INFO FOR TABLE knowledge_fact;`,
+      );
+      return (info as { fields?: Record<string, string> })?.fields ?? {};
+    });
+    expect(fields.embedding).toBeDefined();
+    expect(fields.altEmbedding).toBeUndefined();
+
+    const create = await f.http.post('/v1/admin/maintenance/hnsw').set(auth()).send({});
+    expect(create.status).toBe(201);
+    expect([...create.body.indexes].sort()).toEqual([
+      'fact_embedding_hnsw',
+      'segment_embedding_hnsw',
+    ]);
+    expect(create.body.ready).toBe(true);
+
+    const leftovers = await surreal.withCompany(f.companyId, async (db) => {
+      const [fact] = await db.query<[{ indexes?: Record<string, string> }]>(
+        `INFO FOR TABLE knowledge_fact;`,
+      );
+      const [entity] = await db.query<[{ indexes?: Record<string, string> }]>(
+        `INFO FOR TABLE knowledge_entity;`,
+      );
+      return [
+        ...Object.keys((fact as { indexes?: Record<string, string> })?.indexes ?? {}),
+        ...Object.keys((entity as { indexes?: Record<string, string> })?.indexes ?? {}),
+      ].filter((n) => n.endsWith('_hnsw'));
+    });
+    expect(leftovers).toEqual(['fact_embedding_hnsw']);
+  });
+
+  it('the segment leg takes KNN with the index and the exact scan without it — same rows either way', async () => {
+    const surreal = f.app.get(SurrealService);
+    const embedder = f.app.get(EmbedderService);
+    const queryVector = await embedder.embed(TEXTS[2]!);
+    const tuning = { hnswEnabled: true, hnswEf: 100, hnswOverfetch: 4 };
+
+    const run = (db: Surreal, hnswEnabled: boolean) => {
+      const sqls: string[] = [];
+      const spy: Pick<Surreal, 'query'> = {
+        query: ((sql: string, params?: Record<string, unknown>) => {
+          sqls.push(sql);
+          return db.query(sql, params);
+        }) as Surreal['query'],
+      };
+      return runSegmentLegs({
+        db: spy,
+        queryText: TEXTS[2]!,
+        queryVector,
+        fetchK: 3,
+        callerScopes: ['brain:read', 'brain:read_pii'],
+        mode: 'vector',
+        tuning: { ...tuning, hnswEnabled },
+      }).then((r) => ({ sqls, ids: r.vectorRows.map((row) => String(row.id)) }));
+    };
+
+    // With the index (built by the previous test): the dense statement is
+    // the KNN operator, and the exact text is the top hit.
+    const knn = await surreal.withCompany(f.companyId, (db) => run(db, true));
+    expect(knn.sqls.some((s) => s.includes('<|'))).toBe(true);
+    expect(knn.ids).toHaveLength(3);
+
+    // Flag off: the exact scan, same rows in the same order.
+    const brute = await surreal.withCompany(f.companyId, (db) => run(db, false));
+    expect(brute.sqls.some((s) => s.includes('vector::similarity::cosine'))).toBe(true);
+    expect(brute.sqls.some((s) => s.includes('<|'))).toBe(false);
+    expect(brute.ids).toEqual(knn.ids);
+
+    // Index gone, flag still on: the dropped operator is detected and the
+    // exact scan answers — still the same rows.
+    await surreal.withCompany(f.companyId, async (db) => {
+      await db.query(`REMOVE INDEX IF EXISTS segment_embedding_hnsw ON episode_segment;`);
+    });
+    const fallback = await surreal.withCompany(f.companyId, (db) => run(db, true));
+    expect(fallback.sqls.some((s) => s.includes('vector::similarity::cosine'))).toBe(true);
+    expect(fallback.ids).toEqual(knn.ids);
+  });
+});


### PR DESCRIPTION
V-4 from the #501-wave review, decided by measurement rather than by asking: of the four HNSW indexes `HnswMaintenanceService` built, waited for and counted in readiness, only `fact_embedding_hnsw` had a consumer. Every `<|K,EF|>` in the application runs over `knowledge_fact.embedding` (fact legs, dedup seed, inline entity resolution) or `episode_segment.embedding` (the coverage-scan lane).

**Based on #540 (`fix/vector-corpus-width`)** — it keeps the width gate #540 adds to the segment scans and the truth test that enforces it; merge #540 first (this PR then rebases to a two-commit diff on main).

## Retired (migration `0139_retire_alt_and_entity_hnsw.surql`)
- `knowledge_fact.altEmbedding` + `fact_alt_embedding_hnsw`: the HyPE column has had no writer since the experiment was reverted and no reader; empty on every deployment. `REMOVE INDEX`, `REMOVE FIELD`; dropped from `INDEX_SPECS`, `VECTOR_COLUMNS`, `EMBEDDING_TABLES`; the `.env.example` HyPE stanza (which promised the writer) is gone.
- `entity_embedding_hnsw`: `knowledge_entity.embedding` has no KNN and no cosine consumer (entity resolution compares fact vectors). Index removed; the column stays (written by ingest, swept by reindex).
- `test/embedding-space-truth.unit-spec.ts`: the collector now folds `REMOVE FIELD [IF EXISTS] f ON [TABLE] t` into the schema it derives from the migrations, so a retired column is not expected to be classified.
- Comments that described four indexes — and the #512 line about the entity index standing between a tenant and a duplicate entity — now describe what is measured.

## Wired: `segment_embedding_hnsw` is consumed
The three segment cosine scans (`src/search/internals/segment-leg.ts`, `src/synthesize/segment-lane.service.ts` ×2) go through `runDenseScanLeg` (the shared HNSW-first path from #525: KNN → dropped-operator memo → exact scan). The search leg takes the request's leg tuning (`ctx.tuning`); the segment lane resolves the same `SEARCH_HNSW_ENABLED/_EF/_OVERFETCH` per call. The exact scan is byte-identical to the previous query, width gate included, so with the flag off or no index nothing changes.

## Proof
- Unit: `hnsw-concurrent-build`, `hnsw-provisioning`, `knn-index-memo`, `knn-missing-index`, `embedding-space*`, `segment*`, `migrator*`, `scan-leg` — 20 suites / 228 tests green on the two-index set.
- Real SurrealDB, new `test/segment-hnsw.e2e-spec.ts`: a migrated tenant's `knowledge_fact` has no `altEmbedding` field; `POST /v1/admin/maintenance/hnsw` builds exactly `fact_embedding_hnsw` + `segment_embedding_hnsw` and leaves no retired index on `knowledge_fact`/`knowledge_entity`; the segment leg returns the same rows in the same order with the KNN operator (index present), the exact scan (flag off) and the fallback (index dropped while the flag is on). `hnsw.e2e`, `scan-hnsw.e2e`, `segment-user-fence.e2e`, `migration` e2e green.
- tsc app + spec, eslint, prettier clean.

Left out: the HyPE mentions in `fact-resolver.service.ts` / `ingest.service.ts` docstrings (comment debt, no behaviour); `docs/roadmap/*` keep their historical D8/D12 wording; PR #541 (flags) also edits `create()` in the maintenance service — expect a small conflict on whichever lands second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhrQxeisXJZEt4sg3PGyU6