### PR TITLE
fix(auth): background fan-outs walk one roster — registry-active tenants, never the static union

### DIFF
--- a/src/admin/admin-hnsw.controller.ts
+++ b/src/admin/admin-hnsw.controller.ts
@@ -107,6 +107,7 @@ export class AdminHnswController {
     const scope = new Set(
       resolvePlatformTenantScope(req, undefined, {
         knownTenants: () => this.apiKeys.knownCompanyIds(),
+        fanOutTenants: () => this.apiKeys.fanOutRoster(),
       }),
     );
     const tenants = (await this.provision.rosterState()).filter((r) => scope.has(r.companyId));
@@ -130,6 +131,7 @@ export class AdminHnswController {
   ): Promise<HnswProvisionRunResult> {
     const tenants = resolvePlatformTenantScope(req, body.tenant, {
       knownTenants: () => this.apiKeys.knownCompanyIds(),
+      fanOutTenants: () => this.apiKeys.fanOutRoster(),
     });
     return this.provision.reconcileAll({ dryRun: body.dryRun === true, tenants });
   }

--- a/src/admin/admin-infra.service.ts
+++ b/src/admin/admin-infra.service.ts
@@ -40,6 +40,7 @@ export class AdminInfraService {
     // operator (scope + gate) keeps the cross-tenant drift audit.
     const tenants = resolvePlatformTenantScope(req, undefined, {
       knownTenants: () => this.apiKeys.knownCompanyIds(),
+      fanOutTenants: () => this.apiKeys.fanOutRoster(),
     });
     const perTenant: Array<{
       companyId: string;

--- a/src/admin/admin-jobs.controller.ts
+++ b/src/admin/admin-jobs.controller.ts
@@ -295,7 +295,7 @@ export class AdminJobsController {
           }),
         ]
       : platformTenantCapable(req.brainAuth.scopes)
-        ? this.apiKeys.knownCompanyIds()
+        ? this.apiKeys.fanOutRoster()
         : [req.brainAuth.companyId];
     void (async () => {
       for (const companyId of target) {
@@ -370,7 +370,7 @@ export class AdminJobsController {
       hostTenant = reindexTenant;
     } else if (platformTenantCapable(req.brainAuth.scopes)) {
       reindexTenant = undefined;
-      hostTenant = this.apiKeys.knownCompanyIds()[0];
+      hostTenant = this.apiKeys.hostTenant();
     } else {
       reindexTenant = req.brainAuth.companyId;
       hostTenant = req.brainAuth.companyId;
@@ -450,7 +450,7 @@ export class AdminJobsController {
     // tenant. The scenarios themselves run against synthetic scratch
     // tenants — hostTenant only carries the job_run bookkeeping row.
     const hostTenant = platformTenantCapable(req.brainAuth.scopes)
-      ? this.apiKeys.knownCompanyIds()[0]
+      ? this.apiKeys.hostTenant()
       : req.brainAuth.companyId;
     if (!hostTenant) {
       throw new BadRequestException('No registered tenant to run scenarios');
@@ -539,7 +539,7 @@ export class AdminJobsController {
           }),
         ]
       : platformTenantCapable(req.brainAuth.scopes)
-        ? this.apiKeys.knownCompanyIds()
+        ? this.apiKeys.fanOutRoster()
         : [req.brainAuth.companyId];
     const emits: Array<Record<string, unknown>> = [];
     for (const companyId of tenants) {
@@ -631,7 +631,7 @@ export class AdminJobsController {
     // operator keeps the all-tenant cockpit. Leader leases + pod identity
     // are cluster-orchestration state (no tenant dimension), shown as-is.
     const claimTenants = platformTenantCapable(req.brainAuth.scopes)
-      ? this.apiKeys.knownCompanyIds()
+      ? this.apiKeys.fanOutRoster()
       : [req.brainAuth.companyId];
     const [leaderLeases, activeClaims] = await Promise.all([
       this.leaderLease.list(),
@@ -688,6 +688,7 @@ export class AdminJobsController {
     const scope = new Set(
       resolvePlatformTenantScope(req, undefined, {
         knownTenants: () => this.apiKeys.knownCompanyIds(),
+        fanOutTenants: () => this.apiKeys.fanOutRoster(),
       }),
     );
     const cursors = allCursors.filter((c) => scope.has(c.companyId));

--- a/src/admin/admin.service.ts
+++ b/src/admin/admin.service.ts
@@ -205,6 +205,7 @@ export class AdminService {
     // all-tenant console.
     const tenants = resolvePlatformTenantScope(req, undefined, {
       knownTenants: () => this.apiKeys.knownCompanyIds(),
+      fanOutTenants: () => this.apiKeys.fanOutRoster(),
     });
     const metricsSnapshot = await this.snapshotMetrics();
 
@@ -464,6 +465,7 @@ export class AdminService {
   ): Promise<AdminDeadLetterRow[]> {
     const tenants = resolvePlatformTenantScope(req, filter.companyId, {
       knownTenants: () => this.apiKeys.knownCompanyIds(),
+      fanOutTenants: () => this.apiKeys.fanOutRoster(),
     });
     const limit = Math.min(Math.max(filter.limit ?? 200, 1), 1000);
     const out: AdminDeadLetterRow[] = [];
@@ -540,6 +542,7 @@ export class AdminService {
   ): Promise<AdminForgottenRow[]> {
     const tenants = resolvePlatformTenantScope(req, filter.companyId, {
       knownTenants: () => this.apiKeys.knownCompanyIds(),
+      fanOutTenants: () => this.apiKeys.fanOutRoster(),
     });
     const limit = Math.min(Math.max(filter.limit ?? 200, 1), 2000);
     const where: string[] = [];
@@ -604,6 +607,7 @@ export class AdminService {
   > {
     const tenants = resolvePlatformTenantScope(req, undefined, {
       knownTenants: () => this.apiKeys.knownCompanyIds(),
+      fanOutTenants: () => this.apiKeys.fanOutRoster(),
     });
     const out: Array<{
       companyId: string;
@@ -677,6 +681,7 @@ export class AdminService {
     const limit = Math.min(Math.max(q.limit ?? 100, 1), 500);
     const tenants = resolvePlatformTenantScope(req, q.companyId, {
       knownTenants: () => this.apiKeys.knownCompanyIds(),
+      fanOutTenants: () => this.apiKeys.fanOutRoster(),
     });
     const events: AuditEventRow[] = [];
     const totalsBySource: Record<string, number> = {};

--- a/src/admin/hnsw-provision.service.ts
+++ b/src/admin/hnsw-provision.service.ts
@@ -340,7 +340,7 @@ export class HnswProvisionService implements OnModuleInit {
       dryRun: opts.dryRun === true,
     };
     let builds = 0;
-    for (const companyId of opts.tenants ?? this.roster()) {
+    for (const companyId of opts.tenants ?? this.apiKeys.fanOutRoster()) {
       if (Date.now() >= deadline) {
         // Nothing is lost — an un-indexed tenant is rediscovered by the
         // next walk. Count what we did not start rather than drop it.
@@ -418,17 +418,6 @@ export class HnswProvisionService implements OnModuleInit {
    * have a ready index". Registry only — no tenant database is opened and no
    * DDL is emitted, so it is safe to call at any cadence.
    */
-  /**
-   * Tenants the sweep walks: the registry's ACTIVE roster when it has one
-   * (suspended tenants and dormant static keys are not provisioned, and a
-   * walk over every known key would CREATE a database for each), else the
-   * static key roster of a registry-less deployment.
-   */
-  private roster(): readonly string[] {
-    const active = this.registry?.activeCompanyIds() ?? [];
-    return active.length > 0 ? active : this.apiKeys.knownCompanyIds();
-  }
-
   async rosterState(): Promise<TenantIndexStateRow[]> {
     return (await this.registry?.listIndexState()) ?? [];
   }

--- a/src/admin/operator-action.service.ts
+++ b/src/admin/operator-action.service.ts
@@ -73,6 +73,7 @@ export class OperatorActionService {
     const apiKeys = this.apiKeys;
     const tenants = resolvePlatformTenantScope(req, filter.actor, {
       knownTenants: () => apiKeys.knownCompanyIds(),
+      fanOutTenants: () => apiKeys.fanOutRoster(),
     });
     const limit = Math.min(Math.max(filter.limit ?? 200, 1), 1000);
     const where: string[] = [];

--- a/src/admin/scene-maintenance.service.ts
+++ b/src/admin/scene-maintenance.service.ts
@@ -197,7 +197,7 @@ export class SceneMaintenanceService {
     const startedAt = Date.now();
     const deadline = startedAt + sceneMaintenanceTimeBudgetMs();
     const maxConversations = sceneMaintenanceMaxConversations();
-    const roster = this.apiKeys.knownCompanyIds();
+    const roster = this.apiKeys.fanOutRoster();
     const result: SceneMaintenanceRunResult = {
       tenants: [],
       budgetExhausted: false,

--- a/src/admin/vector-corpus.service.ts
+++ b/src/admin/vector-corpus.service.ts
@@ -2,7 +2,6 @@ import { Injectable, Logger, OnModuleInit, Optional } from '@nestjs/common';
 import { Cron } from '@nestjs/schedule';
 import type { Surreal } from 'surrealdb';
 import { ApiKeyService } from '../auth/api-key.service';
-import { TenantRegistryService } from '../auth/tenant-registry.service';
 import { SurrealService } from '../db/surreal.service';
 import { EmbedderService } from '../ai/embedder.service';
 import { VECTOR_COLUMNS } from '../ai/embedder/embedding-space';
@@ -114,7 +113,6 @@ export class VectorCorpusService implements OnModuleInit {
     private readonly reindex: ReindexEmbeddingsService,
     private readonly apiKeys: ApiKeyService,
     @Optional() private readonly jobs?: JobRunService,
-    @Optional() private readonly registry?: TenantRegistryService,
     @Optional() private readonly metrics?: MetricsService,
     @Optional() private readonly guard?: DistributedLeaseGuard,
   ) {}
@@ -192,7 +190,7 @@ export class VectorCorpusService implements OnModuleInit {
     const results: VectorCorpusRepairResult[] = [];
     const totals = new Map<string, number>();
     let tenantsNonConforming = 0;
-    for (const companyId of this.roster()) {
+    for (const companyId of this.apiKeys.fanOutRoster()) {
       try {
         const r = await this.reconcileTenant(companyId, trigger);
         results.push(r);
@@ -435,10 +433,5 @@ export class VectorCorpusService implements OnModuleInit {
         `until re-embedded; ${inv.repairable} repairable by the reindex sweep, ` +
         `${inv.producerOwned} producer-owned.`,
     );
-  }
-
-  private roster(): readonly string[] {
-    const active = this.registry?.activeCompanyIds() ?? [];
-    return active.length > 0 ? active : this.apiKeys.knownCompanyIds();
   }
 }

--- a/src/ai/calibration/calibration-refit-job.service.ts
+++ b/src/ai/calibration/calibration-refit-job.service.ts
@@ -48,7 +48,7 @@ export class CalibrationRefitJobService {
   }
 
   private async runWithJobRow(opts: RunTrackedOptions): Promise<number> {
-    const hostTenant = this.apiKeys.knownCompanyIds()[0];
+    const hostTenant = this.apiKeys.hostTenant();
     let jobRow = null as null | Awaited<ReturnType<JobRunService['start']>>;
     if (hostTenant && this.jobs) {
       try {

--- a/src/ai/calibration/calibration-refit-queue.service.ts
+++ b/src/ai/calibration/calibration-refit-queue.service.ts
@@ -47,7 +47,7 @@ export class CalibrationRefitQueueService {
    * tenant internally). Uses the first known tenant as the row's home.
    */
   async enqueueRefit(jobType: JobType): Promise<{ enqueued: boolean }> {
-    const hostTenant = this.apiKeys.knownCompanyIds()[0];
+    const hostTenant = this.apiKeys.hostTenant();
     if (!hostTenant) {
       this.logger.warn(`enqueue ${jobType} skipped — no known tenants`);
       return { enqueued: false };

--- a/src/ai/calibration/calibration-refit-runner.service.ts
+++ b/src/ai/calibration/calibration-refit-runner.service.ts
@@ -46,7 +46,7 @@ export class CalibrationRefitRunnerService {
   ) {}
 
   async refitSourceTrust(onProgress?: RefitProgress): Promise<RefitOutcome> {
-    const tenants = this.apiKeys.knownCompanyIds();
+    const tenants = this.apiKeys.fanOutRoster();
     let upserted = 0;
     for (const companyId of tenants) {
       try {
@@ -63,7 +63,7 @@ export class CalibrationRefitRunnerService {
   }
 
   async refitCalibration(onProgress?: RefitProgress): Promise<RefitOutcome> {
-    const tenants = this.apiKeys.knownCompanyIds();
+    const tenants = this.apiKeys.fanOutRoster();
     const allPairs: CalibrationPair[] = [];
     for (const companyId of tenants) {
       try {
@@ -119,8 +119,7 @@ export class CalibrationRefitRunnerService {
       createdAt?: string | undefined;
     }>
   > {
-    const tenants = this.apiKeys.knownCompanyIds();
-    const host = tenants[0];
+    const host = this.apiKeys.hostTenant();
     if (!host) return [];
     return this.surreal.withCompany(host, async (db) => {
       const [rows] = await db.query<
@@ -368,8 +367,7 @@ export class CalibrationRefitRunnerService {
   }
 
   private async persistCalibrationMap(map: CalibrationMap): Promise<void> {
-    const tenants = this.apiKeys.knownCompanyIds();
-    const host = tenants[0];
+    const host = this.apiKeys.hostTenant();
     if (!host) {
       this.logger.warn('calibration persist skipped — no known tenants to host the row');
       return;

--- a/src/ai/calibration/calibration.service.ts
+++ b/src/ai/calibration/calibration.service.ts
@@ -89,7 +89,7 @@ export class CalibrationService implements OnModuleInit, OnModuleDestroy {
    */
   async refreshFromTable(): Promise<void> {
     if (this.refreshing || this.disabled || !this.surreal || !this.apiKeys) return;
-    const host = this.apiKeys.knownCompanyIds()[0];
+    const host = this.apiKeys.hostTenant();
     if (!host) return;
     this.refreshing = true;
     try {

--- a/src/ai/embedder/reindex-embeddings.service.ts
+++ b/src/ai/embedder/reindex-embeddings.service.ts
@@ -73,7 +73,7 @@ export class ReindexEmbeddingsService {
     const started = Date.now();
     const dryRun = opts.dryRun === true;
     const maxFacts = opts.maxFacts ?? Number.MAX_SAFE_INTEGER;
-    const tenants = opts.tenant ? [opts.tenant] : this.apiKeys.knownCompanyIds();
+    const tenants = opts.tenant ? [opts.tenant] : this.apiKeys.fanOutRoster();
 
     const allTables = opts.allTables === true;
     const breakdown = allTables || opts.tables !== undefined;

--- a/src/audit/changefeed-consumer.service.ts
+++ b/src/audit/changefeed-consumer.service.ts
@@ -94,7 +94,7 @@ export class ChangefeedConsumerService {
     let pendingThisTick = 0;
     let consumedThisTick = 0;
     try {
-      for (const companyId of this.apiKeys.knownCompanyIds()) {
+      for (const companyId of this.apiKeys.fanOutRoster()) {
         try {
           if (!(await this.holdLease())) {
             this.logger.warn('[changefeed] lease lost mid-walk — stopping this tick');
@@ -192,7 +192,7 @@ export class ChangefeedConsumerService {
     this.inFlight = true;
     const consumed: Record<string, number> = {};
     let pending = 0;
-    const tenants = this.apiKeys.knownCompanyIds();
+    const tenants = this.apiKeys.fanOutRoster();
     try {
       for (const companyId of tenants) {
         try {
@@ -227,7 +227,7 @@ export class ChangefeedConsumerService {
   async cursorState(): Promise<Array<{ companyId: string; source: string; cursor: number }>> {
     if (!this.drain.enabled) return [];
     const out: Array<{ companyId: string; source: string; cursor: number }> = [];
-    for (const companyId of this.apiKeys.knownCompanyIds()) {
+    for (const companyId of this.apiKeys.fanOutRoster()) {
       try {
         const rows = await this.drain.cursorStateForTenant(companyId);
         for (const r of rows) {

--- a/src/auth/api-key.service.ts
+++ b/src/auth/api-key.service.ts
@@ -107,7 +107,8 @@ export class ApiKeyService implements OnModuleInit {
    * targeting it is how it gets provisioned. It is NOT the roster for
    * background fan-outs — a sweep over the union provisions `co_<id>` (with
    * the full migration set) for every dormant static key; use fanOutRoster()
-   * there. Synchronous: the registry read is served from the in-memory cache.
+   * there. A static tenant the registry knows to be suspended is absent from
+   * BOTH rosters. Synchronous: the registry read is served from the cache.
    */
   knownCompanyIds(): string[] {
     const staticIds = this.staticCompanyIds();
@@ -146,8 +147,17 @@ export class ApiKeyService implements OnModuleInit {
     return this.fanOutRoster()[0];
   }
 
+  /**
+   * The static BRAIN_API_KEYS tenants minus any the registry KNOWS to be
+   * non-active (suspended, provisioning): a key never lifts a recorded
+   * lifecycle, in either roster. Only an unknown lifecycle falls back to it.
+   */
   private staticCompanyIds(): string[] {
-    return [...new Set([...this.byHash.values()].map((r) => r.companyId))];
+    const ids = [...new Set([...this.byHash.values()].map((r) => r.companyId))];
+    return ids.filter((id) => {
+      const status = this.tenantRegistry?.statusOf(id);
+      return status === undefined || status === 'active';
+    });
   }
 
   /**

--- a/src/auth/api-key.service.ts
+++ b/src/auth/api-key.service.ts
@@ -99,31 +99,55 @@ export class ApiKeyService implements OnModuleInit {
   }
 
   /**
-   * Distinct companyIds the platform knows about — the roster every
-   * background fan-out (compaction, retention, dreams, calibration, reindex,
-   * changefeed drain, subscriptions) and the platform-operator cross-tenant
-   * scope enumerate through.
-   *
-   * The static BRAIN_API_KEYS set (byHash) is the dev/bootstrap seed and the
-   * fallback; the DB-backed tenant_registry (TenantRegistryService, R4) is
-   * the production source that fills as tenants authenticate/provision. We
-   * UNION the two, static-first, so:
-   *   - registry EMPTY (dev, single-tenant, bootstrap, or a remote verifier
-   *     that hasn't seen its first request yet) ⇒ return the static set
-   *     unchanged — byte-identical to pre-R4 behaviour, including order.
-   *   - static EMPTY (prod-JWKS, BRAIN_API_KEYS unset) ⇒ return the
-   *     registry roster, which is the whole point: fan-out is no longer [].
-   *   - both present (dev with registered tenants) ⇒ the deduped union;
-   *     where the registry only mirrors static keys the result equals the
-   *     static set byte-for-byte.
-   * knownCompanyIds() stays SYNCHRONOUS: the registry read is served from
-   * TenantRegistryService's in-memory cache, so no fan-out caller changes.
+   * The VALIDATION roster: every companyId the platform knows about — the
+   * static BRAIN_API_KEYS set UNIONED (static-first, deduped) with the
+   * registry's active roster. This answers "may an operator target tenant X"
+   * (resolvePlatformTenant's `knownTenants` closures): a static key whose
+   * tenant has never authenticated is a legitimate operator target, because
+   * targeting it is how it gets provisioned. It is NOT the roster for
+   * background fan-outs — a sweep over the union provisions `co_<id>` (with
+   * the full migration set) for every dormant static key; use fanOutRoster()
+   * there. Synchronous: the registry read is served from the in-memory cache.
    */
   knownCompanyIds(): string[] {
-    const staticIds = [...new Set([...this.byHash.values()].map((r) => r.companyId))];
+    const staticIds = this.staticCompanyIds();
     const registryIds = this.tenantRegistry?.activeCompanyIds() ?? [];
     if (registryIds.length === 0) return staticIds; // fallback: byte-identical
     return [...new Set([...staticIds, ...registryIds])];
+  }
+
+  /**
+   * The FAN-OUT roster: the ONE tenant list every background loop (cron
+   * sweeps, the worker poller, the reaper, cross-tenant bookkeeping "host
+   * tenant" picks) iterates. Registry-active tenants (status='active') when
+   * the registry has any; otherwise — dev, bootstrap, a remote verifier that
+   * has not seen its first request — the static BRAIN_API_KEYS set, the same
+   * members knownCompanyIds() falls back to. Never the union: a static key
+   * whose tenant never authenticated must not be walked, because opening its
+   * scope creates and migrates its database. Deduped and SORTED, so `[0]` is
+   * the same host tenant on every pod and sweep order is stable. Synchronous.
+   */
+  fanOutRoster(): string[] {
+    const registryIds = this.tenantRegistry?.activeCompanyIds() ?? [];
+    const roster = registryIds.length > 0 ? registryIds : this.staticCompanyIds();
+    return [...new Set(roster)].sort();
+  }
+
+  /**
+   * The tenant that hosts a cross-tenant bookkeeping row (a refit or
+   * registry-mirror job_run, the operator-wide calibration table): the
+   * lexicographically smallest id of the fan-out roster. Deterministic across
+   * replicas — the registry cache fills from an unordered read plus
+   * request-path touch() inserts, so "first cached" differs per pod, and two
+   * pods hosting the same job under different tenants both enqueue it (the
+   * dedup index is per tenant database). Undefined when the roster is empty.
+   */
+  hostTenant(): string | undefined {
+    return this.fanOutRoster()[0];
+  }
+
+  private staticCompanyIds(): string[] {
+    return [...new Set([...this.byHash.values()].map((r) => r.companyId))];
   }
 
   /**

--- a/src/auth/tenant-registry.service.ts
+++ b/src/auth/tenant-registry.service.ts
@@ -54,7 +54,7 @@ const REFRESH_MS = 60_000;
  */
 const TOUCH_THROTTLE_MS = 5 * 60_000;
 
-type TenantStatus = NonNullable<TenantRegistryMeta['status']>;
+export type TenantStatus = NonNullable<TenantRegistryMeta['status']>;
 
 /** A roster row as the registry reads it back — companyId plus lifecycle status. */
 interface RosterRow extends TenantRow {
@@ -99,6 +99,15 @@ export class TenantRegistryService implements OnModuleInit, OnModuleDestroy {
    * window until the next refresh (audit 2026-09-06, F9).
    */
   private readonly knownStatus = new Map<string, TenantStatus>();
+  /**
+   * Monotone counter bumped by every status write, plus the count each
+   * tenant's status was last written at. refresh() captures the counter
+   * before its read and keeps any status noted after that point: the row
+   * set it read is a snapshot from before such a write, so replaying it
+   * would lift a suspension that landed mid-read until the next refresh.
+   */
+  private statusWrites = 0;
+  private readonly statusWrittenAt = new Map<string, number>();
   /** companyId -> last epoch-ms we wrote lastSeen (touch throttle). */
   private readonly lastWriteAt = new Map<string, number>();
   private refreshTimer?: ReturnType<typeof setInterval>;
@@ -127,6 +136,16 @@ export class TenantRegistryService implements OnModuleInit, OnModuleDestroy {
    */
   activeCompanyIds(): string[] {
     return [...this.activeCache];
+  }
+
+  /**
+   * The lifecycle this pod has recorded for a tenant — from a refresh read,
+   * a register() write or a touch() echo — or undefined when the registry
+   * has never learned about it. Lets ApiKeyService tell "unknown: fall back
+   * to the static key" from "known non-active: keep it out of every roster".
+   */
+  statusOf(companyId: string): TenantStatus | undefined {
+    return this.knownStatus.get(companyId);
   }
 
   /**
@@ -262,6 +281,7 @@ export class TenantRegistryService implements OnModuleInit, OnModuleDestroy {
         ? status
         : 'suspended';
     this.knownStatus.set(companyId, known);
+    this.statusWrittenAt.set(companyId, ++this.statusWrites);
     if (known === 'active') this.activeCache.add(companyId);
     else this.activeCache.delete(companyId);
   }
@@ -371,13 +391,28 @@ export class TenantRegistryService implements OnModuleInit, OnModuleDestroy {
    * EVERY row, not only the active ones: a suspension written by another
    * pod has to be learned here, or a touch() on this pod would keep the
    * tenant's status unknown and its lastSeen writes would decide.
+   *
+   * The read is a snapshot taken before it returned, so a status this pod
+   * wrote while it was in flight is newer than the row it carries: those
+   * tenants keep their local status instead of being replayed from the
+   * snapshot, which is what stops a mid-read register(suspended) from
+   * being lifted until the next refresh.
    */
   private async refresh(): Promise<void> {
+    const readAt = this.statusWrites;
     try {
       const roster = await this.readRoster();
+      const concurrent = [...this.knownStatus].filter(
+        ([companyId]) => (this.statusWrittenAt.get(companyId) ?? 0) > readAt,
+      );
+      const written = new Set(concurrent.map(([companyId]) => companyId));
       this.activeCache.clear();
       this.knownStatus.clear();
-      for (const row of roster) this.noteStatus(row.companyId, row.status);
+      this.statusWrittenAt.clear();
+      for (const row of roster) {
+        if (!written.has(row.companyId)) this.noteStatus(row.companyId, row.status);
+      }
+      for (const [companyId, status] of concurrent) this.noteStatus(companyId, status);
     } catch (e) {
       // Transient DB error — keep the last-known-good cache rather than
       // wiping the roster (which would starve fan-out).

--- a/src/auth/tenant-registry.service.ts
+++ b/src/auth/tenant-registry.service.ts
@@ -64,24 +64,23 @@ interface RosterRow extends TenantRow {
 /**
  * TenantRegistryService — the production tenant roster (R4 finding #1).
  *
- * ApiKeyService.knownCompanyIds() (the enumeration every background fan-out
- * and the platform-operator cross-tenant scope go through) historically
- * read companyIds off the in-memory BRAIN_API_KEYS table. In production
- * with a remote verifier (JWKS / introspection) that static table is
- * disabled and typically empty, so the roster was [] and every fan-out
- * silently did nothing. This service backs the roster with a real DB table
- * (`tenant_registry`, migration 0104) living in the SYSTEM database — the
- * one place every tenant can be enumerated from regardless of credential
- * source — and keeps a synchronously-readable in-memory cache so
- * knownCompanyIds() stays synchronous and no fan-out caller has to change.
+ * Tenant enumeration historically read companyIds off the in-memory
+ * BRAIN_API_KEYS table. In production with a remote verifier (JWKS /
+ * introspection) that static table is disabled and typically empty, so the
+ * roster was [] and every fan-out silently did nothing. This service backs
+ * the roster with a real DB table (`tenant_registry`, migration 0104)
+ * living in the SYSTEM database — the one place every tenant can be
+ * enumerated from regardless of credential source — and keeps a
+ * synchronously-readable in-memory cache so the ApiKeyService accessors
+ * stay synchronous. Two of them read it: fanOutRoster() (background loops;
+ * registry-active ONLY, static keys just as the empty-registry fallback)
+ * and knownCompanyIds() (operator `?tenant=` validation; the union).
  *
  * Fallback: the cache reflects only what the registry contains. When the
- * registry is empty or unavailable, ApiKeyService.knownCompanyIds() unions
- * this (empty) set with the static BRAIN_API_KEYS set and returns the
- * latter unchanged — byte-identical to pre-0104 dev / single-tenant /
- * bootstrap behaviour. In prod the registry fills at runtime as tenants
- * authenticate (touch() from CredentialResolverService) or are provisioned
- * (register()).
+ * registry is empty or unavailable, both accessors return the static
+ * BRAIN_API_KEYS set — the pre-0104 dev / single-tenant / bootstrap
+ * behaviour. In prod the registry fills at runtime as tenants authenticate
+ * (touch() from CredentialResolverService) or are provisioned (register()).
  *
  * Optional SurrealService: unit-test fixtures construct this with no
  * connection; every method degrades to a pure in-memory no-op then.

--- a/src/auth/tenant-scope.ts
+++ b/src/auth/tenant-scope.ts
@@ -55,6 +55,16 @@ export interface ResolvePlatformTenantOptions {
    * cross-tenant path, never on the hot own-tenant path.
    */
   knownTenants?: () => readonly string[];
+  /**
+   * The fan-out roster (ApiKeyService.fanOutRoster) — what an omitted
+   * `?tenant=` expands to for a platform operator in
+   * resolvePlatformTenantScope. Kept apart from knownTenants on purpose:
+   * the validation roster may name a dormant static tenant an operator can
+   * TARGET, but expanding "all tenants" over it would create a database per
+   * dormant key. Absent ⇒ the omitted case stays on the caller's own tenant;
+   * it never falls back to knownTenants.
+   */
+  fanOutTenants?: () => readonly string[];
 }
 
 /**
@@ -102,8 +112,9 @@ export function resolvePlatformTenant(
  * without the platform capability, then a 400 if unknown).
  *
  * Use this wherever a handler/service would otherwise fan a read out over
- * apiKeys.knownCompanyIds() and return the result to the caller, so a
- * plain admin never observes another tenant's data or activity.
+ * apiKeys.fanOutRoster() and return the result to the caller, so a plain
+ * admin never observes another tenant's data or activity. The omitted case
+ * expands over `fanOutTenants` only — never over `knownTenants`.
  */
 export function resolvePlatformTenantScope(
   req: AuthenticatedRequest,
@@ -113,6 +124,6 @@ export function resolvePlatformTenantScope(
   const target = requested?.trim();
   if (target) return [resolvePlatformTenant(req, target, opts)];
   return platformTenantCapable(req.brainAuth.scopes)
-    ? (opts.knownTenants?.() ?? [req.brainAuth.companyId])
+    ? (opts.fanOutTenants?.() ?? [req.brainAuth.companyId])
     : [req.brainAuth.companyId];
 }

--- a/src/compaction/compaction-queue.service.ts
+++ b/src/compaction/compaction-queue.service.ts
@@ -32,7 +32,7 @@ export class CompactionQueueService {
   }
 
   knownTenants(): string[] {
-    return this.apiKeys.knownCompanyIds();
+    return this.apiKeys.fanOutRoster();
   }
 
   queueModeEnabled(): boolean {
@@ -54,7 +54,7 @@ export class CompactionQueueService {
 
   /** Enqueue one compaction row per known tenant (idempotent per day). */
   async enqueueAllTenants(jobType: JobType): Promise<{ enqueued: number }> {
-    const tenants = this.apiKeys.knownCompanyIds();
+    const tenants = this.apiKeys.fanOutRoster();
     const today = new Date().toISOString().slice(0, 10);
     let enqueued = 0;
     for (const companyId of tenants) {

--- a/src/compaction/recompose.service.ts
+++ b/src/compaction/recompose.service.ts
@@ -142,7 +142,7 @@ export class RecomposeService implements OnModuleInit {
     if (!this.claim) return { enqueued: 0 };
     const today = new Date().toISOString().slice(0, 10);
     let enqueued = 0;
-    for (const companyId of this.apiKeys.knownCompanyIds()) {
+    for (const companyId of this.apiKeys.fanOutRoster()) {
       try {
         const { created } = await this.claim.enqueue({
           jobType: 'recompose',

--- a/src/documents/candidate-sweeper.service.ts
+++ b/src/documents/candidate-sweeper.service.ts
@@ -55,7 +55,7 @@ export class CandidateSweeperService implements OnModuleInit {
   @Cron('45 3 * * *', { timeZone: 'UTC' })
   async runNightly(): Promise<{ enqueued: number }> {
     if (!this.claim) return { enqueued: 0 };
-    const tenants = this.apiKeys.knownCompanyIds();
+    const tenants = this.apiKeys.fanOutRoster();
     const today = new Date().toISOString().slice(0, 10);
     let enqueued = 0;
     for (const companyId of tenants) {

--- a/src/dreams/dreams.service.ts
+++ b/src/dreams/dreams.service.ts
@@ -194,7 +194,7 @@ export class DreamsService implements OnModuleInit {
    * first row instead of double-queueing.
    */
   private async enqueueDailyForAllTenants(): Promise<{ enqueued: number }> {
-    const tenants = this.apiKeys.knownCompanyIds();
+    const tenants = this.apiKeys.fanOutRoster();
     const today = new Date().toISOString().slice(0, 10);
     let enqueued = 0;
     for (const companyId of tenants) {
@@ -268,7 +268,7 @@ export class DreamsService implements OnModuleInit {
    * rest — errors are logged and folded into the per-tenant stats.
    */
   async runAll(operations?: DreamsOperation[]): Promise<DreamsTenantStats[]> {
-    const tenants = this.apiKeys.knownCompanyIds();
+    const tenants = this.apiKeys.fanOutRoster();
     const ops = operations ? new Set(operations) : this.defaultOps;
     this.logger.log(
       `Dreams starting — ${tenants.length} tenant(s), ops=${[...ops].join(',') || '(none)'}`,

--- a/src/episodes/episode-subscription.service.ts
+++ b/src/episodes/episode-subscription.service.ts
@@ -144,7 +144,7 @@ export class EpisodeSubscriptionService {
     if (this.lease) {
       if (!(await this.acquireLease())) return;
     }
-    for (const companyId of this.apiKeys.knownCompanyIds()) {
+    for (const companyId of this.apiKeys.fanOutRoster()) {
       try {
         if (!(await this.holdLease())) {
           this.logger.warn('episode-subscription dispatch stopped — the lease lapsed mid-walk');

--- a/src/evidence/orphan-blob-gc.service.ts
+++ b/src/evidence/orphan-blob-gc.service.ts
@@ -195,7 +195,7 @@ function emptyTenantResult(companyId: string, dryRun: boolean): OrphanBlobGcTena
  * no query that can see all rows at once and none is attempted. Instead
  * the sweep is per-tenant on both sides of the join and the two sides
  * are pinned to the same tenant:
- *   * the roster comes from ApiKeyService.knownCompanyIds() — the same
+ *   * the roster comes from ApiKeyService.fanOutRoster() — the same
  *     source every other maintenance pass walks. A blob directory
  *     belonging to a tenant that is NOT on the roster is never
  *     enumerated, so a deregistered tenant's bytes are left alone rather
@@ -301,7 +301,7 @@ export class EvidenceOrphanBlobGcService {
       budgetExhausted: false,
       skippedForBudget: 0,
     };
-    for (const companyId of this.apiKeys.knownCompanyIds()) {
+    for (const companyId of this.apiKeys.fanOutRoster()) {
       if (Date.now() >= deadline) {
         // Nothing is lost: an orphan is rediscovered by enumeration on
         // the next run. Count what we did not start rather than drop it.

--- a/src/jobs/job-reaper.service.ts
+++ b/src/jobs/job-reaper.service.ts
@@ -54,7 +54,7 @@ export class JobReaperService {
    */
   async reap(): Promise<ReapResult | null> {
     if (!this.claim || !this.apiKeys) return null;
-    const tenants = this.apiKeys.knownCompanyIds();
+    const tenants = this.apiKeys.fanOutRoster();
     let requeued = 0;
     let failed = 0;
     const erroredTenants: string[] = [];

--- a/src/jobs/job-run.service.ts
+++ b/src/jobs/job-run.service.ts
@@ -388,7 +388,7 @@ export class JobRunService {
   }): Promise<JobRunRow[]> {
     if (!this.persistEnabled || !this.surreal || !this.apiKeys) return [];
     const limit = Math.min(Math.max(filter.limit ?? 50, 1), 500);
-    const tenants = filter.companyId ? [filter.companyId] : this.apiKeys.knownCompanyIds();
+    const tenants = filter.companyId ? [filter.companyId] : this.apiKeys.fanOutRoster();
     const where = buildJobRunListWhere(filter);
     const out: JobRunRow[] = [];
     for (const companyId of tenants) {

--- a/src/jobs/worker-poller.service.ts
+++ b/src/jobs/worker-poller.service.ts
@@ -124,7 +124,7 @@ export class WorkerPollerService {
       }
       let claimed: JobClaim | null = null;
       try {
-        const tenants = this.sampleByFairness(reg.jobType, this.apiKeys?.knownCompanyIds() ?? []);
+        const tenants = this.sampleByFairness(reg.jobType, this.apiKeys?.fanOutRoster() ?? []);
         for (const companyId of tenants) {
           if (control.signal.aborted || !control.isLeader()) break;
           claimed = await this.claim!.claimNext({
@@ -229,7 +229,7 @@ export class WorkerPollerService {
     limits: ConcurrencyLimits,
   ): Promise<JobClaim | null> {
     try {
-      const eligible = (this.apiKeys?.knownCompanyIds() ?? []).filter(
+      const eligible = (this.apiKeys?.fanOutRoster() ?? []).filter(
         (companyId) =>
           (this.inFlightByTenant.get(`${reg.jobType}::${companyId}`) ?? 0) < limits.tenantMax,
       );

--- a/src/metrics/capability-probe.service.ts
+++ b/src/metrics/capability-probe.service.ts
@@ -8,7 +8,6 @@ import {
 } from '@nestjs/common';
 import { SurrealService } from '../db/surreal.service';
 import { ApiKeyService } from '../auth/api-key.service';
-import { TenantRegistryService } from '../auth/tenant-registry.service';
 import { EmbedderService } from '../ai/embedder.service';
 import { MetricsService } from './metrics.service';
 import { envFlagNotDisabled } from '../common/env-validation';
@@ -132,9 +131,6 @@ export class CapabilityProbeService implements OnApplicationBootstrap, OnApplica
     // unit fixture) still gets the scoped-read probe; the embed probe then
     // reports `skipped` rather than pretending to have run.
     @Optional() private readonly embedder?: EmbedderService,
-    // The production roster. Optional for the same unit fixtures; without
-    // it the canary comes from the static key set alone.
-    @Optional() private readonly registry?: TenantRegistryService,
     // The blob-adapter registry (global EvidenceStorageModule). Optional
     // for the same fixtures; without it the store probe reports `skipped`.
     @Optional()
@@ -255,10 +251,9 @@ export class CapabilityProbeService implements OnApplicationBootstrap, OnApplica
   /**
    * The canary tenant, or why there is none.
    *
-   * The registry's ACTIVE roster is the source: it is what production
-   * provisions from and what a suspension removes a tenant from. The static
-   * key set (BRAIN_API_KEYS) only stands in where the registry knows nothing
-   * — dev, unit fixtures, a fresh install. Sorted, so the probe hits the
+   * The fan-out roster (ApiKeyService.fanOutRoster) is the source: the
+   * registry's ACTIVE tenants, with the static key set standing in only
+   * where the registry knows nothing. It is sorted, so the probe hits the
    * same database every tick and its cost is bounded.
    *
    * An explicit CAPABILITY_PROBE_TENANT must name a tenant the process
@@ -273,7 +268,7 @@ export class CapabilityProbeService implements OnApplicationBootstrap, OnApplica
    * load by the roster size to re-answer the same question.
    */
   private probeTenant(): { tenant: string } | { tenant?: undefined; reason: ProbeReport } {
-    const known = this.knownRoster();
+    const known = this.apiKeys.fanOutRoster();
     if (this.tenantOverride) {
       if (known.includes(this.tenantOverride)) return { tenant: this.tenantOverride };
       return {
@@ -296,13 +291,6 @@ export class CapabilityProbeService implements OnApplicationBootstrap, OnApplica
         detail: 'no tenant in the roster to probe (set CAPABILITY_PROBE_TENANT to pin one)',
       },
     };
-  }
-
-  /** Registry-active first, static keys only when the registry is silent. */
-  private knownRoster(): string[] {
-    const active = this.registry?.activeCompanyIds() ?? [];
-    const roster = active.length > 0 ? active : this.apiKeys.knownCompanyIds();
-    return [...new Set(roster)].sort();
   }
 
   private async probeScopedRead(): Promise<ProbeReport> {

--- a/src/metrics/memory-quality.service.ts
+++ b/src/metrics/memory-quality.service.ts
@@ -67,7 +67,7 @@ export class MemoryQualityService {
    * Compute the cross-tenant snapshot and publish it to the gauges.
    *
    * `tenantScope` overrides the roster: the nightly cron passes nothing and
-   * fans out over the full production roster (ApiKeyService.knownCompanyIds()),
+   * fans out over the full production roster (ApiKeyService.fanOutRoster()),
    * while a caller that needs a deterministic, self-contained measurement —
    * the e2e, where the shared test container's tenant_registry accumulates
    * every suite's tenants — passes an explicit tenant list. Production
@@ -82,7 +82,7 @@ export class MemoryQualityService {
       policySetsActive: 0,
     };
     let failed = 0;
-    const tenants = tenantScope ?? this.apiKeys.knownCompanyIds();
+    const tenants = tenantScope ?? this.apiKeys.fanOutRoster();
     for (const companyId of tenants) {
       try {
         this.mergeInto(snapshot, await this.collectTenant(companyId));

--- a/src/outcomes/outcome-prune.service.ts
+++ b/src/outcomes/outcome-prune.service.ts
@@ -56,7 +56,7 @@ const LEASE_TTL_SECONDS = 60 * 60;
  * gated on the master flag, under the distributed lease guard so one
  * replica walks the roster, with an in-flight flag as the process-local
  * reentrancy layer. Tenant roster comes from
- * ApiKeyService.knownCompanyIds(), the same way the compaction cron
+ * ApiKeyService.fanOutRoster(), the same way the compaction cron
  * enumerates tenants.
  */
 @Injectable()
@@ -104,7 +104,7 @@ export class OutcomePruneService {
     if (!this.guard) noteUnguarded(this.logger, 'outcome prune');
     this.running = true;
     try {
-      const tenants = this.apiKeys.knownCompanyIds();
+      const tenants = this.apiKeys.fanOutRoster();
       let pruned = 0;
       for (const companyId of tenants) {
         try {

--- a/src/registry/registry-mirror.service.ts
+++ b/src/registry/registry-mirror.service.ts
@@ -70,7 +70,7 @@ export class RegistryMirrorService implements OnModuleInit {
   async runScheduled(): Promise<{ enqueued: boolean }> {
     const upstream = this.upstreamUrl();
     if (!upstream || !this.claim) return { enqueued: false };
-    const hostTenant = this.apiKeys.knownCompanyIds()[0];
+    const hostTenant = this.apiKeys.hostTenant();
     if (!hostTenant) {
       this.logger.warn('registry_mirror enqueue skipped — no known tenants');
       return { enqueued: false };

--- a/src/strategy/strategy-distill.service.ts
+++ b/src/strategy/strategy-distill.service.ts
@@ -378,7 +378,7 @@ export class StrategyDistillService {
     if (!this.guard) noteUnguarded(this.logger, 'strategy sweep');
     this.sweepInFlight = true;
     try {
-      const tenants = this.apiKeys.knownCompanyIds();
+      const tenants = this.apiKeys.fanOutRoster();
       stats.tenants = tenants.length;
       for (const companyId of tenants) {
         try {

--- a/test/admin-tenant-isolation.unit-spec.ts
+++ b/test/admin-tenant-isolation.unit-spec.ts
@@ -25,7 +25,11 @@ import { StrategyAdminController } from '../src/strategy/strategy-admin.controll
 import { AdminJobsController } from '../src/admin/admin-jobs.controller';
 
 const KNOWN = ['tenant-a', 'tenant-b'];
-const apiKeys = { knownCompanyIds: () => KNOWN } as never;
+const apiKeys = {
+  knownCompanyIds: () => KNOWN,
+  fanOutRoster: () => KNOWN,
+  hostTenant: () => KNOWN[0],
+} as never;
 const ADMIN: BrainScope[] = ['brain:admin'];
 const PLATFORM: BrainScope[] = ['brain:admin', PLATFORM_TENANT_SCOPE];
 
@@ -78,7 +82,7 @@ describe('resolvePlatformTenant — cross-tenant is default-deny (P0)', () => {
 });
 
 describe('resolvePlatformTenantScope — aggregate reads default to own tenant (P0)', () => {
-  const opts = { knownTenants: () => KNOWN };
+  const opts = { knownTenants: () => KNOWN, fanOutTenants: () => KNOWN };
 
   it('no tenant requested, plain brain:admin → own tenant only', () => {
     expect(resolvePlatformTenantScope(req(ADMIN), undefined, opts)).toEqual(['tenant-a']);
@@ -86,9 +90,22 @@ describe('resolvePlatformTenantScope — aggregate reads default to own tenant (
   it('no tenant requested, platform scope but gate OFF → own tenant only', () => {
     expect(resolvePlatformTenantScope(req(PLATFORM), undefined, opts)).toEqual(['tenant-a']);
   });
-  it('no tenant requested, platform scope + gate ON → all registered tenants', () => {
+  it('no tenant requested, platform scope + gate ON → the FAN-OUT roster', () => {
     gateOn();
     expect(resolvePlatformTenantScope(req(PLATFORM), undefined, opts)).toEqual(KNOWN);
+  });
+  it('omitted tenant never expands over the VALIDATION roster: without fanOutTenants → own only', () => {
+    // knownTenants may name a dormant static tenant an operator can target;
+    // "all tenants" must not create a database per such key (A-10 / V-5).
+    gateOn();
+    const validationOnly = { knownTenants: () => [...KNOWN, 'tenant-dormant'] };
+    expect(resolvePlatformTenantScope(req(PLATFORM), undefined, validationOnly)).toEqual([
+      'tenant-a',
+    ]);
+    // …while a single requested dormant tenant still validates through it.
+    expect(resolvePlatformTenantScope(req(PLATFORM), 'tenant-dormant', validationOnly)).toEqual([
+      'tenant-dormant',
+    ]);
   });
   it('own tenant requested → own tenant only', () => {
     expect(resolvePlatformTenantScope(req(ADMIN), 'tenant-a', opts)).toEqual(['tenant-a']);

--- a/test/app-fixture.ts
+++ b/test/app-fixture.ts
@@ -7,6 +7,7 @@ import { EmbedderService } from '../src/ai/embedder.service';
 import { ExtractorService } from '../src/ai/extractor.service';
 import { LocalCrossEncoderProvider } from '../src/ai/cross-encoder/local-cross-encoder.provider';
 import { correlationIdMiddleware } from '../src/common/correlation-id.middleware';
+import { TenantRegistryService } from '../src/auth/tenant-registry.service';
 import { StubEmbedder, StubExtractor, StubLocalCrossEncoder } from './test-doubles';
 
 export interface AppFixture {
@@ -140,6 +141,13 @@ export async function createApp(
     }),
   );
   await app.init();
+  // Provision the fixture tenant the way production does (register()), so it
+  // is on the FAN-OUT roster. Background loops walk registry-active tenants
+  // only — a static key alone is not membership — and the shared e2e
+  // container's tenant_registry already holds every earlier suite's tenant,
+  // so a sweep a spec invokes directly (before any request has touched the
+  // tenant) would otherwise walk those and never this one.
+  await app.get(TenantRegistryService).register(companyId);
 
   const http = request(app.getHttpServer());
   return {

--- a/test/calibration-bootstrap-key.unit-spec.ts
+++ b/test/calibration-bootstrap-key.unit-spec.ts
@@ -44,7 +44,7 @@ describe('calibration bootstrap promptHash — persist/load contract', () => {
   it('refit persist and loader read bind the identical hashed promptHash', async () => {
     const binds: Array<Record<string, any>> = [];
     const surreal = fakeSurreal(binds);
-    const apiKeys = { knownCompanyIds: () => ['co_a'] } as any;
+    const apiKeys = { hostTenant: () => 'co_a' } as any;
 
     // Write side.
     const refit = new CalibrationRefitRunnerService(surreal, {} as any, apiKeys);

--- a/test/calibration-persisted-bootstrap.unit-spec.ts
+++ b/test/calibration-persisted-bootstrap.unit-spec.ts
@@ -45,7 +45,7 @@ function mkSvc(opts: {
           },
         } as any);
   const apiKeys = {
-    knownCompanyIds: () => opts.apiKeysReturn ?? ['co_a'],
+    hostTenant: () => (opts.apiKeysReturn ?? ['co_a'])[0],
   } as any;
   return new CalibrationService(config, surreal, apiKeys);
 }
@@ -97,7 +97,7 @@ describe('CalibrationService.onModuleInit — persisted bootstrap', () => {
     expect(out).toBe(0.75);
   });
 
-  it('stays synthetic when no tenants are registered (knownCompanyIds empty)', async () => {
+  it('stays synthetic when no tenants are registered (hostTenant undefined)', async () => {
     const svc = mkSvc({
       persistedRow: { thresholds: [1], values: [0.5], sampleCount: 50 },
       apiKeysReturn: [],

--- a/test/calibration-table-poll.unit-spec.ts
+++ b/test/calibration-table-poll.unit-spec.ts
@@ -55,7 +55,7 @@ function mkSvc(state: FakeState): CalibrationService {
         },
       }),
   } as any;
-  const apiKeys = { knownCompanyIds: () => state.tenants } as any;
+  const apiKeys = { hostTenant: () => [...state.tenants].sort()[0] } as any;
   return new CalibrationService(config, surreal, apiKeys);
 }
 

--- a/test/capability-probe.e2e-spec.ts
+++ b/test/capability-probe.e2e-spec.ts
@@ -102,7 +102,7 @@ describe('Capability probe — scoped read path', () => {
     metrics = new MetricsService();
     probe = new CapabilityProbeService(
       svc,
-      { knownCompanyIds: () => [tenant] } as unknown as ApiKeyService,
+      { fanOutRoster: () => [tenant] } as unknown as ApiKeyService,
       metrics,
       undefined,
     );

--- a/test/capability-probe.unit-spec.ts
+++ b/test/capability-probe.unit-spec.ts
@@ -27,16 +27,15 @@ const FAIL_CLOSED =
 
 type Stubs = {
   surreal: { withScopedCompany: jest.Mock };
-  apiKeys: { knownCompanyIds: jest.Mock };
+  /** The fan-out roster as ApiKeyService.fanOutRoster() would hand it over: sorted. */
+  apiKeys: { fanOutRoster: jest.Mock };
   embedder: { primaryDimensions: jest.Mock; embedUncached: jest.Mock; activeSpaceId: jest.Mock };
-  /** The registry's active roster; absent = the process has no registry wired. */
-  registry?: { activeCompanyIds: jest.Mock };
 };
 
 function makeStubs(overrides: Partial<Stubs> = {}): Stubs {
   return {
     surreal: { withScopedCompany: jest.fn().mockResolvedValue([[]]) },
-    apiKeys: { knownCompanyIds: jest.fn().mockReturnValue(['acme']) },
+    apiKeys: { fanOutRoster: jest.fn().mockReturnValue(['acme']) },
     embedder: {
       primaryDimensions: jest.fn().mockReturnValue(1024),
       embedUncached: jest.fn().mockResolvedValue(new Array(1024).fill(0.1)),
@@ -53,7 +52,6 @@ function build(stubs: Stubs): { svc: CapabilityProbeService; metrics: MetricsSer
     stubs.apiKeys as any,
     metrics,
     stubs.embedder as any,
-    stubs.registry as any,
   );
   return { svc, metrics };
 }
@@ -202,7 +200,7 @@ describe('capability probe — scoped read', () => {
 
   it('SKIPS (does not fail) when the roster has no tenant to probe', async () => {
     const stubs = makeStubs();
-    stubs.apiKeys.knownCompanyIds.mockReturnValue([]);
+    stubs.apiKeys.fanOutRoster.mockReturnValue([]);
     const { svc, metrics } = build(stubs);
 
     const [scoped] = await svc.runOnce();
@@ -216,7 +214,7 @@ describe('capability probe — scoped read', () => {
     process.env.CAPABILITY_PROBE_TENANT = 'canary';
     try {
       const stubs = makeStubs();
-      stubs.apiKeys.knownCompanyIds.mockReturnValue(['acme', 'canary']);
+      stubs.apiKeys.fanOutRoster.mockReturnValue(['acme', 'canary']);
       const { svc } = build(stubs);
       await svc.runOnce();
       expect(stubs.surreal.withScopedCompany.mock.calls[0][0]).toBe('canary');
@@ -245,29 +243,22 @@ describe('capability probe — scoped read', () => {
     }
   });
 
-  it("picks the canary from the registry's ACTIVE roster before the static key set", async () => {
+  it('picks the canary as the FIRST tenant of the fan-out roster — the same one every tick', async () => {
+    // fanOutRoster() is sorted, so [0] is stable across ticks and pods; the
+    // probe must not re-order or re-source it.
     const stubs = makeStubs({
-      registry: { activeCompanyIds: jest.fn().mockReturnValue(['zed', 'beta']) },
+      apiKeys: { fanOutRoster: jest.fn().mockReturnValue(['beta', 'zed']) },
     });
     const { svc } = build(stubs);
     await svc.runOnce();
-    // Sorted for a stable canary; the static 'acme' is not consulted.
     expect(stubs.surreal.withScopedCompany.mock.calls[0][0]).toBe('beta');
+    expect(stubs.apiKeys.fanOutRoster).toHaveBeenCalled();
   });
 
-  it('falls back to the static key set only when the registry knows nothing', async () => {
-    const stubs = makeStubs({ registry: { activeCompanyIds: jest.fn().mockReturnValue([]) } });
-    const { svc } = build(stubs);
-    await svc.runOnce();
-    expect(stubs.surreal.withScopedCompany.mock.calls[0][0]).toBe('acme');
-  });
-
-  it('a suspended tenant named by the override is not known — it is refused, not probed', async () => {
+  it('a suspended tenant named by the override is not on the fan-out roster — refused, not probed', async () => {
     process.env.CAPABILITY_PROBE_TENANT = 'sleeper';
     try {
-      const stubs = makeStubs({
-        registry: { activeCompanyIds: jest.fn().mockReturnValue(['acme']) },
-      });
+      const stubs = makeStubs({ apiKeys: { fanOutRoster: jest.fn().mockReturnValue(['acme']) } });
       const { svc } = build(stubs);
       const [scoped] = await svc.runOnce();
       expect(scoped?.outcome).toBe('error');

--- a/test/changefeed-consumer.unit-spec.ts
+++ b/test/changefeed-consumer.unit-spec.ts
@@ -358,7 +358,7 @@ function mkConsumer(opts: {
   );
   const drain = { enabled: true, sources: [], perBatchLimit: 500, consumeForTenant };
   const tryAcquire = opts.acquire ?? jest.fn(async () => true);
-  const apiKeys = { knownCompanyIds: () => opts.tenants };
+  const apiKeys = { fanOutRoster: () => opts.tenants };
   const svc = new ChangefeedConsumerService(
     apiKeys as never,
     drain as never,

--- a/test/contracts-admin-changefeed-state.unit-spec.ts
+++ b/test/contracts-admin-changefeed-state.unit-spec.ts
@@ -18,7 +18,10 @@ import type { ChangefeedConsumerService } from '../src/audit/changefeed-consumer
 import type { ApiKeyService } from '../src/auth/api-key.service';
 
 const KNOWN = ['tenant-a', 'tenant-b'];
-const apiKeys = { knownCompanyIds: () => KNOWN } as unknown as ApiKeyService;
+const apiKeys = {
+  knownCompanyIds: () => KNOWN,
+  fanOutRoster: () => KNOWN,
+} as unknown as ApiKeyService;
 
 const OLD_GATE = process.env.BRAIN_TENANT_OVERRIDE_ENABLED;
 afterEach(() => {

--- a/test/contracts-admin-leases.unit-spec.ts
+++ b/test/contracts-admin-leases.unit-spec.ts
@@ -76,6 +76,7 @@ function makeController(): AdminJobsController {
 
   const apiKeys = {
     knownCompanyIds: () => ['tenant-a', 'tenant-b'],
+    fanOutRoster: () => ['tenant-a', 'tenant-b'],
   } as unknown as ApiKeyService;
 
   const config = {
@@ -179,6 +180,7 @@ function capturingController() {
   } as unknown as JobWorkerPool;
   const apiKeys = {
     knownCompanyIds: () => ['tenant-a', 'tenant-b'],
+    fanOutRoster: () => ['tenant-a', 'tenant-b'],
   } as unknown as ApiKeyService;
   const config = { get: () => 'enqueue' } as unknown as ConfigService;
   const undef = undefined as unknown as never;

--- a/test/contracts-admin-migrations.unit-spec.ts
+++ b/test/contracts-admin-migrations.unit-spec.ts
@@ -32,6 +32,7 @@ function makeController(): AdminInfraController {
   } as unknown as SurrealService;
   const apiKeys = {
     knownCompanyIds: () => ['tenant-a', 'tenant-b'],
+    fanOutRoster: () => ['tenant-a', 'tenant-b'],
   } as unknown as ApiKeyService;
   const adminInfra = new AdminInfraService(surreal, apiKeys);
   return makeAdminInfraController({ adminInfra });

--- a/test/dreams-orchestrator.unit-spec.ts
+++ b/test/dreams-orchestrator.unit-spec.ts
@@ -26,7 +26,7 @@ describe('DreamsService', () => {
 
   function makeApiKeys(ids: string[]): ApiKeyService {
     return {
-      knownCompanyIds: () => ids,
+      fanOutRoster: () => ids,
     } as unknown as ApiKeyService;
   }
 

--- a/test/episode-subscription.unit-spec.ts
+++ b/test/episode-subscription.unit-spec.ts
@@ -44,7 +44,7 @@ function makeService(opts: {
     metaSince: async () => opts.meta ?? [],
   } as unknown as EpisodeReadStoreService;
   const apiKeys = {
-    knownCompanyIds: () => opts.tenants ?? ['co_x'],
+    fanOutRoster: () => opts.tenants ?? ['co_x'],
   } as unknown as ApiKeyService;
   return {
     svc: new EpisodeSubscriptionService(surreal, episodes, apiKeys, opts.lease as never),

--- a/test/evidence-orphan-blob-gc.unit-spec.ts
+++ b/test/evidence-orphan-blob-gc.unit-spec.ts
@@ -180,7 +180,7 @@ function makeService(
   queries: string[];
 } {
   const { surreal, queries } = makeSurreal(tenants);
-  const apiKeys = { knownCompanyIds: () => Object.keys(tenants) } as unknown as ApiKeyService;
+  const apiKeys = { fanOutRoster: () => Object.keys(tenants) } as unknown as ApiKeyService;
   const registry: EvidenceStorageRegistry = new Map([['fs', makeAdapter(store, adapterOpts)]]);
   return {
     service: new EvidenceOrphanBlobGcService(surreal, apiKeys, registry),

--- a/test/evidence-storage-selection.unit-spec.ts
+++ b/test/evidence-storage-selection.unit-spec.ts
@@ -260,9 +260,8 @@ describe('the store is exercised continuously, not only at deploy time', () => {
   function probe(registry?: EvidenceStorageRegistry): CapabilityProbeService {
     return new CapabilityProbeService(
       { withScopedCompany: jest.fn().mockResolvedValue([[]]) } as never,
-      { knownCompanyIds: () => ['acme'] } as never,
+      { fanOutRoster: () => ['acme'] } as never,
       new MetricsService(),
-      undefined,
       undefined,
       registry,
     );

--- a/test/hnsw-provisioning.unit-spec.ts
+++ b/test/hnsw-provisioning.unit-spec.ts
@@ -191,14 +191,12 @@ function provision(opts: {
       created: action === 'ensure' ? ['segment_embedding_hnsw'] : [],
     }));
   const registry = {
-    // No registry roster in these fixtures: the sweep falls back to the static keys.
-    activeCompanyIds: () => [] as string[],
     recordIndexState: jest.fn(async (companyId: string, o: { state: string }) => {
       opts.recorded?.push({ companyId, state: o.state });
     }),
     listIndexState: jest.fn(async () => []),
   };
-  const apiKeys = { knownCompanyIds: () => opts.roster ?? ['co1'] };
+  const apiKeys = { fanOutRoster: () => opts.roster ?? ['co1'] };
   const svc = new HnswProvisionService(
     surreal as never,
     { apply } as never,

--- a/test/hnsw.e2e-spec.ts
+++ b/test/hnsw.e2e-spec.ts
@@ -255,7 +255,13 @@ describe('HNSW provisioning + roster (real SurrealDB)', () => {
   const auth = () => ({ Authorization: `Bearer ${f.apiKey}` });
 
   beforeAll(async () => {
-    process.env.HNSW_PROVISION_ENABLED = '1';
+    // The premise below is "a tenant that exists WITHOUT indexes", so the
+    // database is created (first ingest) while provisioning is still off:
+    // with the flag on, the schema-ready hook would provision it right
+    // here and `ensure` would have nothing left to create. (This used to
+    // pass by accident — a boot-time host-tenant read created the database
+    // before the hook was registered, which depended on BRAIN_API_KEYS
+    // order.)
     f = await createApp({ companyId: 'co_hnsw_prov_e2e' });
     await f.http
       .post('/v1/ingest/fact')
@@ -268,6 +274,7 @@ describe('HNSW provisioning + roster (real SurrealDB)', () => {
         confidence: 0.9,
         source: { vertical: 'rent', recorder: 'bot' },
       });
+    process.env.HNSW_PROVISION_ENABLED = '1';
   });
 
   afterAll(async () => {

--- a/test/l0-user-scope.unit-spec.ts
+++ b/test/l0-user-scope.unit-spec.ts
@@ -160,7 +160,7 @@ describe('episode subscriptions — single-writer + per-subscription breaker', (
       metaSince: async () => [],
     } as unknown as EpisodeReadStoreService;
     const apiKeys = {
-      knownCompanyIds: () => ['co_x'],
+      fanOutRoster: () => ['co_x'],
     } as unknown as ApiKeyService;
     const lease = {
       tryAcquire: async () => false,
@@ -177,7 +177,7 @@ describe('episode subscriptions — single-writer + per-subscription breaker', (
       metaSince: async () => [],
     } as unknown as EpisodeReadStoreService;
     const apiKeys = {
-      knownCompanyIds: () => ['co_x'],
+      fanOutRoster: () => ['co_x'],
     } as unknown as ApiKeyService;
     const names: string[] = [];
     const lease = {

--- a/test/lease-guard-sweeps.unit-spec.ts
+++ b/test/lease-guard-sweeps.unit-spec.ts
@@ -96,7 +96,7 @@ function prune(guard?: DistributedLeaseGuard) {
         },
       }),
   };
-  const apiKeys = { knownCompanyIds: () => ['co_a', 'co_b'] };
+  const apiKeys = { fanOutRoster: () => ['co_a', 'co_b'] };
   return { svc: new OutcomePruneService(surreal as never, apiKeys as never, guard), queries };
 }
 
@@ -152,7 +152,7 @@ function sweep(guard?: DistributedLeaseGuard) {
     isEnabled: () => true,
     deprecateSweep: jest.fn(async () => ({ scanned: 4, deprecated: 1 })),
   };
-  const apiKeys = { knownCompanyIds: () => ['co_a', 'co_b'] };
+  const apiKeys = { fanOutRoster: () => ['co_a', 'co_b'] };
   const svc = new StrategyDistillService(
     strategies as never,
     apiKeys as never,
@@ -207,7 +207,7 @@ function quality(guard?: DistributedLeaseGuard) {
   const surreal = {
     withCompany: jest.fn(async (_c: string, fn: (d: typeof db) => Promise<unknown>) => fn(db)),
   };
-  const apiKeys = { knownCompanyIds: () => ['co_a'] };
+  const apiKeys = { fanOutRoster: () => ['co_a'] };
   const metrics = { setMemoryQuality: jest.fn() };
   const svc = new MemoryQualityService(surreal as never, apiKeys as never, metrics as never, guard);
   return { svc, surreal, metrics };

--- a/test/memory-outcome.unit-spec.ts
+++ b/test/memory-outcome.unit-spec.ts
@@ -526,7 +526,7 @@ describe('OutcomePruneService', () => {
     delete process.env.OUTCOME_TELEMETRY_ENABLED;
   });
 
-  const apiKeys = (ids: string[]) => ({ knownCompanyIds: () => ids }) as unknown as ApiKeyService;
+  const apiKeys = (ids: string[]) => ({ fanOutRoster: () => ids }) as unknown as ApiKeyService;
 
   it('prune query is the bounded DELETE-subquery shape', () => {
     expect(OUTCOME_PRUNE_BATCH_QUERY).toBe(

--- a/test/memory-quality.unit-spec.ts
+++ b/test/memory-quality.unit-spec.ts
@@ -42,7 +42,7 @@ describe('MemoryQualityService', () => {
         return fn(tenantDb);
       },
     };
-    const apiKeys = { knownCompanyIds: () => ['co_a', 'co_b', 'co_broken'] };
+    const apiKeys = { fanOutRoster: () => ['co_a', 'co_b', 'co_broken'] };
     const svc = new MemoryQualityService(surreal as never, apiKeys as never, metrics);
 
     const snapshot = await svc.collectNow();

--- a/test/recompose.unit-spec.ts
+++ b/test/recompose.unit-spec.ts
@@ -52,7 +52,7 @@ describe('RecomposeService', () => {
     const surreal = {
       withCompany: (_c: string, fn: (db: unknown) => Promise<unknown>) => fn(db),
     };
-    const apiKeys = { knownCompanyIds: () => ['co_x'] };
+    const apiKeys = { fanOutRoster: () => ['co_x'] };
     const generator = {
       generate: jest.fn(async (_group: any[]) => opts.summaryText ?? 'regenerated summary'),
     };

--- a/test/reindex-outcome.unit-spec.ts
+++ b/test/reindex-outcome.unit-spec.ts
@@ -135,7 +135,7 @@ describe('ReindexEmbeddingsService — roster fold', () => {
   function makeRoster(
     perTenant: Record<string, () => Promise<{ factsScanned: number; factsUpdated: number }>>,
   ) {
-    const apiKeys = { knownCompanyIds: () => Object.keys(perTenant) } as unknown as ApiKeyService;
+    const apiKeys = { fanOutRoster: () => Object.keys(perTenant) } as unknown as ApiKeyService;
     const engine = {
       providerId: () => 'stub',
       reindexTenant: async (companyId: string) => {

--- a/test/reindex-readiness.unit-spec.ts
+++ b/test/reindex-readiness.unit-spec.ts
@@ -9,7 +9,7 @@ describe('ReindexEmbeddingsService warmup failure', () => {
       providerId: () => 'bge-m3:Xenova/bge-m3:1024',
     };
     const svc = new ReindexEmbeddingsService(
-      { knownCompanyIds: () => ['tenant-a', 'tenant-b'] } as any,
+      { fanOutRoster: () => ['tenant-a', 'tenant-b'] } as any,
       engine as any,
     );
     await expect(svc.run({ allTables: true })).rejects.toBe(unavailable);

--- a/test/scene-maintenance.e2e-spec.ts
+++ b/test/scene-maintenance.e2e-spec.ts
@@ -204,13 +204,17 @@ describe('scheduled scene maintenance (e2e)', () => {
       await ingest(QUIET_CONV, 2, '2026-04-02T09:10:00.000Z', 'And one here too.');
       expect(await dirtyRows()).toHaveLength(2);
 
+      // The roster is shared with every other suite's tenant in this
+      // container and sorted, so find this tenant's row rather than [0].
+      const own = (run: { tenants: Array<{ companyId: string }> }) =>
+        run.tenants.find((t) => t.companyId === f.companyId);
       const first = await maintenance().runNightly();
-      expect(first.tenants[0]).toMatchObject({ dirty: 1, cleared: 1 });
+      expect(own(first)).toMatchObject({ dirty: 1, cleared: 1 });
       // Exactly one mark consumed; the other waits for the next run.
       expect(await dirtyRows()).toHaveLength(1);
 
       const second = await maintenance().runNightly();
-      expect(second.tenants[0]).toMatchObject({ dirty: 1, cleared: 1 });
+      expect(own(second)).toMatchObject({ dirty: 1, cleared: 1 });
       expect(await dirtyRows()).toHaveLength(0);
     } finally {
       delete process.env.SCENES_MAINTENANCE_MAX_CONVERSATIONS;

--- a/test/scene-maintenance.unit-spec.ts
+++ b/test/scene-maintenance.unit-spec.ts
@@ -97,7 +97,7 @@ function makeSurreal(tenants: Record<string, FakeTenant>): {
 }
 
 function makeApiKeys(ids: string[]): ApiKeyService {
-  return { knownCompanyIds: () => ids } as unknown as ApiKeyService;
+  return { fanOutRoster: () => ids } as unknown as ApiKeyService;
 }
 
 function makeComposer(
@@ -172,7 +172,7 @@ describe('SceneMaintenanceService — flag gate', () => {
     const { composer, calls } = makeComposer(async () => composed());
     const svc = new SceneMaintenanceService(
       makeSurreal({}).surreal,
-      { knownCompanyIds: roster } as unknown as ApiKeyService,
+      { fanOutRoster: roster } as unknown as ApiKeyService,
       composer,
       makeBeliefs().beliefs,
     );
@@ -191,7 +191,7 @@ describe('SceneMaintenanceService — flag gate', () => {
     const roster = jest.fn(() => ['co_a']);
     const svc = new SceneMaintenanceService(
       makeSurreal({}).surreal,
-      { knownCompanyIds: roster } as unknown as ApiKeyService,
+      { fanOutRoster: roster } as unknown as ApiKeyService,
       makeComposer(async () => composed()).composer,
       makeBeliefs().beliefs,
     );

--- a/test/strategy-revision.unit-spec.ts
+++ b/test/strategy-revision.unit-spec.ts
@@ -83,7 +83,7 @@ function distillConfig(): ConfigService {
   } as unknown as ConfigService;
 }
 
-const apiKeysStub = { knownCompanyIds: () => ['c1'] } as unknown as ApiKeyService;
+const apiKeysStub = { fanOutRoster: () => ['c1'] } as unknown as ApiKeyService;
 
 /** Script the distiller's two LLM calls in order: proposal, then merge decision. */
 function mockDistillOpenAi(svc: StrategyDistillService, responses: string[]): void {

--- a/test/tenant-registry.service.unit-spec.ts
+++ b/test/tenant-registry.service.unit-spec.ts
@@ -51,12 +51,15 @@ function makeFakeSurreal() {
   let stateRows: Array<Record<string, unknown>> = [];
   /** What the registry row's status reads as when a touch() write echoes it. */
   const statusInDb = new Map<string, string>();
+  /** Set while a roster read is being held open, to interleave a write. */
+  let rosterGate: Promise<void> | undefined;
   const surreal = {
     async withAdminDb<T>(fn: (db: unknown) => Promise<T>): Promise<T> {
       const db = {
         async query<R>(sql: string, vars?: Record<string, unknown>): Promise<R> {
           queries.push({ sql, vars });
           if (sql.includes('SELECT companyId, status FROM tenant_registry')) {
+            if (rosterGate) await rosterGate;
             return [rosterRows] as unknown as R;
           }
           if (sql.includes('indexState')) return [stateRows] as unknown as R;
@@ -86,6 +89,17 @@ function makeFakeSurreal() {
     setStatusInDb(companyId: string, status: string) {
       statusInDb.set(companyId, status);
     },
+    /** Hold the next roster read open; the returned function releases it. */
+    holdRosterRead() {
+      let release = () => {};
+      rosterGate = new Promise<void>((resolve) => {
+        release = () => {
+          rosterGate = undefined;
+          resolve();
+        };
+      });
+      return release;
+    },
     setStateRows(rows: Array<Record<string, unknown>>) {
       stateRows = rows;
     },
@@ -102,6 +116,7 @@ describe('ApiKeyService.fanOutRoster() — registry-active only, static keys as 
     // opening its scope creates and migrates `co_<id>` (audit A-10 / V-5).
     const registry = {
       activeCompanyIds: () => ['co_live2', 'co_live1'],
+      statusOf: () => undefined,
     } as unknown as TenantRegistryService;
     const svc = makeApiKeys(['co_dormant', 'co_live1'], registry);
     expect(svc.fanOutRoster()).toEqual(['co_live1', 'co_live2']);
@@ -109,7 +124,10 @@ describe('ApiKeyService.fanOutRoster() — registry-active only, static keys as 
   });
 
   it('registry empty → the static set (bootstrap / dev fallback)', () => {
-    const registry = { activeCompanyIds: () => [] } as unknown as TenantRegistryService;
+    const registry = {
+      activeCompanyIds: () => [],
+      statusOf: () => undefined,
+    } as unknown as TenantRegistryService;
     expect(makeApiKeys(['co_b', 'co_a'], registry).fanOutRoster()).toEqual(['co_a', 'co_b']);
   });
 
@@ -120,6 +138,7 @@ describe('ApiKeyService.fanOutRoster() — registry-active only, static keys as 
   it('is never the union: a static-only tenant is absent whenever the registry has anyone', () => {
     const registry = {
       activeCompanyIds: () => ['co_prod'],
+      statusOf: () => undefined,
     } as unknown as TenantRegistryService;
     const svc = makeApiKeys(['co_static'], registry);
     expect(svc.fanOutRoster()).toEqual(['co_prod']);
@@ -130,6 +149,7 @@ describe('ApiKeyService.fanOutRoster() — registry-active only, static keys as 
   it('is sorted and deduped, so sweep order is stable across pods', () => {
     const registry = {
       activeCompanyIds: () => ['co_c', 'co_a', 'co_b', 'co_a'],
+      statusOf: () => undefined,
     } as unknown as TenantRegistryService;
     expect(makeApiKeys([], registry).fanOutRoster()).toEqual(['co_a', 'co_b', 'co_c']);
   });
@@ -140,8 +160,8 @@ describe('ApiKeyService.hostTenant() — deterministic across replicas', () => {
     // The cache fills from an unordered read plus request-path touch()
     // inserts, so "first cached" differs per pod; the dedup index on
     // (jobType, dedupKey) is per tenant DB and cannot collapse two hosts.
-    const podA = { activeCompanyIds: () => ['co_z', 'co_m', 'co_b'] };
-    const podB = { activeCompanyIds: () => ['co_b', 'co_z', 'co_m'] };
+    const podA = { activeCompanyIds: () => ['co_z', 'co_m', 'co_b'], statusOf: () => undefined };
+    const podB = { activeCompanyIds: () => ['co_b', 'co_z', 'co_m'], statusOf: () => undefined };
     const hostA = makeApiKeys([], podA as unknown as TenantRegistryService).hostTenant();
     const hostB = makeApiKeys([], podB as unknown as TenantRegistryService).hostTenant();
     expect(hostA).toBe('co_b');
@@ -151,6 +171,7 @@ describe('ApiKeyService.hostTenant() — deterministic across replicas', () => {
   it('is the lexicographically smallest id of the FAN-OUT roster, never a dormant static key', () => {
     const registry = {
       activeCompanyIds: () => ['co_live'],
+      statusOf: () => undefined,
     } as unknown as TenantRegistryService;
     // 'co_aaa' sorts first in the union but is static-only: not a host.
     expect(makeApiKeys(['co_aaa'], registry).hostTenant()).toBe('co_live');
@@ -162,6 +183,50 @@ describe('ApiKeyService.hostTenant() — deterministic across replicas', () => {
   });
 });
 
+// ── F5: a KNOWN non-active lifecycle is never lifted by a static key ─────
+// Real TenantRegistryService without a connection: register() is remembered
+// in memory, which is exactly the state the audit repro exercised.
+describe('static keys vs a recorded suspension (round2 F5)', () => {
+  it('empty active roster: the suspended static tenant is in NEITHER roster', async () => {
+    const registry = new TenantRegistryService();
+    const svc = makeApiKeys(['co_paused'], registry);
+    await registry.register('co_paused', { status: 'suspended' });
+    expect(registry.activeCompanyIds()).toEqual([]);
+    // Before: empty active roster ⇒ the static set, suspension and all.
+    expect(svc.fanOutRoster()).toEqual([]);
+    expect(svc.knownCompanyIds()).toEqual([]);
+    expect(svc.hostTenant()).toBeUndefined();
+  });
+
+  it('mixed roster: the suspended static tenant stays out while the active one is in', async () => {
+    const registry = new TenantRegistryService();
+    const svc = makeApiKeys(['co_paused'], registry);
+    await registry.register('co_paused', { status: 'suspended' });
+    await registry.register('co_other', { status: 'active' });
+    expect(registry.activeCompanyIds()).toEqual(['co_other']);
+    // Before: non-empty ⇒ the union, which re-admitted co_paused.
+    expect(svc.fanOutRoster()).toEqual(['co_other']);
+    expect(svc.knownCompanyIds()).toEqual(['co_other']);
+  });
+
+  it('any known non-active status is out; only an UNKNOWN lifecycle falls back to the key', async () => {
+    const registry = new TenantRegistryService();
+    const svc = makeApiKeys(['co_prov', 'co_fresh'], registry);
+    await registry.register('co_prov', { status: 'provisioning' });
+    expect(svc.fanOutRoster()).toEqual(['co_fresh']);
+    expect(svc.knownCompanyIds()).toEqual(['co_fresh']);
+  });
+
+  it('statusOf() reports what the pod recorded, undefined for a stranger', async () => {
+    const registry = new TenantRegistryService();
+    expect(registry.statusOf('co_x')).toBeUndefined();
+    await registry.register('co_x', { status: 'suspended' });
+    expect(registry.statusOf('co_x')).toBe('suspended');
+    await registry.register('co_x', { status: 'active' });
+    expect(registry.statusOf('co_x')).toBe('active');
+  });
+});
+
 // ── knownCompanyIds fallback / union ────────────────────────────────────
 describe('ApiKeyService.knownCompanyIds() — registry-backed with BRAIN_API_KEYS fallback', () => {
   it('no registry injected → static set (byte-identical to pre-R4)', () => {
@@ -170,7 +235,10 @@ describe('ApiKeyService.knownCompanyIds() — registry-backed with BRAIN_API_KEY
   });
 
   it('empty registry → static set unchanged, order preserved (byte-identical)', () => {
-    const registry = { activeCompanyIds: () => [] } as unknown as TenantRegistryService;
+    const registry = {
+      activeCompanyIds: () => [],
+      statusOf: () => undefined,
+    } as unknown as TenantRegistryService;
     const withReg = makeApiKeys(['co_a', 'co_b'], registry);
     const withoutReg = makeApiKeys(['co_a', 'co_b']);
     expect(withReg.knownCompanyIds()).toEqual(withoutReg.knownCompanyIds());
@@ -180,6 +248,7 @@ describe('ApiKeyService.knownCompanyIds() — registry-backed with BRAIN_API_KEY
   it('registry that only mirrors static keys → still byte-identical (static-first union)', () => {
     const registry = {
       activeCompanyIds: () => ['co_a', 'co_b'],
+      statusOf: () => undefined,
     } as unknown as TenantRegistryService;
     const svc = makeApiKeys(['co_a', 'co_b'], registry);
     expect(svc.knownCompanyIds()).toEqual(['co_a', 'co_b']);
@@ -188,6 +257,7 @@ describe('ApiKeyService.knownCompanyIds() — registry-backed with BRAIN_API_KEY
   it('registry adds new tenants → deduped union, static first', () => {
     const registry = {
       activeCompanyIds: () => ['co_b', 'co_c', 'co_d'],
+      statusOf: () => undefined,
     } as unknown as TenantRegistryService;
     const svc = makeApiKeys(['co_a', 'co_b'], registry);
     expect(svc.knownCompanyIds()).toEqual(['co_a', 'co_b', 'co_c', 'co_d']);
@@ -196,6 +266,7 @@ describe('ApiKeyService.knownCompanyIds() — registry-backed with BRAIN_API_KEY
   it('prod-JWKS: BRAIN_API_KEYS empty + registry populated → roster (fan-out no longer [])', () => {
     const registry = {
       activeCompanyIds: () => ['co_prod1', 'co_prod2'],
+      statusOf: () => undefined,
     } as unknown as TenantRegistryService;
     const svc = makeApiKeys([], registry); // static table disabled/empty in prod
     expect(svc.knownCompanyIds()).toEqual(['co_prod1', 'co_prod2']);
@@ -204,6 +275,7 @@ describe('ApiKeyService.knownCompanyIds() — registry-backed with BRAIN_API_KEY
   it('is the VALIDATION roster: a dormant static tenant stays targetable even once the registry is live', () => {
     const registry = {
       activeCompanyIds: () => ['co_live'],
+      statusOf: () => undefined,
     } as unknown as TenantRegistryService;
     const svc = makeApiKeys(['co_dormant'], registry);
     expect(svc.knownCompanyIds()).toContain('co_dormant');
@@ -214,6 +286,7 @@ describe('ApiKeyService.knownCompanyIds() — registry-backed with BRAIN_API_KEY
     const touched: string[] = [];
     const registry = {
       activeCompanyIds: () => [],
+      statusOf: () => undefined,
       touch: (id: string) => touched.push(id),
     } as unknown as TenantRegistryService;
     const svc = makeApiKeys([], registry);
@@ -357,6 +430,32 @@ describe('TenantRegistryService', () => {
     expect(svc.activeCompanyIds()).toEqual(['co_b']);
     // And the learned status governs the next touch.
     svc.touch('co_a');
+    expect(svc.activeCompanyIds()).toEqual(['co_b']);
+    svc.onModuleDestroy();
+  });
+
+  it('a suspension that lands mid-refresh survives the stale snapshot', async () => {
+    const { surreal, setRoster, holdRosterRead } = makeFakeSurreal();
+    setRoster([
+      { companyId: 'co_a', status: 'active' },
+      { companyId: 'co_b', status: 'active' },
+    ]);
+    const svc = new TenantRegistryService(surreal);
+    const release = holdRosterRead();
+    svc.onModuleInit(); // refresh starts and blocks inside the roster read
+    await flush();
+
+    // The offboarding write lands while the read is in flight, so the rows
+    // it returns still say 'active' for co_a.
+    await svc.register('co_a', { status: 'suspended' });
+    expect(svc.activeCompanyIds()).toEqual([]);
+
+    release();
+    await flush();
+    await flush();
+    // The snapshot may not lift what this pod wrote after the read began;
+    // every other tenant still loads from it.
+    expect(svc.statusOf('co_a')).toBe('suspended');
     expect(svc.activeCompanyIds()).toEqual(['co_b']);
     svc.onModuleDestroy();
   });

--- a/test/tenant-registry.service.unit-spec.ts
+++ b/test/tenant-registry.service.unit-spec.ts
@@ -95,6 +95,73 @@ function makeFakeSurreal() {
 /** Let fire-and-forget touch() writes settle. */
 const flush = () => new Promise((r) => setImmediate(r));
 
+// ── fanOutRoster / hostTenant — the ONE roster background loops walk ────
+describe('ApiKeyService.fanOutRoster() — registry-active only, static keys as the empty fallback', () => {
+  it('registry non-empty → registry tenants ONLY, even when static keys name extra tenants', () => {
+    // A static key whose tenant never authenticated must not be walked:
+    // opening its scope creates and migrates `co_<id>` (audit A-10 / V-5).
+    const registry = {
+      activeCompanyIds: () => ['co_live2', 'co_live1'],
+    } as unknown as TenantRegistryService;
+    const svc = makeApiKeys(['co_dormant', 'co_live1'], registry);
+    expect(svc.fanOutRoster()).toEqual(['co_live1', 'co_live2']);
+    expect(svc.fanOutRoster()).not.toContain('co_dormant');
+  });
+
+  it('registry empty → the static set (bootstrap / dev fallback)', () => {
+    const registry = { activeCompanyIds: () => [] } as unknown as TenantRegistryService;
+    expect(makeApiKeys(['co_b', 'co_a'], registry).fanOutRoster()).toEqual(['co_a', 'co_b']);
+  });
+
+  it('no registry wired → the static set', () => {
+    expect(makeApiKeys(['co_a']).fanOutRoster()).toEqual(['co_a']);
+  });
+
+  it('is never the union: a static-only tenant is absent whenever the registry has anyone', () => {
+    const registry = {
+      activeCompanyIds: () => ['co_prod'],
+    } as unknown as TenantRegistryService;
+    const svc = makeApiKeys(['co_static'], registry);
+    expect(svc.fanOutRoster()).toEqual(['co_prod']);
+    // …while the validation roster still knows the static tenant.
+    expect(svc.knownCompanyIds()).toEqual(['co_static', 'co_prod']);
+  });
+
+  it('is sorted and deduped, so sweep order is stable across pods', () => {
+    const registry = {
+      activeCompanyIds: () => ['co_c', 'co_a', 'co_b', 'co_a'],
+    } as unknown as TenantRegistryService;
+    expect(makeApiKeys([], registry).fanOutRoster()).toEqual(['co_a', 'co_b', 'co_c']);
+  });
+});
+
+describe('ApiKeyService.hostTenant() — deterministic across replicas', () => {
+  it('two replicas whose registry caches filled in different orders pick the SAME host', () => {
+    // The cache fills from an unordered read plus request-path touch()
+    // inserts, so "first cached" differs per pod; the dedup index on
+    // (jobType, dedupKey) is per tenant DB and cannot collapse two hosts.
+    const podA = { activeCompanyIds: () => ['co_z', 'co_m', 'co_b'] };
+    const podB = { activeCompanyIds: () => ['co_b', 'co_z', 'co_m'] };
+    const hostA = makeApiKeys([], podA as unknown as TenantRegistryService).hostTenant();
+    const hostB = makeApiKeys([], podB as unknown as TenantRegistryService).hostTenant();
+    expect(hostA).toBe('co_b');
+    expect(hostB).toBe(hostA);
+  });
+
+  it('is the lexicographically smallest id of the FAN-OUT roster, never a dormant static key', () => {
+    const registry = {
+      activeCompanyIds: () => ['co_live'],
+    } as unknown as TenantRegistryService;
+    // 'co_aaa' sorts first in the union but is static-only: not a host.
+    expect(makeApiKeys(['co_aaa'], registry).hostTenant()).toBe('co_live');
+  });
+
+  it('falls back to the smallest static id, and is undefined with no tenants at all', () => {
+    expect(makeApiKeys(['co_b', 'co_a']).hostTenant()).toBe('co_a');
+    expect(makeApiKeys([]).hostTenant()).toBeUndefined();
+  });
+});
+
 // ── knownCompanyIds fallback / union ────────────────────────────────────
 describe('ApiKeyService.knownCompanyIds() — registry-backed with BRAIN_API_KEYS fallback', () => {
   it('no registry injected → static set (byte-identical to pre-R4)', () => {
@@ -132,6 +199,15 @@ describe('ApiKeyService.knownCompanyIds() — registry-backed with BRAIN_API_KEY
     } as unknown as TenantRegistryService;
     const svc = makeApiKeys([], registry); // static table disabled/empty in prod
     expect(svc.knownCompanyIds()).toEqual(['co_prod1', 'co_prod2']);
+  });
+
+  it('is the VALIDATION roster: a dormant static tenant stays targetable even once the registry is live', () => {
+    const registry = {
+      activeCompanyIds: () => ['co_live'],
+    } as unknown as TenantRegistryService;
+    const svc = makeApiKeys(['co_dormant'], registry);
+    expect(svc.knownCompanyIds()).toContain('co_dormant');
+    expect(svc.fanOutRoster()).not.toContain('co_dormant');
   });
 
   it('noteResolvedTenant() forwards the resolved tenant to the registry (the auth hook)', () => {

--- a/test/tool-observation.unit-spec.ts
+++ b/test/tool-observation.unit-spec.ts
@@ -186,7 +186,7 @@ describe('ToolObservationService.verifyRef', () => {
 });
 
 describe('OutcomePruneService — tool_observation leg', () => {
-  const apiKeys = (ids: string[]) => ({ knownCompanyIds: () => ids }) as unknown as ApiKeyService;
+  const apiKeys = (ids: string[]) => ({ fanOutRoster: () => ids }) as unknown as ApiKeyService;
 
   afterEach(() => {
     delete process.env.TOOL_OBSERVATIONS_ENABLED;

--- a/test/vector-corpus.unit-spec.ts
+++ b/test/vector-corpus.unit-spec.ts
@@ -60,14 +60,13 @@ describe('VectorCorpusService', () => {
       setVectorCorpusTenantsNonconforming: jest.fn(),
       countVectorCorpusRepair: jest.fn(),
     };
-    const apiKeys = { knownCompanyIds: () => ['co_x'] };
+    const apiKeys = { fanOutRoster: () => ['co_x'] };
     const svc = new VectorCorpusService(
       surreal as never,
       embedder as never,
       reindex as never,
       apiKeys as never,
       jobs as never,
-      undefined,
       metrics as never,
     );
     return { svc, reindex, jobs, metrics, queries };

--- a/test/worker-poller-concurrency.unit-spec.ts
+++ b/test/worker-poller-concurrency.unit-spec.ts
@@ -111,7 +111,7 @@ function makeQueue(jobs: Record<string, number>) {
 }
 
 function makeApiKeys(companyIds: string[]) {
-  return { knownCompanyIds: () => companyIds };
+  return { fanOutRoster: () => companyIds };
 }
 
 function makePoller(args: {


### PR DESCRIPTION
## What

- **One fan-out roster.** `ApiKeyService.fanOutRoster()`: the registry's ACTIVE tenants when the registry has any, otherwise the static `BRAIN_API_KEYS` set (bootstrap/dev fallback), deduped and sorted. Never the union.
- **One host tenant.** `ApiKeyService.hostTenant()`: the lexicographically smallest id of the fan-out roster, for cross-tenant bookkeeping rows (refit queue/job, registry mirror, calibration persist/read). Deterministic across replicas.
- **Every background loop switched** to `fanOutRoster()` / `hostTenant()`: memory-quality, orphan-blob GC, episode subscriptions, scene maintenance, recompose, outcome prune, changefeed consumer (tick / drainNow / cursorState), candidate sweeper, dreams (enqueue + runAll), strategy distill, registry mirror, compaction queue, calibration (refit runner x4, refit queue, refit job, boot-time persisted bootstrap), job reaper, worker poller (both claim paths), capability probe, vector-corpus sweep, HNSW provision sweep.
- **Three ad-hoc copies removed** (`capability-probe`, `vector-corpus`, `hnsw-provision` each had `active.length > 0 ? active : knownCompanyIds()`).
- **A static key no longer resurrects a known non-active tenant** (audit round2-runtime-2026-09-09, **F5**). `TenantRegistryService.statusOf()` reports the lifecycle this pod has recorded, and the static set is filtered through it: an id whose status is explicitly non-active (suspended / provisioning) is out of `fanOutRoster()` **and** `knownCompanyIds()`; only an UNKNOWN lifecycle falls back to the key.
- **`refresh()` can no longer lift a suspension on its own pod.** Its row set is a snapshot read before a concurrent `register()` landed, and replaying it re-noted the tenant active until the next 60s pass — contradicting the file's own claim. Status writes bump a counter that `refresh()` captures before its read; a tenant written after that point keeps its local status.
- **Operator "omit `?tenant=` → all tenants" paths are fan-outs now**, not validation: `resolvePlatformTenantScope` takes `fanOutTenants` for the omitted case and never falls back to `knownTenants` for it (`admin-jobs.controller` compaction / dreams-emits / leases / reindex + scenario host picks, `job-run.service.list()`, `reindex-embeddings.run()`, plus the admin aggregate reads that share the helper).
- **`knownCompanyIds()` stays the VALIDATION roster** for every single operator-supplied `?tenant=` — an operator may legitimately target a dormant static tenant to provision it.

No cron schedules, lease logic or sweep bodies changed beyond the roster source. No new flags or env knobs.

## Why

Audit finding **A-10 / V-5**: `knownCompanyIds()` returned the UNION of static `BRAIN_API_KEYS` tenants and the registry roster, so a nightly sweep over it called `withCompany(co_<id>)` for every static key whose tenant never authenticated — and `ensureSchema` creates and fully migrates that database on first entry. Three services had already grown their own workaround; ~20 other loops had not.

The cross-tenant "host tenant" was `knownCompanyIds()[0]`. The registry cache fills from an unordered read plus request-path `touch()` inserts, so two replicas could pick different `[0]` and both enqueue the same cross-tenant job — the `(jobType, dedupKey)` UNIQUE index is per tenant database and cannot dedupe across hosts.

Audit finding **F5**: with a static key for `paused` plus `register('paused', {status:'suspended'})`, both rosters still contained `paused` — an empty active roster fell back to the whole static set, a non-empty one unioned it. The characterization repro in `docs/audits/round2-runtime-2026-09-09-repros/cache-roster.patch` is inverted into regression tests here (empty roster, mixed roster, provisioning, `statusOf`).

## Root cause of the red e2e on the previous push

`source-trust-scoped` (shard 2), `scene-maintenance` (shard 3) and `hnsw` (shard 4) failed for one reason: e2e fixture tenants are not on the fan-out roster.

`tenant_registry` lives in the SYSTEM database, which the whole e2e run shares (one container, `maxWorkers: 1`), so by mid-run it holds every earlier suite's tenant. A fixture tenant that has not authenticated yet is NOT in it — so `refitSourceTrust()` walked those other tenants and wrote nothing into the tenant the spec then read, and all three of its tests failed on empty tables. The fixture now does what provisioning does (`TenantRegistryService.register()`), so persist and load agree on one roster from boot.

The other two were roster *order*: the fan-out roster is sorted, not static-first, so `tenants[0]` is no longer "my tenant". `scene-maintenance` looks its own row up by `companyId`; `hnsw` turns `HNSW_PROVISION_ENABLED` on after the first ingest so "a tenant that exists without indexes" is the spec's actual premise rather than an artefact of when the boot hook first saw the tenant. No fixture hard-codes a host.

## How verified

Tests that fail without the change:
- `test/tenant-registry.service.unit-spec.ts` — `fanOutRoster()` (registry-only / static fallback / never the union / sorted+deduped), `hostTenant()` (same host from differently-ordered caches, never a dormant static key), **F5** (empty roster: suspended static tenant in NEITHER roster; mixed roster: stays out while the active one is in; `provisioning` is out; unknown falls back), and the refresh race (a suspension that lands mid-refresh survives the stale snapshot).
- `test/admin-tenant-isolation.unit-spec.ts` — an omitted `?tenant=` never expands over the validation roster, while a single dormant tenant still validates through it.
- `test/capability-probe.unit-spec.ts` — canary = first tenant of the fan-out roster.

```
pnpm typecheck    -> clean
pnpm lint:ci      -> 0 problems
pnpm format:check -> All matched files use Prettier code style!
pnpm jest --config ./test/jest-unit.json (FULL, rebased onto #557)
                  -> Test Suites: 439 passed, 439 total; Tests: 5350 passed, 5350 total
pnpm jest --config ./test/jest-e2e.json --testPathPatterns
  'source-trust-scoped|scene-maintenance|hnsw|tenant-registry-suspended|capability-probe|evidence-storage'
                  -> Test Suites: 8 passed, 8 total; Tests: 58 passed, 58 total
CI on the pre-#555/#557 rebase of this branch (run 34524357335): every job green, including
engine-e2e shards 1-4, engine-unit, engine-checks, engine-jobs-e2e and build-test.
pnpm jest --config ./test/jest-e2e.json (FULL, 152 suites, before the rebase onto #552/#553)
                  -> 150 passed; 2 unrelated flakes: memory-decision (jest worker SIGSEGV — the
                     native ONNX teardown corruption documented in test/jest-e2e.json) and
                     concurrent-single-active (2 of 8 concurrent ingests lost to root-pool
                     contention under load). Both pass in isolation: 2 suites / 6 tests passed.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhrQxeisXJZEt4sg3PGyU6

