### PR TITLE
fix(landing): pay down react-hooks warning debt by user-visible effect, then ratchet it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -376,10 +376,12 @@ jobs:
         run: pnpm lint:i18n
 
       # Full ESLint over the whole landing app (Next 16 removed `next lint`, so
-      # this is eslint-config-next via the flat config). Gates on errors; the
-      # stricter react-hooks-7 rules are warnings tracked as tech debt.
-      - name: Lint (full)
-        run: pnpm lint
+      # this is eslint-config-next via the flat config). Gates on errors AND
+      # ratchets the react-hooks-7 warnings: `lint:ci` carries a
+      # `--max-warnings` cap equal to the current count, so the number can
+      # only go down. Fix a warning, lower the cap in the same PR.
+      - name: Lint (full, warning ratchet)
+        run: pnpm lint:ci
 
       - name: Typecheck
         run: pnpm typecheck

--- a/brain-landing/__tests__/force-layout.test.ts
+++ b/brain-landing/__tests__/force-layout.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+import {
+  graphStructureKey,
+  reconcileSimNodes,
+  type SimNode,
+} from '../lib/force-layout'
+
+const node = (id: string, x = 0, y = 0) => ({ id, position: { x, y } })
+
+describe('graphStructureKey', () => {
+  it('is stable across position-only updates (one simulation tick)', () => {
+    const before = graphStructureKey(
+      [node('a', 0, 0), node('b', 10, 10)],
+      [{ source: 'a', target: 'b' }],
+    )
+    const after = graphStructureKey(
+      [node('a', 3.2, -1.7), node('b', 12.4, 9.1)],
+      [{ source: 'a', target: 'b' }],
+    )
+    expect(after).toBe(before)
+  })
+
+  it('changes when a node is added or removed', () => {
+    const base = graphStructureKey([node('a'), node('b')], [])
+    expect(graphStructureKey([node('a'), node('b'), node('c')], [])).not.toBe(
+      base,
+    )
+    expect(graphStructureKey([node('a')], [])).not.toBe(base)
+  })
+
+  it('changes when the visible edge set changes', () => {
+    const nodes = [node('a'), node('b')]
+    const linked = graphStructureKey(nodes, [{ source: 'a', target: 'b' }])
+    const filtered = graphStructureKey(nodes, [])
+    expect(filtered).not.toBe(linked)
+  })
+})
+
+describe('reconcileSimNodes', () => {
+  it('keeps the body (position and velocity) of nodes that already exist', () => {
+    const pool = new Map<string, SimNode>()
+    const [a] = reconcileSimNodes(pool, [node('a', 0, 0)])
+    a!.x = 42
+    a!.y = -7
+    a!.vx = 1.5
+    a!.vy = -0.5
+
+    const next = reconcileSimNodes(pool, [node('a', 999, 999)])
+    expect(next[0]).toBe(a)
+    expect(next[0]).toMatchObject({ x: 42, y: -7, vx: 1.5, vy: -0.5 })
+  })
+
+  it('seeds new ids from their rendered position and returns bodies in node order', () => {
+    const pool = new Map<string, SimNode>()
+    reconcileSimNodes(pool, [node('a', 1, 2)])
+    const next = reconcileSimNodes(pool, [node('b', 5, 6), node('a', 1, 2)])
+    expect(next.map((n) => n.id)).toEqual(['b', 'a'])
+    expect(next[0]).toMatchObject({ id: 'b', x: 5, y: 6 })
+    expect(pool.get('b')).toBe(next[0])
+  })
+
+  it('leaves x/y undefined for nodes without a position so d3 can place them', () => {
+    const pool = new Map<string, SimNode>()
+    const [c] = reconcileSimNodes(pool, [{ id: 'c' }])
+    expect(c!.x).toBeUndefined()
+    expect(c!.y).toBeUndefined()
+  })
+
+  it('evicts bodies whose node was removed', () => {
+    const pool = new Map<string, SimNode>()
+    reconcileSimNodes(pool, [node('a'), node('b'), node('c')])
+    const next = reconcileSimNodes(pool, [node('b')])
+    expect(next.map((n) => n.id)).toEqual(['b'])
+    expect([...pool.keys()]).toEqual(['b'])
+  })
+})

--- a/brain-landing/app/[lang]/admin/scenarios/page.tsx
+++ b/brain-landing/app/[lang]/admin/scenarios/page.tsx
@@ -25,7 +25,6 @@ export default function ScenariosListPage() {
   const [results, setResults] = useState<ScenarioRunOutcome[] | null>(null)
 
   useEffect(() => {
-    setLoading(true)
     fetch('/api/admin/proxy/v1/admin/scenarios')
       .then((r) => r.json())
       .then((data) => {

--- a/brain-landing/app/[lang]/admin/traces/page.tsx
+++ b/brain-landing/app/[lang]/admin/traces/page.tsx
@@ -1,28 +1,27 @@
 'use client'
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useCallback, useMemo, useRef, useState } from 'react'
 import Link from 'next/link'
 import { useParams } from 'next/navigation'
 import { Radio, RefreshCw } from 'lucide-react'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import { normalizeLang } from '../../../../lib/i18n'
 import type { TraceListItem as TraceMeta } from '../../../../lib/contracts/admin-traces'
+import { useLoader } from '../../../../hooks/useLoader'
+import { useEventSource } from '../../../../hooks/useEventSource'
 
 export default function TracesListPage() {
   const params = useParams<{ lang: string }>()
   const lang = normalizeLang(params?.lang)
   const [traces, setTraces] = useState<TraceMeta[]>([])
   const [error, setError] = useState<string | null>(null)
-  const [loading, setLoading] = useState(true)
   const [live, setLive] = useState(true)
-  const [sseStatus, setSseStatus] = useState<'idle' | 'open' | 'closed'>('idle')
   const [q, setQ] = useState('')
   const [methodFilter, setMethodFilter] = useState('')
   const [statusFilter, setStatusFilter] = useState<'all' | 'ok' | 'err'>('all')
   const scrollRef = useRef<HTMLDivElement>(null)
 
   const load = useCallback(async () => {
-    setLoading(true)
     try {
       const res = await fetch('/api/admin/proxy/v1/admin/traces')
       const data = await res.json()
@@ -31,26 +30,16 @@ export default function TracesListPage() {
       setError(null)
     } catch (e) {
       setError((e as Error).message)
-    } finally {
-      setLoading(false)
     }
   }, [])
 
-  useEffect(() => {
-    void load()
-  }, [load])
+  const { loading, reload } = useLoader(load)
 
-  useEffect(() => {
-    if (!live) {
-      setSseStatus('idle')
-      return
-    }
-    const url = '/api/admin/sse/v1/admin/traces/stream'
-    const src = new EventSource(url)
-    setSseStatus('open')
-    src.onmessage = (e) => {
+  const sseStatus = useEventSource(
+    live ? '/api/admin/sse/v1/admin/traces/stream' : null,
+    (frame) => {
       try {
-        const meta = JSON.parse(e.data) as TraceMeta
+        const meta = JSON.parse(frame) as TraceMeta
         setTraces((prev) => {
           if (prev.some((p) => p.requestId === meta.requestId)) return prev
           return [meta, ...prev].slice(0, 500)
@@ -58,15 +47,8 @@ export default function TracesListPage() {
       } catch {
         // tolerate malformed frames
       }
-    }
-    src.onerror = () => {
-      setSseStatus('closed')
-    }
-    return () => {
-      src.close()
-      setSseStatus('idle')
-    }
-  }, [live])
+    },
+  )
 
   const filtered = useMemo(() => {
     return traces.filter((t) => {
@@ -101,7 +83,7 @@ export default function TracesListPage() {
         <h1 className="text-base font-semibold text-[var(--text)]">Traces</h1>
         <button
           type="button"
-          onClick={() => void load()}
+          onClick={() => void reload()}
           className="text-xs text-[var(--text-muted)] hover:text-[var(--text)] flex items-center gap-1"
         >
           <RefreshCw className={`w-3 h-3 ${loading ? 'animate-spin' : ''}`} />

--- a/brain-landing/app/[lang]/app/communities/page.tsx
+++ b/brain-landing/app/[lang]/app/communities/page.tsx
@@ -2,9 +2,10 @@
 
  
 
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useState } from 'react'
 import { Users, Search } from 'lucide-react'
 import { useProxyBase } from '../../../../components/playground/usePlaygroundCall'
+import { useLoader } from '../../../../hooks/useLoader'
 
 interface Community {
   communityId: string
@@ -26,37 +27,33 @@ export default function CommunitiesPage() {
   const [items, setItems] = useState<Community[]>([])
   const [query, setQuery] = useState('')
   const [searching, setSearching] = useState(false)
-  const [loading, setLoading] = useState(true)
+  const [searchBusy, setSearchBusy] = useState(false)
   const [err, setErr] = useState<string | null>(null)
 
   const loadList = useCallback(async () => {
-    setLoading(true)
-    setErr(null)
     try {
       const res = await fetch(`${proxyBase}/v1/communities?limit=50`)
       const data = await res.json()
       if (!res.ok) throw new Error(data?.error ?? `Failed (${res.status})`)
       setItems((data?.communities ?? []) as Community[])
       setSearching(false)
+      setErr(null)
     } catch (e) {
       setErr((e as Error).message)
       setItems([])
-    } finally {
-      setLoading(false)
     }
   }, [proxyBase])
 
-  useEffect(() => {
-    void loadList()
-  }, [loadList])
+  const { loading: listLoading, reload: reloadList } = useLoader(loadList)
+  const loading = listLoading || searchBusy
 
   const runSearch = useCallback(
     async (q: string) => {
       if (!q.trim()) {
-        void loadList()
+        void reloadList()
         return
       }
-      setLoading(true)
+      setSearchBusy(true)
       setErr(null)
       try {
         const res = await fetch(
@@ -70,10 +67,10 @@ export default function CommunitiesPage() {
         setErr((e as Error).message)
         setItems([])
       } finally {
-        setLoading(false)
+        setSearchBusy(false)
       }
     },
-    [proxyBase, loadList],
+    [proxyBase, reloadList],
   )
 
   return (
@@ -113,7 +110,7 @@ export default function CommunitiesPage() {
             type="button"
             onClick={() => {
               setQuery('')
-              void loadList()
+              void reloadList()
             }}
             className="px-3 h-9 rounded-md border border-[var(--border)] text-sm text-[var(--text-muted)] hover:text-[var(--text)]"
           >

--- a/brain-landing/app/[lang]/app/usage/page.tsx
+++ b/brain-landing/app/[lang]/app/usage/page.tsx
@@ -2,7 +2,8 @@
 
  
 
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useState } from 'react'
+import { useLoader } from '../../../../hooks/useLoader'
 import {
   Boxes,
   CircleCheck,
@@ -46,28 +47,22 @@ const CARDS: Array<{
 export default function UsagePage() {
   const proxyBase = useProxyBase()
   const [stats, setStats] = useState<MemoryStats | null>(null)
-  const [loading, setLoading] = useState(true)
   const [err, setErr] = useState<string | null>(null)
 
   const load = useCallback(async () => {
-    setLoading(true)
-    setErr(null)
     try {
       const res = await fetch(`${proxyBase}/v1/stats/overview`)
       const data = await res.json()
       if (!res.ok) throw new Error(data?.error ?? `Failed (${res.status})`)
       setStats(data as MemoryStats)
+      setErr(null)
     } catch (e) {
       setErr((e as Error).message)
       setStats(null)
-    } finally {
-      setLoading(false)
     }
   }, [proxyBase])
 
-  useEffect(() => {
-    void load()
-  }, [load])
+  const { loading, reload } = useLoader(load)
 
   return (
     <div className="max-w-3xl space-y-4">

--- a/brain-landing/components/admin/ActivityPanel.tsx
+++ b/brain-landing/components/admin/ActivityPanel.tsx
@@ -2,7 +2,8 @@
 
 /* eslint-disable react/jsx-no-literals -- TODO i18n migration: pre-Phase-J component, queued for separate pass. New code MUST go through getMessages(lang). */
 
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
+import { useLoader } from '../../hooks/useLoader'
 import { Loader2, Radio, RefreshCw } from 'lucide-react'
 import type {
   NowResponse as ActivityResponse,
@@ -13,13 +14,13 @@ export type { InFlightRequest }
 
 export function ActivityPanel() {
   const [data, setData] = useState<ActivityResponse | null>(null)
-  const [loading, setLoading] = useState(true)
   const [auto, setAuto] = useState(true)
   const [error, setError] = useState<string | null>(null)
-  const [, force] = useState({})
+  // Wall clock the elapsed column is measured against — advanced on every
+  // poll and by a 500ms tick in between, so render itself stays pure.
+  const [now, setNow] = useState(0)
 
-  const load = async () => {
-    setLoading(true)
+  const load = useCallback(async () => {
     try {
       const res = await fetch('/api/admin/proxy/v1/admin/now', {
         cache: 'no-store',
@@ -30,31 +31,27 @@ export function ActivityPanel() {
         throw new Error(err ?? `Failed ${res.status}`)
       }
       setData(json as ActivityResponse)
+      setNow(Date.now())
       setError(null)
     } catch (e) {
       setError((e as Error).message)
-    } finally {
-      setLoading(false)
     }
-  }
-
-  useEffect(() => {
-    void load()
   }, [])
+
+  const { loading, reload } = useLoader(load)
 
   useEffect(() => {
     if (!auto) return
-    const t = setInterval(load, 2000)
+    const t = setInterval(() => void reload(), 2000)
     return () => clearInterval(t)
-  }, [auto])
+  }, [auto, reload])
 
   // Re-tick every 500ms so "elapsed" updates even while no new fetch
   useEffect(() => {
-    const t = setInterval(() => force({}), 500)
+    const t = setInterval(() => setNow(Date.now()), 500)
     return () => clearInterval(t)
   }, [])
 
-  const now = Date.now()
   const rows = (data?.inFlight ?? []).map((r) => ({
     ...r,
     elapsedMs: now - r.startedAtMs,
@@ -76,7 +73,7 @@ export function ActivityPanel() {
         <div className="flex items-center gap-2">
           <button
             type="button"
-            onClick={() => void load()}
+            onClick={() => void reload()}
             className="text-xs text-[var(--text-muted)] hover:text-[var(--text)] flex items-center gap-1"
           >
             <RefreshCw className={`w-3 h-3 ${loading ? 'animate-spin' : ''}`} />

--- a/brain-landing/components/admin/AuditLog.tsx
+++ b/brain-landing/components/admin/AuditLog.tsx
@@ -2,7 +2,8 @@
 
 /* eslint-disable react/jsx-no-literals -- TODO i18n migration: pre-Phase-J component, queued for separate pass. New code MUST go through getMessages(lang). */
 
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
+import { useLoader } from '../../hooks/useLoader'
 import {
   Bar,
   BarChart,
@@ -34,7 +35,6 @@ const OP_TONE: Record<string, string> = {
 
 export function AuditLog() {
   const [data, setData] = useState<AuditPage | null>(null)
-  const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [filter, setFilter] = useState({
     companyId: '',
@@ -46,7 +46,6 @@ export function AuditLog() {
   const [selected, setSelected] = useState<AuditEvent | null>(null)
 
   const load = useCallback(async () => {
-    setLoading(true)
     try {
       const params = new URLSearchParams()
       if (filter.companyId) params.set('companyId', filter.companyId)
@@ -67,14 +66,10 @@ export function AuditLog() {
       setError(null)
     } catch (e) {
       setError((e as Error).message)
-    } finally {
-      setLoading(false)
     }
   }, [filter])
 
-  useEffect(() => {
-    void load()
-  }, [load])
+  const { loading, reload } = useLoader(load)
 
   const sourceData = useMemo(
     () =>
@@ -108,7 +103,7 @@ export function AuditLog() {
         </div>
         <button
           type="button"
-          onClick={() => void load()}
+          onClick={() => void reload()}
           className="text-xs text-[var(--text-muted)] hover:text-[var(--text)] flex items-center gap-1"
         >
           <RefreshCw className={`w-3 h-3 ${loading ? 'animate-spin' : ''}`} />

--- a/brain-landing/components/admin/BaselinesPage.tsx
+++ b/brain-landing/components/admin/BaselinesPage.tsx
@@ -2,7 +2,8 @@
 
 /* eslint-disable react/jsx-no-literals -- TODO i18n migration: pre-Phase-J component, queued for separate pass. New code MUST go through getMessages(lang). */
 
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
+import { useLoader } from '../../hooks/useLoader'
 import {
   ArrowRight,
   CheckCircle2,
@@ -49,7 +50,6 @@ const VERDICT_ICON: Record<DiffEntry['verdict'], typeof TrendingUp> = {
 export function BaselinesPage() {
   const [items, setItems] = useState<BaselineEntry[]>([])
   const [scenarios, setScenarios] = useState<ScenarioSummary[]>([])
-  const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [diffName, setDiffName] = useState<string | null>(null)
   const [diff, setDiff] = useState<DiffResult | null>(null)
@@ -57,7 +57,6 @@ export function BaselinesPage() {
   const [showCreate, setShowCreate] = useState(false)
 
   const load = useCallback(async () => {
-    setLoading(true)
     try {
       const [bRes, sRes] = await Promise.all([
         fetch('/api/admin/proxy/v1/admin/baselines', { cache: 'no-store' }),
@@ -70,14 +69,10 @@ export function BaselinesPage() {
       setError(null)
     } catch (e) {
       setError((e as Error).message)
-    } finally {
-      setLoading(false)
     }
   }, [])
 
-  useEffect(() => {
-    void load()
-  }, [load])
+  const { loading, reload } = useLoader(load)
 
   const runDiff = useCallback(
     async (name: string) => {
@@ -139,7 +134,7 @@ export function BaselinesPage() {
         <div className="flex items-center gap-2">
           <button
             type="button"
-            onClick={() => void load()}
+            onClick={() => void reload()}
             className="text-xs text-[var(--text-muted)] hover:text-[var(--text)] flex items-center gap-1"
           >
             <RefreshCw className={`w-3 h-3 ${loading ? 'animate-spin' : ''}`} />
@@ -312,7 +307,7 @@ export function BaselinesPage() {
           onClose={() => setShowCreate(false)}
           onSaved={() => {
             setShowCreate(false)
-            void load()
+            void reload()
           }}
         />
       )}

--- a/brain-landing/components/admin/CalibrationPanel.tsx
+++ b/brain-landing/components/admin/CalibrationPanel.tsx
@@ -2,7 +2,8 @@
 
 /* eslint-disable react/jsx-no-literals -- TODO i18n migration: pre-Phase-J component, queued for separate pass. New code MUST go through getMessages(lang). */
 
-import { useEffect, useState } from 'react'
+import { useCallback, useState } from 'react'
+import { useLoader } from '../../hooks/useLoader'
 import {
   CartesianGrid,
   Cell,
@@ -29,12 +30,10 @@ export type { ReliabilityBin, CurvePoint, CalibrationVersion }
 
 export function CalibrationPanel() {
   const [data, setData] = useState<CalibrationResponse | null>(null)
-  const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [refitting, setRefitting] = useState(false)
 
-  const load = async () => {
-    setLoading(true)
+  const load = useCallback(async () => {
     try {
       const res = await fetch('/api/admin/proxy/v1/admin/calibration', {
         cache: 'no-store',
@@ -50,14 +49,10 @@ export function CalibrationPanel() {
       setError(null)
     } catch (e) {
       setError((e as Error).message)
-    } finally {
-      setLoading(false)
     }
-  }
-
-  useEffect(() => {
-    void load()
   }, [])
+
+  const { loading, reload } = useLoader(load)
 
   const triggerRefit = async () => {
     setRefitting(true)
@@ -69,7 +64,7 @@ export function CalibrationPanel() {
       )
       const json = await res.json()
       if (!res.ok) throw new Error(json.error ?? `Failed ${res.status}`)
-      await load()
+      await reload()
     } catch (e) {
       setError((e as Error).message)
     } finally {
@@ -104,7 +99,7 @@ export function CalibrationPanel() {
         <div className="flex items-center gap-2">
           <button
             type="button"
-            onClick={() => void load()}
+            onClick={() => void reload()}
             className="text-xs text-[var(--text-muted)] hover:text-[var(--text)] flex items-center gap-1"
           >
             <RefreshCw className={`w-3 h-3 ${loading ? 'animate-spin' : ''}`} />

--- a/brain-landing/components/admin/ConfigPanel.tsx
+++ b/brain-landing/components/admin/ConfigPanel.tsx
@@ -2,7 +2,8 @@
 
 /* eslint-disable react/jsx-no-literals -- TODO i18n migration: pre-Phase-J component, queued for separate pass. New code MUST go through getMessages(lang). */
 
-import { useEffect, useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
+import { useLoader } from '../../hooks/useLoader'
 import { AlertTriangle, KeyRound, RefreshCw, Settings2 } from 'lucide-react'
 import { CONFIG_CATEGORIES } from '../../lib/contracts/admin-config'
 import type { ConfigEntry } from '../../lib/contracts/admin-config'
@@ -13,14 +14,12 @@ export const CATEGORY_ORDER: readonly string[] = CONFIG_CATEGORIES
 
 export function ConfigPanel() {
   const [entries, setEntries] = useState<ConfigEntry[]>([])
-  const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [q, setQ] = useState('')
   const [category, setCategory] = useState<string>('')
   const [onlyOverridden, setOnlyOverridden] = useState(false)
 
-  const load = async () => {
-    setLoading(true)
+  const load = useCallback(async () => {
     try {
       const res = await fetch('/api/admin/proxy/v1/admin/config', {
         cache: 'no-store',
@@ -31,14 +30,10 @@ export function ConfigPanel() {
       setError(null)
     } catch (e) {
       setError((e as Error).message)
-    } finally {
-      setLoading(false)
     }
-  }
-
-  useEffect(() => {
-    void load()
   }, [])
+
+  const { loading, reload } = useLoader(load)
 
   const filtered = useMemo(() => {
     return entries.filter((e) => {
@@ -93,7 +88,7 @@ export function ConfigPanel() {
         </div>
         <button
           type="button"
-          onClick={() => void load()}
+          onClick={() => void reload()}
           className="text-xs text-[var(--text-muted)] hover:text-[var(--text)] flex items-center gap-1"
         >
           <RefreshCw className={`w-3 h-3 ${loading ? 'animate-spin' : ''}`} />

--- a/brain-landing/components/admin/CostPanel.tsx
+++ b/brain-landing/components/admin/CostPanel.tsx
@@ -2,7 +2,8 @@
 
 /* eslint-disable react/jsx-no-literals -- TODO i18n migration: pre-Phase-J component, queued for separate pass. New code MUST go through getMessages(lang). */
 
-import { useEffect, useState } from 'react'
+import { useCallback, useState } from 'react'
+import { useLoader } from '../../hooks/useLoader'
 import { Coins, RefreshCw } from 'lucide-react'
 import {
   Bar,
@@ -23,11 +24,9 @@ export type { CostBucket }
 
 export function CostPanel() {
   const [data, setData] = useState<CostResponse | null>(null)
-  const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
-  const load = async () => {
-    setLoading(true)
+  const load = useCallback(async () => {
     try {
       const res = await fetch('/api/admin/proxy/v1/admin/cost', {
         cache: 'no-store',
@@ -41,14 +40,10 @@ export function CostPanel() {
       setError(null)
     } catch (e) {
       setError((e as Error).message)
-    } finally {
-      setLoading(false)
     }
-  }
-
-  useEffect(() => {
-    void load()
   }, [])
+
+  const { loading, reload } = useLoader(load)
 
   return (
     <div className="space-y-4">
@@ -66,7 +61,7 @@ export function CostPanel() {
         </div>
         <button
           type="button"
-          onClick={() => void load()}
+          onClick={() => void reload()}
           className="text-xs text-[var(--text-muted)] hover:text-[var(--text)] flex items-center gap-1"
         >
           <RefreshCw className={`w-3 h-3 ${loading ? 'animate-spin' : ''}`} />

--- a/brain-landing/components/admin/DlqPanel.tsx
+++ b/brain-landing/components/admin/DlqPanel.tsx
@@ -2,14 +2,14 @@
 
 /* eslint-disable react/jsx-no-literals -- TODO i18n migration: pre-Phase-J component, queued for separate pass. New code MUST go through getMessages(lang). */
 
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
+import { useLoader } from '../../hooks/useLoader'
 import { ChevronRight, RefreshCw, Trash2 } from 'lucide-react'
 import { JsonView } from './JsonView'
 import type { AdminDeadLetterRow as DlqRow } from '../../lib/contracts/admin-overview'
 
 export function DlqPanel() {
   const [rows, setRows] = useState<DlqRow[]>([])
-  const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [tenant, setTenant] = useState('')
   const [reason, setReason] = useState('')
@@ -17,7 +17,6 @@ export function DlqPanel() {
   const [deleting, setDeleting] = useState<string | null>(null)
 
   const load = useCallback(async () => {
-    setLoading(true)
     try {
       const params = new URLSearchParams()
       if (tenant) params.set('companyId', tenant)
@@ -33,14 +32,10 @@ export function DlqPanel() {
       setError(null)
     } catch (e) {
       setError((e as Error).message)
-    } finally {
-      setLoading(false)
     }
   }, [tenant, reason])
 
-  useEffect(() => {
-    void load()
-  }, [load])
+  const { loading, reload } = useLoader(load)
 
   const reasons = useMemo(
     () => Array.from(new Set(rows.map((r) => r.reason))).sort(),
@@ -64,14 +59,14 @@ export function DlqPanel() {
         const data = await res.json()
         if (!res.ok) throw new Error(data.error ?? `Failed ${res.status}`)
         if (selected?.id === r.id) setSelected(null)
-        await load()
+        await reload()
       } catch (e) {
         setError((e as Error).message)
       } finally {
         setDeleting(null)
       }
     },
-    [load, selected],
+    [reload, selected],
   )
 
   return (
@@ -90,7 +85,7 @@ export function DlqPanel() {
         </div>
         <button
           type="button"
-          onClick={() => void load()}
+          onClick={() => void reload()}
           className="text-xs text-[var(--text-muted)] hover:text-[var(--text)] flex items-center gap-1"
         >
           <RefreshCw className={`w-3 h-3 ${loading ? 'animate-spin' : ''}`} />

--- a/brain-landing/components/admin/DreamsPanel.tsx
+++ b/brain-landing/components/admin/DreamsPanel.tsx
@@ -3,6 +3,7 @@
 /* eslint-disable react/jsx-no-literals -- TODO i18n migration: pre-Phase-J component, queued for separate pass. New code MUST go through getMessages(lang). */
 
 import { useCallback, useEffect, useState } from 'react'
+import { useLoader } from '../../hooks/useLoader'
 import {
   ArrowRightLeft,
   Link as LinkIcon,
@@ -53,9 +54,14 @@ type Op = (typeof OPS)[number]
 
 export function DreamsPanel() {
   const [summary, setSummary] = useState<Summary | null>(null)
-  const [emits, setEmits] = useState<DreamEmit[] | null>(null)
+  // Emits are keyed by the run they belong to: selecting another run shows
+  // the drill-down as loading instead of the previous run's rows, and a
+  // late response for an old run is never displayed.
+  const [emitsFor, setEmitsFor] = useState<{
+    runId: string
+    emits: DreamEmit[]
+  } | null>(null)
   const [selectedRun, setSelectedRun] = useState<JobRow | null>(null)
-  const [loading, setLoading] = useState(true)
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [pickedOps, setPickedOps] = useState<Set<Op>>(
@@ -63,7 +69,6 @@ export function DreamsPanel() {
   )
 
   const load = useCallback(async () => {
-    setLoading(true)
     try {
       const res = await fetch('/api/admin/proxy/v1/admin/dreams/summary', {
         cache: 'no-store',
@@ -75,30 +80,34 @@ export function DreamsPanel() {
       setError(null)
     } catch (e) {
       setError((e as Error).message)
-    } finally {
-      setLoading(false)
     }
   }, [])
 
-  useEffect(() => {
-    void load()
-  }, [load])
+  const { loading, reload } = useLoader(load)
 
   useEffect(() => {
-    if (!selectedRun) {
-      setEmits(null)
-      return
-    }
+    if (!selectedRun) return
+    const { runId, companyId } = selectedRun
+    let current = true
     const params = new URLSearchParams()
-    params.set('companyId', selectedRun.companyId)
+    params.set('companyId', companyId)
     fetch(
-      `/api/admin/proxy/v1/admin/dreams/runs/${encodeURIComponent(selectedRun.runId)}/emits?${params.toString()}`,
+      `/api/admin/proxy/v1/admin/dreams/runs/${encodeURIComponent(runId)}/emits?${params.toString()}`,
       { cache: 'no-store' },
     )
       .then((r) => r.json())
-      .then((data) => setEmits(data.emits ?? []))
-      .catch(() => setEmits([]))
+      .then((data) => {
+        if (current) setEmitsFor({ runId, emits: data.emits ?? [] })
+      })
+      .catch(() => {
+        if (current) setEmitsFor({ runId, emits: [] })
+      })
+    return () => {
+      current = false
+    }
   }, [selectedRun])
+  const emits =
+    selectedRun && emitsFor?.runId === selectedRun.runId ? emitsFor.emits : null
 
   const trigger = useCallback(async () => {
     if (pickedOps.size === 0) return
@@ -115,13 +124,13 @@ export function DreamsPanel() {
       )
       const data = await res.json()
       if (!res.ok) throw new Error(data.error ?? `Failed ${res.status}`)
-      await load()
+      await reload()
     } catch (e) {
       setError((e as Error).message)
     } finally {
       setBusy(false)
     }
-  }, [pickedOps, load])
+  }, [pickedOps, reload])
 
   const toggleOp = (op: Op) => {
     setPickedOps((prev) => {
@@ -148,7 +157,7 @@ export function DreamsPanel() {
         </div>
         <button
           type="button"
-          onClick={() => void load()}
+          onClick={() => void reload()}
           className="text-xs text-[var(--text-muted)] hover:text-[var(--text)] flex items-center gap-1"
         >
           <RefreshCw className={`w-3 h-3 ${loading ? 'animate-spin' : ''}`} />

--- a/brain-landing/components/admin/EntityPanel.tsx
+++ b/brain-landing/components/admin/EntityPanel.tsx
@@ -83,19 +83,23 @@ export function EntityPanel({
   onExpand,
 }: Props) {
   const proxyBase = useProxyBase()
-  const [profile, setProfile] = useState<EntityProfile | null>(null)
-  const [timeline, setTimeline] = useState<TimelineEvent[] | null>(null)
-  const [loading, setLoading] = useState(false)
-  const [err, setErr] = useState<string | null>(null)
+  // One fetch result per (entity, asOf, recordedAt) key. Profile, timeline
+  // and error are derived from the result matching the *current* key, so
+  // switching entity shows "Loading…" instead of the previous entity's
+  // facts, and a late response for an old key is never displayed.
+  const key = entityId
+    ? JSON.stringify([entityId, asOf ?? null, recordedAt ?? null])
+    : null
+  const [result, setResult] = useState<{
+    key: string
+    profile: EntityProfile | null
+    timeline: TimelineEvent[] | null
+    err: string | null
+  } | null>(null)
 
   useEffect(() => {
-    if (!entityId) {
-      setProfile(null)
-      setTimeline(null)
-      return
-    }
-    setLoading(true)
-    setErr(null)
+    if (!entityId || !key) return
+    let current = true
     // Axis wiring: asOf (world-time) shapes the PROFILE's active-fact
     // set only; timeline events live on the transaction-time axis, so
     // the tx slider (recordedAt) is the one that cuts both surfaces.
@@ -124,12 +128,33 @@ export function EntityPanel({
         const profileData = await p.json()
         const timelineData = await t.json()
         if (!p.ok) throw new Error(profileData?.error ?? `Profile ${p.status}`)
-        setProfile(profileData as EntityProfile)
-        setTimeline((timelineData?.events ?? []) as TimelineEvent[])
+        if (!current) return
+        setResult({
+          key,
+          profile: profileData as EntityProfile,
+          timeline: (timelineData?.events ?? []) as TimelineEvent[],
+          err: null,
+        })
       })
-      .catch((e) => setErr((e as Error).message))
-      .finally(() => setLoading(false))
-  }, [entityId, asOf, recordedAt, proxyBase])
+      .catch((e) => {
+        if (!current) return
+        setResult({
+          key,
+          profile: null,
+          timeline: null,
+          err: (e as Error).message,
+        })
+      })
+    return () => {
+      current = false
+    }
+  }, [entityId, key, asOf, recordedAt, proxyBase])
+
+  const shown = result?.key === key ? result : null
+  const profile = shown?.profile ?? null
+  const timeline = shown?.timeline ?? null
+  const err = shown?.err ?? null
+  const loading = key !== null && shown === null
 
   if (!entityId) return null
 

--- a/brain-landing/components/admin/EntitySearch.tsx
+++ b/brain-landing/components/admin/EntitySearch.tsx
@@ -27,11 +27,12 @@ export function EntitySearch({ onSelect }: Props) {
   const [loading, setLoading] = useState(false)
   const [err, setErr] = useState<string | null>(null)
 
+  // Hits belong to a non-empty query: an emptied box shows none without the
+  // effect having to clear the fetched list.
+  const hits = q.trim() ? results : []
+
   useEffect(() => {
-    if (!q.trim()) {
-      setResults([])
-      return
-    }
+    if (!q.trim()) return
     const ctrl = new AbortController()
     const t = setTimeout(async () => {
       setLoading(true)
@@ -98,12 +99,12 @@ export function EntitySearch({ onSelect }: Props) {
           <span className="text-[10px] text-[var(--text-faint)]">…</span>
         )}
       </div>
-      {open && (results.length > 0 || err) && (
+      {open && (hits.length > 0 || err) && (
         <div className="absolute z-40 left-0 right-0 mt-1 max-h-80 overflow-y-auto rounded-md border border-[var(--border)] bg-[var(--bg-elevated)] shadow-lg">
           {err && (
             <div className="px-3 py-2 text-xs text-[var(--danger)]">{err}</div>
           )}
-          {results.map((r) => (
+          {hits.map((r) => (
             <button
               key={r.entityId}
               type="button"

--- a/brain-landing/components/admin/ForgottenPanel.tsx
+++ b/brain-landing/components/admin/ForgottenPanel.tsx
@@ -2,20 +2,19 @@
 
 /* eslint-disable react/jsx-no-literals -- TODO i18n migration: pre-Phase-J component, queued for separate pass. New code MUST go through getMessages(lang). */
 
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
+import { useLoader } from '../../hooks/useLoader'
 import { Download, RefreshCw, Skull } from 'lucide-react'
 import type { AdminForgottenRow as ForgottenRow } from '../../lib/contracts/admin-overview'
 
 export function ForgottenPanel() {
   const [rows, setRows] = useState<ForgottenRow[]>([])
-  const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [tenant, setTenant] = useState('')
   const [since, setSince] = useState('')
   const [reason, setReason] = useState('')
 
   const load = useCallback(async () => {
-    setLoading(true)
     try {
       const params = new URLSearchParams()
       if (tenant) params.set('companyId', tenant)
@@ -32,14 +31,10 @@ export function ForgottenPanel() {
       setError(null)
     } catch (e) {
       setError((e as Error).message)
-    } finally {
-      setLoading(false)
     }
   }, [tenant, since, reason])
 
-  useEffect(() => {
-    void load()
-  }, [load])
+  const { loading, reload } = useLoader(load)
 
   const reasons = useMemo(
     () => Array.from(new Set(rows.map((r) => r.reason))).sort(),
@@ -79,7 +74,7 @@ export function ForgottenPanel() {
         <div className="flex items-center gap-2">
           <button
             type="button"
-            onClick={() => void load()}
+            onClick={() => void reload()}
             className="text-xs text-[var(--text-muted)] hover:text-[var(--text)] flex items-center gap-1"
           >
             <RefreshCw className={`w-3 h-3 ${loading ? 'animate-spin' : ''}`} />

--- a/brain-landing/components/admin/HealthPanel.tsx
+++ b/brain-landing/components/admin/HealthPanel.tsx
@@ -2,7 +2,8 @@
 
 /* eslint-disable react/jsx-no-literals -- TODO i18n migration: pre-Phase-J component, queued for separate pass. New code MUST go through getMessages(lang). */
 
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
+import { useLoader } from '../../hooks/useLoader'
 import { CheckCircle2, Heart, Loader2, RefreshCw, XCircle, AlertTriangle } from 'lucide-react'
 import type {
   HealthComponentsResponse as HealthResponse,
@@ -29,12 +30,10 @@ const STATUS_ICON: Record<Component['status'], typeof CheckCircle2> = {
 
 export function HealthPanel() {
   const [data, setData] = useState<HealthResponse | null>(null)
-  const [loading, setLoading] = useState(true)
   const [auto, setAuto] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
-  const load = async () => {
-    setLoading(true)
+  const load = useCallback(async () => {
     try {
       const res = await fetch('/api/admin/proxy/v1/admin/health/components', {
         cache: 'no-store',
@@ -48,20 +47,16 @@ export function HealthPanel() {
       setError(null)
     } catch (e) {
       setError((e as Error).message)
-    } finally {
-      setLoading(false)
     }
-  }
-
-  useEffect(() => {
-    void load()
   }, [])
+
+  const { loading, reload } = useLoader(load)
 
   useEffect(() => {
     if (!auto) return
-    const t = setInterval(load, 10000)
+    const t = setInterval(() => void reload(), 10000)
     return () => clearInterval(t)
-  }, [auto])
+  }, [auto, reload])
 
   return (
     <div className="space-y-4">
@@ -79,7 +74,7 @@ export function HealthPanel() {
         <div className="flex items-center gap-2">
           <button
             type="button"
-            onClick={() => void load()}
+            onClick={() => void reload()}
             className="text-xs text-[var(--text-muted)] hover:text-[var(--text)] flex items-center gap-1"
           >
             <RefreshCw className={`w-3 h-3 ${loading ? 'animate-spin' : ''}`} />

--- a/brain-landing/components/admin/JobsPanel.tsx
+++ b/brain-landing/components/admin/JobsPanel.tsx
@@ -1,6 +1,8 @@
 'use client'
 
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
+import { useLoader } from '../../hooks/useLoader'
+import { useEventSource } from '../../hooks/useEventSource'
 import { useParams, useSearchParams } from 'next/navigation'
 import {
   CheckCircle2,
@@ -38,7 +40,6 @@ export function JobsPanel() {
   const searchParams = useSearchParams()
   const initialRunId = searchParams?.get('runId') ?? null
   const [jobs, setJobs] = useState<JobRow[]>([])
-  const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [selected, setSelected] = useState<string | null>(initialRunId)
   const [filter, setFilter] = useState({
@@ -47,7 +48,6 @@ export function JobsPanel() {
     companyId: '',
   })
   const [live, setLive] = useState(true)
-  const [sseStatus, setSseStatus] = useState<'idle' | 'open' | 'closed'>('idle')
   // Backend JobType union keeps growing — the dropdown derives from observed
   // rows instead of a hardcoded list so it can never drift. Types accumulate
   // across loads/SSE frames; otherwise an active type filter would shrink
@@ -61,7 +61,6 @@ export function JobsPanel() {
   }, [seenTypes, filter.jobType])
 
   const load = useCallback(async () => {
-    setLoading(true)
     try {
       const params = new URLSearchParams()
       if (filter.jobType) params.set('jobType', filter.jobType)
@@ -80,26 +79,16 @@ export function JobsPanel() {
       setError(null)
     } catch (e) {
       setError((e as Error).message)
-    } finally {
-      setLoading(false)
     }
   }, [filter])
 
-  useEffect(() => {
-    void load()
-  }, [load])
+  const { loading, reload } = useLoader(load)
 
-  useEffect(() => {
-    if (!live) {
-      setSseStatus('idle')
-      return
-    }
-    const url = '/api/admin/sse/v1/admin/jobs/stream'
-    const src = new EventSource(url)
-    setSseStatus('open')
-    src.onmessage = (e) => {
+  const sseStatus = useEventSource(
+    live ? '/api/admin/sse/v1/admin/jobs/stream' : null,
+    (frame) => {
       try {
-        const j = JSON.parse(e.data) as JobRow
+        const j = JSON.parse(frame) as JobRow
         setJobs((prev) => {
           const idx = prev.findIndex((p) => p.runId === j.runId)
           if (idx < 0) return [j, ...prev].slice(0, 200)
@@ -111,13 +100,8 @@ export function JobsPanel() {
       } catch {
         // ignore malformed frame
       }
-    }
-    src.onerror = () => setSseStatus('closed')
-    return () => {
-      src.close()
-      setSseStatus('idle')
-    }
-  }, [live])
+    },
+  )
 
   const selectedJob = useMemo(
     () => jobs.find((j) => j.runId === selected) ?? null,
@@ -147,7 +131,7 @@ export function JobsPanel() {
         <div className="flex items-center gap-2 text-xs">
           <button
             type="button"
-            onClick={() => void load()}
+            onClick={() => void reload()}
             className="text-[var(--text-muted)] hover:text-[var(--text)] flex items-center gap-1"
           >
             <RefreshCw className={`w-3 h-3 ${loading ? 'animate-spin' : ''}`} />

--- a/brain-landing/components/admin/LeasesPanel.tsx
+++ b/brain-landing/components/admin/LeasesPanel.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
+import { useLoader } from '../../hooks/useLoader'
 import { useParams } from 'next/navigation'
 import { Lock, RefreshCw, AlertTriangle, Cpu } from 'lucide-react'
 import { getMessages, normalizeLang } from '../../lib/i18n'
@@ -15,12 +16,10 @@ export function LeasesPanel() {
   const lang = normalizeLang(params?.lang)
   const t = getMessages(lang).admin
   const [data, setData] = useState<LeasesResponse | null>(null)
-  const [loading, setLoading] = useState(true)
   const [auto, setAuto] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
-  const load = async () => {
-    setLoading(true)
+  const load = useCallback(async () => {
     try {
       const res = await fetch('/api/admin/proxy/v1/admin/leases', {
         cache: 'no-store',
@@ -34,20 +33,16 @@ export function LeasesPanel() {
       setError(null)
     } catch (e) {
       setError((e as Error).message)
-    } finally {
-      setLoading(false)
     }
-  }
-
-  useEffect(() => {
-    void load()
   }, [])
+
+  const { loading, reload } = useLoader(load)
 
   useEffect(() => {
     if (!auto) return
-    const t = setInterval(load, 5000)
+    const t = setInterval(() => void reload(), 5000)
     return () => clearInterval(t)
-  }, [auto])
+  }, [auto, reload])
 
   return (
     <div className="space-y-6">
@@ -63,7 +58,7 @@ export function LeasesPanel() {
         <div className="flex items-center gap-2">
           <button
             type="button"
-            onClick={() => void load()}
+            onClick={() => void reload()}
             className="text-xs text-[var(--text-muted)] hover:text-[var(--text)] flex items-center gap-1"
           >
             <RefreshCw className={`w-3 h-3 ${loading ? 'animate-spin' : ''}`} />

--- a/brain-landing/components/admin/MaintenancePanel.tsx
+++ b/brain-landing/components/admin/MaintenancePanel.tsx
@@ -1,7 +1,8 @@
 'use client'
 
 import Link from 'next/link'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
+import { useLoader } from '../../hooks/useLoader'
 import { useParams } from 'next/navigation'
 import {
   AlertTriangle,
@@ -40,12 +41,10 @@ export function MaintenancePanel() {
   const [changefeed, setChangefeed] = useState<ChangefeedStateResponse | null>(
     null,
   )
-  const [loading, setLoading] = useState(true)
   const [busy, setBusy] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
 
   const load = useCallback(async () => {
-    setLoading(true)
     try {
       const [sRes, jRes, cRes] = await Promise.all([
         fetch('/api/admin/proxy/v1/admin/scheduler', { cache: 'no-store' }),
@@ -68,14 +67,10 @@ export function MaintenancePanel() {
       setError(null)
     } catch (e) {
       setError((e as Error).message)
-    } finally {
-      setLoading(false)
     }
   }, [])
 
-  useEffect(() => {
-    void load()
-  }, [load])
+  const { loading, reload } = useLoader(load)
 
   const lastByJobType = useMemo(() => {
     const map = new Map<string, JobRow>()
@@ -117,14 +112,14 @@ export function MaintenancePanel() {
         })
         const data = await res.json()
         if (!res.ok) throw new Error(data.error ?? `Failed ${res.status}`)
-        await load()
+        await reload()
       } catch (e) {
         setError((e as Error).message)
       } finally {
         setBusy(null)
       }
     },
-    [load],
+    [reload],
   )
 
   // Card metadata is i18n-resolved at render via t.maintenance.cards.<kind>.
@@ -193,7 +188,7 @@ export function MaintenancePanel() {
         </div>
         <button
           type="button"
-          onClick={() => void load()}
+          onClick={() => void reload()}
           className="text-xs text-[var(--text-muted)] hover:text-[var(--text)] flex items-center gap-1"
         >
           <RefreshCw className={`w-3 h-3 ${loading ? 'animate-spin' : ''}`} />

--- a/brain-landing/components/admin/MarketplacePanel.tsx
+++ b/brain-landing/components/admin/MarketplacePanel.tsx
@@ -1,8 +1,9 @@
 'use client'
 
 import Link from 'next/link'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import { useParams } from 'next/navigation'
+import { useLoader } from '../../hooks/useLoader'
 import {
   BadgeCheck,
   Download,
@@ -46,7 +47,6 @@ export function MarketplacePanel() {
 
   const [packs, setPacks] = useState<RegistryPackSummary[]>([])
   const [filter, setFilter] = useState({ q: '', publisher: '', tag: '' })
-  const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [selected, setSelected] = useState<string | null>(null)
   const [detail, setDetail] = useState<RegistryVersionsResponse | null>(null)
@@ -56,7 +56,6 @@ export function MarketplacePanel() {
   const [publisherOpen, setPublisherOpen] = useState<string | null>(null)
 
   const load = useCallback(async () => {
-    setLoading(true)
     try {
       const qp = new URLSearchParams()
       if (filter.q) qp.set('q', filter.q)
@@ -73,14 +72,10 @@ export function MarketplacePanel() {
       setError(null)
     } catch (e) {
       setError((e as Error).message)
-    } finally {
-      setLoading(false)
     }
   }, [filter])
 
-  useEffect(() => {
-    void load()
-  }, [load])
+  const { loading, reload } = useLoader(load)
 
   const loadDetail = useCallback(async (packId: string) => {
     try {
@@ -159,9 +154,9 @@ export function MarketplacePanel() {
         path: `v1/admin/registry/packs/${encodeURIComponent(pack.packId)}/${action}`,
         scope: 'registry:curate',
       })
-      if (ok) await load()
+      if (ok) await reload()
     },
-    [load, write],
+    [reload, write],
   )
 
   const clearPricing = useCallback(
@@ -172,9 +167,9 @@ export function MarketplacePanel() {
         path: `v1/admin/registry/packs/${encodeURIComponent(packId)}/pricing`,
         scope: 'registry:publish',
       })
-      if (ok) await load()
+      if (ok) await reload()
     },
-    [load, write],
+    [reload, write],
   )
 
   const yank = useCallback(
@@ -203,10 +198,10 @@ export function MarketplacePanel() {
         scope: 'registry:publish',
       })
       if (ok) {
-        await Promise.all([load(), loadDetail(v.packId)])
+        await Promise.all([reload(), loadDetail(v.packId)])
       }
     },
-    [load, loadDetail, m, write],
+    [reload, loadDetail, m, write],
   )
 
   return (
@@ -220,7 +215,7 @@ export function MarketplacePanel() {
         </div>
         <button
           type="button"
-          onClick={() => void load()}
+          onClick={() => void reload()}
           className="text-xs text-[var(--text-muted)] hover:text-[var(--text)] flex items-center gap-1"
         >
           <RefreshCw className={`w-3 h-3 ${loading ? 'animate-spin' : ''}`} />
@@ -369,7 +364,7 @@ export function MarketplacePanel() {
               body,
               scope: 'registry:publish',
             })
-            if (ok) await load()
+            if (ok) await reload()
             setPricingFor(null)
           }}
         />
@@ -724,9 +719,7 @@ function PublisherDrawer({
     }
   }, [publisher])
 
-  useEffect(() => {
-    void load()
-  }, [load])
+  const { reload } = useLoader(load)
 
   const save = async () => {
     setSaving(true)
@@ -754,7 +747,7 @@ function PublisherDrawer({
       }
       const json = await res.json()
       if (!res.ok) throw new Error(errorMessage(json, res.status))
-      await load()
+      await reload()
     } catch (e) {
       setError((e as Error).message)
     } finally {

--- a/brain-landing/components/admin/MigrationsPanel.tsx
+++ b/brain-landing/components/admin/MigrationsPanel.tsx
@@ -2,7 +2,8 @@
 
 /* eslint-disable react/jsx-no-literals -- TODO i18n migration: pre-Phase-J component, queued for separate pass. New code MUST go through getMessages(lang). */
 
-import { useEffect, useState } from 'react'
+import { useCallback, useState } from 'react'
+import { useLoader } from '../../hooks/useLoader'
 import { AlertTriangle, CheckCircle2, Database, RefreshCw } from 'lucide-react'
 import type {
   MigrationsResponse,
@@ -16,11 +17,9 @@ export type { Migration, TenantState }
 
 export function MigrationsPanel() {
   const [data, setData] = useState<MigrationsResponse | null>(null)
-  const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
-  const load = async () => {
-    setLoading(true)
+  const load = useCallback(async () => {
     try {
       const res = await fetch('/api/admin/proxy/v1/admin/migrations', {
         cache: 'no-store',
@@ -34,14 +33,10 @@ export function MigrationsPanel() {
       setError(null)
     } catch (e) {
       setError((e as Error).message)
-    } finally {
-      setLoading(false)
     }
-  }
-
-  useEffect(() => {
-    void load()
   }, [])
+
+  const { loading, reload } = useLoader(load)
 
   return (
     <div className="space-y-4">
@@ -58,7 +53,7 @@ export function MigrationsPanel() {
         </div>
         <button
           type="button"
-          onClick={() => void load()}
+          onClick={() => void reload()}
           className="text-xs text-[var(--text-muted)] hover:text-[var(--text)] flex items-center gap-1"
         >
           <RefreshCw className={`w-3 h-3 ${loading ? 'animate-spin' : ''}`} />

--- a/brain-landing/components/admin/OperatorActionsPanel.tsx
+++ b/brain-landing/components/admin/OperatorActionsPanel.tsx
@@ -2,14 +2,14 @@
 
 /* eslint-disable react/jsx-no-literals -- TODO i18n migration: pre-Phase-J component, queued for separate pass. New code MUST go through getMessages(lang). */
 
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
+import { useLoader } from '../../hooks/useLoader'
 import { KeyRound, RefreshCw } from 'lucide-react'
 import { JsonView } from './JsonView'
 import type { OperatorActionRow as ActionRow } from '../../lib/contracts/admin-operator-actions'
 
 export function OperatorActionsPanel() {
   const [rows, setRows] = useState<ActionRow[]>([])
-  const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [actor, setActor] = useState('')
   const [pathPrefix, setPathPrefix] = useState('')
@@ -17,7 +17,6 @@ export function OperatorActionsPanel() {
   const [selected, setSelected] = useState<ActionRow | null>(null)
 
   const load = useCallback(async () => {
-    setLoading(true)
     try {
       const params = new URLSearchParams()
       if (actor) params.set('actor', actor)
@@ -34,14 +33,10 @@ export function OperatorActionsPanel() {
       setError(null)
     } catch (e) {
       setError((e as Error).message)
-    } finally {
-      setLoading(false)
     }
   }, [actor, pathPrefix, since])
 
-  useEffect(() => {
-    void load()
-  }, [load])
+  const { loading, reload } = useLoader(load)
 
   const methodTone = (m: string) =>
     m === 'GET'
@@ -79,7 +74,7 @@ export function OperatorActionsPanel() {
         </div>
         <button
           type="button"
-          onClick={() => void load()}
+          onClick={() => void reload()}
           className="text-xs text-[var(--text-muted)] hover:text-[var(--text)] flex items-center gap-1"
         >
           <RefreshCw className={`w-3 h-3 ${loading ? 'animate-spin' : ''}`} />

--- a/brain-landing/components/admin/PacksPanel.tsx
+++ b/brain-landing/components/admin/PacksPanel.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useState } from 'react'
+import { useLoader } from '../../hooks/useLoader'
 import { useParams, useSearchParams } from 'next/navigation'
 import {
   CheckCircle2,
@@ -51,7 +52,6 @@ export function PacksPanel() {
   const searchParams = useSearchParams()
 
   const [data, setData] = useState<PacksListResponse | null>(null)
-  const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
 
   // Install-from-registry form (prefillable via ?install=<packId> — the
@@ -78,7 +78,6 @@ export function PacksPanel() {
   const [evalFor, setEvalFor] = useState<string | null>(null)
 
   const load = useCallback(async () => {
-    setLoading(true)
     try {
       const res = await fetch('/api/admin/proxy/v1/admin/packs', {
         cache: 'no-store',
@@ -89,14 +88,10 @@ export function PacksPanel() {
       setError(null)
     } catch (e) {
       setError((e as Error).message)
-    } finally {
-      setLoading(false)
     }
   }, [])
 
-  useEffect(() => {
-    void load()
-  }, [load])
+  const { loading, reload } = useLoader(load)
 
   const doInstall = useCallback(
     async (source: InstallSource, opts?: { accept?: boolean }) => {
@@ -155,14 +150,14 @@ export function PacksPanel() {
         }
         if (!res.ok) throw new Error(errorMessage(json, res.status))
         setSuccess(json as InstallPackResponse)
-        await load()
+        await reload()
       } catch (e) {
         setError((e as Error).message)
       } finally {
         setInstallBusy(null)
       }
     },
-    [expectedChecksum, load, manifestText, p, regPackId, regVersion],
+    [expectedChecksum, reload, manifestText, p, regPackId, regVersion],
   )
 
   const createCheckout = useCallback(async () => {
@@ -216,12 +211,12 @@ export function PacksPanel() {
               ),
             ),
         )
-        await load()
+        await reload()
       } catch (e) {
         setError((e as Error).message)
       }
     },
-    [load, p],
+    [reload, p],
   )
 
   return (
@@ -235,7 +230,7 @@ export function PacksPanel() {
         </div>
         <button
           type="button"
-          onClick={() => void load()}
+          onClick={() => void reload()}
           className="text-xs text-[var(--text-muted)] hover:text-[var(--text)] flex items-center gap-1"
         >
           <RefreshCw className={`w-3 h-3 ${loading ? 'animate-spin' : ''}`} />

--- a/brain-landing/components/admin/PiiInventoryPanel.tsx
+++ b/brain-landing/components/admin/PiiInventoryPanel.tsx
@@ -2,7 +2,8 @@
 
 /* eslint-disable react/jsx-no-literals -- TODO i18n migration: pre-Phase-J component, queued for separate pass. New code MUST go through getMessages(lang). */
 
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
+import { useLoader } from '../../hooks/useLoader'
 import { RefreshCw, ShieldAlert } from 'lucide-react'
 import type { PiiRow } from '../../lib/contracts/admin-pii'
 
@@ -15,13 +16,11 @@ const CLASS_TONE: Record<string, string> = {
 
 export function PiiInventoryPanel() {
   const [rows, setRows] = useState<PiiRow[]>([])
-  const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [tenantFilter, setTenantFilter] = useState('')
   const [classFilter, setClassFilter] = useState('')
 
   const load = useCallback(async () => {
-    setLoading(true)
     try {
       const res = await fetch('/api/admin/proxy/v1/admin/pii', {
         cache: 'no-store',
@@ -32,14 +31,10 @@ export function PiiInventoryPanel() {
       setError(null)
     } catch (e) {
       setError((e as Error).message)
-    } finally {
-      setLoading(false)
     }
   }, [])
 
-  useEffect(() => {
-    void load()
-  }, [load])
+  const { loading, reload } = useLoader(load)
 
   const classes = useMemo(
     () => Array.from(new Set(rows.map((r) => r.piiClass))).sort(),
@@ -85,7 +80,7 @@ export function PiiInventoryPanel() {
         </div>
         <button
           type="button"
-          onClick={() => void load()}
+          onClick={() => void reload()}
           className="text-xs text-[var(--text-muted)] hover:text-[var(--text)] flex items-center gap-1"
         >
           <RefreshCw className={`w-3 h-3 ${loading ? 'animate-spin' : ''}`} />

--- a/brain-landing/components/admin/PredicateRegistry.tsx
+++ b/brain-landing/components/admin/PredicateRegistry.tsx
@@ -2,7 +2,8 @@
 
 /* eslint-disable react/jsx-no-literals -- TODO i18n migration: pre-Phase-J component, queued for separate pass. New code MUST go through getMessages(lang). */
 
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
+import { useLoader } from '../../hooks/useLoader'
 import {
   ArrowRight,
   CheckCircle2,
@@ -42,7 +43,6 @@ const PII_TONE: Record<PiiClass, string> = {
 
 export function PredicateRegistry() {
   const [items, setItems] = useState<Predicate[]>([])
-  const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [q, setQ] = useState('')
   const [filter, setFilter] = useState<Filter>('all')
@@ -52,7 +52,6 @@ export function PredicateRegistry() {
   const [busyId, setBusyId] = useState<string | null>(null)
 
   const load = useCallback(async () => {
-    setLoading(true)
     try {
       const res = await fetch('/api/admin/proxy/v1/admin/predicates', {
         cache: 'no-store',
@@ -66,14 +65,10 @@ export function PredicateRegistry() {
       setError(null)
     } catch (e) {
       setError((e as Error).message)
-    } finally {
-      setLoading(false)
     }
   }, [])
 
-  useEffect(() => {
-    void load()
-  }, [load])
+  const { loading, reload } = useLoader(load)
 
   const filtered = useMemo(() => {
     return items.filter((p) => {
@@ -110,14 +105,14 @@ export function PredicateRegistry() {
         )
         const data = await res.json()
         if (!res.ok) throw new Error(data.error ?? `Failed ${res.status}`)
-        await load()
+        await reload()
       } catch (e) {
         setError((e as Error).message)
       } finally {
         setBusyId(null)
       }
     },
-    [load],
+    [reload],
   )
 
   const deprecate = useCallback(
@@ -137,14 +132,14 @@ export function PredicateRegistry() {
         )
         const data = await res.json()
         if (!res.ok) throw new Error(data.error ?? `Failed ${res.status}`)
-        await load()
+        await reload()
       } catch (e) {
         setError((e as Error).message)
       } finally {
         setBusyId(null)
       }
     },
-    [load],
+    [reload],
   )
 
   return (
@@ -162,7 +157,7 @@ export function PredicateRegistry() {
         <div className="flex items-center gap-2">
           <button
             type="button"
-            onClick={() => void load()}
+            onClick={() => void reload()}
             className="text-xs text-[var(--text-muted)] hover:text-[var(--text)] flex items-center gap-1"
           >
             <RefreshCw className={`w-3 h-3 ${loading ? 'animate-spin' : ''}`} />
@@ -255,7 +250,7 @@ export function PredicateRegistry() {
           onClose={() => setCreating(false)}
           onSaved={() => {
             setCreating(false)
-            void load()
+            void reload()
           }}
         />
       )}
@@ -266,7 +261,7 @@ export function PredicateRegistry() {
           onClose={() => setEditing(null)}
           onSaved={() => {
             setEditing(null)
-            void load()
+            void reload()
           }}
         />
       )}
@@ -280,7 +275,7 @@ export function PredicateRegistry() {
           onClose={() => setAliasing(null)}
           onSaved={() => {
             setAliasing(null)
-            void load()
+            void reload()
           }}
         />
       )}

--- a/brain-landing/components/admin/RouterStats.tsx
+++ b/brain-landing/components/admin/RouterStats.tsx
@@ -3,6 +3,7 @@
 /* eslint-disable react/jsx-no-literals -- TODO i18n migration: pre-Phase-J component, queued for separate pass. New code MUST go through getMessages(lang). */
 
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { useLoader } from '../../hooks/useLoader'
 import { RefreshCw } from 'lucide-react'
 import {
   CartesianGrid,
@@ -28,13 +29,11 @@ export function RouterStats() {
   const [data, setData] = useState<RouterStatsResponse | null>(null)
   const [tenant, setTenant] = useState('')
   const [auto, setAuto] = useState(false)
-  const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const samplesRef = useRef<Sample[]>([])
   const [samples, setSamples] = useState<Sample[]>([])
 
   const load = useCallback(async () => {
-    setLoading(true)
     try {
       const url = new URL(
         '/api/admin/proxy/v1/admin/router/stats',
@@ -64,20 +63,16 @@ export function RouterStats() {
       setSamples(samplesRef.current)
     } catch (e) {
       setError((e as Error).message)
-    } finally {
-      setLoading(false)
     }
   }, [tenant])
 
-  useEffect(() => {
-    void load()
-  }, [load])
+  const { loading, reload } = useLoader(load)
 
   useEffect(() => {
     if (!auto) return
-    const t = setInterval(load, 5000)
+    const t = setInterval(() => void reload(), 5000)
     return () => clearInterval(t)
-  }, [auto, load])
+  }, [auto, reload])
 
   const formattedSamples = samples.map((s) => ({
     ...s,
@@ -106,7 +101,7 @@ export function RouterStats() {
           />
           <button
             type="button"
-            onClick={() => void load()}
+            onClick={() => void reload()}
             className="text-[var(--text-muted)] hover:text-[var(--text)] flex items-center gap-1"
           >
             <RefreshCw className={`w-3 h-3 ${loading ? 'animate-spin' : ''}`} />

--- a/brain-landing/components/admin/SourcesPanel.tsx
+++ b/brain-landing/components/admin/SourcesPanel.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
+import { useLoader } from '../../hooks/useLoader'
 import { useParams } from 'next/navigation'
 import { Fingerprint, Loader2, RefreshCw } from 'lucide-react'
 import { ErrorLine, Field, Segmented, inputCls } from './policies/ui'
@@ -51,13 +52,11 @@ export function SourcesPanel() {
   const s = t.sources
 
   const [sources, setSources] = useState<SourceSummary[]>([])
-  const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [selected, setSelected] = useState<string | null>(null)
   const [detail, setDetail] = useState<SourceDetailResponse | null>(null)
 
   const load = useCallback(async () => {
-    setLoading(true)
     try {
       const res = await fetch('/api/admin/proxy/v1/admin/sources', {
         cache: 'no-store',
@@ -68,14 +67,10 @@ export function SourcesPanel() {
       setError(null)
     } catch (e) {
       setError((e as Error).message)
-    } finally {
-      setLoading(false)
     }
   }, [])
 
-  useEffect(() => {
-    void load()
-  }, [load])
+  const { loading, reload } = useLoader(load)
 
   const loadDetail = useCallback(async (sourceKey: string) => {
     try {
@@ -116,7 +111,7 @@ export function SourcesPanel() {
         </div>
         <button
           type="button"
-          onClick={() => void load()}
+          onClick={() => void reload()}
           className="text-xs text-[var(--text-muted)] hover:text-[var(--text)] flex items-center gap-1"
         >
           <RefreshCw className={`w-3 h-3 ${loading ? 'animate-spin' : ''}`} />
@@ -202,7 +197,7 @@ export function SourcesPanel() {
               detail={detail}
               s={s}
               onDeclared={async () => {
-                await Promise.all([load(), loadDetail(detail.sourceKey)])
+                await Promise.all([reload(), loadDetail(detail.sourceKey)])
               }}
             />
           ) : selected ? (

--- a/brain-landing/components/admin/ThrottlerPanel.tsx
+++ b/brain-landing/components/admin/ThrottlerPanel.tsx
@@ -2,7 +2,8 @@
 
 /* eslint-disable react/jsx-no-literals -- TODO i18n migration: pre-Phase-J component, queued for separate pass. New code MUST go through getMessages(lang). */
 
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
+import { useLoader } from '../../hooks/useLoader'
 import { RefreshCw, SlidersHorizontal } from 'lucide-react'
 import type {
   ThrottlerResponse as ThrottlerSnapshot,
@@ -14,12 +15,10 @@ export type { RouteRow, ActorRow }
 
 export function ThrottlerPanel() {
   const [data, setData] = useState<ThrottlerSnapshot | null>(null)
-  const [loading, setLoading] = useState(true)
   const [auto, setAuto] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
-  const load = async () => {
-    setLoading(true)
+  const load = useCallback(async () => {
     try {
       const res = await fetch('/api/admin/proxy/v1/admin/throttler', {
         cache: 'no-store',
@@ -33,20 +32,16 @@ export function ThrottlerPanel() {
       setError(null)
     } catch (e) {
       setError((e as Error).message)
-    } finally {
-      setLoading(false)
     }
-  }
-
-  useEffect(() => {
-    void load()
   }, [])
+
+  const { loading, reload } = useLoader(load)
 
   useEffect(() => {
     if (!auto) return
-    const t = setInterval(load, 5000)
+    const t = setInterval(() => void reload(), 5000)
     return () => clearInterval(t)
-  }, [auto])
+  }, [auto, reload])
 
   return (
     <div className="space-y-4">
@@ -66,7 +61,7 @@ export function ThrottlerPanel() {
         <div className="flex items-center gap-2">
           <button
             type="button"
-            onClick={() => void load()}
+            onClick={() => void reload()}
             className="text-xs text-[var(--text-muted)] hover:text-[var(--text)] flex items-center gap-1"
           >
             <RefreshCw className={`w-3 h-3 ${loading ? 'animate-spin' : ''}`} />

--- a/brain-landing/components/admin/policies/DecisionsFeed.tsx
+++ b/brain-landing/components/admin/policies/DecisionsFeed.tsx
@@ -3,6 +3,7 @@
 /* eslint-disable react/jsx-no-literals -- TODO i18n migration: queued with the admin-wide pass. */
 
 import { useCallback, useEffect, useState } from 'react'
+import { useLoader } from '../../../hooks/useLoader'
 import { Radio, RefreshCw, Scale } from 'lucide-react'
 import {
   Bar,
@@ -32,13 +33,11 @@ export function DecisionsFeed() {
   const [cursor, setCursor] = useState<string | undefined>()
   const [stats, setStats] = useState<PolicyDecisionsStatsResponse | null>(null)
   const [filter, setFilter] = useState<DecisionFilter>('all')
-  const [loading, setLoading] = useState(true)
   const [live, setLive] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
   const load = useCallback(
     async (before?: string) => {
-      setLoading(true)
       try {
         const qs = new URLSearchParams()
         if (filter !== 'all') qs.set('decision', filter)
@@ -67,24 +66,20 @@ export function DecisionsFeed() {
         setError(null)
       } catch (e) {
         setError((e as Error).message)
-      } finally {
-        setLoading(false)
       }
     },
     [filter],
   )
 
-  useEffect(() => {
-    void load()
-  }, [load])
+  const { loading, reload } = useLoader(load)
 
   // Live tail — plain polling (the decision sink flushes every ~5 s
   // anyway, so an SSE stream would buy nothing over a 10 s poll).
   useEffect(() => {
     if (!live) return
-    const t = setInterval(() => void load(), 10_000)
+    const t = setInterval(() => void reload(), 10_000)
     return () => clearInterval(t)
-  }, [live, load])
+  }, [live, reload])
 
   const totals = stats?.series.reduce(
     (acc, d) => ({
@@ -241,7 +236,7 @@ export function DecisionsFeed() {
           </button>
           <button
             type="button"
-            onClick={() => void load()}
+            onClick={() => void reload()}
             className="rounded border border-[var(--border)] p-1.5 text-[var(--text-muted)] hover:text-[var(--text)]"
             aria-label="Refresh"
           >
@@ -309,7 +304,7 @@ export function DecisionsFeed() {
         <button
           type="button"
           disabled={loading}
-          onClick={() => void load(cursor)}
+          onClick={() => void reload(cursor)}
           className="mt-3 rounded border border-[var(--border)] px-3 py-1.5 text-xs text-[var(--text-muted)] hover:text-[var(--text)] disabled:opacity-50"
         >
           {loading ? 'loading…' : 'Load older'}

--- a/brain-landing/components/admin/policies/KeyLens.tsx
+++ b/brain-landing/components/admin/policies/KeyLens.tsx
@@ -2,7 +2,13 @@
 
 /* eslint-disable react/jsx-no-literals -- TODO i18n migration: queued with the admin-wide pass. */
 
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  useSyncExternalStore,
+} from 'react'
 import { useSearchParams } from 'next/navigation'
 import { KeyRound, Play, ScanEye } from 'lucide-react'
 import type {
@@ -21,6 +27,21 @@ import { ErrorLine, Segmented, inputCls } from './ui'
 type SubjectKind = 'key' | 'policySet' | 'draft'
 type Tab = 'data' | 'actions' | 'graph'
 
+const subscribeToNothing = () => () => {}
+const noDraft = (): string | null => null
+/**
+ * The editor hands unsaved drafts over through sessionStorage. Read as an
+ * external store: the server (and hydration) sees no draft, the client
+ * picks it up on its first post-hydration render.
+ */
+function readDraft(): string | null {
+  try {
+    return sessionStorage.getItem(DRAFT_STORAGE_KEY)
+  } catch {
+    return null
+  }
+}
+
 /**
  * Key Lens — simulate what a key (or a saved set, or an unsaved draft
  * handed over from the editor) can see and call. The data lens runs the
@@ -29,20 +50,57 @@ type Tab = 'data' | 'actions' | 'graph'
  */
 export function KeyLens() {
   const searchParams = useSearchParams()
-  const [subjectKind, setSubjectKind] = useState<SubjectKind>('policySet')
+  const presetSet = searchParams?.get('policySet') ?? null
+  const wantsDraft = searchParams?.get('draft') === '1'
+  const draftRaw = useSyncExternalStore(
+    subscribeToNothing,
+    wantsDraft ? readDraft : noDraft,
+    noDraft,
+  )
+  const draft = useMemo<Record<string, unknown> | null>(() => {
+    if (!draftRaw) return null
+    try {
+      return JSON.parse(draftRaw) as Record<string, unknown>
+    } catch {
+      return null /* stale/corrupt draft — ignore */
+    }
+  }, [draftRaw])
+
+  const [subjectKind, setSubjectKind] = useState<SubjectKind>(() =>
+    draft ? 'draft' : 'policySet',
+  )
   const [tab, setTab] = useState<Tab>('data')
   const [keys, setKeys] = useState<AdminKeysResponse['keys']>([])
   const [sets, setSets] = useState<PolicySetsListResponse['policySets']>([])
   const [keyId, setKeyId] = useState('')
-  const [setNames, setSetNames] = useState<string[]>([])
-  const [draft, setDraft] = useState<Record<string, unknown> | null>(null)
+  const [setNames, setSetNames] = useState<string[]>(() =>
+    presetSet ? [presetSet] : [],
+  )
   const [enforceOverride, setEnforceOverride] = useState(true)
   const [query, setQuery] = useState('')
   const [limit, setLimit] = useState(10)
   const [error, setError] = useState<string | null>(null)
   const [busy, setBusy] = useState(false)
   const [searchResult, setSearchResult] = useState<SimulateSearchResponse | null>(null)
-  const [actionsResult, setActionsResult] = useState<SimulateActionsResponse | null>(null)
+  const [actionsCache, setActionsCache] = useState<{
+    key: string
+    data: SimulateActionsResponse
+  } | null>(null)
+
+  // Deep links: ?policySet=name from the list page, ?draft=1 from the editor.
+  // The initial state above reads them; a *changed* link (client navigation,
+  // or the draft arriving after hydration) re-selects the subject during
+  // render, once per distinct link, leaving later manual changes alone.
+  const deepLink = JSON.stringify([presetSet, draftRaw])
+  const [appliedDeepLink, setAppliedDeepLink] = useState(deepLink)
+  if (deepLink !== appliedDeepLink) {
+    setAppliedDeepLink(deepLink)
+    if (presetSet) {
+      setSubjectKind('policySet')
+      setSetNames([presetSet])
+    }
+    if (draft) setSubjectKind('draft')
+  }
 
   useEffect(() => {
     void (async () => {
@@ -63,26 +121,6 @@ export function KeyLens() {
     })()
   }, [])
 
-  // Deep links: ?policySet=name from the list page, ?draft=1 from the editor.
-  useEffect(() => {
-    const preset = searchParams?.get('policySet')
-    if (preset) {
-      setSubjectKind('policySet')
-      setSetNames([preset])
-    }
-    if (searchParams?.get('draft') === '1') {
-      const raw = sessionStorage.getItem(DRAFT_STORAGE_KEY)
-      if (raw) {
-        try {
-          setDraft(JSON.parse(raw) as Record<string, unknown>)
-          setSubjectKind('draft')
-        } catch {
-          /* stale/corrupt draft — ignore */
-        }
-      }
-    }
-  }, [searchParams])
-
   const subject = useMemo(() => {
     const base: Record<string, unknown> = {}
     if (subjectKind === 'key' && keyId) base.keyId = keyId
@@ -99,26 +137,12 @@ export function KeyLens() {
     (subjectKind === 'policySet' && setNames.length > 0) ||
     (subjectKind === 'draft' && !!draft)
 
-  const runActions = useCallback(async () => {
-    setBusy(true)
-    try {
-      const res = await fetch('/api/admin/proxy/v1/admin/policy/simulate/actions', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ subject }),
-      })
-      const data = await res.json()
-      if (!res.ok) {
-        throw new Error(data.message?.message ?? data.error ?? `Failed ${res.status}`)
-      }
-      setActionsResult(data as SimulateActionsResponse)
-      setError(null)
-    } catch (e) {
-      setError((e as Error).message)
-    } finally {
-      setBusy(false)
-    }
-  }, [subject])
+  // The matrix belongs to the subject it was evaluated for: a changed
+  // subject reads "evaluating…" instead of the previous subject's verdicts,
+  // and a late response for an old subject is never displayed.
+  const subjectKey = useMemo(() => JSON.stringify(subject), [subject])
+  const actionsResult =
+    actionsCache?.key === subjectKey ? actionsCache.data : null
 
   const runSearch = useCallback(async () => {
     if (!query.trim()) return
@@ -145,9 +169,35 @@ export function KeyLens() {
   // The action matrix costs one cheap call — refresh it whenever the
   // subject changes and the tab is open.
   useEffect(() => {
-    if (tab === 'actions' && subjectReady) void runActions()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [tab, subject, subjectReady])
+    if (tab !== 'actions' || !subjectReady) return
+    let current = true
+    void (async () => {
+      try {
+        const res = await fetch(
+          '/api/admin/proxy/v1/admin/policy/simulate/actions',
+          {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ subject }),
+          },
+        )
+        const data = await res.json()
+        if (!res.ok) {
+          throw new Error(
+            data.message?.message ?? data.error ?? `Failed ${res.status}`,
+          )
+        }
+        if (!current) return
+        setActionsCache({ key: subjectKey, data: data as SimulateActionsResponse })
+        setError(null)
+      } catch (e) {
+        if (current) setError((e as Error).message)
+      }
+    })()
+    return () => {
+      current = false
+    }
+  }, [tab, subject, subjectKey, subjectReady])
 
   return (
     <div className="p-6">
@@ -172,7 +222,7 @@ export function KeyLens() {
             onChange={(v) => {
               setSubjectKind(v)
               setSearchResult(null)
-              setActionsResult(null)
+              setActionsCache(null)
             }}
           />
           {subjectKind === 'key' ? (

--- a/brain-landing/components/admin/policies/PolicySetEditor.tsx
+++ b/brain-landing/components/admin/policies/PolicySetEditor.tsx
@@ -4,6 +4,7 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useParams, useRouter } from 'next/navigation'
+import { useLoader } from '../../../hooks/useLoader'
 import { ArrowLeft, KeyRound, Plus, ScanEye } from 'lucide-react'
 import type {
   PolicyRule,
@@ -79,9 +80,7 @@ export function PolicySetEditor({ name }: { name: string }) {
     }
   }, [name])
 
-  useEffect(() => {
-    void load()
-  }, [load])
+  const { reload } = useLoader(load)
 
   const dirty = useMemo(() => {
     if (!saved || !draft) return false
@@ -245,7 +244,7 @@ export function PolicySetEditor({ name }: { name: string }) {
           </span>
           <button
             type="button"
-            onClick={() => void load()}
+            onClick={() => void reload()}
             className="rounded border border-[var(--warning)]/50 px-2 py-0.5 font-medium hover:bg-[var(--warning)]/20"
           >
             Reload
@@ -469,7 +468,7 @@ export function PolicySetEditor({ name }: { name: string }) {
         <AttachKeysDrawer
           policySet={saved}
           onClose={() => setAttachOpen(false)}
-          onApplied={() => void load()}
+          onApplied={() => void reload()}
         />
       ) : null}
 

--- a/brain-landing/components/admin/policies/PolicySetsList.tsx
+++ b/brain-landing/components/admin/policies/PolicySetsList.tsx
@@ -2,7 +2,8 @@
 
 /* eslint-disable react/jsx-no-literals -- TODO i18n migration: queued with the admin-wide pass. */
 
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useState } from 'react'
+import { useLoader } from '../../../hooks/useLoader'
 import { useParams, useRouter } from 'next/navigation'
 import {
   KeyRound,
@@ -103,12 +104,10 @@ export function PolicySetsList() {
   const params = useParams<{ lang: string }>()
   const lang = params?.lang ?? 'en'
   const [items, setItems] = useState<PolicySet[]>([])
-  const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [busy, setBusy] = useState<string | null>(null)
 
   const load = useCallback(async () => {
-    setLoading(true)
     try {
       const res = await fetch('/api/admin/proxy/v1/admin/policy-sets', {
         cache: 'no-store',
@@ -119,14 +118,10 @@ export function PolicySetsList() {
       setError(null)
     } catch (e) {
       setError((e as Error).message)
-    } finally {
-      setLoading(false)
     }
   }, [])
 
-  useEffect(() => {
-    void load()
-  }, [load])
+  const { loading, reload } = useLoader(load)
 
   const createFromTemplate = useCallback(
     async (t: Template) => {
@@ -167,14 +162,14 @@ export function PolicySetsList() {
         if (!res.ok) {
           throw new Error(data.message?.message ?? data.error ?? `Failed ${res.status}`)
         }
-        await load()
+        await reload()
       } catch (e) {
         setError((e as Error).message)
       } finally {
         setBusy(null)
       }
     },
-    [load],
+    [reload],
   )
 
   if (loading) {
@@ -242,7 +237,7 @@ export function PolicySetsList() {
         <div className="flex items-center gap-2">
           <button
             type="button"
-            onClick={() => void load()}
+            onClick={() => void reload()}
             className="rounded border border-[var(--border)] p-1.5 text-[var(--text-muted)] hover:text-[var(--text)]"
             aria-label="Refresh"
           >

--- a/brain-landing/components/admin/policies/RuleMatchPreview.tsx
+++ b/brain-landing/components/admin/policies/RuleMatchPreview.tsx
@@ -16,8 +16,14 @@ import type {
  * active facts), so it's an estimate, not an audit.
  */
 export function RuleMatchPreview({ rule }: { rule: PolicyRule }) {
-  const [preview, setPreview] = useState<PreviewRuleResponse | null>(null)
-  const [pending, setPending] = useState(false)
+  // The count belongs to the rule signature it was computed for. Deriving
+  // preview/pending from that key makes an edited rule read "counting…"
+  // instead of the previous rule's number, and a late response for an old
+  // signature is never displayed.
+  const [cache, setCache] = useState<{
+    signature: string
+    preview: PreviewRuleResponse | null
+  } | null>(null)
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const ready =
@@ -34,14 +40,12 @@ export function RuleMatchPreview({ rule }: { rule: PolicyRule }) {
   const signature = JSON.stringify({ m: rule.match, e: rule.effect, i: rule.id })
 
   useEffect(() => {
-    if (!ready) {
-      setPreview(null)
-      return
-    }
-    setPending(true)
+    if (!ready) return
+    let current = true
     if (timer.current) clearTimeout(timer.current)
     timer.current = setTimeout(() => {
       void (async () => {
+        let preview: PreviewRuleResponse | null = null
         try {
           const res = await fetch(
             '/api/admin/proxy/v1/admin/policy/preview-rule',
@@ -52,21 +56,24 @@ export function RuleMatchPreview({ rule }: { rule: PolicyRule }) {
             },
           )
           const data = await res.json()
-          if (res.ok) setPreview(data as PreviewRuleResponse)
+          if (res.ok) preview = data as PreviewRuleResponse
         } catch {
           /* preview is best-effort — silence transport hiccups */
-        } finally {
-          setPending(false)
         }
+        if (current) setCache({ signature, preview })
       })()
     }, 600)
     return () => {
+      current = false
       if (timer.current) clearTimeout(timer.current)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [signature, ready])
 
   if (!ready) return null
+
+  const preview = cache?.signature === signature ? cache.preview : null
+  const pending = cache?.signature !== signature
 
   const pct =
     preview && preview.sampled > 0

--- a/brain-landing/components/admin/policies/ui.tsx
+++ b/brain-landing/components/admin/policies/ui.tsx
@@ -1,7 +1,5 @@
 'use client'
 
-/* eslint-disable react/jsx-no-literals -- TODO i18n migration: queued with the admin-wide pass. */
-
 import { ReactNode } from 'react'
 import { X } from 'lucide-react'
 

--- a/brain-landing/eslint.config.mjs
+++ b/brain-landing/eslint.config.mjs
@@ -33,11 +33,11 @@ const config = [
   },
   ...next,
   {
-    // react-hooks 7 (Next 16) added stricter rules that flag patterns which are
-    // widespread and intentional in this dashboard — fetch-in-effect + setState,
-    // d3-force refs mutated across renders. Kept as warnings (visible, tracked
-    // as tech debt) so the CI gate blocks on genuine errors without a mass
-    // hook-refactor. Burn these down file-by-file, then promote back to error.
+    // react-hooks 7 (Next 16) added stricter rules. Kept as warnings so the
+    // remaining hits stay visible without blocking on errors; `lint:ci`
+    // (CI's lint step) caps the total with `--max-warnings <current count>`,
+    // a ratchet that only goes down. When you fix one, lower the cap in
+    // package.json in the same change; at zero, promote the rule to error.
     rules: {
       'react-hooks/set-state-in-effect': 'warn',
       'react-hooks/refs': 'warn',

--- a/brain-landing/hooks/useEventSource.ts
+++ b/brain-landing/hooks/useEventSource.ts
@@ -1,0 +1,66 @@
+'use client'
+
+import { useEffect, useRef, useState, useSyncExternalStore } from 'react'
+
+export type EventSourceStatus = 'idle' | 'open' | 'closed'
+
+interface StatusStore {
+  get(): EventSourceStatus
+  set(next: EventSourceStatus): void
+  subscribe(listener: () => void): () => void
+}
+
+function createStatusStore(): StatusStore {
+  let status: EventSourceStatus = 'idle'
+  const listeners = new Set<() => void>()
+  return {
+    get: () => status,
+    set: (next) => {
+      if (next === status) return
+      status = next
+      for (const listener of listeners) listener()
+    },
+    subscribe: (listener) => {
+      listeners.add(listener)
+      return () => {
+        listeners.delete(listener)
+      }
+    },
+  }
+}
+
+const getServerStatus = (): EventSourceStatus => 'idle'
+
+/**
+ * Owns one EventSource for `url` (none while `url` is null) and exposes its
+ * connection state as an external store — the browser connection is the
+ * source of truth, so the status is read through useSyncExternalStore
+ * rather than mirrored into React state from the effect. `onMessage`
+ * always sees the latest closure. The source is closed on unmount and
+ * reopened whenever `url` changes; the status is 'idle' while there is no
+ * source, 'open' once one exists and 'closed' after it reported an error.
+ */
+export function useEventSource(
+  url: string | null,
+  onMessage: (data: string) => void,
+): EventSourceStatus {
+  const onMessageRef = useRef(onMessage)
+  useEffect(() => {
+    onMessageRef.current = onMessage
+  })
+  const [store] = useState(createStatusStore)
+
+  useEffect(() => {
+    if (!url) return
+    const src = new EventSource(url)
+    store.set('open')
+    src.onmessage = (e: MessageEvent<string>) => onMessageRef.current(e.data)
+    src.onerror = () => store.set('closed')
+    return () => {
+      src.close()
+      store.set('idle')
+    }
+  }, [url, store])
+
+  return useSyncExternalStore(store.subscribe, store.get, getServerStatus)
+}

--- a/brain-landing/hooks/useForceLayout.ts
+++ b/brain-landing/hooks/useForceLayout.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect, useMemo, useRef } from 'react'
+import { useCallback, useEffect, useMemo, useRef } from 'react'
 import {
   forceCenter,
   forceCollide,
@@ -8,15 +8,14 @@ import {
   forceManyBody,
   forceSimulation,
   type Simulation,
-  type SimulationLinkDatum,
-  type SimulationNodeDatum,
 } from 'd3-force'
 import { useReactFlow, type Edge, type Node } from 'reactflow'
-
-interface SimNode extends SimulationNodeDatum {
-  id: string
-}
-type SimEdge = SimulationLinkDatum<SimNode>
+import {
+  graphStructureKey,
+  reconcileSimNodes,
+  type SimLink,
+  type SimNode,
+} from '../lib/force-layout'
 
 interface Options {
   /** When false, the simulation stops and positions are frozen. */
@@ -36,9 +35,10 @@ interface Options {
  * - reactflow owns rendering + user drag. When the user drags a node we
  *   pin it via `fx`/`fy` so the simulation respects the manual override;
  *   on drag-stop we release it back to the physics.
- * - The simulation auto-restarts whenever the node/edge set changes
- *   so freshly-expanded neighbours settle in alongside the existing
- *   network instead of teleporting.
+ * - The simulation is (re)built only when the node/edge *set* changes, so
+ *   freshly-expanded neighbours settle in alongside the existing network
+ *   instead of teleporting — and the per-tick position writes that flow
+ *   back through `nodes` never restart it, so it cools down and stops.
  *
  * Returns drag callbacks the caller should wire to ReactFlow's
  * `onNodeDragStart` / `onNodeDrag` / `onNodeDragStop`.
@@ -49,51 +49,41 @@ export function useForceLayout(
   opts: Options,
 ) {
   const { setNodes } = useReactFlow()
-  const simRef = useRef<Simulation<SimNode, SimEdge> | null>(null)
-  // Stable per-id ref so simulation node objects survive across renders.
-  const simNodesRef = useRef<Map<string, SimNode>>(new Map())
+  const { enabled, linkDistance = 180, charge = -500, collide = 70 } = opts
+  const simRef = useRef<Simulation<SimNode, SimLink> | null>(null)
+  // Body per node id; only touched from effects and drag handlers.
+  const poolRef = useRef<Map<string, SimNode>>(new Map())
+  // Latest props for the structure-keyed effect below, which must not
+  // re-run on position-only updates.
+  const latestRef = useRef({ nodes, edges })
+  useEffect(() => {
+    latestRef.current = { nodes, edges }
+  })
 
-  const { linkDistance = 180, charge = -500, collide = 70 } = opts
-
-  // Sync sim node set with the React node set. Preserve x/y/vx/vy for
-  // existing ids so neighbours that already settled don't jump.
-  const simNodes = useMemo<SimNode[]>(() => {
-    const next: SimNode[] = []
-    const seen = new Set<string>()
-    for (const n of nodes) {
-      const prev = simNodesRef.current.get(n.id)
-      const sn: SimNode = prev ?? {
-        id: n.id,
-        x: n.position?.x,
-        y: n.position?.y,
-      }
-      next.push(sn)
-      seen.add(n.id)
-    }
-    // Drop sim nodes for removed reactflow nodes
-    for (const id of simNodesRef.current.keys()) {
-      if (!seen.has(id)) simNodesRef.current.delete(id)
-    }
-    for (const sn of next) simNodesRef.current.set(sn.id, sn)
-    return next
-  }, [nodes])
-
-  const simEdges = useMemo<SimEdge[]>(
-    () => edges.map((e) => ({ source: e.source, target: e.target })),
-    [edges],
+  const structureKey = useMemo(
+    () => graphStructureKey(nodes, edges),
+    [nodes, edges],
   )
+  const empty = nodes.length === 0
 
   useEffect(() => {
-    if (!opts.enabled || simNodes.length === 0) {
+    if (!enabled || empty) {
       simRef.current?.stop()
       simRef.current = null
       return
     }
 
-    const sim = forceSimulation<SimNode, SimEdge>(simNodes)
+    const { nodes: currentNodes, edges: currentEdges } = latestRef.current
+    const bodies = reconcileSimNodes(poolRef.current, currentNodes)
+    const links: SimLink[] = currentEdges.map((e) => ({
+      source: e.source,
+      target: e.target,
+    }))
+
+    const sim = forceSimulation<SimNode, SimLink>(bodies)
       .force(
         'link',
-        forceLink<SimNode, SimEdge>(simEdges)
+        forceLink<SimNode, SimLink>(links)
           .id((d) => d.id)
           .distance(linkDistance)
           .strength(0.3),
@@ -105,15 +95,13 @@ export function useForceLayout(
       .alphaDecay(0.025)
 
     sim.on('tick', () => {
+      const pool = poolRef.current
       setNodes((prev) =>
         prev.map((node) => {
-          const sn = simNodesRef.current.get(node.id)
-          if (!sn || sn.x === undefined || sn.y === undefined) return node
-          // Pinned drag: caller set fx/fy — skip overwriting x/y from sim.
-          return {
-            ...node,
-            position: { x: sn.x, y: sn.y },
-          }
+          const body = pool.get(node.id)
+          if (!body || body.x === undefined || body.y === undefined) return node
+          // A pinned (dragged) body has fx/fy, which d3 copies into x/y.
+          return { ...node, position: { x: body.x, y: body.y } }
         }),
       )
     })
@@ -122,42 +110,37 @@ export function useForceLayout(
     return () => {
       sim.stop()
     }
-  }, [
-    simNodes,
-    simEdges,
-    opts.enabled,
-    setNodes,
-    linkDistance,
-    charge,
-    collide,
-  ])
+  }, [structureKey, empty, enabled, setNodes, linkDistance, charge, collide])
 
-  return {
-    onNodeDragStart: (_: unknown, node: Node) => {
-      const sn = simNodesRef.current.get(node.id)
-      if (sn) {
-        sn.fx = node.position.x
-        sn.fy = node.position.y
-      }
-      simRef.current?.alphaTarget(0.3).restart()
-    },
-    onNodeDrag: (_: unknown, node: Node) => {
-      const sn = simNodesRef.current.get(node.id)
-      if (sn) {
-        sn.fx = node.position.x
-        sn.fy = node.position.y
-      }
-    },
-    onNodeDragStop: (_: unknown, node: Node) => {
-      const sn = simNodesRef.current.get(node.id)
-      if (sn) {
-        sn.fx = null
-        sn.fy = null
-      }
-      simRef.current?.alphaTarget(0)
-    },
-    reheat: () => {
-      simRef.current?.alpha(0.7).restart()
-    },
-  }
+  const onNodeDragStart = useCallback((_: unknown, node: Node) => {
+    const body = poolRef.current.get(node.id)
+    if (body) {
+      body.fx = node.position.x
+      body.fy = node.position.y
+    }
+    simRef.current?.alphaTarget(0.3).restart()
+  }, [])
+  const onNodeDrag = useCallback((_: unknown, node: Node) => {
+    const body = poolRef.current.get(node.id)
+    if (body) {
+      body.fx = node.position.x
+      body.fy = node.position.y
+    }
+  }, [])
+  const onNodeDragStop = useCallback((_: unknown, node: Node) => {
+    const body = poolRef.current.get(node.id)
+    if (body) {
+      body.fx = null
+      body.fy = null
+    }
+    simRef.current?.alphaTarget(0)
+  }, [])
+  const reheat = useCallback(() => {
+    simRef.current?.alpha(0.7).restart()
+  }, [])
+
+  return useMemo(
+    () => ({ onNodeDragStart, onNodeDrag, onNodeDragStop, reheat }),
+    [onNodeDragStart, onNodeDrag, onNodeDragStop, reheat],
+  )
 }

--- a/brain-landing/hooks/useLoader.ts
+++ b/brain-landing/hooks/useLoader.ts
@@ -1,0 +1,48 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+
+type Load<A extends unknown[]> = ((...args: A) => Promise<unknown>) &
+  (() => Promise<unknown>)
+
+/**
+ * Drives a fetch-into-state function from the component lifecycle without
+ * writing state inside the effect. `load` runs whenever its identity
+ * changes (memoise it on the inputs it reads); `reload` runs it from an
+ * event — button, interval, after a mutation — and resolves when it has
+ * settled. `loading` is derived during render: true from mount, or from the
+ * moment `load` changed or `reload` was called, until that exact run has
+ * settled, so a slow earlier request can never clear the indicator while a
+ * newer one is still in flight. `load` is expected to route its own
+ * failures into state; a rejection surfaces exactly as `void load()` would.
+ */
+export function useLoader<A extends unknown[] = []>(
+  load: Load<A>,
+): { loading: boolean; reload: (...args: A) => Promise<void> } {
+  const [settled, setSettled] = useState<{ load: Load<A> } | null>(null)
+  const [pending, setPending] = useState(0)
+
+  useEffect(() => {
+    let current = true
+    void load().finally(() => {
+      if (current) setSettled({ load })
+    })
+    return () => {
+      current = false
+    }
+  }, [load])
+
+  const reload = useCallback(
+    async (...args: A) => {
+      setPending((n) => n + 1)
+      try {
+        await load(...args)
+      } finally {
+        setPending((n) => n - 1)
+      }
+    },
+    [load],
+  )
+
+  return { loading: settled?.load !== load || pending > 0, reload }
+}

--- a/brain-landing/lib/force-layout.ts
+++ b/brain-landing/lib/force-layout.ts
@@ -1,0 +1,60 @@
+import type { SimulationLinkDatum, SimulationNodeDatum } from 'd3-force'
+
+/** One d3-force body. Survives across renders so x/y/vx/vy carry over. */
+export interface SimNode extends SimulationNodeDatum {
+  id: string
+}
+export type SimLink = SimulationLinkDatum<SimNode>
+
+export interface PositionedNode {
+  id: string
+  position?: { x: number; y: number }
+}
+export interface LinkedEdge {
+  source: string
+  target: string
+}
+
+/**
+ * Identity of the graph's *structure* — which nodes and which links exist,
+ * in order. Position-only updates (every simulation tick writes new node
+ * positions) produce the same key, so a simulation keyed on it is rebuilt
+ * only when a node or edge is added or removed.
+ */
+export function graphStructureKey(
+  nodes: readonly { id: string }[],
+  edges: readonly LinkedEdge[],
+): string {
+  return JSON.stringify([
+    nodes.map((n) => n.id),
+    edges.map((e) => [e.source, e.target]),
+  ])
+}
+
+/**
+ * Bring the simulation body pool in line with the rendered node set.
+ * Existing bodies are kept as-is (position and velocity intact, so nodes
+ * that already settled do not jump); new ids are seeded from the node's
+ * rendered position; bodies whose node is gone are evicted. Returns the
+ * bodies in node order, ready for `forceSimulation(...)`.
+ */
+export function reconcileSimNodes(
+  pool: Map<string, SimNode>,
+  nodes: readonly PositionedNode[],
+): SimNode[] {
+  const next: SimNode[] = []
+  const seen = new Set<string>()
+  for (const n of nodes) {
+    let body = pool.get(n.id)
+    if (!body) {
+      body = { id: n.id, x: n.position?.x, y: n.position?.y }
+      pool.set(n.id, body)
+    }
+    next.push(body)
+    seen.add(n.id)
+  }
+  for (const id of [...pool.keys()]) {
+    if (!seen.has(id)) pool.delete(id)
+  }
+  return next
+}

--- a/brain-landing/package.json
+++ b/brain-landing/package.json
@@ -10,6 +10,7 @@
     "build": "next build",
     "start": "next start -p 3030",
     "lint": "eslint .",
+    "lint:ci": "eslint . --max-warnings 8",
     "lint:i18n": "eslint components/admin",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"


### PR DESCRIPTION
## What

Frontend (`brain-landing/`) react-hooks warning debt: **54 → 8 warnings**, categories (a) ref-access-during-render and (b) setState-in-effect fixed for real, and the remainder turned into a CI ratchet (`pnpm lint:ci` = `eslint . --max-warnings 8`) that can only go down.

| rule | before | after |
|---|---:|---:|
| `react-hooks/refs` | 8 | 0 |
| `react-hooks/set-state-in-effect` | 36 | 0 |
| `react-hooks/purity` | 1 | 0 |
| unused `eslint-disable` directive | 1 | 0 |
| `react-hooks/exhaustive-deps` (logical expression in memo deps) | 7 | 7 |
| `react-hooks/incompatible-library` (`@tanstack/react-virtual`, compiler bailout) | 1 | 1 |
| **total** | **54** | **8** |

**Ratchet number: 8.** Fix a warning → lower `--max-warnings` in `brain-landing/package.json` in the same PR; at 0, promote the rules to `error` in `eslint.config.mjs`.

### Graph view (the real bug under the `refs` warnings)

`hooks/useForceLayout.ts` read and mutated its d3 body pool inside a `useMemo` keyed on `nodes`. Every simulation tick writes positions back through `setNodes` → controlled `onNodesChange` → a new `nodes` array, so that memo re-ran **per frame** and the effect keyed on it stopped and rebuilt the simulation at `alpha(0.8)` on every tick — the layout never cooled. Now:

- the simulation is keyed on graph *structure* (`lib/force-layout.ts#graphStructureKey`: node ids + edge pairs), so position-only updates never touch it and it settles;
- the body pool is reconciled inside the effect (`reconcileSimNodes`: keep existing bodies with their x/y/vx/vy, seed new ids from the rendered position, evict removed) — no ref access during render;
- drag handlers / `reheat` are stable (`useCallback`), so `GraphExplorer`'s `updateGraph` stops re-creating each render.

Both helpers are pure and covered by `__tests__/force-layout.test.ts`.

### Big lists + every `load()` panel (`set-state-in-effect`)

31 sites had the same shape — `useEffect(() => { void load() }, [load])` where `load` flips a `loading` flag. The rule taints any component-local function that calls setState (verified with a probe: even setState after `await` is flagged when the function is called from the effect), so the honest fix is structural, not cosmetic:

- **`hooks/useLoader(load)`** — runs `load` when its identity changes, derives `loading` **during render** (true until the *current* run has settled) and returns `reload` for buttons / intervals / post-mutation refreshes. No state is written inside the effect. Side effect of the derivation: a slow earlier request's `finally { setLoading(false) }` can no longer clear the spinner while a newer request (filter change, refresh) is still in flight — that was a live glitch in every filterable panel.
- **`hooks/useEventSource(url, onMessage)`** — the SSE connection state (jobs, traces list) is external state, so it is read via `useSyncExternalStore` instead of being mirrored into React state from the effect.
- **Keyed results instead of reset-in-effect** — `EntityPanel`, `EntitySearch`, `DreamsPanel` (emits), `policies/RuleMatchPreview`, `policies/KeyLens` (action matrix) store the fetched result together with the input it answers and derive the displayed value. This also stops a stale result for the *previous* entity / run / rule / subject from being displayed while the next one loads, and drops late responses for superseded inputs.
- **`KeyLens` deep links** — applied via `useState` initialisers plus the adjust-on-change pattern (once per distinct link); the editor's sessionStorage draft is read through `useSyncExternalStore` with a `null` server snapshot, so SSR/hydration see no draft and the client picks it up post-hydration.
- `ActivityPanel`: the elapsed clock is state advanced by its 500 ms tick and by each poll instead of `Date.now()` in render (`purity`) — with the compiler on, the old version would have frozen.
- `admin/scenarios`: the `setLoading(true)` at the top of a mount-only effect was a no-op (initial state is `true`) — removed.
- `policies/ui.tsx`: stale `eslint-disable` directive removed.

Converted components: `ActivityPanel, AuditLog, BaselinesPage, CalibrationPanel, ConfigPanel, CostPanel, DlqPanel, DreamsPanel, EntityPanel, EntitySearch, ForgottenPanel, HealthPanel, JobsPanel, LeasesPanel, MaintenancePanel, MarketplacePanel (list + PublisherProfile), MigrationsPanel, OperatorActionsPanel, PacksPanel, PiiInventoryPanel, PredicateRegistry, RouterStats, SourcesPanel, ThrottlerPanel, policies/{DecisionsFeed, KeyLens, PolicySetEditor, PolicySetsList, RuleMatchPreview, ui}, app/[lang]/admin/{scenarios, traces}, app/[lang]/app/{communities, usage}, hooks/useForceLayout`.

No `eslint-disable` lines were added. No dependency changes. No backend changes. Left for the ratchet (category c, no user-visible effect): the 7 `exhaustive-deps` "logical expression in memo deps" notes and the react-virtual compiler bailout on the traces page.

### Behaviour notes (small, intentional)

- Panels that show stale data while the next item loads (entity panel facts, dream emits, rule match count, key-lens matrix) now show their loading state instead. `EntitySearch` shows the last hits again if you clear the box and retype the same query until the debounced fetch replaces them.
- `communities` / `usage`: the error banner is cleared on the next *success* rather than at request start, so it stays visible during an in-flight retry.
- `KeyLens`: the automatic action-matrix run no longer toggles `busy`; that flag only ever disabled the data-tab Simulate button, which is not rendered while the actions tab is open.

## Why

Audit `docs/audits/2026-09-06-current-state-review.md`, "Дополнительные замечания" item 5: the warning debt is real but not 54 bugs — go through it by user-visible effect starting with the graph and the big lists, then ratchet, don't ban all warnings in one change.

## How verified

Inside `brain-landing/` (branch rebased onto `origin/main` at `e0c5854`):

```
pnpm lint            # before: 54 warnings, 0 errors  → after: 8 warnings, 0 errors
pnpm lint:ci         # exit 0 (cap 8)
pnpm eslint . --max-warnings 7   # exit 1 — the cap bites
pnpm typecheck       # clean
pnpm test            # Test Files 10 passed (10), Tests 53 passed (53) — 7 new in __tests__/force-layout.test.ts
pnpm build           # OK (full route table, no errors)
```

`.github/workflows/ci.yml` web job: "Lint (full)" now runs `pnpm lint:ci` (parsed with js-yaml to confirm the edit is valid YAML). Nothing under `src/` was touched, so the root gates do not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhrQxeisXJZEt4sg3PGyU6
