### PR TITLE
fix(synthesize): give the L3 degrade path window centers from every anchor source

### DIFF
--- a/src/synthesize/l3-escalation.service.ts
+++ b/src/synthesize/l3-escalation.service.ts
@@ -33,6 +33,9 @@ import {
   adaptiveL3SessionCount,
   estimateTokens,
   mergeAnchorSources,
+  momentCenters,
+  selectWindowCenters,
+  type L3AnchorCenter,
   type L3SessionAnchor,
   type L3AdaptiveGate,
   type L3AnchorSource,
@@ -100,6 +103,13 @@ interface L3Turn {
 interface L3Fences {
   includePii: boolean;
   userId?: string | undefined;
+}
+
+/** What every anchor source hands back: the ranking anchors AND the
+ *  window centers the over-budget degrade path widens on. */
+interface L3AnchorProbe {
+  anchors: L3SessionAnchor[];
+  centers: L3AnchorCenter[];
 }
 
 export interface L3EscalateInput {
@@ -220,8 +230,8 @@ const L3_DEGRADE_SPAN_MULT = 4;
 /** Ceiling on episode ids resolved per escalation (bounds the IN set). */
 const ANCHOR_EPISODE_CAP = 300;
 /** Aux anchor source top-Ks (L3 anchor independence). Their sum stays
- *  far under ANCHOR_EPISODE_CAP, so aux episodeById insertions are
- *  bounded by construction. */
+ *  far under ANCHOR_EPISODE_CAP, so aux window centers are bounded by
+ *  construction. */
 const L3_DIRECT_ANCHOR_TOPK = 20;
 const L3_SEGMENT_ANCHOR_TOPK = 12;
 const L3_TEMPORAL_ANCHOR_TOPK = 10;
@@ -361,17 +371,23 @@ export class L3EscalationService {
     const includePii = input.callerScopes.includes('brain:read_pii');
     const userId = dto.userId || undefined;
     const fences = { includePii, userId };
-    const { anchors: factAnchors, episodeById } = await this.resolveAnchors(input, fences);
+    const fact = await this.resolveAnchors(input, fences);
+    const factAnchors = fact.anchors;
     let sources: L3AnchorSource[] = [{ source: 'fact', anchors: factAnchors }];
     let anchors = factAnchors;
+    // The degrade-path window centers travel with the anchors from
+    // whichever source produced them, so no anchored session lacks one.
+    let centers = fact.centers;
     if (factAnchors.length === 0) {
       // L3 anchor independence: the aux sources run ONLY on the empty-
       // fact-anchor residual, so a fact-anchored escalation is byte-
       // identical to before, and skipped_no_anchor below now means
       // "every ENABLED anchor source came up empty". No hint boost here:
       // aux anchors carry no predicate, so there is nothing to match.
-      sources = await this.resolveAuxiliaryAnchors(input, fences, episodeById);
+      const aux = await this.resolveAuxiliaryAnchors(input, fences);
+      sources = aux.sources;
       anchors = mergeAnchorSources(sources);
+      centers = aux.centers;
     } else {
       // Attention hints (FOVEA_ATTENTION_HINTS): resolved lazily — the
       // memory-model reader is consulted ONLY here, flag on, on a fired
@@ -423,7 +439,7 @@ export class L3EscalationService {
     const episodeCitations = l3EpisodeCitationsEnabled();
     const ctx = await this.assembleContext(input, {
       sessionIds,
-      episodeById,
+      centers,
       includePii,
       userId,
       episodeCitations,
@@ -505,10 +521,7 @@ export class L3EscalationService {
   private async resolveAnchors(
     input: L3EscalateInput,
     fences: { includePii: boolean; userId?: string | undefined },
-  ): Promise<{
-    anchors: L3SessionAnchor[];
-    episodeById: Map<string, { conversationId: string; atMs?: number | undefined }>;
-  }> {
+  ): Promise<L3AnchorProbe> {
     const factScore = new Map<string, number>();
     // factId → stored predicate id, stamped onto the anchors so the
     // attention-hint boost (FOVEA_ATTENTION_HINTS) can match; inert
@@ -523,7 +536,7 @@ export class L3EscalationService {
       }
     }
     const factIds = [...factScore.keys()];
-    if (factIds.length === 0) return { anchors: [], episodeById: new Map() };
+    if (factIds.length === 0) return { anchors: [], centers: [] };
 
     const factEps = await this.surreal.withCompany(input.companyId, async (db) => {
       const [rows] = await db.query<[Array<{ id?: unknown; eps?: unknown }>]>(
@@ -546,7 +559,7 @@ export class L3EscalationService {
         if (allEpisodeIds.size < ANCHOR_EPISODE_CAP) allEpisodeIds.add(e);
       }
     }
-    if (allEpisodeIds.size === 0) return { anchors: [], episodeById: new Map() };
+    if (allEpisodeIds.size === 0) return { anchors: [], centers: [] };
 
     const episodeRows = await this.episodes.byIds({
       companyId: input.companyId,
@@ -555,12 +568,15 @@ export class L3EscalationService {
       ...(fences.userId !== undefined ? { userId: fences.userId } : {}),
     });
     const episodeById = new Map<string, { conversationId: string; atMs?: number | undefined }>();
+    // One window center per grounding episode (≤ ANCHOR_EPISODE_CAP).
+    const centers: L3AnchorCenter[] = [];
     for (const r of episodeRows) {
       if (!r.conversationId) continue;
-      episodeById.set(String(r.id), {
-        conversationId: String(r.conversationId),
-        atMs: toMs(r.occurredAt),
-      });
+      const episodeId = String(r.id);
+      const conversationId = String(r.conversationId);
+      const atMs = toMs(r.occurredAt);
+      episodeById.set(episodeId, { conversationId, atMs });
+      if (atMs !== undefined) centers.push({ episodeId, conversationId, atMs });
     }
     // One anchor per (fact, conversation): a fact grounded in several
     // turns of one session still counts once toward that session's
@@ -580,7 +596,7 @@ export class L3EscalationService {
         });
       }
     }
-    return { anchors, episodeById };
+    return { anchors, centers };
   }
 
   /**
@@ -591,10 +607,7 @@ export class L3EscalationService {
    * own profile flag, each individually fail-soft (warn + contribute
    * nothing):
    *   direct   — BM25 episode hits on the query text, via the SAME
-   *              fenced searchText read the episode lane uses; returned
-   *              rows also seed `episodeById` (bounded by the source
-   *              topK ≪ ANCHOR_EPISODE_CAP) so the over-budget degrade
-   *              path has window centers.
+   *              fenced searchText read the episode lane uses.
    *   segment  — dense+BM25 RRF-fused segment hits, recall-first (no
    *              rerank).
    *   temporal — conversations active in a query-named absolute period,
@@ -602,22 +615,24 @@ export class L3EscalationService {
    *              here UNCONDITIONALLY (discovery) — distinct from the
    *              lane-gated rank-only window preference in
    *              runEscalation, which is untouched.
-   * All flags off ⇒ empty result, byte-identical skipped_no_anchor.
-   * Every read composes the same PII/user/scope fences as the fact
-   * path.
+   * Every probe returns its window centers alongside its anchors (one
+   * per hit/moment, bounded by the source topK ≪ ANCHOR_EPISODE_CAP),
+   * so the over-budget degrade path can widen around a session only an
+   * aux source named. All flags off ⇒ empty result, byte-identical
+   * skipped_no_anchor. Every read composes the same PII/user/scope
+   * fences as the fact path.
    */
   private async resolveAuxiliaryAnchors(
     input: L3EscalateInput,
     fences: L3Fences,
-    episodeById: Map<string, { conversationId: string; atMs?: number | undefined }>,
-  ): Promise<L3AnchorSource[]> {
+  ): Promise<{ sources: L3AnchorSource[]; centers: L3AnchorCenter[] }> {
     const { profile } = input;
     const probes: Array<{
       source: L3AnchorSource['source'];
-      run: () => Promise<L3SessionAnchor[]>;
+      run: () => Promise<L3AnchorProbe>;
     }> = [];
     if (profile.l3DirectAnchor) {
-      probes.push({ source: 'direct', run: () => this.directAnchors(input, fences, episodeById) });
+      probes.push({ source: 'direct', run: () => this.directAnchors(input, fences) });
     }
     if (profile.l3SegmentAnchor && this.segments) {
       probes.push({ source: 'segment', run: () => this.segmentAnchors(input, fences) });
@@ -626,27 +641,25 @@ export class L3EscalationService {
       probes.push({ source: 'temporal', run: () => this.temporalAnchors(input, fences) });
     }
     const sources: L3AnchorSource[] = [];
+    const centers: L3AnchorCenter[] = [];
     for (const probe of probes) {
       try {
-        const anchors = await probe.run();
-        if (anchors.length > 0) sources.push({ source: probe.source, anchors });
+        const probed = await probe.run();
+        if (probed.anchors.length === 0) continue;
+        sources.push({ source: probe.source, anchors: probed.anchors });
+        centers.push(...probed.centers);
       } catch (e) {
         this.logger.warn(
           `L3 ${probe.source} anchor source failed (companyId=${input.companyId}): ${(e as Error).message}`,
         );
       }
     }
-    return sources;
+    return { sources, centers };
   }
 
-  /** Direct aux probe: fenced BM25 episode hits → session anchors; the
-   *  rows also seed episodeById (window centers for the degrade path),
-   *  bounded by the source topK ≪ ANCHOR_EPISODE_CAP. */
-  private async directAnchors(
-    input: L3EscalateInput,
-    fences: L3Fences,
-    episodeById: Map<string, { conversationId: string; atMs?: number | undefined }>,
-  ): Promise<L3SessionAnchor[]> {
+  /** Direct aux probe: fenced BM25 episode hits → session anchors, each
+   *  hit its own episode-keyed window center. */
+  private async directAnchors(input: L3EscalateInput, fences: L3Fences): Promise<L3AnchorProbe> {
     const rows = await this.episodes.searchText({
       companyId: input.companyId,
       query: input.dto.query,
@@ -655,24 +668,26 @@ export class L3EscalationService {
       ...(fences.userId !== undefined ? { userId: fences.userId } : {}),
     });
     const anchors: L3SessionAnchor[] = [];
+    const centers: L3AnchorCenter[] = [];
     for (const r of rows) {
       if (!r.conversationId) continue;
       const conversationId = String(r.conversationId);
       const atMs = toMs(r.occurredAt);
       anchors.push({ conversationId, score: r.score ?? 0, atMs });
-      if (r.id !== undefined && episodeById.size < ANCHOR_EPISODE_CAP) {
-        const key = String(r.id);
-        if (!episodeById.has(key)) episodeById.set(key, { conversationId, atMs });
+      if (atMs !== undefined) {
+        centers.push({
+          conversationId,
+          atMs,
+          ...(r.id !== undefined ? { episodeId: String(r.id) } : {}),
+        });
       }
     }
-    return anchors;
+    return { anchors, centers };
   }
 
-  /** Segment aux probe: fused segment hits → session anchors. */
-  private async segmentAnchors(
-    input: L3EscalateInput,
-    fences: L3Fences,
-  ): Promise<L3SessionAnchor[]> {
+  /** Segment aux probe: fused segment hits → session anchors, one
+   *  moment center per hit. */
+  private async segmentAnchors(input: L3EscalateInput, fences: L3Fences): Promise<L3AnchorProbe> {
     const rows =
       (await this.segments?.topSegmentAnchors({
         companyId: input.companyId,
@@ -681,22 +696,20 @@ export class L3EscalationService {
         ...(fences.userId !== undefined ? { userId: fences.userId } : {}),
         limit: L3_SEGMENT_ANCHOR_TOPK,
       })) ?? [];
-    return rows.map((r): L3SessionAnchor => ({
+    const anchors = rows.map((r): L3SessionAnchor => ({
       conversationId: r.conversationId,
       score: r.score,
       atMs: toMs(r.occurredAt),
     }));
+    return { anchors, centers: momentCenters(anchors) };
   }
 
   /** Temporal aux probe: conversations active in the query-named
-   *  absolute period, scored by visible turn count. No parseable
-   *  period → no read, no anchors. */
-  private async temporalAnchors(
-    input: L3EscalateInput,
-    fences: L3Fences,
-  ): Promise<L3SessionAnchor[]> {
+   *  absolute period, scored by visible turn count, one moment center
+   *  per conversation. No parseable period → no read, no anchors. */
+  private async temporalAnchors(input: L3EscalateInput, fences: L3Fences): Promise<L3AnchorProbe> {
     const range = parseQueryTimeRange(input.dto.query);
-    if (!range) return [];
+    if (!range) return { anchors: [], centers: [] };
     const rows = await this.episodes.conversationsInRange({
       companyId: input.companyId,
       fromIso: new Date(range.fromMs).toISOString(),
@@ -705,24 +718,27 @@ export class L3EscalationService {
       includePii: fences.includePii,
       ...(fences.userId !== undefined ? { userId: fences.userId } : {}),
     });
-    return rows.map((r): L3SessionAnchor => ({
+    const anchors = rows.map((r): L3SessionAnchor => ({
       conversationId: r.conversationId,
       score: r.turns,
       atMs: r.atMs,
     }));
+    return { anchors, centers: momentCenters(anchors) };
   }
 
   /**
    * Fetch the selected full sessions and render them as fenced
    * transcript sections. When the assembled context exceeds the token
-   * cap, degrade to widened L2 raw-turn windows around the anchor turns
-   * of those sessions instead of truncating a session mid-way.
+   * cap, degrade to widened L2 raw-turn windows around the anchor
+   * centers of those sessions instead of truncating a session mid-way.
    */
   private async assembleContext(
     input: L3EscalateInput,
     args: {
       sessionIds: string[];
-      episodeById: Map<string, { conversationId: string; atMs?: number | undefined }>;
+      /** Every anchor source's window centers; narrowed to the selected
+       *  sessions here (selectWindowCenters). */
+      centers: L3AnchorCenter[];
       includePii: boolean;
       userId?: string | undefined;
       /** FOVEA_L3_EPISODE_CITATIONS: render [episode:...] turn headers
@@ -750,25 +766,20 @@ export class L3EscalationService {
         turnsById: args.episodeCitations ? citableTurnsOf(sessions) : new Map(),
       };
     }
-    // Over budget: widen the L2 windows around the anchor turns of the
+    // Over budget: widen the L2 windows around the anchor centers of the
     // selected sessions (reuse windowAround) rather than truncating.
-    const selected = new Set(args.sessionIds);
-    const centers = [...args.episodeById.entries()].filter(([, v]) =>
-      selected.has(v.conversationId),
-    );
+    const centers = selectWindowCenters(args.centers, args.sessionIds);
     const span = Math.max(1, input.profile.rawWindowSpan * L3_DEGRADE_SPAN_MULT);
     const windows = await Promise.all(
-      centers.map(([, v]): Promise<L3Turn[]> =>
-        v.atMs === undefined
-          ? Promise.resolve([])
-          : this.episodes.windowAround({
-              companyId: input.companyId,
-              conversationId: v.conversationId,
-              centerIso: new Date(v.atMs).toISOString(),
-              span,
-              includePii: args.includePii,
-              ...(args.userId !== undefined ? { userId: args.userId } : {}),
-            }),
+      centers.map((c): Promise<L3Turn[]> =>
+        this.episodes.windowAround({
+          companyId: input.companyId,
+          conversationId: c.conversationId,
+          centerIso: new Date(c.atMs).toISOString(),
+          span,
+          includePii: args.includePii,
+          ...(args.userId !== undefined ? { userId: args.userId } : {}),
+        }),
       ),
     );
     const byId = new Map<string, L3Turn>();

--- a/src/synthesize/l3-escalation.ts
+++ b/src/synthesize/l3-escalation.ts
@@ -280,6 +280,55 @@ export function mergeAnchorSources(
 }
 
 /**
+ * One window center for the over-budget degrade path: the moment inside
+ * a session an anchor points at. EVERY anchor source populates centers
+ * alongside its anchors — fact stamps one per grounding episode, the
+ * direct probe one per BM25 hit, segment/temporal one per anchor moment
+ * — so a session selected from any source has ≥1 center to widen a raw
+ * window around. An anchor with no parseable time yields no center.
+ */
+export interface L3AnchorCenter {
+  conversationId: string;
+  atMs: number;
+  /** The centering turn when the source knows it (fact/direct);
+   *  segment/temporal centers are moment-only. */
+  episodeId?: string | undefined;
+}
+
+/** Moment-only centers, one per anchor that carries a time — the
+ *  segment/temporal probes' contribution. Pure; no IO. */
+export function momentCenters(anchors: ReadonlyArray<L3SessionAnchor>): L3AnchorCenter[] {
+  const out: L3AnchorCenter[] = [];
+  for (const a of anchors) {
+    if (typeof a.atMs !== 'number' || !Number.isFinite(a.atMs)) continue;
+    out.push({ conversationId: a.conversationId, atMs: a.atMs });
+  }
+  return out;
+}
+
+/**
+ * The centers the degrade path widens on: those inside the selected
+ * sessions, deduplicated by episodeId when known and by
+ * (conversationId, atMs) otherwise, in first-seen order. Pure; no IO.
+ */
+export function selectWindowCenters(
+  centers: ReadonlyArray<L3AnchorCenter>,
+  sessionIds: ReadonlyArray<string>,
+): L3AnchorCenter[] {
+  const selected = new Set(sessionIds);
+  const seen = new Set<string>();
+  const out: L3AnchorCenter[] = [];
+  for (const c of centers) {
+    if (!selected.has(c.conversationId)) continue;
+    const key = c.episodeId ?? `${c.conversationId}|${c.atMs}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(c);
+  }
+  return out;
+}
+
+/**
  * Cheap token estimate for the L3 budget check — chars / 4, the usual
  * English-token rule of thumb. Deliberately an over-approximation-safe
  * heuristic (no tokenizer dependency on the escalation hot path): the

--- a/test/l3-escalation.unit-spec.ts
+++ b/test/l3-escalation.unit-spec.ts
@@ -9,7 +9,8 @@
  *    preference for windowed (temporal-class) questions.
  *  - Service: anchor requirement (no session → skipped_no_anchor, no
  *    full-context call), the flip / no-flip telemetry, and the
- *    over-budget → widened-window degrade path.
+ *    over-budget → widened-window degrade path, whose window centers
+ *    come from EVERY anchor source (fact / direct / segment / temporal).
  */
 import type OpenAI from 'openai';
 import {
@@ -19,6 +20,9 @@ import {
   estimateTokens,
   adaptiveL3SessionCount,
   mergeAnchorSources,
+  momentCenters,
+  selectWindowCenters,
+  type L3AnchorCenter,
   type L3SessionAnchor,
 } from '../src/synthesize/l3-escalation';
 import { hasUsableCalibration } from '../src/synthesize/focus-signal';
@@ -390,6 +394,50 @@ describe('mergeAnchorSources — attention-hint boost', () => {
   });
 });
 
+describe('momentCenters + selectWindowCenters — degrade-path window centers', () => {
+  it('momentCenters: one moment-only center per timed anchor; untimed anchors yield none', () => {
+    const anchors: L3SessionAnchor[] = [
+      { conversationId: 'a', score: 1, atMs: 1000 },
+      { conversationId: 'a', score: 1, atMs: 2000 },
+      { conversationId: 'b', score: 1 },
+      { conversationId: 'c', score: 1, atMs: Number.NaN },
+    ];
+    expect(momentCenters(anchors)).toEqual([
+      { conversationId: 'a', atMs: 1000 },
+      { conversationId: 'a', atMs: 2000 },
+    ]);
+  });
+
+  it('selectWindowCenters: keeps only the selected sessions, in first-seen order', () => {
+    const centers: L3AnchorCenter[] = [
+      { conversationId: 'b', atMs: 5, episodeId: 'episode:b1' },
+      { conversationId: 'a', atMs: 1 },
+      { conversationId: 'c', atMs: 9 },
+    ];
+    expect(selectWindowCenters(centers, ['a', 'b'])).toEqual([
+      { conversationId: 'b', atMs: 5, episodeId: 'episode:b1' },
+      { conversationId: 'a', atMs: 1 },
+    ]);
+    expect(selectWindowCenters(centers, [])).toEqual([]);
+  });
+
+  it('selectWindowCenters: dedupes by episodeId when known, by (session, moment) otherwise', () => {
+    const centers: L3AnchorCenter[] = [
+      { conversationId: 'a', atMs: 1, episodeId: 'episode:e1' },
+      { conversationId: 'a', atMs: 1, episodeId: 'episode:e1' },
+      // A second turn at the same moment is a distinct episode-keyed center.
+      { conversationId: 'a', atMs: 1, episodeId: 'episode:e2' },
+      { conversationId: 'a', atMs: 7 },
+      { conversationId: 'a', atMs: 7 },
+    ];
+    expect(selectWindowCenters(centers, ['a'])).toEqual([
+      { conversationId: 'a', atMs: 1, episodeId: 'episode:e1' },
+      { conversationId: 'a', atMs: 1, episodeId: 'episode:e2' },
+      { conversationId: 'a', atMs: 7 },
+    ]);
+  });
+});
+
 describe('verifierPasses + estimateTokens', () => {
   it('passes only on supported (and answering under topic coverage)', () => {
     expect(verifierPasses({ verdict: 'supported' }, false)).toBe(true);
@@ -411,6 +459,9 @@ interface Mocks {
   /** One entry per counted episode-citation outcome (n expanded). */
   episodeCitationOutcomes: string[];
   windowAroundCalls: number;
+  /** Every windowAround call's center, in order — the observable
+   *  degrade-path window centers. */
+  windowAroundArgs: Array<{ conversationId: string; centerIso: string; span: number }>;
   conversationTurnsCalls: number;
   /** conversationIds fetched, in order — the observable session ranking. */
   conversationTurnsIds: string[];
@@ -496,6 +547,7 @@ function makeService(opts: {
     anchorSources: [],
     episodeCitationOutcomes: [],
     windowAroundCalls: 0,
+    windowAroundArgs: [],
     conversationTurnsCalls: 0,
     conversationTurnsIds: [],
     searchTextCalls: 0,
@@ -514,8 +566,13 @@ function makeService(opts: {
       mocks.conversationTurnsIds.push(a.conversationId);
       return opts.sessionTurns[a.conversationId] ?? [];
     },
-    windowAround: async () => {
+    windowAround: async (a: { conversationId: string; centerIso: string; span: number }) => {
       mocks.windowAroundCalls += 1;
+      mocks.windowAroundArgs.push({
+        conversationId: a.conversationId,
+        centerIso: a.centerIso,
+        span: a.span,
+      });
       return opts.windowTurns ?? [];
     },
     searchText: async () => {
@@ -1049,6 +1106,169 @@ describe('L3EscalationService — auxiliary anchor sources', () => {
       expect(mocks.conversationsInRangeCalls).toBe(1);
       expect(mocks.anchorSources).toEqual(['temporal']);
     }
+  });
+});
+
+// ── service: degrade-path window centers per anchor source ──────────
+describe('L3EscalationService — over-budget degrade centers from every anchor source', () => {
+  // A session that blows the tiny token cap on its own: the widened
+  // windows (windowAround) are the only way any transcript reaches the
+  // generator, so an anchor source without centers yields NO evidence.
+  const bigText = 'x'.repeat(2000);
+  const flipScript = () =>
+    fakeOpenAi([
+      JSON.stringify({ answer: 'sapphire', citedFactIds: [] }),
+      JSON.stringify({ verdict: 'supported', unsupportedClaims: [] }),
+    ]);
+  const windowTurns = [
+    {
+      id: 'episode:w1',
+      speaker: 'user',
+      text: 'tier is sapphire',
+      occurredAt: '2026-04-01T00:00:00Z',
+    },
+  ];
+  const overBudget = (overrides: Partial<RetrievalProfile>) =>
+    makeProfile({ l3TokenCap: 10, ...overrides });
+  // makeProfile's rawWindowSpan 2 × the L3 degrade multiplier 4.
+  const DEGRADE_SPAN = 8;
+  const bigSession = (id: string, occurredAt: string) => [
+    { id, speaker: 'user', text: bigText, occurredAt },
+  ];
+
+  it('segment-only anchors + long conversation → windows around the segment moments', async () => {
+    const { service, mocks } = makeService({
+      factEps: [],
+      episodesByIds: [],
+      sessionTurns: { conv_seg: bigSession('episode:s1', '2026-04-01T00:00:00Z') },
+      segmentAnchors: [
+        { conversationId: 'conv_seg', occurredAt: '2026-04-01T00:00:00Z', score: 0.03 },
+        { conversationId: 'conv_seg', occurredAt: '2026-04-02T00:00:00Z', score: 0.02 },
+      ],
+      windowTurns,
+    });
+    const out = await service.escalate(
+      baseInput(flipScript(), overBudget({ l3SegmentAnchor: true })),
+    );
+    expect(out?.answer).toBe('sapphire');
+    expect(mocks.outcomes).toEqual(['fired', 'over_budget_degraded', 'flipped']);
+    expect(mocks.anchorSources).toEqual(['segment']);
+    expect(mocks.windowAroundArgs).toEqual([
+      { conversationId: 'conv_seg', centerIso: '2026-04-01T00:00:00.000Z', span: DEGRADE_SPAN },
+      { conversationId: 'conv_seg', centerIso: '2026-04-02T00:00:00.000Z', span: DEGRADE_SPAN },
+    ]);
+  });
+
+  it('temporal-only anchors + long conversation → a window around the in-range moment', async () => {
+    const { service, mocks } = makeService({
+      factEps: [],
+      episodesByIds: [],
+      sessionTurns: { conv_range: bigSession('episode:t1', '2023-05-03T00:00:00Z') },
+      rangeConversations: [{ conversationId: 'conv_range', atMs: Date.UTC(2023, 4, 3), turns: 4 }],
+      windowTurns,
+    });
+    const out = await service.escalate({
+      ...baseInput(flipScript(), overBudget({ l3TemporalAnchor: true })),
+      dto: { query: 'what tier did I have in May 2023?' } as SynthesizeDto,
+    });
+    expect(out?.answer).toBe('sapphire');
+    expect(mocks.outcomes).toEqual(['fired', 'over_budget_degraded', 'flipped']);
+    expect(mocks.anchorSources).toEqual(['temporal']);
+    expect(mocks.windowAroundArgs).toEqual([
+      { conversationId: 'conv_range', centerIso: '2023-05-03T00:00:00.000Z', span: DEGRADE_SPAN },
+    ]);
+  });
+
+  it('direct-only anchors + long conversation → one window per BM25 hit (unchanged)', async () => {
+    const { service, mocks } = makeService({
+      factEps: [],
+      episodesByIds: [],
+      sessionTurns: { conv_direct: bigSession('episode:d1', '2026-04-01T00:00:00Z') },
+      searchTextRows: [
+        {
+          id: 'episode:d1',
+          conversationId: 'conv_direct',
+          speaker: 'user',
+          text: 'tier',
+          occurredAt: '2026-04-01T00:00:00Z',
+          score: 3.2,
+        },
+        {
+          id: 'episode:d2',
+          conversationId: 'conv_direct',
+          speaker: 'user',
+          text: 'sapphire',
+          occurredAt: '2026-04-03T00:00:00Z',
+          score: 1.1,
+        },
+      ],
+      windowTurns,
+    });
+    const out = await service.escalate(
+      baseInput(flipScript(), overBudget({ l3DirectAnchor: true })),
+    );
+    expect(out?.answer).toBe('sapphire');
+    expect(mocks.outcomes).toEqual(['fired', 'over_budget_degraded', 'flipped']);
+    expect(mocks.anchorSources).toEqual(['direct']);
+    expect(mocks.windowAroundArgs).toEqual([
+      { conversationId: 'conv_direct', centerIso: '2026-04-01T00:00:00.000Z', span: DEGRADE_SPAN },
+      { conversationId: 'conv_direct', centerIso: '2026-04-03T00:00:00.000Z', span: DEGRADE_SPAN },
+    ]);
+  });
+
+  it('fact anchors + long conversation → one window per grounding episode of the SELECTED sessions only (unchanged)', async () => {
+    const F2 = 'knowledge_fact:f2';
+    const hit = (factId: string, score: number): SearchHit => ({
+      entityId: 'knowledge_entity:e1',
+      entityType: 'topic',
+      canonicalName: 'tier',
+      externalRefs: {},
+      facts: [
+        {
+          factId,
+          predicate: 'tier',
+          object: 'sapphire',
+          confidence: 0.9,
+          validFrom: '2026-04-01T00:00:00Z',
+          status: 'active',
+          score,
+        },
+      ],
+      score,
+    });
+    const { service, mocks } = makeService({
+      // f1 grounds in two turns of conv1, f2 in one turn of conv2.
+      factEps: [
+        { id: FACT_ID, eps: ['episode:ep1', 'episode:ep2'] },
+        { id: F2, eps: ['episode:ep3'] },
+      ],
+      episodesByIds: [
+        { id: 'episode:ep1', conversationId: 'conv1', occurredAt: '2026-04-01T00:00:00Z' },
+        { id: 'episode:ep2', conversationId: 'conv1', occurredAt: '2026-04-01T01:00:00Z' },
+        { id: 'episode:ep3', conversationId: 'conv2', occurredAt: '2026-04-02T00:00:00Z' },
+      ],
+      sessionTurns: {
+        conv1: bigSession('episode:ep1', '2026-04-01T00:00:00Z'),
+        conv2: bigSession('episode:ep3', '2026-04-02T00:00:00Z'),
+      },
+      windowTurns,
+    });
+    // Both scores stay under the coverage floor (the ladder must fire);
+    // equal density (one fact each), so f1's higher score ranks conv1
+    // first and l3MaxSessions 1 selects it alone.
+    const out = await service.escalate({
+      ...baseInput(flipScript(), overBudget({ l3MaxSessions: 1 })),
+      results: [hit(FACT_ID, 0.2), hit(F2, 0.1)],
+    });
+    expect(out?.answer).toBe('sapphire');
+    expect(mocks.outcomes).toEqual(['fired', 'over_budget_degraded', 'flipped']);
+    expect(mocks.anchorSources).toEqual(['fact']);
+    expect(mocks.conversationTurnsIds).toEqual(['conv1']);
+    // Both conv1 grounding turns are centers; conv2's is not selected.
+    expect(mocks.windowAroundArgs).toEqual([
+      { conversationId: 'conv1', centerIso: '2026-04-01T00:00:00.000Z', span: DEGRADE_SPAN },
+      { conversationId: 'conv1', centerIso: '2026-04-01T01:00:00.000Z', span: DEGRADE_SPAN },
+    ]);
   });
 });
 


### PR DESCRIPTION
## What

The L3 over-budget fallback now gets its widened-window centers from **every** anchor source, not only from the fact grounding stamps.

- `src/synthesize/l3-escalation.ts` (pure): new `L3AnchorCenter { conversationId, atMs, episodeId? }` plus two pure helpers — `momentCenters(anchors)` (one moment-only center per timed anchor) and `selectWindowCenters(centers, sessionIds)` (narrow to the ranked sessions, dedupe by `episodeId` when known, else by `(conversationId, atMs)`).
- `src/synthesize/l3-escalation.service.ts`: every anchor probe returns `{ anchors, centers }` (`L3AnchorProbe`) — fact stamps one center per grounding episode, direct one per BM25 hit (episode-keyed), segment and temporal one per anchor moment. `runEscalation` carries the centers of whichever source anchored the escalation, and `assembleContext()` takes `centers` instead of `episodeById` and widens around `selectWindowCenters(centers, sessionIds)`. The `episodeById` map survives only as the local episode→conversation lookup inside `resolveAnchors`.
- Ranking (`rankL3Sessions` / `mergeAnchorSources`), lane selection and the retrieval profiles are untouched; the fact and direct paths issue exactly the same `windowAround` calls as before (same centers, same span).

## Why

Audit `docs/audits/2026-09-06-current-state-review.md`, "Дополнительные замечания" item 3: the segment and temporal probes returned only conversation/time and never filled `episodeById`, so a segment- or temporal-only escalation whose ranked session exceeded `l3TokenCap` had **zero** window centers — `assembleContext()` rendered nothing and `runEscalation` returned `null` (no `over_budget_degraded`, no generation). The L3 lane exists precisely for the case where extraction missed the information (no fact anchors), which is where these aux sources fire, so the fallback was empty exactly when it was needed.

## How verified

- New unit tests in `test/l3-escalation.unit-spec.ts`:
  - pure: `momentCenters` + `selectWindowCenters` (selection, order, dedupe rules);
  - service: **segment-only** and **temporal-only** anchors + a session over the cap → `['fired', 'over_budget_degraded', 'flipped']` with `windowAround` called at the segment moments / the in-range moment (both FAIL against `origin/main`'s service: `out === null`, no window read);
  - regressions: **direct-only** (one window per BM25 hit) and **fact anchors** (one window per grounding episode of the SELECTED sessions only, span = `rawWindowSpan × 4`) — unchanged behaviour, pinned by the captured `windowAround` args.
- Gap proof: with `origin/main`'s `l3-escalation.service.ts` swapped in, the new describe block runs `2 failed, 2 passed` (segment/temporal fail, direct/fact pass); with this branch `84 passed`.
- `pnpm typecheck` — pass.
- `pnpm format:check` — "All matched files use Prettier code style!".
- `pnpm jest --config ./test/jest-unit.json --testPathIgnorePatterns='/node_modules/' --modulePathIgnorePatterns='/__none__/' --testPathPatterns 'l3-escalation|engine-gates|flag-budget|l3-citations'` — `Test Suites: 4 passed, 4 total; Tests: 84 passed, 84 total` (engine layering / dead-export gates and the flag budget included; no new knobs).
- `pnpm jest --config ./test/jest-e2e.json ... --testPathPatterns 'l3-escalation.e2e'` (Docker testcontainers) — `Test Suites: 1 passed, 1 total; Tests: 14 passed, 14 total`.
- `pnpm lint:ci` — fails on one **pre-existing** offender unrelated to this PR (`test/capability-probe.unit-spec.ts:511` no-floating-promises, identical on `origin/main`); the files touched here are lint-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhrQxeisXJZEt4sg3PGyU6
