### PR TITLE
fix(router): move the NLI intent model to a public repo, back off failed warmups, and show them as degraded

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -145,15 +145,19 @@ SEARCH_RERANKER_SC_N=1
 # SEARCH_CROSS_ENCODER_LOCAL_WORKER=1    # 0 = in-thread (benchmarks/constrained envs)
 
 # ── Chat-route NLI intent classifier ─────────────────────────────────────
-# Zero-shot NLI model (~135MB ONNX via @xenova/transformers) that classifies
+# Zero-shot NLI model (~340MB ONNX via @xenova/transformers) that classifies
 # chat messages as ask/tell on the router's local pre-pass. On by default;
 # until the model warms up, the router uses the punctuation-only heuristic.
+# The model must be a public HuggingFace repo with a transformers.js export
+# (the former default Xenova/distilbert-base-multilingual-cased-finetuned-mnli
+# is gated: HTTP 401, never warms). A failed warmup retries with backoff
+# (5m doubling to 1h) and shows as degraded on /v1/admin/health/components.
 # CHAT_ROUTE_NLI_ENABLED=true
-# CHAT_ROUTE_NLI_MODEL=Xenova/distilbert-base-multilingual-cased-finetuned-mnli
+# CHAT_ROUTE_NLI_MODEL=Xenova/mDeBERTa-v3-base-xnli-multilingual-nli-2mil7
 # CHAT_ROUTE_NLI_ASK_THRESHOLD=0.6
 #
-# Inference runs in a dedicated worker_thread so the ~100-200ms ONNX pass never
-# blocks the event loop (set TRANSFORMERS_CACHE so the model caches across
+# Inference runs in a dedicated worker_thread so the ONNX pass (hundreds of ms)
+# never blocks the event loop (set TRANSFORMERS_CACHE so the model caches across
 # restarts). If a classify RPC exceeds the deadline, the router keeps the
 # punctuation fallback and the classifier latches off for 5 minutes.
 # CHAT_ROUTE_NLI_WORKER=1        # 0 = in-thread (benchmarks/constrained envs)

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -343,7 +343,7 @@ under the `ProcessRole` context.
 |---|---|---|
 | `all` (default) | none | Byte-identical single-process behavior. |
 | `api` | `WORKER_LOOP_ENABLED=0`, `JOB_WORKER_POOL_SIZE=0` | Serves HTTP; never claims/dispatches queued jobs; skips the `worker_threads` job pool (it serves cpuBound *job* handlers only — nothing on the request path uses it). |
-| `worker` | `CHAT_ROUTE_NLI_ENABLED=false` | Runs the queue loop + crons. Keeps the HTTP server up (healthcheck + `/v1/admin/*` need it) but the compose recipe publishes no ports. Skips the ~135MB NLI intent-classifier ONNX model — a worker pod doesn't chat-route. |
+| `worker` | `CHAT_ROUTE_NLI_ENABLED=false` | Runs the queue loop + crons. Keeps the HTTP server up (healthcheck + `/v1/admin/*` need it) but the compose recipe publishes no ports. Skips the ~340MB NLI intent-classifier ONNX model — a worker pod doesn't chat-route. |
 
 **`JOBS_QUEUE_MODE=enqueue` is required** (it is the default):
 `PROCESS_ROLE=api|worker` combined with `JOBS_QUEUE_MODE=inline` fails
@@ -392,7 +392,7 @@ worker service out of the single-process deployment.
 - A second pod is a second full Node + Nest RSS (~200-300MB baseline
   before models) plus its own SurrealDB connection pool
   (`SURREALDB_POOL_SIZE` per pod). Budget both against the host.
-- ONNX models lazy-load where used: the NLI intent classifier (~135MB)
+- ONNX models lazy-load where used: the NLI intent classifier (~340MB)
   loads only where chat routing runs (api pod; disabled on worker by
   the role default), the local cross-encoder (~279MB, opt-in) only
   where search runs. The BGE-M3 embedder (~150MB, when

--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -356,6 +356,15 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
     isBooleanFlag: true,
   },
   {
+    key: 'CHAT_ROUTE_NLI_MODEL',
+    category: 'router',
+    defaultValue: 'Xenova/mDeBERTa-v3-base-xnli-multilingual-nli-2mil7',
+    runtimeMutable: false,
+    isBooleanFlag: false,
+    description:
+      'HuggingFace repo of the zero-shot NLI intent model (transformers.js ONNX export, must cover English + Russian). Xenova/distilbert-base-multilingual-cased-finetuned-mnli, Xenova/mDeBERTa-v3-base-mnli-xnli and Xenova/xlm-roberta-large-xnli answer HTTP 401 on the Hub and never warm. A gated/removed repo shows as degraded on /v1/admin/health/components with the reason.',
+  },
+  {
     key: 'CHAT_ROUTE_NLI_ASK_THRESHOLD',
     category: 'router',
     defaultValue: '0.6',

--- a/src/admin/health-components.service.ts
+++ b/src/admin/health-components.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { envFlagNotDisabled } from '../common/env-validation';
 import { HealthService, type ReadinessReport } from '../common/health.service';
+import type { WarmupStatus } from '../common/warmup-status';
 import { EmbedderService } from '../ai/embedder.service';
 import { CapabilityProbeService, type LastProbeReport } from '../metrics/capability-probe.service';
 import { isConclusive } from '../metrics/capability-probe';
@@ -104,19 +105,13 @@ export class HealthComponentsService {
     const name = `embedder (${stats.provider})`;
     const w = r.detail.embedder;
     if (!r.embedderReady) {
-      const attempt = w.failures > 0 ? `warmup failed ${w.failures}×` : 'warming up';
-      const detail = w.lastError ? ` (last error: ${w.lastError})` : '';
-      const next = w.inFlight
-        ? 'attempt in flight'
-        : w.nextRetryAt
-          ? `next attempt at ${w.nextRetryAt}`
-          : 'the next readiness poll re-arms an attempt';
       return {
         name,
         status: w.failures > 0 ? 'degraded' : 'warming',
         message: joinParts(
-          `${attempt}${detail}; ${next}. Queries that need the configured space are refused ` +
-            `(503) until the primary is ready; hybrid search answers lexical-only`,
+          `${warmupSummary(w, 'the next readiness poll re-arms an attempt')}. Queries that need ` +
+            `the configured space are refused (503) until the primary is ready; hybrid search ` +
+            `answers lexical-only`,
           probeSummary(probe),
         ),
       };
@@ -130,14 +125,34 @@ export class HealthComponentsService {
     };
   }
 
+  /**
+   * Not a `/ready` gate — chat routing answers with the punctuation
+   * heuristic while the model is missing — but the same warmup bookkeeping
+   * as the embedder row, so a model repo that vanished from the Hub reads
+   * `degraded` with the reason instead of `warming` forever.
+   */
   private intentRow(): HealthComponent {
     const intentStats = this.intent.stats();
+    const name = 'intent classifier';
+    if (!intentStats.enabled) {
+      return { name, status: 'disabled', message: 'CHAT_ROUTE_NLI_ENABLED=0' };
+    }
+    if (!intentStats.ready) {
+      const w = this.intent.warmupStatus();
+      return {
+        name,
+        status: w.failures > 0 ? 'degraded' : 'warming',
+        message: joinParts(
+          `${warmupSummary(w, 'the next chat-route request re-arms an attempt')}. Chat routing ` +
+            `answers with the punctuation-only intent heuristic meanwhile`,
+          `model=${intentStats.model}`,
+        ),
+      };
+    }
     return {
-      name: 'intent classifier',
-      status: !intentStats.enabled ? 'disabled' : intentStats.ready ? 'ok' : 'warming',
-      message: intentStats.enabled
-        ? `model=${intentStats.model} cache=${intentStats.cacheSize}`
-        : 'CHAT_ROUTE_NLI_ENABLED=0',
+      name,
+      status: 'ok',
+      message: `model=${intentStats.model} cache=${intentStats.cacheSize}`,
     };
   }
 
@@ -175,6 +190,22 @@ export class HealthComponentsService {
       message: 'see /admin/calibration for ECE + version history',
     };
   }
+}
+
+/**
+ * `warmup failed 3× (last error: …); next attempt at …` — one wording for
+ * every not-ready model row; `rearm` says what triggers an attempt when
+ * none is scheduled.
+ */
+function warmupSummary(w: WarmupStatus, rearm: string): string {
+  const attempt = w.failures > 0 ? `warmup failed ${w.failures}×` : 'warming up';
+  const detail = w.lastError ? ` (last error: ${w.lastError})` : '';
+  const next = w.inFlight
+    ? 'attempt in flight'
+    : w.nextRetryAt
+      ? `next attempt at ${w.nextRetryAt}`
+      : rearm;
+  return `${attempt}${detail}; ${next}`;
 }
 
 /** `probe serving 12s ago`, or the failure with its detail when conclusive. */

--- a/src/admin/intent-classifier.service.ts
+++ b/src/admin/intent-classifier.service.ts
@@ -5,6 +5,7 @@ import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { LRUCache } from '../common/lru-cache';
 import { envFlagEnabled, envFlagNotDisabled } from '../common/env-validation';
+import type { WarmupStatus } from '../common/warmup-status';
 
 /**
  * Zero-shot intent classifier — multilingual NLI without enumerated
@@ -30,17 +31,23 @@ import { envFlagEnabled, envFlagNotDisabled } from '../common/env-validation';
  * reranker, src/ai/cross-encoder/local-cross-encoder.provider.ts). Every
  * worker failure mode — spawn failure, warmup failure, RPC timeout,
  * crash — degrades to the punctuation fallback, i.e. exactly the
- * pre-warmup behavior, and latches for FAIL_RETRY_MS before re-warming.
+ * pre-warmup behavior, and waits out the retry backoff before re-warming.
  * The LRU cache stays on the main thread, so repeat queries never pay
  * the RPC hop.
  *
- * Model choice: `Xenova/distilbert-base-multilingual-cased-finetuned-mnli`
- * (~135MB ONNX). XNLI-finetuned distilbert, 100+ languages including
- * English + Russian. Trade-off vs `Xenova/mDeBERTa-v3-base-mnli-xnli`
- * (~330MB, better quality): the distilled model gives sub-200ms
- * inference on Node CPU, which keeps the LLM-skip path latency budget
- * intact. Override with CHAT_ROUTE_NLI_MODEL when better accuracy is
- * worth the latency.
+ * Model contract: a public HuggingFace repo with a transformers.js
+ * zero-shot-classification ONNX export that covers English and Russian.
+ * Default `Xenova/mDeBERTa-v3-base-xnli-multilingual-nli-2mil7` (~340MB
+ * quantized). The previous default (`Xenova/distilbert-base-multilingual-
+ * cased-finetuned-mnli`) and the other Xenova XNLI exports now answer HTTP
+ * 401 on the Hub, so a deployment that still names one of them never
+ * warms. Override with CHAT_ROUTE_NLI_MODEL.
+ *
+ * Warmup failures back off (5m, doubling, capped at 1h) with a timer-driven
+ * retry; a 401/403/404 from the Hub means the repo is gated or gone, so
+ * that failure starts at the ceiling instead of climbing to it. The
+ * bookkeeping is `warmupStatus()`, the same shape the embedder reports,
+ * so the admin health grid shows the classifier degraded with the reason.
  *
  * No hardcoded phrase lists, no wh-pronoun catalogues, no
  * "interrogative cues" tables — every signal is derived from the
@@ -64,12 +71,24 @@ export interface IntentResult {
 }
 
 const CACHE_SIZE = 2000;
-const DEFAULT_MODEL = 'Xenova/distilbert-base-multilingual-cased-finetuned-mnli';
+const DEFAULT_MODEL = 'Xenova/mDeBERTa-v3-base-xnli-multilingual-nli-2mil7';
 const NLI_LABELS = ['question', 'statement'];
 const HYPOTHESIS_TEMPLATE = 'This text is a {}.';
-const WORKER_WARMUP_TIMEOUT_MS = 120_000;
+const WORKER_WARMUP_TIMEOUT_MS = 300_000;
 const DEFAULT_CLASSIFY_TIMEOUT_MS = 3_000;
+/** Latch after a classify RPC timeout before a replacement worker is warmed. */
 const FAIL_RETRY_MS = 5 * 60_000;
+/** First retry after a failed warmup; doubles per failure. */
+const WARMUP_RETRY_BASE_MS = 5 * 60_000;
+/** Ceiling on the warmup retry interval. */
+const WARMUP_RETRY_MAX_MS = 60 * 60_000;
+/**
+ * transformers.js wording for the Hub statuses that mean the repo is gated
+ * or gone (401/403/404). No retry fixes that model id, so the backoff
+ * starts at its ceiling.
+ */
+const PERMANENT_LOAD_ERROR =
+  /Unauthorized access to file|Forbidden access to file|Could not locate file|\b(?:401|403|404)\b/;
 
 @Injectable()
 export class IntentClassifierService implements OnModuleInit, OnApplicationShutdown {
@@ -93,7 +112,12 @@ export class IntentClassifierService implements OnModuleInit, OnApplicationShutd
     { resolve: (v: unknown) => void; reject: (e: Error) => void }
   >();
   private warmupPromise: Promise<void> | null = null;
-  private failedUntil = 0;
+  private warmupTimer: NodeJS.Timeout | null = null;
+  private warmupFailures = 0;
+  private lastWarmupError: string | undefined;
+  /** Earliest time the next warmup may start (backoff or classify-timeout latch). */
+  private nextWarmupAt = 0;
+  private stopped = false;
 
   constructor(private readonly config: ConfigService) {
     this.enabled = envFlagNotDisabled(this.config.get<string>('CHAT_ROUTE_NLI_ENABLED'));
@@ -125,6 +149,11 @@ export class IntentClassifierService implements OnModuleInit, OnApplicationShutd
    * (same contract as LocalCrossEncoderProvider.terminate()). Idempotent.
    */
   async onApplicationShutdown(): Promise<void> {
+    this.stopped = true;
+    if (this.warmupTimer) {
+      clearTimeout(this.warmupTimer);
+      this.warmupTimer = null;
+    }
     const w = this.worker;
     this.worker = null;
     this.workerReady = false;
@@ -154,6 +183,19 @@ export class IntentClassifierService implements OnModuleInit, OnApplicationShutd
     };
   }
 
+  /** Warmup bookkeeping for the health surfaces (the embedder's shape). */
+  warmupStatus(): WarmupStatus {
+    const status: WarmupStatus = {
+      ready: this.isReady(),
+      failures: this.warmupFailures,
+      inFlight: this.warmupPromise !== null,
+    };
+    if (this.lastWarmupError !== undefined) status.lastError = this.lastWarmupError;
+    if (this.nextWarmupAt > Date.now())
+      status.nextRetryAt = new Date(this.nextWarmupAt).toISOString();
+    return status;
+  }
+
   /** Test-only seam — injects a mock pipeline so unit tests can drive
    *  the NLI code path without loading the real model. A seam pipeline
    *  always runs in-thread (classify() prefers it over the worker). */
@@ -174,8 +216,8 @@ export class IntentClassifierService implements OnModuleInit, OnApplicationShutd
     }
     if (!this.hasNliRuntime()) {
       // A crashed / timed-out worker re-warms in the background once the
-      // failure latch expires; this request keeps the punctuation
-      // fallback (a request never blocks on a model load).
+      // backoff expires; this request keeps the punctuation fallback (a
+      // request never blocks on a model load).
       if (this.useWorker && this.worker && this.enabled) void this.warmup();
       return { intent: 'tell', confidence: 0.7, source: 'punctuation' };
     }
@@ -209,7 +251,7 @@ export class IntentClassifierService implements OnModuleInit, OnApplicationShutd
    *  failure latch. */
   private hasNliRuntime(): boolean {
     if (this.classifier !== null) return true;
-    return this.workerReady && Date.now() >= this.failedUntil;
+    return this.workerReady && Date.now() >= this.nextWarmupAt;
   }
 
   private toIntent(result: { labels: string[]; scores: number[] }): {
@@ -225,29 +267,54 @@ export class IntentClassifierService implements OnModuleInit, OnApplicationShutd
   }
 
   /** Load (or await the in-flight load of) the model. Idempotent; a
-   *  failed load latches for FAIL_RETRY_MS so we don't re-download on
-   *  every request. */
+   *  failed load schedules the next attempt after the backoff, so a
+   *  request never re-downloads and a quiet host still retries. */
   private async warmup(): Promise<void> {
-    if (this.isReady()) return;
+    if (this.isReady() || this.stopped) return;
     if (this.warmupPromise) return this.warmupPromise;
-    if (Date.now() < this.failedUntil) return;
+    if (Date.now() < this.nextWarmupAt) return;
+    const attempt = this.warmupFailures + 1;
     const start = Date.now();
     this.warmupPromise = (this.useWorker ? this.warmupWorker() : this.warmupInThread())
       .then(() => {
+        this.warmupFailures = 0;
+        this.nextWarmupAt = 0;
+        this.lastWarmupError = undefined;
         this.logger.log(
-          `NLI classifier ready (${this.modelId}${this.useWorker ? ', worker' : ''}) — warmup ${Date.now() - start}ms`,
+          `NLI classifier ready (${this.modelId}${this.useWorker ? ', worker' : ''}) — warmup ${Date.now() - start}ms, attempt ${attempt}`,
         );
       })
       .catch((e) => {
-        this.failedUntil = Date.now() + FAIL_RETRY_MS;
+        const message = (e as Error).message;
+        const permanent = PERMANENT_LOAD_ERROR.test(message);
+        this.warmupFailures = attempt;
+        this.lastWarmupError = permanent
+          ? `model repo unavailable (gated or removed; set CHAT_ROUTE_NLI_MODEL to a public repo): ${message}`
+          : message;
+        const delay = permanent
+          ? WARMUP_RETRY_MAX_MS
+          : Math.min(WARMUP_RETRY_BASE_MS * 2 ** (attempt - 1), WARMUP_RETRY_MAX_MS);
+        this.nextWarmupAt = Date.now() + delay;
         this.logger.warn(
-          `NLI classifier warmup failed for ${this.modelId}: ${(e as Error).message}; punctuation-only, retrying after ${Math.round(FAIL_RETRY_MS / 60000)}m`,
+          `NLI classifier warmup attempt ${attempt} failed for ${this.modelId}: ${this.lastWarmupError}; punctuation-only, retrying in ${Math.round(delay / 60000)}m`,
         );
+        this.scheduleWarmupRetry(delay);
       })
       .finally(() => {
         this.warmupPromise = null;
       });
     return this.warmupPromise;
+  }
+
+  private scheduleWarmupRetry(delayMs: number): void {
+    if (this.stopped) return;
+    if (this.warmupTimer) clearTimeout(this.warmupTimer);
+    this.warmupTimer = setTimeout(() => {
+      this.warmupTimer = null;
+      void this.warmup();
+    }, delayMs);
+    // A pending retry must never keep the process (or a jest worker) alive.
+    this.warmupTimer.unref?.();
   }
 
   private async warmupInThread(): Promise<void> {
@@ -272,7 +339,7 @@ export class IntentClassifierService implements OnModuleInit, OnApplicationShutd
   private async warmupWorker(): Promise<void> {
     // Re-warmup after a classify-RPC timeout must not orphan the previous
     // worker: an un-terminated worker_threads.Worker keeps its message
-    // listener (and the ~135 MB loaded model) alive for the process
+    // listener (and the ~340 MB loaded model) alive for the process
     // lifetime — one leaked worker per timeout incident. Tear the old
     // one down before spawning its replacement.
     const stale = this.worker;
@@ -330,7 +397,7 @@ export class IntentClassifierService implements OnModuleInit, OnApplicationShutd
       return Promise.reject(new Error('intent-classifier worker not initialised'));
     }
     const id = this.nextReqId++;
-    // Warmup downloads/loads a ~135MB model; a classify call is a single
+    // Warmup downloads/loads a ~340MB model; a classify call is a single
     // inference bounded by CHAT_ROUTE_NLI_TIMEOUT_MS so a wedged worker
     // can't pend forever.
     const timeoutMs = kind === 'warmup' ? WORKER_WARMUP_TIMEOUT_MS : this.classifyTimeoutMs;
@@ -341,11 +408,11 @@ export class IntentClassifierService implements OnModuleInit, OnApplicationShutd
           // Latch like a warmup failure: without this, the next classify()
           // immediately re-warms (spawning a replacement worker) while
           // the wedged one may still be mid-inference — on a persistently
-          // slow host that would cycle a new ~135 MB worker per timeout.
+          // slow host that would cycle a new ~340 MB worker per timeout.
           // The latch gives the host FAIL_RETRY_MS to recover; intent
           // degrades to the punctuation heuristic meanwhile.
           if (kind === 'classify') {
-            this.failedUntil = Date.now() + FAIL_RETRY_MS;
+            this.nextWarmupAt = Date.now() + FAIL_RETRY_MS;
           }
           reject(new Error(`intent-classifier '${kind}' RPC timed out after ${timeoutMs}ms`));
         }

--- a/src/admin/intent-classifier.worker.ts
+++ b/src/admin/intent-classifier.worker.ts
@@ -3,8 +3,8 @@
  *
  * Why a dedicated worker: @xenova/transformers runs ONNX inference (WASM or
  * native) on the main thread by default. The intent model
- * (Xenova/distilbert-base-multilingual-cased-finetuned-mnli, ~135MB ONNX)
- * takes ~100-200ms per classification — every cache-missed chat-route
+ * (Xenova/mDeBERTa-v3-base-xnli-multilingual-nli-2mil7, ~340MB ONNX)
+ * takes hundreds of ms per classification — every cache-missed chat-route
  * request froze the event loop, and every other tenant's request, for the
  * whole inference. Hosting the model in a worker_thread confines the
  * blocking to a dedicated loop, exactly as the cross-encoder reranker

--- a/src/ai/embedder.service.ts
+++ b/src/ai/embedder.service.ts
@@ -16,6 +16,7 @@ import { createOpenAiClient, createOpenAiClientOrThrow } from './openai-client';
 import { OpenAIEmbedderProvider } from './embedder/openai-embedder.provider';
 import { BgeM3EmbedderProvider } from './embedder/bge-m3-embedder.provider';
 import { envFlagEnabled, envFlagNotDisabled } from '../common/env-validation';
+import type { WarmupStatus } from '../common/warmup-status';
 import {
   DEFAULT_EMBEDDER_PROVIDER,
   declaredSpace,
@@ -34,17 +35,8 @@ const WARMUP_RETRY_BASE_MS = 5_000;
 /** Ceiling on the warmup retry interval. */
 const WARMUP_RETRY_MAX_MS = 5 * 60_000;
 
-export interface EmbedderWarmupStatus {
-  /** The primary provider can serve right now. */
-  ready: boolean;
-  /** Consecutive failed warmup attempts (0 once ready). */
-  failures: number;
-  /** A warmup attempt is currently running. */
-  inFlight: boolean;
-  lastError?: string;
-  /** ISO time of the next scheduled attempt, when one is pending. */
-  nextRetryAt?: string;
-}
+/** The primary provider's warmup bookkeeping, in the shared vocabulary. */
+export type EmbedderWarmupStatus = WarmupStatus;
 
 /**
  * EmbedderService — thin facade in front of an EmbedderProvider.

--- a/src/common/process-role.ts
+++ b/src/common/process-role.ts
@@ -20,7 +20,7 @@
  *                     leader-lease-gated — see docs/operations.md.
  *   worker          — keeps the HTTP server (healthcheck + admin need it;
  *                     the compose recipe publishes no ports) and sets
- *                     CHAT_ROUTE_NLI_ENABLED=false so the ~135MB NLI ONNX
+ *                     CHAT_ROUTE_NLI_ENABLED=false so the ~340MB NLI ONNX
  *                     model never loads on a pod that doesn't chat-route.
  *
  * Precedence: a flag the operator set explicitly ALWAYS wins — the role

--- a/src/common/warmup-status.ts
+++ b/src/common/warmup-status.ts
@@ -1,0 +1,17 @@
+/**
+ * Warmup bookkeeping every lazily-loaded model reports to the health
+ * surfaces (`/ready` detail, the admin components grid). One shape for the
+ * embedder and the NLI intent classifier, so "not ready" carries the same
+ * attempt count, last error and next retry wherever an operator looks.
+ */
+export interface WarmupStatus {
+  /** The model can serve right now. */
+  ready: boolean;
+  /** Consecutive failed warmup attempts (0 once ready). */
+  failures: number;
+  /** A warmup attempt is currently running. */
+  inFlight: boolean;
+  lastError?: string;
+  /** ISO time of the next scheduled attempt, when one is pending. */
+  nextRetryAt?: string;
+}

--- a/test/app-fixture.ts
+++ b/test/app-fixture.ts
@@ -88,8 +88,8 @@ export async function createApp(
   // EmbedderService / ExtractorService stubs below already apply, now
   // extended to the two models AppModule boots on its own. This is the
   // NLI one: IntentClassifierService.onModuleInit fire-and-forgets a
-  // warmup that spawns a worker_thread and pulls ~135MB of weights
-  // (Xenova/distilbert-base-multilingual-cased-finetuned-mnli) on EVERY
+  // warmup that spawns a worker_thread and pulls ~340MB of weights
+  // (Xenova/mDeBERTa-v3-base-xnli-multilingual-nli-2mil7) on EVERY
   // createApp(). No e2e spec asserts on NLI intent (the wire contract is
   // covered by test/contracts-admin-health-components.unit-spec.ts, the
   // classifier by test/chat-router-intent.unit-spec.ts), and the model

--- a/test/health-components.unit-spec.ts
+++ b/test/health-components.unit-spec.ts
@@ -10,10 +10,17 @@
 import { HealthComponentsService } from '../src/admin/health-components.service';
 import { HealthComponentsResponseSchema } from '../src/contracts/admin/health-components.schema';
 import type { ReadinessReport } from '../src/common/health.service';
+import type { WarmupStatus } from '../src/common/warmup-status';
 import type { LastProbeReport } from '../src/metrics/capability-probe.service';
 import type { CapabilityName } from '../src/metrics/capability-probe';
 
 type LastReports = Partial<Record<CapabilityName, LastProbeReport>>;
+
+interface IntentFixture {
+  enabled?: boolean;
+  ready?: boolean;
+  warmup?: WarmupStatus;
+}
 
 const READY: ReadinessReport = {
   dbOk: true,
@@ -35,17 +42,27 @@ const at = (secondsAgo: number) => new Date(Date.now() - secondsAgo * 1000).toIS
 function grid(
   readiness: Partial<Omit<ReadinessReport, 'detail'>> & { detail?: DetailOverrides } = {},
   last: LastReports = {},
+  intent: IntentFixture = {},
 ) {
   const report: ReadinessReport = {
     ...READY,
     ...readiness,
     detail: { ...READY.detail, ...(readiness.detail ?? {}) },
   };
+  const intentReady = intent.ready ?? true;
   const svc = new HealthComponentsService(
     { readiness: async () => report } as never,
     { lastReports: () => last } as never,
     { cacheStats: () => ({ provider: 'bge-m3', size: 7 }) } as never,
-    { stats: () => ({ enabled: true, ready: true, model: 'mini', cacheSize: 0 }) } as never,
+    {
+      stats: () => ({
+        enabled: intent.enabled ?? true,
+        ready: intentReady,
+        model: 'mini',
+        cacheSize: 0,
+      }),
+      warmupStatus: () => intent.warmup ?? { ready: intentReady, failures: 0, inFlight: false },
+    } as never,
     {
       stats: () => ({
         enabled: false,
@@ -199,6 +216,58 @@ describe('health grid — embedder row from the warmup bookkeeping', () => {
     );
     expect(r.status).toBe('degraded');
     expect(r.message).toContain('1536-wide');
+  });
+});
+
+describe('health grid — intent classifier row from the same warmup bookkeeping', () => {
+  it('is ok with the model and cache size once the model serves', async () => {
+    const r = await row('intent classifier');
+    expect(r.status).toBe('ok');
+    expect(r.message).toBe('model=mini cache=0');
+  });
+
+  it('is disabled, not warming, when the classifier is switched off', async () => {
+    const r = await row('intent classifier', {}, {}, { enabled: false });
+    expect(r.status).toBe('disabled');
+    expect(r.message).toBe('CHAT_ROUTE_NLI_ENABLED=0');
+  });
+
+  it('is warming with the attempt in flight while the first load runs', async () => {
+    const r = await row(
+      'intent classifier',
+      {},
+      {},
+      { ready: false, warmup: { ready: false, failures: 0, inFlight: true } },
+    );
+    expect(r.status).toBe('warming');
+    expect(r.message).toContain('warming up; attempt in flight');
+    expect(r.message).toContain('punctuation-only intent heuristic');
+  });
+
+  it('is DEGRADED with the reason and the next retry once a warmup has failed (a gated repo used to read "warming" forever)', async () => {
+    const r = await row(
+      'intent classifier',
+      {},
+      {},
+      {
+        ready: false,
+        warmup: {
+          ready: false,
+          failures: 3,
+          inFlight: false,
+          lastError:
+            'model repo unavailable (gated or removed; set CHAT_ROUTE_NLI_MODEL to a public repo): ' +
+            'Unauthorized access to file: "https://huggingface.co/Xenova/gone/resolve/main/config.json".',
+          nextRetryAt: '2026-09-09T16:00:00.000Z',
+        },
+      },
+    );
+    expect(r.status).toBe('degraded');
+    expect(r.message).toContain('warmup failed 3×');
+    expect(r.message).toContain('Unauthorized access to file');
+    expect(r.message).toContain('CHAT_ROUTE_NLI_MODEL');
+    expect(r.message).toContain('next attempt at 2026-09-09T16:00:00.000Z');
+    expect(r.message).toContain('model=mini');
   });
 });
 

--- a/test/intent-classifier-warmup.unit-spec.ts
+++ b/test/intent-classifier-warmup.unit-spec.ts
@@ -1,0 +1,197 @@
+/**
+ * IntentClassifierService warmup lifecycle.
+ *
+ * The default model repo went gated on the Hub (HTTP 401), and the
+ * classifier answered by retrying every five minutes for the life of the
+ * process while the health grid said "warming". These pin: the default is
+ * a public repo; a failed warmup backs off (5m, doubling, capped at 1h) on a
+ * timer; a gated/missing repo starts at the ceiling; and the bookkeeping the
+ * grid renders carries the reason. The in-thread path is driven with the
+ * transformers module mocked — no model is ever downloaded.
+ */
+import { ConfigService } from '@nestjs/config';
+
+const mockPipeline = jest.fn<Promise<unknown>, [string, string]>();
+
+jest.mock('@xenova/transformers', () => ({
+  env: {},
+  pipeline: (task: string, modelId: string) => mockPipeline(task, modelId),
+}));
+
+import { IntentClassifierService } from '../src/admin/intent-classifier.service';
+
+const PUBLIC_DEFAULT = 'Xenova/mDeBERTa-v3-base-xnli-multilingual-nli-2mil7';
+const MINUTE = 60_000;
+
+function mkConfig(over: Record<string, string> = {}): ConfigService {
+  const data: Record<string, string> = {
+    CHAT_ROUTE_NLI_ENABLED: 'true',
+    CHAT_ROUTE_NLI_WORKER: '0',
+    ...over,
+  };
+  return {
+    get: (k: string, def?: string) => data[k] ?? def,
+  } as unknown as ConfigService;
+}
+
+/** A pipeline load that fails `failuresBeforeReady` times, then serves. */
+function flakyLoad(
+  failuresBeforeReady: number,
+  message = (n: number) => `HF download failed (attempt ${n})`,
+) {
+  let attempts = 0;
+  mockPipeline.mockImplementation(async () => {
+    await Promise.resolve();
+    attempts += 1;
+    if (attempts <= failuresBeforeReady) throw new Error(message(attempts));
+    return async (text: string) => ({
+      sequence: text,
+      labels: ['question', 'statement'],
+      scores: [0.9, 0.1],
+    });
+  });
+}
+
+/** Let the warmup promise chain settle without moving the clock. */
+const flush = () => jest.advanceTimersByTimeAsync(0);
+
+const minutesUntilRetry = (svc: IntentClassifierService): number => {
+  const at = svc.warmupStatus().nextRetryAt;
+  if (!at) throw new Error('no retry scheduled');
+  return (Date.parse(at) - Date.now()) / MINUTE;
+};
+
+beforeEach(() => {
+  jest.useFakeTimers();
+  mockPipeline.mockReset();
+});
+afterEach(() => jest.useRealTimers());
+
+describe('IntentClassifierService — default model', () => {
+  it('loads a public multilingual repo by default and reports it in stats()', async () => {
+    flakyLoad(0);
+    const svc = new IntentClassifierService(mkConfig());
+    svc.onModuleInit();
+    await flush();
+    expect(mockPipeline).toHaveBeenCalledWith('zero-shot-classification', PUBLIC_DEFAULT);
+    expect(svc.stats().model).toBe(PUBLIC_DEFAULT);
+    expect(svc.isReady()).toBe(true);
+    expect(svc.warmupStatus()).toEqual({ ready: true, failures: 0, inFlight: false });
+    await svc.onApplicationShutdown();
+  });
+
+  it('CHAT_ROUTE_NLI_MODEL still overrides the default', async () => {
+    flakyLoad(0);
+    const svc = new IntentClassifierService(mkConfig({ CHAT_ROUTE_NLI_MODEL: 'Xenova/other' }));
+    svc.onModuleInit();
+    await flush();
+    expect(mockPipeline).toHaveBeenCalledWith('zero-shot-classification', 'Xenova/other');
+    await svc.onApplicationShutdown();
+  });
+});
+
+describe('IntentClassifierService — warmup backoff', () => {
+  it('retries on a timer with a doubling interval that caps at one hour', async () => {
+    flakyLoad(100);
+    const svc = new IntentClassifierService(mkConfig());
+    svc.onModuleInit();
+    await flush();
+    expect(mockPipeline).toHaveBeenCalledTimes(1);
+    expect(svc.isReady()).toBe(false);
+
+    // 5m, 10m, 20m, 40m, then the 60m ceiling — and the ceiling holds.
+    const expected = [5, 10, 20, 40, 60, 60, 60];
+    for (const [i, minutes] of expected.entries()) {
+      expect(svc.warmupStatus()).toMatchObject({ ready: false, failures: i + 1, inFlight: false });
+      expect(svc.warmupStatus().lastError).toBe(`HF download failed (attempt ${i + 1})`);
+      expect(minutesUntilRetry(svc)).toBe(minutes);
+      // The retry is timer-driven: nothing before the boundary, one attempt on it.
+      await jest.advanceTimersByTimeAsync(minutes * MINUTE - 1);
+      expect(mockPipeline).toHaveBeenCalledTimes(i + 1);
+      await jest.advanceTimersByTimeAsync(1);
+      await flush();
+      expect(mockPipeline).toHaveBeenCalledTimes(i + 2);
+    }
+    await svc.onApplicationShutdown();
+  });
+
+  it('a request during the backoff keeps the punctuation fallback and does not re-warm', async () => {
+    flakyLoad(100);
+    const svc = new IntentClassifierService(mkConfig());
+    svc.onModuleInit();
+    await flush();
+    await expect(svc.classify('Maria moved to Berlin')).resolves.toEqual({
+      intent: 'tell',
+      confidence: 0.7,
+      source: 'punctuation',
+    });
+    expect(mockPipeline).toHaveBeenCalledTimes(1);
+    await svc.onApplicationShutdown();
+  });
+
+  it('a gated or missing repo (Hub 401/403/404) starts at the ceiling and names the knob', async () => {
+    flakyLoad(
+      100,
+      () =>
+        'Unauthorized access to file: "https://huggingface.co/Xenova/gone/resolve/main/config.json".',
+    );
+    const svc = new IntentClassifierService(mkConfig({ CHAT_ROUTE_NLI_MODEL: 'Xenova/gone' }));
+    svc.onModuleInit();
+    await flush();
+    const status = svc.warmupStatus();
+    expect(status).toMatchObject({ ready: false, failures: 1, inFlight: false });
+    expect(status.lastError).toContain('gated or removed');
+    expect(status.lastError).toContain('CHAT_ROUTE_NLI_MODEL');
+    expect(status.lastError).toContain('Unauthorized access to file');
+    expect(minutesUntilRetry(svc)).toBe(60);
+    await svc.onApplicationShutdown();
+  });
+
+  it('recovers: a later attempt succeeds, the bookkeeping clears and NLI serves', async () => {
+    flakyLoad(1);
+    const svc = new IntentClassifierService(mkConfig());
+    svc.onModuleInit();
+    await flush();
+    expect(svc.warmupStatus().failures).toBe(1);
+    await jest.advanceTimersByTimeAsync(5 * MINUTE);
+    await flush();
+    expect(svc.warmupStatus()).toEqual({ ready: true, failures: 0, inFlight: false });
+    await expect(svc.classify('where Maria lives')).resolves.toEqual({
+      intent: 'ask',
+      confidence: 0.9,
+      source: 'nli',
+    });
+    await svc.onApplicationShutdown();
+  });
+
+  it('reports the attempt in flight while a load runs', async () => {
+    let release!: () => void;
+    mockPipeline.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          release = () => resolve(async () => ({ sequence: '', labels: [], scores: [] }));
+        }),
+    );
+    const svc = new IntentClassifierService(mkConfig());
+    svc.onModuleInit();
+    // The module import resolves in a microtask; the load itself then hangs.
+    await flush();
+    expect(svc.warmupStatus()).toEqual({ ready: false, failures: 0, inFlight: true });
+    release();
+    await flush();
+    expect(svc.warmupStatus()).toEqual({ ready: true, failures: 0, inFlight: false });
+    await svc.onApplicationShutdown();
+  });
+
+  it('stops retrying once the application shuts down', async () => {
+    flakyLoad(100);
+    const svc = new IntentClassifierService(mkConfig());
+    svc.onModuleInit();
+    await flush();
+    expect(mockPipeline).toHaveBeenCalledTimes(1);
+    await svc.onApplicationShutdown();
+    await jest.advanceTimersByTimeAsync(2 * 60 * MINUTE);
+    await flush();
+    expect(mockPipeline).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/intent-classifier-worker.unit-spec.ts
+++ b/test/intent-classifier-worker.unit-spec.ts
@@ -182,6 +182,39 @@ describe('IntentClassifierService — worker runtime', () => {
     await svc.onApplicationShutdown();
   });
 
+  it('warmup RPC failure → backoff: no replacement worker per request, status carries the reason', async () => {
+    const svc = new IntentClassifierService(mkConfig());
+    mockOnPost = (w, msg) => {
+      if (msg.kind !== 'warmup') return;
+      queueMicrotask(() =>
+        w.emit('message', {
+          id: msg.id,
+          ok: false,
+          error:
+            'Could not locate file: "https://huggingface.co/Xenova/gone/resolve/main/config.json".',
+        }),
+      );
+    };
+    svc.onModuleInit();
+    await waitFor(() => svc.warmupStatus().failures === 1);
+    expect(svc.isReady()).toBe(false);
+    const status = svc.warmupStatus();
+    expect(status.lastError).toContain('Could not locate file');
+    expect(status.lastError).toContain('CHAT_ROUTE_NLI_MODEL');
+    expect(status.nextRetryAt).toBeDefined();
+
+    // Traffic inside the backoff neither spawns a worker nor re-sends warmup.
+    await expect(svc.classify('Maria moved to Berlin')).resolves.toMatchObject({
+      source: 'punctuation',
+    });
+    await expect(svc.classify('another statement')).resolves.toMatchObject({
+      source: 'punctuation',
+    });
+    expect(mockWorkers).toHaveLength(1);
+    expect(mockWorkers[0]!.posted.filter((m) => m.kind === 'warmup')).toHaveLength(1);
+    await svc.onApplicationShutdown();
+  });
+
   it('onApplicationShutdown terminates the worker thread', async () => {
     const svc = new IntentClassifierService(mkConfig());
     const worker = await warmService(svc);


### PR DESCRIPTION
## What

- **Default NLI intent model → `Xenova/mDeBERTa-v3-base-xnli-multilingual-nli-2mil7`** (public, `deberta-v2` zero-shot-classification ONNX export, English + Russian, ~340 MB quantized). The previous default `Xenova/distilbert-base-multilingual-cased-finetuned-mnli` — and the other Xenova XNLI exports (`mDeBERTa-v3-base-mnli-xnli`, `xlm-roberta-large-xnli`) — now answer HTTP 401 on the Hub. `CHAT_ROUTE_NLI_MODEL` still overrides the default and is now a catalogued key (`config-catalog.data.ts`); `.env.example`, `docs/operations.md`, `process-role.ts` and the e2e fixture comment name the new repo / size. The worker warmup RPC deadline goes 120 s → 300 s for the 2.5× larger download.
- **Warmup backoff instead of a flat 5-minute latch.** A failed warmup now schedules a timer-driven retry at 5 m, doubling per consecutive failure, capped at 1 h. A Hub 401/403/404 (transformers.js "Unauthorized access to file" / "Forbidden access to file" / "Could not locate file") means the repo is gated or gone, so that failure starts at the 1 h ceiling and the recorded reason names the knob (`set CHAT_ROUTE_NLI_MODEL to a public repo`). Traffic inside the backoff keeps the punctuation fallback and never spawns a replacement worker. The in-thread path (`CHAT_ROUTE_NLI_WORKER=0`) now retries too (it used to fail once and stay dead). Shutdown clears the timer.
- **Failure visible in the readiness vocabulary.** `IntentClassifierService.warmupStatus()` reports the same shape the embedder does (`ready / failures / inFlight / lastError / nextRetryAt`, now `WarmupStatus` in `src/common/warmup-status.ts`; `EmbedderWarmupStatus` is an alias of it). The admin health grid (`/v1/admin/health/components`) renders the intent row through the same `warmupSummary` helper as the embedder row: `degraded` with `warmup failed N× (last error: …); next attempt at …` once a warmup has failed, `warming` with `attempt in flight` before that, `ok`/`disabled` as before. No wire-schema change.

Classifier inference API and the worker protocol are unchanged; the classify-RPC timeout latch (5 min) is unchanged.

## Why

Review wave #501, preprod: the classifier warmup failed every 5 minutes forever (`punctuation-only, retrying after 5m`) because the default model repo is gated, and the only operator surface said "warming". Chat routing was permanently on the punctuation heuristic with nothing pointing at the cause.

## How verified

Verified the Hub state today with `curl -s -o /dev/null -w '%{http_code}' https://huggingface.co/api/models/<id>`: the three old ids → 401; the new default → 200 (`pipeline_tag: zero-shot-classification`, `model_type: deberta-v2`, `onnx/model_quantized.onnx` 339 MB). `@xenova/transformers` 2.17.2 in the lockfile ships `DebertaV2ForSequenceClassification` + `DebertaV2Tokenizer`.

```
pnpm typecheck                       → clean
pnpm lint:ci                         → clean (0 problems)
pnpm format:check                    → All matched files use Prettier code style!
pnpm jest --config ./test/jest-unit.json … --testPathPatterns 'intent-classifier|health|contracts-admin-health|config-catalog-truth|flag-budget|embedder-warmup-retry|embedder-space-guard|chat-router|local-ner'
                                     → Test Suites: 15 passed, 15 total · Tests: 124 passed, 124 total
pnpm jest --config ./test/jest-e2e.json … --testPathPatterns 'admin-health-components'
                                     → Test Suites: 1 passed · Tests: 3 passed
```

New tests (all against the seam / mocked module — no model download):
- `test/intent-classifier-warmup.unit-spec.ts` — default model id is the public repo and `CHAT_ROUTE_NLI_MODEL` overrides it; retry interval 5→10→20→40→60→60→60 min, timer-driven, boundary-exact; a request during the backoff does not re-warm; a Hub 401 starts at 60 min with the reason naming `CHAT_ROUTE_NLI_MODEL`; recovery clears the bookkeeping and NLI serves; `inFlight` while loading; shutdown stops retries.
- `test/intent-classifier-worker.unit-spec.ts` — worker warmup RPC failure: status carries the reason, traffic inside the backoff spawns no worker and re-sends no warmup.
- `test/health-components.unit-spec.ts` — intent row: `ok`, `disabled`, `warming` (attempt in flight), and `degraded` with `warmup failed 3×`, the reason, the knob and `next attempt at …`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhrQxeisXJZEt4sg3PGyU6
