### PR TITLE
test(metrics): await the async shutdown hook in the probe armed-series spec

### DIFF
--- a/test/capability-probe.unit-spec.ts
+++ b/test/capability-probe.unit-spec.ts
@@ -508,7 +508,7 @@ describe('capability probe — armed series', () => {
     expect(await armed('embed')).toBeUndefined();
     // The capability that actually ran keeps its arming time.
     expect(await armed('scoped_read')).toBeDefined();
-    svc.onApplicationShutdown();
+    await svc.onApplicationShutdown();
     if (savedFlag === undefined) delete process.env.CAPABILITY_PROBE_ENABLED;
     else process.env.CAPABILITY_PROBE_ENABLED = savedFlag;
   });


### PR DESCRIPTION
**What**: `test/capability-probe.unit-spec.ts:511` — await `onApplicationShutdown()` like every other call in the file.

**Why**: main is red since the #515 merge (CI run 34409890132, `engine-checks/Lint`: `@typescript-eslint/no-floating-promises`). #515 was written against the sync shutdown hook; #539 made the hook async on main, and #515 was merged without a rebase, so the merge commit is the first place the two met. The deploy pipeline correctly refused to deploy the red commit.

**How verified**: `pnpm exec eslint test/capability-probe.unit-spec.ts --max-warnings 0` clean; `capability-probe.unit-spec` 33/33 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhrQxeisXJZEt4sg3PGyU6
