### PR TITLE
fix(vectors): retry a boot-deferred corpus repair as soon as the embedder is warm

### DIFF
--- a/src/admin/vector-corpus.service.ts
+++ b/src/admin/vector-corpus.service.ts
@@ -62,6 +62,9 @@ const LEASE_TTL_SECONDS = 30 * 60;
 /** One operator-facing line per tenant per hour about a corpus that is still
  *  non-conforming; the metric carries the number continuously. */
 const WARN_EVERY_MS = 60 * 60_000;
+/** A repair deferred at boot re-checks the embedder every minute, for an hour. */
+const DEFERRED_RETRY_EVERY_MS = 60_000;
+const DEFERRED_RETRY_MAX_ATTEMPTS = 60;
 
 /**
  * Corpus census and self-repair for the thirteen vector columns.
@@ -205,11 +208,20 @@ export class VectorCorpusService implements OnModuleInit {
       return { companyId, before, after: null, outcome: 'nothing_to_repair' };
     }
     if (!this.embedder.isReady()) {
+      // The schema-ready hook fires during boot, before the primary embedder
+      // has finished warming (bge-m3: ~30 s in-thread), so a boot-time census
+      // almost always lands here. Waiting for the nightly pass would leave the
+      // tenant's dense retrieval blind for a day; instead the tenant is
+      // re-queued once the embedder reports ready, polling every minute for
+      // up to an hour (a warmup that never completes is #518's problem and
+      // is visible on /ready).
       this.logger.warn(
         `vector corpus repair for ${companyId} deferred: ${before.repairable} row(s) need the ` +
-          `primary embedder (${before.spaceId}) and it is not ready yet; retried on the next pass`,
+          `primary embedder (${before.spaceId}) and it is not ready yet; ` +
+          `retried as soon as it is`,
       );
       this.metrics?.countVectorCorpusRepair('deferred');
+      if (trigger === 'startup') this.retryWhenReady(companyId);
       return { companyId, before, after: null, outcome: 'embedder_not_ready' };
     }
     const run = await this.jobs?.start({
@@ -253,6 +265,27 @@ export class VectorCorpusService implements OnModuleInit {
       this.logger.error(`vector corpus repair for ${companyId} failed: ${message}`);
       return { companyId, before, after: null, outcome: 'failed', error: message };
     }
+  }
+
+  /** Poll the embedder's readiness and re-queue the tenant the moment it is warm. */
+  private retryWhenReady(companyId: string, attempt = 0): void {
+    if (attempt >= DEFERRED_RETRY_MAX_ATTEMPTS) {
+      this.logger.warn(
+        `vector corpus repair for ${companyId} still deferred after ` +
+          `${DEFERRED_RETRY_MAX_ATTEMPTS} checks — the nightly pass will retry`,
+      );
+      return;
+    }
+    const timer = setTimeout(() => {
+      if (this.embedder.isReady()) {
+        this.seen.delete(companyId);
+        this.noteTenant(companyId);
+      } else {
+        this.retryWhenReady(companyId, attempt + 1);
+      }
+    }, DEFERRED_RETRY_EVERY_MS);
+    // Never keep the process alive for it.
+    timer.unref?.();
   }
 
   /** Read-only census of every vector column. */

--- a/test/vector-corpus.unit-spec.ts
+++ b/test/vector-corpus.unit-spec.ts
@@ -166,6 +166,47 @@ describe('VectorCorpusService', () => {
     expect(metrics.countVectorCorpusRepair).toHaveBeenCalledWith('deferred');
   });
 
+  it('a repair deferred at boot runs by itself once the embedder is warm — not the next night', async () => {
+    jest.useFakeTimers();
+    try {
+      let ready = false;
+      const { svc, reindex } = make({
+        census: { 'knowledge_fact.embedding': [{ width: 1536, count: 39 }] },
+        afterRepair: { 'knowledge_fact.embedding': [{ width: 1024, count: 39 }] },
+      });
+      (svc as unknown as { embedder: { isReady: () => boolean } }).embedder.isReady = () => ready;
+      const first = await svc.reconcileTenant('co_x', 'startup');
+      expect(first.outcome).toBe('embedder_not_ready');
+      expect(reindex.run).not.toHaveBeenCalled();
+      // Two checks while still warming: nothing happens.
+      await jest.advanceTimersByTimeAsync(2 * 60_000);
+      expect(reindex.run).not.toHaveBeenCalled();
+      // Warm now: the next check re-queues the tenant and the sweep runs.
+      ready = true;
+      await jest.advanceTimersByTimeAsync(60_000);
+      await jest.advanceTimersByTimeAsync(0);
+      expect(reindex.run).toHaveBeenCalledTimes(1);
+      expect(reindex.run).toHaveBeenCalledWith({ tenant: 'co_x', allTables: true });
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it('a deferral on the nightly pass does not start a poller — the next night retries', async () => {
+    jest.useFakeTimers();
+    try {
+      const { svc, reindex } = make({
+        census: { 'knowledge_fact.embedding': [{ width: 1536, count: 39 }] },
+        ready: false,
+      });
+      await svc.reconcileTenant('co_x', 'cron');
+      await jest.advanceTimersByTimeAsync(2 * 60 * 60_000);
+      expect(reindex.run).not.toHaveBeenCalled();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
   it('a conforming corpus is a no-op: no sweep, no job run', async () => {
     const { svc, reindex, jobs } = make({
       census: { 'knowledge_fact.embedding': [{ width: 1024, count: 40 }] },


### PR DESCRIPTION
Follow-up to #540, from its first boot on preprod: the census found the 39 foreign-width `knowledge_fact` rows and deferred the repair because bge-m3 was still warming — the schema-ready hook fires before the ~30 s in-thread warmup completes — and "retried on the next pass" meant the 05:40 UTC cron. That is a day of blind dense retrieval for the tenant.

A deferral on the startup path now polls the embedder's readiness every minute for up to an hour and re-queues the tenant the moment it reports ready (timer unref'd; a warmup that never completes is #518's concern and visible on `/ready`). A deferral on the nightly pass behaves as before.

Unit (`test/vector-corpus.unit-spec.ts`, 10/10): the deferred sweep runs by itself once the embedder is warm and never while it is warming; a cron deferral starts no poller. tsc app + spec, eslint, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhrQxeisXJZEt4sg3PGyU6