### PR TITLE
fix(jobs): put every replica-unsafe sweep and boot hook under the lease, and make cursor advances forward-only

### DIFF
--- a/src/admin/hnsw-provision.service.ts
+++ b/src/admin/hnsw-provision.service.ts
@@ -4,7 +4,7 @@ import { ApiKeyService } from '../auth/api-key.service';
 import { TenantRegistryService, type TenantIndexStateRow } from '../auth/tenant-registry.service';
 import { SurrealService } from '../db/surreal.service';
 import { MetricsService } from '../metrics/metrics.service';
-import { DistributedLeaseGuard } from '../common/distributed-lease.guard';
+import { DistributedLeaseGuard, tenantLeaseKey } from '../common/distributed-lease.guard';
 import { InFlightGuard } from '../common/in-flight-guard';
 import { envFlagEnabled } from '../common/env-validation';
 import { HnswMaintenanceService, type HnswMaintenanceResult } from './hnsw-maintenance.service';
@@ -126,6 +126,10 @@ export interface HnswProvisionOptions {
 }
 
 const LOCK_KEY = 'hnsw_provision_all';
+/** Per-tenant lease of the schema-ready hook's provisioning. */
+const STARTUP_LOCK_PREFIX = 'hnsw_provision_startup_';
+/** Covers the DDL round-trips of one tenant with room for a slow server; released on completion. */
+const STARTUP_LEASE_TTL_SECONDS = 30 * 60;
 
 /**
  * Lease TTL for the nightly sweep. Comfortably longer than the default
@@ -248,12 +252,36 @@ export class HnswProvisionService implements OnModuleInit {
         this.pending.delete(companyId);
         this.seen.add(companyId);
         if (!HnswProvisionService.enabled()) continue;
-        const result = await this.provisionTenant(companyId, {});
-        if (result.created.length > 0) await sleep(STAGGER_MS);
+        const result = await this.provisionAtStartup(companyId);
+        if (result !== null && result.created.length > 0) await sleep(STAGGER_MS);
       }
     } finally {
       this.draining = false;
     }
+  }
+
+  /**
+   * The hook's body for one tenant, under a per-tenant lease: the
+   * schema-ready hook fires on every replica that serves the tenant's first
+   * request, and `DEFINE INDEX … CONCURRENTLY` from N replicas is N
+   * concurrent builds of the same index. A replica that finds the lease held
+   * skips; `ensure` on the holder never restarts a build in flight, so the
+   * late replica has nothing to add. Without a guard (JobsModule not wired)
+   * the hook runs bare, as a single process may.
+   */
+  private async provisionAtStartup(companyId: string): Promise<HnswProvisionTenantResult | null> {
+    if (!this.guard) return this.provisionTenant(companyId, {});
+    const run = await this.guard.run(
+      tenantLeaseKey(STARTUP_LOCK_PREFIX, companyId),
+      () => this.provisionTenant(companyId, {}),
+      STARTUP_LEASE_TTL_SECONDS,
+    );
+    if (run === null) {
+      this.logger.log(
+        `hnsw provisioning for ${companyId} skipped — another replica holds the lease`,
+      );
+    }
+    return run;
   }
 
   /**

--- a/src/admin/vector-corpus.service.ts
+++ b/src/admin/vector-corpus.service.ts
@@ -10,7 +10,7 @@ import { ReindexEmbeddingsService } from '../ai/embedder/reindex-embeddings.serv
 import { REINDEX_SWEPT_COLUMNS } from '../ai/embedder/reindex-engine.service';
 import { JobRunService } from '../jobs/job-run.service';
 import { MetricsService } from '../metrics/metrics.service';
-import { DistributedLeaseGuard } from '../common/distributed-lease.guard';
+import { DistributedLeaseGuard, tenantLeaseKey } from '../common/distributed-lease.guard';
 import { InFlightGuard } from '../common/in-flight-guard';
 
 /** One vector column of one tenant, counted by stored width and space. */
@@ -58,6 +58,8 @@ interface CensusRow {
 }
 
 const LOCK_KEY = 'vector-corpus-reconcile';
+/** Per-tenant lease of the schema-ready hook's census and repair. */
+const STARTUP_LOCK_PREFIX = 'vector_corpus_startup_';
 const LEASE_TTL_SECONDS = 30 * 60;
 /** One operator-facing line per tenant per hour about a corpus that is still
  *  non-conforming; the metric carries the number continuously. */
@@ -135,13 +137,40 @@ export class VectorCorpusService implements OnModuleInit {
         this.pending.delete(companyId);
         this.seen.add(companyId);
         try {
-          await this.reconcileTenant(companyId, 'startup');
+          await this.reconcileAtStartup(companyId);
         } catch (e) {
           this.logger.warn(`vector corpus census failed for ${companyId}: ${(e as Error).message}`);
         }
       }
     } finally {
       this.draining = false;
+    }
+  }
+
+  /**
+   * The hook's census and repair for one tenant, under a per-tenant lease:
+   * the schema-ready hook fires on every replica that serves the tenant's
+   * first request, and the repair is a full re-embed of that tenant's
+   * corpus — N replicas meant N× the embedding spend and concurrent UPDATEs
+   * on the same rows. A replica that finds the lease held skips; the holder
+   * either repairs, or defers and polls the embedder itself (retryWhenReady),
+   * re-entering through the same lease once it is warm. Without a guard
+   * (JobsModule not wired) the hook runs bare, as a single process may.
+   */
+  private async reconcileAtStartup(companyId: string): Promise<void> {
+    if (!this.guard) {
+      await this.reconcileTenant(companyId, 'startup');
+      return;
+    }
+    const run = await this.guard.run(
+      tenantLeaseKey(STARTUP_LOCK_PREFIX, companyId),
+      () => this.reconcileTenant(companyId, 'startup'),
+      LEASE_TTL_SECONDS,
+    );
+    if (run === null) {
+      this.logger.log(
+        `vector corpus census for ${companyId} skipped — another replica holds the lease`,
+      );
     }
   }
 

--- a/src/audit/changefeed-consumer.service.ts
+++ b/src/audit/changefeed-consumer.service.ts
@@ -5,6 +5,13 @@ import { LeaderLeaseService } from '../jobs/leader-lease.service';
 import { MetricsService } from '../metrics/metrics.service';
 import { ChangefeedDrainService } from './changefeed-drain.service';
 
+/** One lease per deployment; the walking pod holds and renews it. */
+const LEASE_NAME = 'changefeed_consumer';
+/** 3x the cron cadence: a GC pause cannot strand the lease past the next tick. */
+const LEASE_TTL_SECONDS = 180;
+/** Renew once less than half the TTL is left, so no tenant drain starts on a lease about to lapse. */
+const LEASE_RENEW_BELOW_MS = (LEASE_TTL_SECONDS * 1000) / 2;
+
 /**
  * Periodic SurrealDB CHANGEFEED reader.
  *
@@ -42,6 +49,8 @@ export class ChangefeedConsumerService {
   // could double-emit on a slow tenant. Each cron firing checks +
   // skips if a previous one is still running.
   private inFlight = false;
+  /** Epoch-ms horizon of the lease as of the last acquire/renew. */
+  private leaseUntil = 0;
 
   /** Last successful tick timestamp (ISO). Exposed for admin status. */
   private lastTickAt: string | null = null;
@@ -71,16 +80,15 @@ export class ChangefeedConsumerService {
   //
   // Multi-pod gate: take the `changefeed_consumer` leader_lease so
   // only one pod drains the per-tenant SHOW CHANGES SINCE cursor at
-  // a time. Two pods racing the cursor would double-emit audit_event
-  // rows AND clobber each other's UPSERT of changefeed_state.
+  // a time, and keep it renewed across the walk — a walk longer than
+  // the TTL used to let a second pod start mid-roster. The cursor
+  // advance is a CAS on top of that (ChangefeedDrainService), so even
+  // an overlap cannot rewind a cursor; it only stops the slower pod.
   @Cron(CronExpression.EVERY_MINUTE)
   async tick(): Promise<void> {
     if (!this.drain.enabled || this.inFlight) return;
     if (this.lease) {
-      // ttl=180s leaves 3x the 60s cron cadence as headroom — a GC pause
-      // can't strand the lease past the next tick attempt.
-      const got = await this.lease.tryAcquire('changefeed_consumer', 180);
-      if (!got) return;
+      if (!(await this.acquireLease())) return;
     }
     this.inFlight = true;
     let pendingThisTick = 0;
@@ -88,9 +96,19 @@ export class ChangefeedConsumerService {
     try {
       for (const companyId of this.apiKeys.knownCompanyIds()) {
         try {
+          if (!(await this.holdLease())) {
+            this.logger.warn('[changefeed] lease lost mid-walk — stopping this tick');
+            break;
+          }
           const r = await this.drain.consumeForTenant(companyId);
           pendingThisTick += r.pendingRemaining;
           consumedThisTick += Object.values(r.consumed).reduce((a, b) => a + b, 0);
+          if (r.cursorRaceLost) {
+            this.logger.warn(
+              `[changefeed] tenant=${companyId}: another drainer is ahead — stopping this tick`,
+            );
+            break;
+          }
         } catch (err) {
           this.logger.warn(`[changefeed] tenant=${companyId} failed: ${(err as Error).message}`);
           this.lastError = {
@@ -109,6 +127,25 @@ export class ChangefeedConsumerService {
     } finally {
       this.inFlight = false;
     }
+  }
+
+  /** Take the lease (a same-identity re-acquire is its renew branch). */
+  private async acquireLease(): Promise<boolean> {
+    if (!this.lease) return true;
+    const got = await this.lease.tryAcquire(LEASE_NAME, LEASE_TTL_SECONDS);
+    if (got) this.leaseUntil = Date.now() + LEASE_TTL_SECONDS * 1000;
+    return got;
+  }
+
+  /**
+   * Keep the lease alive across a long walk: checked before every tenant,
+   * hits the database only once the horizon is inside the renew margin.
+   * False means the lease lapsed and another pod may be draining — stop.
+   */
+  private async holdLease(): Promise<boolean> {
+    if (!this.lease) return true;
+    if (Date.now() < this.leaseUntil - LEASE_RENEW_BELOW_MS) return true;
+    return this.acquireLease();
   }
 
   /**
@@ -164,6 +201,7 @@ export class ChangefeedConsumerService {
             consumed[k] = (consumed[k] ?? 0) + v;
           }
           pending += r.pendingRemaining;
+          if (r.cursorRaceLost) break;
         } catch (e) {
           this.lastError = {
             message: (e as Error).message,

--- a/src/audit/changefeed-drain.service.ts
+++ b/src/audit/changefeed-drain.service.ts
@@ -73,9 +73,13 @@ export class ChangefeedDrainService {
   async consumeForTenant(companyId: string): Promise<{
     consumed: Record<string, number>;
     pendingRemaining: number;
+    /** A cursor was already past this drain's batch: another drainer is
+     *  ahead of us on this tenant and the walk should stop. */
+    cursorRaceLost: boolean;
   }> {
     const consumed: Record<string, number> = {};
     let pendingRemaining = 0;
+    let cursorRaceLost = false;
 
     await this.surreal.withCompany(companyId, async (db) => {
       for (const source of ChangefeedDrainService.SOURCES) {
@@ -99,37 +103,18 @@ export class ChangefeedDrainService {
         const trailing = sorted.length - batch.length;
         pendingRemaining += trailing;
 
-        // Emit the batch AND advance the cursor in ONE transaction. They
-        // were two separate round-trips before: a crash in the gap either
-        // re-inserted the whole batch on restart (INSERT succeeded, cursor
-        // never advanced) or dropped it (cursor advanced first) — R4 #3.
-        // `runTransaction` sends both as one BEGIN…COMMIT block (the driver
-        // rejects BEGIN/COMMIT issued as separate query() calls). The batch
-        // still travels in a single INSERT so the per-tick round-trip count
-        // stays at one per (tenant × source) — the load fix that replaced
-        // 75K serial CREATEs.
         const events = this.buildAuditEventBatch(source, batch);
         const lastChange = batch[batch.length - 1];
         const lastVs = lastChange ? (lastChange.versionstamp as bigint) : undefined;
         if (lastVs !== undefined) {
-          await runTransaction(db, (tx) => {
-            // INSERT IGNORE: each event carries a deterministic record id
-            // (source+versionstamp+ordinal), so a re-drain of the same
-            // window collides on the primary key and no-ops instead of
-            // duplicating — idempotent without a UNIQUE index / migration.
-            if (events.length > 0) {
-              tx.add('INSERT IGNORE INTO audit_event $events').bind('events', events);
-            }
-            tx.add(
-              `UPSERT changefeed_state:[$source] CONTENT {
-                  source: $source,
-                  lastVersionstamp: $vs,
-                  updatedAt: time::now()
-               }`,
-            )
-              .bind('source', source)
-              .bind('vs', lastVs);
-          });
+          const advanced = await this.emitAndAdvance(db, { source, events, lastVs });
+          if (!advanced) {
+            this.logger.warn(
+              `[changefeed] ${source}: cursor already past ${lastVs} — another drainer is ahead, stopping`,
+            );
+            cursorRaceLost = true;
+            break;
+          }
         }
         consumed[source] = batch.length;
       }
@@ -145,7 +130,44 @@ export class ChangefeedDrainService {
       // invisible to "sustained non-zero" alerting.
     }
 
-    return { consumed, pendingRemaining };
+    return { consumed, pendingRemaining, cursorRaceLost };
+  }
+
+  /**
+   * Emit the batch and advance the cursor in ONE transaction, and only while
+   * the cursor is still behind the batch. Events and advance were two
+   * round-trips once (a crash in the gap re-inserted or dropped the batch);
+   * one BEGIN…COMMIT fixed that. The advance is conditional because an
+   * unconditional UPSERT let a slower drainer — a second pod whose lease had
+   * lapsed mid-walk, or a manual drain — rewind the cursor below a faster one
+   * and re-emit the window. INSERT IGNORE on the deterministic event id keeps
+   * the emit idempotent; the cursor is read by record id (no table scan in
+   * the read-set). Returns false, with nothing written, when the cursor was
+   * already at or past `lastVs`.
+   */
+  private async emitAndAdvance(
+    db: Surreal,
+    batch: { source: string; events: Array<Record<string, unknown>>; lastVs: bigint },
+  ): Promise<boolean> {
+    const insert = batch.events.length > 0 ? 'INSERT IGNORE INTO audit_event $events;' : '';
+    const out = await runTransaction<unknown>(db, (tx) => {
+      tx.bind('source', batch.source).bind('vs', batch.lastVs).bind('events', batch.events);
+      tx.add(`LET $cur = (SELECT VALUE lastVersionstamp FROM changefeed_state:[$source])[0]`);
+      tx.add(
+        `IF $cur IS NONE OR $cur < $vs {
+           ${insert}
+           UPSERT changefeed_state:[$source] CONTENT {
+             source: $source,
+             lastVersionstamp: $vs,
+             updatedAt: time::now()
+           };
+           RETURN true;
+         } ELSE {
+           RETURN false;
+         }`,
+      );
+    });
+    return out === true;
   }
 
   /** Per-source cursor snapshot for ONE tenant. */

--- a/src/common/distributed-lease.guard.ts
+++ b/src/common/distributed-lease.guard.ts
@@ -61,3 +61,26 @@ export class DistributedLeaseGuard {
     }) as Promise<T | null>;
   }
 }
+
+/**
+ * A per-tenant lease key. Lease names are record ids in `leader_lease`
+ * (`'leader_lease:' + name`), so the tenant id is folded to [A-Za-z0-9_];
+ * two ids that fold to the same key merely serialise behind one lease.
+ */
+export function tenantLeaseKey(prefix: string, companyId: string): string {
+  return `${prefix}${companyId.replace(/[^A-Za-z0-9_]/g, '_')}`;
+}
+
+const unguardedNoted = new Set<string>();
+
+/**
+ * One warning per process for a cron that runs without the distributed
+ * guard: only a single-replica deployment (or a unit fixture) is safe there.
+ */
+export function noteUnguarded(logger: Logger, cron: string): void {
+  if (unguardedNoted.has(cron)) return;
+  unguardedNoted.add(cron);
+  logger.warn(
+    `${cron} runs without a distributed lease (JobsModule not wired) — safe for a single replica only`,
+  );
+}

--- a/src/compaction/compaction.service.ts
+++ b/src/compaction/compaction.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger, OnModuleInit, Optional } from '@nestjs/common';
 import { Cron } from '@nestjs/schedule';
+import { DistributedLeaseGuard, noteUnguarded } from '../common/distributed-lease.guard';
 import { MetricsService } from '../metrics/metrics.service';
 import { type JobContext } from '../jobs/worker-loop.service';
 import { CompactionRunnerService } from './compaction-runner.service';
@@ -9,6 +10,11 @@ import { CompactionStats } from './compaction.types';
 
 export { SUMMARY_GENERATOR } from './compaction.types';
 export type { CompactionStats } from './compaction.types';
+
+/** Lock key of the inline (non-queue) daily pass. */
+const INLINE_LOCK_KEY = 'compaction_all';
+/** The inline pass walks every tenant serially; well past queue mode's 15 min per tenant. */
+const INLINE_LEASE_TTL_SECONDS = 60 * 60;
 
 /**
  * CompactionService — daily retention pass per spec.
@@ -21,8 +27,10 @@ export type { CompactionStats } from './compaction.types';
  *   known tenant; WorkerLoopService dispatches each to the handler
  *   registered in onModuleInit. CAS handles multi-pod races.
  *
- *   Legacy fallback (no claim service — single-process tests): keep the
- *   original in-flight bool guard and run the tenant fan-out inline.
+ *   Inline fallback (queue mode off, or no claim service): run the tenant
+ *   fan-out inline under the distributed lease guard, with the in-flight
+ *   bool as the process-local reentrancy layer. Without the guard (unit
+ *   fixtures) the pass runs bare, which only a single replica may.
  *
  * Metrics (countCompacted) are emitted here per tenant; the runner stays
  * metrics-free so it's a pure engine. Splitting the runner (engine) and
@@ -42,6 +50,7 @@ export class CompactionService implements OnModuleInit {
     private readonly queue: CompactionQueueService,
     private readonly promotion: PromotionRunnerService,
     @Optional() private readonly metrics?: MetricsService,
+    @Optional() private readonly guard?: DistributedLeaseGuard,
   ) {}
 
   onModuleInit(): void {
@@ -83,6 +92,23 @@ export class CompactionService implements OnModuleInit {
       this.logger.warn('compaction cron skipped — previous run still in flight');
       return [];
     }
+    const run = this.guard
+      ? await this.guard.run(
+          INLINE_LOCK_KEY,
+          () => this.compactAllInline(),
+          INLINE_LEASE_TTL_SECONDS,
+        )
+      : await this.compactAllInline();
+    if (run === null) {
+      this.logger.warn('compaction cron skipped — another run holds the lease');
+      return [];
+    }
+    return run;
+  }
+
+  /** The inline pass under the process-local single-flight flag. */
+  private async compactAllInline(): Promise<CompactionStats[]> {
+    if (!this.guard) noteUnguarded(this.logger, 'compaction');
     this.compactionInFlight = true;
     try {
       return await this.compactAll();

--- a/src/episodes/episode-subscription.service.ts
+++ b/src/episodes/episode-subscription.service.ts
@@ -38,6 +38,12 @@ export interface EpisodesAvailableEvent {
 
 const BATCH_CAP = 200;
 const DELIVERY_TIMEOUT_MS = 5_000;
+/** One dispatcher per deployment; the walking pod holds and renews it. */
+const LEASE_NAME = 'episode_subscriptions';
+/** 3x the cron cadence, the changefeed consumer's headroom. */
+const LEASE_TTL_SECONDS = 180;
+/** Renew once less than half the TTL is left, so no tenant starts on a lease about to lapse. */
+const LEASE_RENEW_BELOW_MS = (LEASE_TTL_SECONDS * 1000) / 2;
 const BREAKER_MS = 5 * 60_000;
 /** Consecutive failures after which a subscription self-deactivates. */
 const MAX_FAILURES = 100;
@@ -53,11 +59,12 @@ const MAX_FAILURES = 100;
  * payload is METADATA ONLY, so no PII crosses this surface; subscribers
  * pull bodies through GET /v1/episodes under their own scopes.
  *
- * Delivery semantics: at-least-once. The watermark advances via CAS
- * only after a 2xx, so a crash between delivery and advance re-sends
- * the batch; concurrent pods double-send at worst (the CAS keeps the
- * watermark itself consistent). Signature mirrors the indexer webhook:
- * `X-Brain-Signature: sha256=<hex hmac>` over the raw JSON body.
+ * Delivery semantics: at-least-once. The watermark advances only after
+ * a 2xx and only forward (`watermark < new`), so a crash between
+ * delivery and advance re-sends the batch, and a dispatcher that finds
+ * another one already past its batch stops instead of rewinding.
+ * Signature mirrors the indexer webhook: `X-Brain-Signature:
+ * sha256=<hex hmac>` over the raw JSON body.
  */
 @Injectable()
 export class EpisodeSubscriptionService {
@@ -69,6 +76,8 @@ export class EpisodeSubscriptionService {
    * mute the other's pushes.
    */
   private readonly failedUntil = new Map<string, number>();
+  /** Epoch-ms horizon of the lease as of the last acquire/renew. */
+  private leaseUntil = 0;
 
   // eslint-disable-next-line max-params
   constructor(
@@ -124,23 +133,29 @@ export class EpisodeSubscriptionService {
 
   /**
    * One dispatch pass over every tenant. Runs each minute wherever the
-   * flag is on — enable it on ONE role (the worker) in prod; duplicate
-   * pods only risk duplicate pushes, never watermark corruption (CAS).
+   * flag is on; one dispatcher per deployment holds the lease and renews
+   * it across the walk. A lapsed lease, or a watermark another dispatcher
+   * has already moved past, stops the walk — the next tick resumes it.
+   * Absent lease service (single-process deploys) → run.
    */
   @Cron('* * * * *')
   async dispatchTick(): Promise<void> {
     if (!EpisodeSubscriptionService.enabled()) return;
-    // One dispatcher per deployment (audit W1): without this every pod
-    // scans every tenant each minute and double-pushes the same batch.
-    // ttl=180s = 3x the cron cadence, same headroom as the changefeed
-    // consumer. Absent lease service (single-process deploys) → run.
     if (this.lease) {
-      const got = await this.lease.tryAcquire('episode_subscriptions', 180);
-      if (!got) return;
+      if (!(await this.acquireLease())) return;
     }
     for (const companyId of this.apiKeys.knownCompanyIds()) {
       try {
-        await this.dispatchCompany(companyId);
+        if (!(await this.holdLease())) {
+          this.logger.warn('episode-subscription dispatch stopped — the lease lapsed mid-walk');
+          break;
+        }
+        if (!(await this.dispatchCompany(companyId))) {
+          this.logger.warn(
+            `episode-subscription dispatch stopped — another dispatcher is ahead (companyId=${companyId})`,
+          );
+          break;
+        }
       } catch (e) {
         this.logger.warn(
           `episode-subscription dispatch failed (companyId=${companyId}): ${(e as Error).message}`,
@@ -149,7 +164,27 @@ export class EpisodeSubscriptionService {
     }
   }
 
-  private async dispatchCompany(companyId: string): Promise<void> {
+  /** Take the lease (a same-identity re-acquire is its renew branch). */
+  private async acquireLease(): Promise<boolean> {
+    if (!this.lease) return true;
+    const got = await this.lease.tryAcquire(LEASE_NAME, LEASE_TTL_SECONDS);
+    if (got) this.leaseUntil = Date.now() + LEASE_TTL_SECONDS * 1000;
+    return got;
+  }
+
+  /**
+   * Keep the lease alive across a long walk: checked before every tenant,
+   * hits the database only once the horizon is inside the renew margin.
+   * False means the lease lapsed and another pod may be dispatching — stop.
+   */
+  private async holdLease(): Promise<boolean> {
+    if (!this.lease) return true;
+    if (Date.now() < this.leaseUntil - LEASE_RENEW_BELOW_MS) return true;
+    return this.acquireLease();
+  }
+
+  /** False when a watermark advance found another dispatcher ahead. */
+  private async dispatchCompany(companyId: string): Promise<boolean> {
     const subs = await this.surreal.withCompany(companyId, async (db) => {
       const [rows] = await db.query<
         [
@@ -200,14 +235,16 @@ export class EpisodeSubscriptionService {
         secret: sub.secret,
         event,
       });
-      await this.settle({
+      const settled = await this.settle({
         companyId,
         sub,
         ok,
         previousWatermarkIso: sinceIso,
         newWatermarkIso: watermark,
       });
+      if (!settled) return false;
     }
+    return true;
   }
 
   private async deliver({
@@ -245,6 +282,14 @@ export class EpisodeSubscriptionService {
     return false;
   }
 
+  /**
+   * Record the delivery outcome. A success advances the watermark only
+   * forward, by record id (`UPDATE $id … WHERE watermark < new`): zero rows
+   * means another dispatcher already moved past this batch, and the caller
+   * stops rather than rewind. A batch whose newest row floors to the stored
+   * millisecond watermark cannot move it; that is not a race, it is
+   * re-delivered next tick (at-least-once), so no advance is attempted.
+   */
   private async settle({
     companyId,
     sub,
@@ -257,21 +302,16 @@ export class EpisodeSubscriptionService {
     ok: boolean;
     previousWatermarkIso: string;
     newWatermarkIso: string;
-  }): Promise<void> {
-    await this.surreal.withCompany(companyId, async (db: Surreal) => {
+  }): Promise<boolean> {
+    return this.surreal.withCompany(companyId, async (db: Surreal) => {
       if (ok) {
-        // CAS: only advance from the watermark this batch was read at —
-        // a concurrent pod that already advanced wins, we no-op.
-        await db.query(
+        if (newWatermarkIso === previousWatermarkIso) return true;
+        const [rows] = await db.query<[unknown[]]>(
           `UPDATE $id SET watermark = <datetime> $new, failureCount = 0
-            WHERE watermark = <datetime> $old`,
-          {
-            id: new StringRecordId(String(sub.id)),
-            new: newWatermarkIso,
-            old: previousWatermarkIso,
-          },
+            WHERE watermark < <datetime> $new`,
+          { id: new StringRecordId(String(sub.id)), new: newWatermarkIso },
         );
-        return;
+        return ((rows as unknown[]) ?? []).length > 0;
       }
       const failures = sub.failureCount + 1;
       await db.query(
@@ -285,6 +325,7 @@ export class EpisodeSubscriptionService {
           `episode subscription ${String(sub.id)} deactivated after ${failures} failures`,
         );
       }
+      return true;
     });
   }
 }

--- a/src/metrics/memory-quality.service.ts
+++ b/src/metrics/memory-quality.service.ts
@@ -1,13 +1,18 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, Optional } from '@nestjs/common';
 import { Cron } from '@nestjs/schedule';
 import { SurrealService } from '../db/surreal.service';
 import { ApiKeyService } from '../auth/api-key.service';
+import { DistributedLeaseGuard, noteUnguarded } from '../common/distributed-lease.guard';
 import {
   FACT_STATUSES,
   MetricsService,
   MemoryQualitySnapshot,
   STALE_BUCKETS_DAYS,
 } from './metrics.service';
+
+const LOCK_KEY = 'memory_quality';
+/** Eight COUNT aggregates per tenant; half an hour covers the roster. */
+const LEASE_TTL_SECONDS = 30 * 60;
 
 /**
  * MemoryQualityService — nightly snapshot of "is the memory rotting"
@@ -21,11 +26,12 @@ import {
  *
  * Before this, these signals lived only in per-tenant log lines and
  * job_run.stats rows — nothing an operator could alert on. The pass is
- * read-only COUNT aggregates, so unlike compaction/dreams it needs no
- * leader lease or job queue: every pod computes its own snapshot at
- * 03:35 UTC (between compaction 03:17 and the calibration refit 03:42)
- * and pods agree modulo timing. Aggregate across pods with max() in
- * dashboards, same as any per-pod gauge.
+ * read-only COUNT aggregates, but N replicas × every tenant × eight
+ * aggregates is N× the load for one answer, so the 03:35 UTC pass
+ * (between compaction 03:17 and the calibration refit 03:42) runs under
+ * the distributed lease guard: one pod computes and publishes. The gauges
+ * are per-pod, so aggregate across pods with max() in dashboards — a pod
+ * that never held the lease exports nothing for the labelled series.
  *
  * No companyId label (unbounded cardinality) — values are summed across
  * tenants; per-tenant drill-down stays in logs.
@@ -34,16 +40,24 @@ import {
 export class MemoryQualityService {
   private readonly logger = new Logger(MemoryQualityService.name);
 
+  // Fourth dep is the distributed lease guard for the nightly pass.
+  // eslint-disable-next-line max-params
   constructor(
     private readonly surreal: SurrealService,
     private readonly apiKeys: ApiKeyService,
     private readonly metrics: MetricsService,
+    @Optional() private readonly guard?: DistributedLeaseGuard,
   ) {}
 
   @Cron('35 3 * * *', { timeZone: 'UTC' })
   async collectNightly(): Promise<void> {
     try {
-      await this.collectNow();
+      if (!this.guard) noteUnguarded(this.logger, 'memory-quality');
+      const run = this.guard
+        ? await this.guard.run(LOCK_KEY, () => this.collectNow(), LEASE_TTL_SECONDS)
+        : await this.collectNow();
+      if (run === null)
+        this.logger.log('memory-quality pass skipped — another run holds the lease');
     } catch (e) {
       this.logger.warn(`memory-quality pass failed: ${(e as Error).message}`);
     }

--- a/src/outcomes/outcome-prune.service.ts
+++ b/src/outcomes/outcome-prune.service.ts
@@ -1,7 +1,8 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, Optional } from '@nestjs/common';
 import { Cron } from '@nestjs/schedule';
 import { SurrealService } from '../db/surreal.service';
 import { ApiKeyService } from '../auth/api-key.service';
+import { DistributedLeaseGuard, noteUnguarded } from '../common/distributed-lease.guard';
 import {
   outcomeDecisionCaptureEnabled,
   outcomeDecisionRetentionDays,
@@ -39,6 +40,10 @@ export const TOOL_OBSERVATION_PRUNE_BATCH_QUERY = `DELETE (SELECT id FROM tool_o
  */
 export const DECISION_PRUNE_BATCH_QUERY = `DELETE (SELECT id FROM memory_decision WHERE createdAt < $cutoff LIMIT 5000) RETURN BEFORE`;
 
+const LOCK_KEY = 'outcome_prune';
+/** Three bounded delete loops per tenant; an hour covers a long-unpruned roster. */
+const LEASE_TTL_SECONDS = 60 * 60;
+
 /**
  * OutcomePruneService — retention for the RAW outcome event log
  * (memory_outcome, migration 0107). The rollup (memory_outcome_stat) is
@@ -48,8 +53,9 @@ export const DECISION_PRUNE_BATCH_QUERY = `DELETE (SELECT id FROM memory_decisio
  *
  * Nightly at 03:41 UTC — offset from the 03:xx cron neighbourhood
  * (compaction 03:17, memory-quality 03:35, calibration refit 03:42) —
- * gated on the master flag, with an in-flight guard so an overlapping
- * tick never doubles the work. Tenant roster comes from
+ * gated on the master flag, under the distributed lease guard so one
+ * replica walks the roster, with an in-flight flag as the process-local
+ * reentrancy layer. Tenant roster comes from
  * ApiKeyService.knownCompanyIds(), the same way the compaction cron
  * enumerates tenants.
  */
@@ -61,6 +67,7 @@ export class OutcomePruneService {
   constructor(
     private readonly surreal: SurrealService,
     private readonly apiKeys: ApiKeyService,
+    @Optional() private readonly guard?: DistributedLeaseGuard,
   ) {}
 
   @Cron('41 3 * * *', { timeZone: 'UTC' })
@@ -77,15 +84,33 @@ export class OutcomePruneService {
       this.logger.warn('outcome prune still running — skipping this tick');
       return { tenants: 0, pruned: 0 };
     }
+    const legs = { outcome: outcomeLeg, observation: observationLeg, decision: decisionLeg };
+    const run = this.guard
+      ? await this.guard.run(LOCK_KEY, () => this.pruneAll(legs), LEASE_TTL_SECONDS)
+      : await this.pruneAll(legs);
+    if (run === null) {
+      this.logger.warn('outcome prune skipped — another run holds the lease');
+      return { tenants: 0, pruned: 0 };
+    }
+    return run;
+  }
+
+  /** The roster walk under the process-local single-flight flag. */
+  private async pruneAll(legs: {
+    outcome: boolean;
+    observation: boolean;
+    decision: boolean;
+  }): Promise<{ tenants: number; pruned: number }> {
+    if (!this.guard) noteUnguarded(this.logger, 'outcome prune');
     this.running = true;
     try {
       const tenants = this.apiKeys.knownCompanyIds();
       let pruned = 0;
       for (const companyId of tenants) {
         try {
-          if (outcomeLeg) pruned += await this.pruneTenant(companyId);
-          if (observationLeg) pruned += await this.pruneToolObservations(companyId);
-          if (decisionLeg) pruned += await this.pruneDecisions(companyId);
+          if (legs.outcome) pruned += await this.pruneTenant(companyId);
+          if (legs.observation) pruned += await this.pruneToolObservations(companyId);
+          if (legs.decision) pruned += await this.pruneDecisions(companyId);
         } catch (e) {
           this.logger.warn(`outcome prune for ${companyId} failed: ${(e as Error).message}`);
         }

--- a/src/strategy/strategy-distill.service.ts
+++ b/src/strategy/strategy-distill.service.ts
@@ -1,9 +1,10 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, Optional } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Cron } from '@nestjs/schedule';
 import type OpenAI from 'openai';
 import { chatCallParams, createOpenAiClientOrThrow } from '../ai/openai-client';
 import { ApiKeyService } from '../auth/api-key.service';
+import { DistributedLeaseGuard, noteUnguarded } from '../common/distributed-lease.guard';
 import { envFlagEnabled } from '../common/env-validation';
 import {
   StrategyMemoryService,
@@ -105,6 +106,10 @@ export const DISTILL_MAX_ITEMS = 3;
 
 /** Dedup-merge neighbor count (Mem0 idiom, G4 v1: top-3). */
 const MERGE_NEIGHBORS = 3;
+
+const SWEEP_LOCK_KEY = 'strategy_sweep';
+/** One bounded deprecate pass per tenant; half an hour covers the roster. */
+const SWEEP_LEASE_TTL_SECONDS = 30 * 60;
 
 const DISTILL_SYSTEM = `You are a strategy distiller for an answer-synthesis memory system.
 
@@ -225,10 +230,13 @@ export class StrategyDistillService {
   private readonly cronEnabled: boolean;
   private sweepInFlight = false;
 
+  // Fourth dep is the distributed lease guard for the nightly sweep.
+  // eslint-disable-next-line max-params
   constructor(
     private readonly strategies: StrategyMemoryService,
     private readonly apiKeys: ApiKeyService,
     config: ConfigService,
+    @Optional() private readonly guard?: DistributedLeaseGuard,
   ) {
     this.openai = createOpenAiClientOrThrow(config);
     this.model = config.get<string>('OPENAI_CHAT_MODEL', 'gpt-4o-mini');
@@ -340,8 +348,10 @@ export class StrategyDistillService {
   /**
    * Nightly lifecycle sweep at 03:52 UTC — after compaction (03:17)
    * and the calibration refits (03:42/03:51), before dreams (04:00).
-   * Env-gated and reentrancy-guarded; per-tenant failures are
-   * contained (the MemoryQualityService fan-out idiom).
+   * Env-gated, under the distributed lease guard (one replica walks the
+   * roster) with the in-flight flag as the process-local reentrancy
+   * layer; per-tenant failures are contained (the MemoryQualityService
+   * fan-out idiom).
    */
   @Cron('52 3 * * *', { timeZone: 'UTC' })
   async runNightlySweep(): Promise<SweepRunStats> {
@@ -356,6 +366,16 @@ export class StrategyDistillService {
       this.logger.warn('strategy sweep skipped — previous run still in flight');
       return stats;
     }
+    const run = this.guard
+      ? await this.guard.run(SWEEP_LOCK_KEY, () => this.sweepAll(stats), SWEEP_LEASE_TTL_SECONDS)
+      : await this.sweepAll(stats);
+    if (run === null) this.logger.warn('strategy sweep skipped — another run holds the lease');
+    return stats;
+  }
+
+  /** The roster walk under the process-local single-flight flag; fills `stats` in place. */
+  private async sweepAll(stats: SweepRunStats): Promise<SweepRunStats> {
+    if (!this.guard) noteUnguarded(this.logger, 'strategy sweep');
     this.sweepInFlight = true;
     try {
       const tenants = this.apiKeys.knownCompanyIds();

--- a/test/changefeed-consumer.unit-spec.ts
+++ b/test/changefeed-consumer.unit-spec.ts
@@ -13,18 +13,28 @@
  *      array under `update` (R4 #3 post-image parsing).
  *   5. Each event carries a deterministic record id so a re-drain is a
  *      no-op via INSERT IGNORE (R4 #3 idempotency).
+ *   6. The cursor advance is a CAS: a drain whose batch the cursor is
+ *      already past writes nothing and reports the lost race, so a slower
+ *      pod can never rewind a faster one.
+ *
+ * Plus ChangefeedConsumerService's tick: the lease is renewed across the
+ * tenant walk and the walk stops when the renewal fails or a drain finds
+ * another drainer ahead.
  */
 import { StringRecordId } from 'surrealdb';
 import { ChangefeedDrainService } from '../src/audit/changefeed-drain.service';
+import { ChangefeedConsumerService } from '../src/audit/changefeed-consumer.service';
 
 type Captured = { sql: string; params?: Record<string, unknown> | undefined };
 
 function mkSurreal(opts: {
-  cursors?: Record<string, number>;
+  cursors?: Record<string, number | bigint>;
   changes?: Record<string, Array<Record<string, unknown>>>;
+  /** Runs when the drain transaction arrives, before its CAS is evaluated. */
+  beforeTx?: (cursors: Record<string, number | bigint>) => void;
 }) {
   const calls: Captured[] = [];
-  const cursors = { ...(opts.cursors ?? {}) };
+  const cursors: Record<string, number | bigint> = { ...(opts.cursors ?? {}) };
   const changes = opts.changes ?? {};
   // Mirror INSERT IGNORE semantics: a re-inserted primary key is skipped, so
   // the store tracks which deterministic ids have already landed.
@@ -42,16 +52,24 @@ function mkSurreal(opts: {
         const table = match?.[1] ?? '';
         return [changes[table] ?? []];
       }
-      // The drain now composes the INSERT + cursor UPSERT into ONE
-      // BEGIN…COMMIT block (runTransaction), so both statements — and their
-      // merged params — arrive in a single query() call.
-      if (sql.includes('INSERT IGNORE INTO audit_event')) {
-        for (const e of (params?.events as Array<{ id: unknown }> | undefined) ?? []) {
-          inserted.add(String(e.id));
-        }
-      }
+      // The drain composes the INSERT + cursor advance into ONE BEGIN…COMMIT
+      // block (runTransaction), so both statements — and their merged params
+      // — arrive in a single query() call. Mirror the CAS: the block advances
+      // (and inserts) only while the stored cursor is behind the batch, and
+      // its RETURN slot says which way it went.
       if (sql.includes('UPSERT changefeed_state')) {
-        cursors[params?.source as string] = params?.vs as number;
+        opts.beforeTx?.(cursors);
+        const source = params?.source as string;
+        const vs = params?.vs as bigint;
+        const cur = cursors[source];
+        if (cur !== undefined && BigInt(cur) >= vs) return [false];
+        if (sql.includes('INSERT IGNORE INTO audit_event')) {
+          for (const e of (params?.events as Array<{ id: unknown }> | undefined) ?? []) {
+            inserted.add(String(e.id));
+          }
+        }
+        cursors[source] = vs;
+        return [true];
       }
       return [[], [], []];
     },
@@ -59,6 +77,7 @@ function mkSurreal(opts: {
   return {
     db,
     calls,
+    cursors,
     inserted,
     surreal: {
       withCompany: async (_c: string, fn: (d: any) => Promise<any>) => fn(db),
@@ -256,6 +275,169 @@ describe('ChangefeedDrainService', () => {
     const svc = mkSvc(surreal);
     const r = await svc.consumeForTenant('co_a');
     expect(r.consumed).toEqual({});
+    expect(r.cursorRaceLost).toBe(false);
     expect(calls.filter((c) => c.sql.includes('INSERT IGNORE INTO audit_event'))).toHaveLength(0);
+  });
+
+  it('the cursor advance is a CAS inside the drain transaction', async () => {
+    const { surreal, calls } = mkSurreal({
+      changes: {
+        knowledge_entity: [
+          { versionstamp: 10, changes: [{ update: { id: 'knowledge_entity:a' } }] },
+        ],
+      },
+    });
+    await mkSvc(surreal).consumeForTenant('co_a');
+    const tx = drainTx(calls)!;
+    // Read by record id, advance only while behind, say which way it went.
+    expect(tx.sql).toContain('FROM changefeed_state:[$source]');
+    expect(tx.sql).toContain('IF $cur IS NONE OR $cur < $vs');
+    expect(tx.sql).toContain('RETURN false');
+    expect(tx.params?.vs).toBe(10n);
+  });
+
+  it('a slower drain never rewinds the cursor: nothing written, race reported', async () => {
+    // Our window was read at cursor 0 (vs 10, 12). By the time we commit,
+    // another drainer has advanced the cursor to 20 — past our batch.
+    const { surreal, cursors, inserted } = mkSurreal({
+      changes: {
+        knowledge_entity: [
+          { versionstamp: 10, changes: [{ update: { id: 'knowledge_entity:a' } }] },
+          { versionstamp: 12, changes: [{ update: { id: 'knowledge_entity:b' } }] },
+        ],
+        knowledge_fact: [{ versionstamp: 30, changes: [{ update: { id: 'knowledge_fact:x' } }] }],
+      },
+      beforeTx: (c) => {
+        if (c.knowledge_entity === undefined) c.knowledge_entity = 20n;
+      },
+    });
+    const r = await mkSvc(surreal).consumeForTenant('co_a');
+    expect(r.cursorRaceLost).toBe(true);
+    expect(inserted.size).toBe(0);
+    expect(cursors.knowledge_entity).toBe(20n);
+    // The walk stopped at the lost source: the later source was not touched.
+    expect(r.consumed).toEqual({});
+    expect(cursors.knowledge_fact).toBeUndefined();
+  });
+
+  it('a cursor exactly at the batch high-water mark is "already past" too', async () => {
+    const { surreal, inserted } = mkSurreal({
+      changes: {
+        knowledge_entity: [
+          { versionstamp: 12, changes: [{ update: { id: 'knowledge_entity:b' } }] },
+        ],
+      },
+      beforeTx: (c) => {
+        c.knowledge_entity = 12n;
+      },
+    });
+    const r = await mkSvc(surreal).consumeForTenant('co_a');
+    expect(r.cursorRaceLost).toBe(true);
+    expect(inserted.size).toBe(0);
+  });
+});
+
+// ── the consumer tick: lease renewal across the walk ─────────────────────
+
+function mkConsumer(opts: {
+  tenants: string[];
+  acquire?: jest.Mock;
+  drainImpl?: (companyId: string) => Promise<{
+    consumed: Record<string, number>;
+    pendingRemaining: number;
+    cursorRaceLost: boolean;
+  }>;
+}) {
+  const consumeForTenant = jest.fn(
+    opts.drainImpl ??
+      (async () => ({
+        consumed: { knowledge_entity: 1 },
+        pendingRemaining: 0,
+        cursorRaceLost: false,
+      })),
+  );
+  const drain = { enabled: true, sources: [], perBatchLimit: 500, consumeForTenant };
+  const tryAcquire = opts.acquire ?? jest.fn(async () => true);
+  const apiKeys = { knownCompanyIds: () => opts.tenants };
+  const svc = new ChangefeedConsumerService(
+    apiKeys as never,
+    drain as never,
+    {
+      tryAcquire,
+    } as never,
+  );
+  return { svc, consumeForTenant, tryAcquire };
+}
+
+describe('ChangefeedConsumerService — the lease across the tenant walk', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('a short walk takes the lease once and renews nothing', async () => {
+    const { svc, consumeForTenant, tryAcquire } = mkConsumer({ tenants: ['a', 'b', 'c'] });
+    await svc.tick();
+    expect(consumeForTenant).toHaveBeenCalledTimes(3);
+    expect(tryAcquire).toHaveBeenCalledTimes(1);
+    expect(tryAcquire).toHaveBeenCalledWith('changefeed_consumer', 180);
+  });
+
+  it('renews mid-walk once less than half the TTL is left, and keeps walking', async () => {
+    jest.useFakeTimers({ now: 1_000_000 });
+    // Each tenant drain takes 100 s: after the first one 80 s of the 180 s
+    // lease remain (< 90 s), so the second tenant starts with a renew.
+    const { svc, consumeForTenant, tryAcquire } = mkConsumer({
+      tenants: ['a', 'b', 'c'],
+      drainImpl: async () => {
+        jest.setSystemTime(Date.now() + 100_000);
+        return { consumed: {}, pendingRemaining: 0, cursorRaceLost: false };
+      },
+    });
+    await svc.tick();
+    expect(consumeForTenant).toHaveBeenCalledTimes(3);
+    // Acquire at the start, renew before b and before c.
+    expect(tryAcquire).toHaveBeenCalledTimes(3);
+  });
+
+  it('stops the walk when the renewal fails — another pod may be draining', async () => {
+    jest.useFakeTimers({ now: 1_000_000 });
+    let attempts = 0;
+    const acquire = jest.fn(async () => ++attempts === 1);
+    const { svc, consumeForTenant } = mkConsumer({
+      tenants: ['a', 'b', 'c'],
+      acquire,
+      drainImpl: async () => {
+        jest.setSystemTime(Date.now() + 100_000);
+        return { consumed: {}, pendingRemaining: 0, cursorRaceLost: false };
+      },
+    });
+    await svc.tick();
+    expect(consumeForTenant).toHaveBeenCalledTimes(1);
+    expect(consumeForTenant).toHaveBeenCalledWith('a');
+    expect(svc.stats().inFlight).toBe(false);
+  });
+
+  it('stops the walk when a drain finds another drainer ahead of it', async () => {
+    const { svc, consumeForTenant } = mkConsumer({
+      tenants: ['a', 'b', 'c'],
+      drainImpl: async (companyId) => ({
+        consumed: { knowledge_entity: 2 },
+        pendingRemaining: 0,
+        cursorRaceLost: companyId === 'a',
+      }),
+    });
+    await svc.tick();
+    expect(consumeForTenant).toHaveBeenCalledTimes(1);
+    // What was drained before the race was lost still counts.
+    expect(svc.stats().totalConsumed).toBe(2);
+  });
+
+  it('drainNow stops the same way', async () => {
+    const { svc, consumeForTenant } = mkConsumer({
+      tenants: ['a', 'b'],
+      drainImpl: async () => ({ consumed: {}, pendingRemaining: 0, cursorRaceLost: true }),
+    });
+    await svc.drainNow();
+    expect(consumeForTenant).toHaveBeenCalledTimes(1);
   });
 });

--- a/test/changefeed-drain.e2e-spec.ts
+++ b/test/changefeed-drain.e2e-spec.ts
@@ -10,11 +10,14 @@
  *   - Idempotent re-drain: resetting the cursor and draining the same window
  *     again produces NO duplicate audit_event rows (deterministic record id +
  *     INSERT IGNORE).
+ *   - CAS on the cursor: a slower drain that commits after a faster one has
+ *     advanced past its batch writes nothing and does not rewind the cursor.
  *
  * This is the flag-independent path — consumeForTenant() runs regardless of
  * AUDIT_CHANGEFEED_ENABLED (only the cron tick is gated), so the drain logic
  * is exercised directly.
  */
+import { ConfigService } from '@nestjs/config';
 import { StringRecordId } from 'surrealdb';
 import { AppFixture, createApp } from './app-fixture';
 import { SurrealService } from '../src/db/surreal.service';
@@ -126,5 +129,69 @@ describe('changefeed drain: create/update/delete + idempotent re-drain', () => {
     await drain.consumeForTenant(f.companyId);
     const after = await countAll();
     expect(after).toBe(before);
+  });
+
+  it('a slower drain cannot rewind the cursor past a faster one', async () => {
+    const surreal = f.app.get(SurrealService);
+    const fast = f.app.get(ChangefeedDrainService);
+    const slow = new ChangefeedDrainService(surreal, f.app.get(ConfigService));
+
+    const seed = () =>
+      surreal.withCompany(f.companyId, async (db) => {
+        await db.query(
+          `CREATE knowledge_entity SET type = 'other', canonicalName = 'Race', externalRefs = {}`,
+        );
+      });
+    const readCursor = () =>
+      surreal.withCompany(f.companyId, async (db) => {
+        const [rows] = await db.query<[Array<{ lastVersionstamp: number | bigint }>]>(
+          `SELECT lastVersionstamp FROM changefeed_state
+             WHERE source = 'knowledge_entity' LIMIT 1`,
+        );
+        return BigInt(
+          (rows as Array<{ lastVersionstamp: number | bigint }>)[0]?.lastVersionstamp ?? 0,
+        );
+      });
+    const countAll = () =>
+      surreal.withCompany(f.companyId, async (db) => {
+        const [rows] = await db.query<[Array<{ n: number }>]>(
+          `SELECT count() AS n FROM audit_event WHERE source = 'knowledge_entity' GROUP ALL`,
+        );
+        return (rows as Array<{ n: number }>)[0]?.n ?? 0;
+      });
+
+    // Both drains start behind the same one change. The slow drain reads its
+    // window, then — before it commits — the fast drain sees one MORE change
+    // and advances the cursor past the slow drain's batch.
+    await seed();
+    let fastCursor = 0n;
+    let fastCount = 0;
+    const original = (
+      slow as unknown as {
+        fetchChanges: (db: unknown, source: string, since: bigint) => Promise<unknown[]>;
+      }
+    ).fetchChanges.bind(slow);
+    let interposed = false;
+    jest
+      .spyOn(slow as unknown as { fetchChanges: typeof original }, 'fetchChanges')
+      .mockImplementation(async (db, source, since) => {
+        const rows = await original(db, source, since);
+        if (source === 'knowledge_entity' && !interposed) {
+          interposed = true;
+          await seed();
+          const r = await fast.consumeForTenant(f.companyId);
+          expect(r.cursorRaceLost).toBe(false);
+          fastCursor = await readCursor();
+          fastCount = await countAll();
+        }
+        return rows;
+      });
+
+    const r = await slow.consumeForTenant(f.companyId);
+    expect(r.cursorRaceLost).toBe(true);
+    expect(r.consumed.knowledge_entity).toBeUndefined();
+    // Not rewound, and nothing re-emitted.
+    expect(await readCursor()).toBe(fastCursor);
+    expect(await countAll()).toBe(fastCount);
   });
 });

--- a/test/episode-subscription.unit-spec.ts
+++ b/test/episode-subscription.unit-spec.ts
@@ -4,40 +4,70 @@ import type { EpisodeReadStoreService } from '../src/episodes/episode-read-store
 import type { ApiKeyService } from '../src/auth/api-key.service';
 import type { SurrealService } from '../src/db/surreal.service';
 
+type Query = { sql: string; params?: Record<string, unknown> | undefined; companyId: string };
+
 function makeService(opts: {
   subs?: Array<Record<string, unknown>>;
   meta?: Array<Record<string, unknown>>;
+  tenants?: string[];
+  /** Rows the watermark CAS returns; [] means another dispatcher is past us. */
+  advanceRows?: unknown[];
+  /** Runs at each tenant's first query — a hook to move the clock. */
+  onTenant?: (companyId: string) => void;
+  lease?: { tryAcquire: (name: string, ttl: number) => Promise<boolean> };
 }): {
   svc: EpisodeSubscriptionService;
-  queries: Array<{ sql: string; params?: Record<string, unknown> | undefined }>;
+  queries: Query[];
 } {
-  const queries: Array<{ sql: string; params?: Record<string, unknown> | undefined }> = [];
+  const queries: Query[] = [];
   const surreal = {
-    withCompany: async (_co: string, fn: (db: unknown) => Promise<unknown>) =>
-      fn({
+    withCompany: async (companyId: string, fn: (db: unknown) => Promise<unknown>) => {
+      opts.onTenant?.(companyId);
+      return fn({
         query: async (sql: string, params?: Record<string, unknown>) => {
-          queries.push({ sql, params });
+          queries.push({ sql, params, companyId });
           if (sql.includes('FROM episode_subscription')) {
             return [opts.subs ?? []];
           }
           if (sql.includes('CREATE episode_subscription')) {
             return [[{ id: 'episode_subscription:new1' }]];
           }
+          if (sql.includes('SET watermark')) {
+            return [opts.advanceRows ?? [{ id: params?.id }]];
+          }
           return [[]];
         },
-      }),
+      });
+    },
   } as unknown as SurrealService;
   const episodes = {
     metaSince: async () => opts.meta ?? [],
   } as unknown as EpisodeReadStoreService;
   const apiKeys = {
-    knownCompanyIds: () => ['co_x'],
+    knownCompanyIds: () => opts.tenants ?? ['co_x'],
   } as unknown as ApiKeyService;
   return {
-    svc: new EpisodeSubscriptionService(surreal, episodes, apiKeys),
+    svc: new EpisodeSubscriptionService(surreal, episodes, apiKeys, opts.lease as never),
     queries,
   };
 }
+
+const SUB = {
+  id: 'episode_subscription:s1',
+  url: 'https://example.com/hook',
+  secret: 'shh',
+  watermark: '2026-08-01T00:00:00.000Z',
+  failureCount: 0,
+};
+const META = [
+  {
+    id: 'episode:e1',
+    messageId: 'm1',
+    occurredAt: '2026-08-02T10:00:00.000Z',
+    recordedAt: '2026-08-02T10:00:05.000Z',
+  },
+];
+const okFetch = () => (async () => ({ ok: true, status: 200 }) as Response) as typeof fetch;
 
 describe('EpisodeSubscriptionService (driver surface 4)', () => {
   const savedFlag = process.env.EPISODE_SUBSCRIPTIONS_ENABLED;
@@ -119,10 +149,97 @@ describe('EpisodeSubscriptionService (driver surface 4)', () => {
     expect(calls[0]!.sig).toBe(`sha256=${expected}`);
     const advance = queries.find((q) => q.sql.includes('SET watermark'));
     expect(advance).toBeDefined();
-    expect(advance?.sql).toContain('WHERE watermark = <datetime> $old');
-    expect(advance?.params).toMatchObject({
-      new: '2026-08-02T10:00:05.000Z',
-      old: '2026-08-01T00:00:00.000Z',
+    // Forward-only, by record id: a dispatcher that is behind can never
+    // rewind a watermark another one already moved past.
+    expect(advance?.sql).toContain('UPDATE $id SET watermark');
+    expect(advance?.sql).toContain('WHERE watermark < <datetime> $new');
+    expect(advance?.params).toMatchObject({ new: '2026-08-02T10:00:05.000Z' });
+    expect(advance?.params).not.toHaveProperty('old');
+  });
+
+  it('a watermark another dispatcher already moved past stops the walk', async () => {
+    process.env.EPISODE_SUBSCRIPTIONS_ENABLED = '1';
+    let fetches = 0;
+    global.fetch = (async () => {
+      fetches += 1;
+      return { ok: true, status: 200 } as Response;
+    }) as typeof fetch;
+    const { svc, queries } = makeService({
+      subs: [SUB],
+      meta: META,
+      tenants: ['co_x', 'co_y'],
+      advanceRows: [],
+    });
+    await svc.dispatchTick();
+    expect(fetches).toBe(1);
+    expect(queries.some((q) => q.companyId === 'co_y')).toBe(false);
+  });
+
+  it('a batch that cannot move the millisecond watermark is re-delivered, not a lost race', async () => {
+    process.env.EPISODE_SUBSCRIPTIONS_ENABLED = '1';
+    global.fetch = okFetch();
+    // The newest row floors to the stored watermark (a later-nanosecond
+    // episode in the same millisecond): no advance is attempted and the
+    // walk goes on to the next tenant.
+    const { svc, queries } = makeService({
+      subs: [{ ...SUB, watermark: '2026-08-02T10:00:05.000Z' }],
+      meta: META,
+      tenants: ['co_x', 'co_y'],
+      advanceRows: [],
+    });
+    await svc.dispatchTick();
+    expect(queries.some((q) => q.sql.includes('SET watermark'))).toBe(false);
+    expect(queries.some((q) => q.companyId === 'co_y')).toBe(true);
+  });
+
+  describe('the lease across the tenant walk', () => {
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('a short walk takes the lease once and renews nothing', async () => {
+      process.env.EPISODE_SUBSCRIPTIONS_ENABLED = '1';
+      const tryAcquire = jest.fn(async () => true);
+      const { svc, queries } = makeService({
+        subs: [],
+        tenants: ['co_a', 'co_b', 'co_c'],
+        lease: { tryAcquire },
+      });
+      await svc.dispatchTick();
+      expect(new Set(queries.map((q) => q.companyId)).size).toBe(3);
+      expect(tryAcquire).toHaveBeenCalledTimes(1);
+      expect(tryAcquire).toHaveBeenCalledWith('episode_subscriptions', 180);
+    });
+
+    it('renews mid-walk once less than half the TTL is left', async () => {
+      process.env.EPISODE_SUBSCRIPTIONS_ENABLED = '1';
+      jest.useFakeTimers({ now: 1_000_000 });
+      const tryAcquire = jest.fn(async () => true);
+      const { svc, queries } = makeService({
+        subs: [],
+        tenants: ['co_a', 'co_b', 'co_c'],
+        lease: { tryAcquire },
+        // Each tenant takes 100 s of the 180 s lease.
+        onTenant: () => jest.setSystemTime(Date.now() + 100_000),
+      });
+      await svc.dispatchTick();
+      expect(new Set(queries.map((q) => q.companyId)).size).toBe(3);
+      expect(tryAcquire).toHaveBeenCalledTimes(3);
+    });
+
+    it('stops the walk when the renewal fails', async () => {
+      process.env.EPISODE_SUBSCRIPTIONS_ENABLED = '1';
+      jest.useFakeTimers({ now: 1_000_000 });
+      let attempts = 0;
+      const tryAcquire = jest.fn(async () => ++attempts === 1);
+      const { svc, queries } = makeService({
+        subs: [],
+        tenants: ['co_a', 'co_b', 'co_c'],
+        lease: { tryAcquire },
+        onTenant: () => jest.setSystemTime(Date.now() + 100_000),
+      });
+      await svc.dispatchTick();
+      expect(queries.map((q) => q.companyId)).toEqual(['co_a']);
     });
   });
 

--- a/test/hnsw-provisioning.unit-spec.ts
+++ b/test/hnsw-provisioning.unit-spec.ts
@@ -172,6 +172,7 @@ function provision(opts: {
     countHnswProvision: (o: string) => void;
     setHnswIndexTenants: (s: string, n: number) => void;
   };
+  guard?: { run: (key: string, fn: () => Promise<unknown>, ttl?: number) => Promise<unknown> };
 }) {
   const listeners: Array<(c: string) => void> = [];
   const surreal = { onTenantSchemaReady: (l: (c: string) => void) => listeners.push(l) };
@@ -204,8 +205,20 @@ function provision(opts: {
     apiKeys as never,
     registry as never,
     opts.metrics as never,
+    opts.guard as never,
   );
   return { svc, listeners, apply, registry };
+}
+
+function fakeGuard(held = false) {
+  const calls: Array<{ key: string; ttl: number | undefined }> = [];
+  const guard = {
+    run: jest.fn(async (key: string, fn: () => Promise<unknown>, ttl?: number) => {
+      calls.push({ key, ttl });
+      return held ? null : fn();
+    }),
+  };
+  return { guard, calls };
 }
 
 describe('HnswProvisionService — the hook', () => {
@@ -435,5 +448,45 @@ describe('migration 0133 — the roster columns', () => {
     expect(body).not.toMatch(/DEFINE INDEX/);
     // A DEFAULT would make an unobserved tenant look freshly checked.
     expect(body).not.toMatch(/DEFAULT/);
+  });
+});
+
+describe('HnswProvisionService — the hook runs under a per-tenant lease', () => {
+  const flush = async () => {
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
+  };
+  beforeEach(() => {
+    process.env.HNSW_PROVISION_ENABLED = '1';
+  });
+  afterEach(() => {
+    delete process.env.HNSW_PROVISION_ENABLED;
+  });
+
+  it('one tenant, one lease: hnsw_provision_startup_<tenant> (id folded to a record-id-safe key), 30 min', async () => {
+    const { guard, calls } = fakeGuard();
+    const { svc, listeners, apply } = provision({ guard });
+    svc.onModuleInit();
+    listeners[0]!('co-new');
+    await flush();
+    expect(calls).toEqual([{ key: 'hnsw_provision_startup_co_new', ttl: 30 * 60 }]);
+    expect(apply).toHaveBeenCalledWith('co-new', 'ensure');
+  });
+
+  it('a replica that finds the lease held skips: no DDL, no registry write', async () => {
+    const { guard } = fakeGuard(true);
+    const { svc, listeners, apply, registry } = provision({ guard });
+    svc.onModuleInit();
+    listeners[0]!('co-new');
+    await flush();
+    expect(apply).not.toHaveBeenCalled();
+    expect(registry.recordIndexState).not.toHaveBeenCalled();
+  });
+
+  it('the nightly sweep keeps its own roster-wide lease', async () => {
+    const { guard, calls } = fakeGuard();
+    const { svc } = provision({ guard });
+    await svc.runNightly();
+    expect(calls).toEqual([{ key: 'hnsw_provision_all', ttl: 20 * 60 }]);
   });
 });

--- a/test/lease-guard-sweeps.unit-spec.ts
+++ b/test/lease-guard-sweeps.unit-spec.ts
@@ -1,0 +1,238 @@
+/**
+ * The nightly sweeps that used to run raw on every replica — the inline
+ * compaction fallback, outcome prune, the strategy deprecate sweep and the
+ * memory-quality snapshot — now run under DistributedLeaseGuard: each body
+ * runs once, under its own key with a TTL past its worst case, and a replica
+ * that finds the lease held skips with the empty result. Without a guard
+ * (unit fixtures, single-process dev) each body still runs exactly as before.
+ */
+import type { DistributedLeaseGuard } from '../src/common/distributed-lease.guard';
+import { CompactionService } from '../src/compaction/compaction.service';
+import { OutcomePruneService } from '../src/outcomes/outcome-prune.service';
+import { StrategyDistillService } from '../src/strategy/strategy-distill.service';
+import { MemoryQualityService } from '../src/metrics/memory-quality.service';
+
+function fakeGuard(held = false) {
+  const calls: Array<{ key: string; ttl: number | undefined }> = [];
+  const run = jest.fn(async (key: string, fn: () => Promise<unknown>, ttl?: number) => {
+    calls.push({ key, ttl });
+    return held ? null : fn();
+  });
+  return { guard: { run } as unknown as DistributedLeaseGuard, calls, run };
+}
+
+// ── compaction (inline fallback) ─────────────────────────────────────────
+
+function compaction(guard?: DistributedLeaseGuard) {
+  const stats = { companyId: 'co_a', factsCompacted: 3, summariesCreated: 0, bytesFreed: 0 };
+  const runner = { compactAll: jest.fn(async () => [stats]) };
+  // No claim service wired: the cron takes the inline path.
+  const queue = {
+    hasClaim: false,
+    queueModeEnabled: () => true,
+    knownTenants: () => ['co_a'],
+    register: jest.fn(),
+  };
+  const promotion = { isEnabled: () => false };
+  const svc = new CompactionService(
+    runner as never,
+    queue as never,
+    promotion as never,
+    undefined,
+    guard,
+  );
+  return { svc, runner };
+}
+
+describe('CompactionService — inline daily pass under the distributed lease', () => {
+  it('runs the inline pass under compaction_all with an hour of TTL', async () => {
+    const { guard, calls } = fakeGuard();
+    const { svc, runner } = compaction(guard);
+    const out = await svc.runDaily();
+    expect(runner.compactAll).toHaveBeenCalledTimes(1);
+    expect(Array.isArray(out) && out).toHaveLength(1);
+    expect(calls).toEqual([{ key: 'compaction_all', ttl: 60 * 60 }]);
+  });
+
+  it('a replica that finds the lease held skips: nothing compacted, empty result', async () => {
+    const { guard } = fakeGuard(true);
+    const { svc, runner } = compaction(guard);
+    expect(await svc.runDaily()).toEqual([]);
+    expect(runner.compactAll).not.toHaveBeenCalled();
+  });
+
+  it('without a guard the inline pass runs as before', async () => {
+    const { svc, runner } = compaction();
+    expect(await svc.runDaily()).toHaveLength(1);
+    expect(runner.compactAll).toHaveBeenCalledTimes(1);
+  });
+
+  it('the process-local flag still refuses a same-pod overlap', async () => {
+    let release!: () => void;
+    const gate = new Promise<void>((r) => (release = r));
+    const { svc, runner } = compaction();
+    runner.compactAll.mockImplementationOnce(async () => {
+      await gate;
+      return [];
+    });
+    const first = svc.runDaily();
+    expect(await svc.runDaily()).toEqual([]);
+    release();
+    await first;
+    expect(runner.compactAll).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ── outcome prune ────────────────────────────────────────────────────────
+
+function prune(guard?: DistributedLeaseGuard) {
+  const queries: string[] = [];
+  const surreal = {
+    withCompany: async (_c: string, fn: (db: unknown) => Promise<unknown>) =>
+      fn({
+        query: async (sql: string) => {
+          queries.push(sql);
+          return [[]];
+        },
+      }),
+  };
+  const apiKeys = { knownCompanyIds: () => ['co_a', 'co_b'] };
+  return { svc: new OutcomePruneService(surreal as never, apiKeys as never, guard), queries };
+}
+
+describe('OutcomePruneService — nightly prune under the distributed lease', () => {
+  beforeEach(() => {
+    process.env.OUTCOME_TELEMETRY_ENABLED = '1';
+  });
+  afterEach(() => {
+    delete process.env.OUTCOME_TELEMETRY_ENABLED;
+  });
+
+  it('walks the roster under outcome_prune with an hour of TTL', async () => {
+    const { guard, calls } = fakeGuard();
+    const { svc, queries } = prune(guard);
+    expect(await svc.runNightly()).toEqual({ tenants: 2, pruned: 0 });
+    expect(queries).toHaveLength(2);
+    expect(calls).toEqual([{ key: 'outcome_prune', ttl: 60 * 60 }]);
+  });
+
+  it('a replica that finds the lease held skips: no query, empty result', async () => {
+    const { guard } = fakeGuard(true);
+    const { svc, queries } = prune(guard);
+    expect(await svc.runNightly()).toEqual({ tenants: 0, pruned: 0 });
+    expect(queries).toEqual([]);
+  });
+
+  it('the master flag is checked before the lease: a disabled prune never touches it', async () => {
+    delete process.env.OUTCOME_TELEMETRY_ENABLED;
+    const { guard, run } = fakeGuard();
+    const { svc } = prune(guard);
+    expect(await svc.runNightly()).toEqual({ tenants: 0, pruned: 0 });
+    expect(run).not.toHaveBeenCalled();
+  });
+});
+
+// ── strategy deprecate sweep ─────────────────────────────────────────────
+
+function sweep(guard?: DistributedLeaseGuard) {
+  const env: Record<string, string> = {
+    OPENAI_API_KEY: 'sk-test',
+    OPENAI_CHAT_MODEL: 'gpt-4o-mini',
+    STRATEGY_DISTILL_CRON_ENABLED: '1',
+  };
+  const config = {
+    get: (k: string, d?: string) => env[k] ?? d,
+    getOrThrow: (k: string) => {
+      const v = env[k];
+      if (v === undefined) throw new Error(`missing ${k}`);
+      return v;
+    },
+  };
+  const strategies = {
+    isEnabled: () => true,
+    deprecateSweep: jest.fn(async () => ({ scanned: 4, deprecated: 1 })),
+  };
+  const apiKeys = { knownCompanyIds: () => ['co_a', 'co_b'] };
+  const svc = new StrategyDistillService(
+    strategies as never,
+    apiKeys as never,
+    config as never,
+    guard,
+  );
+  return { svc, strategies };
+}
+
+describe('StrategyDistillService — nightly sweep under the distributed lease', () => {
+  it('walks the roster under strategy_sweep with half an hour of TTL', async () => {
+    const { guard, calls } = fakeGuard();
+    const { svc, strategies } = sweep(guard);
+    expect(await svc.runNightlySweep()).toEqual({
+      tenants: 2,
+      scanned: 8,
+      deprecated: 2,
+      failed: 0,
+    });
+    expect(strategies.deprecateSweep).toHaveBeenCalledTimes(2);
+    expect(calls).toEqual([{ key: 'strategy_sweep', ttl: 30 * 60 }]);
+  });
+
+  it('a replica that finds the lease held skips: no sweep, zero stats', async () => {
+    const { guard } = fakeGuard(true);
+    const { svc, strategies } = sweep(guard);
+    expect(await svc.runNightlySweep()).toEqual({
+      tenants: 0,
+      scanned: 0,
+      deprecated: 0,
+      failed: 0,
+    });
+    expect(strategies.deprecateSweep).not.toHaveBeenCalled();
+  });
+
+  it('without a guard the sweep runs as before', async () => {
+    const { svc, strategies } = sweep();
+    expect((await svc.runNightlySweep()).tenants).toBe(2);
+    expect(strategies.deprecateSweep).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ── memory-quality snapshot ──────────────────────────────────────────────
+
+function quality(guard?: DistributedLeaseGuard) {
+  const db = {
+    query: async (sql: string) => {
+      if (sql.includes('GROUP BY status')) return [[{ status: 'active', n: 1 }]];
+      return [[{ n: 0 }]];
+    },
+  };
+  const surreal = {
+    withCompany: jest.fn(async (_c: string, fn: (d: typeof db) => Promise<unknown>) => fn(db)),
+  };
+  const apiKeys = { knownCompanyIds: () => ['co_a'] };
+  const metrics = { setMemoryQuality: jest.fn() };
+  const svc = new MemoryQualityService(surreal as never, apiKeys as never, metrics as never, guard);
+  return { svc, surreal, metrics };
+}
+
+describe('MemoryQualityService — nightly snapshot under the distributed lease', () => {
+  it('collects and publishes under memory_quality with half an hour of TTL', async () => {
+    const { guard, calls } = fakeGuard();
+    const { svc, metrics } = quality(guard);
+    await svc.collectNightly();
+    expect(metrics.setMemoryQuality).toHaveBeenCalledTimes(1);
+    expect(calls).toEqual([{ key: 'memory_quality', ttl: 30 * 60 }]);
+  });
+
+  it('a replica that finds the lease held skips: no query, no gauge write', async () => {
+    const { guard } = fakeGuard(true);
+    const { svc, surreal, metrics } = quality(guard);
+    await svc.collectNightly();
+    expect(surreal.withCompany).not.toHaveBeenCalled();
+    expect(metrics.setMemoryQuality).not.toHaveBeenCalled();
+  });
+
+  it('without a guard the pass runs as before', async () => {
+    const { svc, metrics } = quality();
+    await svc.collectNightly();
+    expect(metrics.setMemoryQuality).toHaveBeenCalledTimes(1);
+  });
+});

--- a/test/vector-corpus.unit-spec.ts
+++ b/test/vector-corpus.unit-spec.ts
@@ -254,4 +254,72 @@ describe('VectorCorpusService', () => {
     );
     expect(metrics.setVectorCorpusTenantsNonconforming).toHaveBeenCalledWith(1);
   });
+  describe('the schema-ready hook runs under a per-tenant lease', () => {
+    const flush = async () => {
+      await new Promise((r) => setImmediate(r));
+      await new Promise((r) => setImmediate(r));
+    };
+    function guarded(opts: Parameters<typeof make>[0] & { held?: boolean }) {
+      const made = make(opts);
+      const calls: Array<{ key: string; ttl: number | undefined }> = [];
+      const guard = {
+        run: jest.fn(async (key: string, fn: () => Promise<unknown>, ttl?: number) => {
+          calls.push({ key, ttl });
+          return opts.held ? null : fn();
+        }),
+      };
+      Object.assign(made.svc, { guard });
+      return { ...made, calls };
+    }
+
+    it('one tenant, one lease: vector_corpus_startup_<tenant>, 30 min, and the repair runs under it', async () => {
+      const { svc, reindex, calls } = guarded({
+        census: { 'knowledge_fact.embedding': [{ width: 1536, count: 39 }] },
+        afterRepair: { 'knowledge_fact.embedding': [{ width: 1024, count: 39 }] },
+      });
+      svc.noteTenant('co_x');
+      await flush();
+      expect(calls).toEqual([{ key: 'vector_corpus_startup_co_x', ttl: 30 * 60 }]);
+      expect(reindex.run).toHaveBeenCalledTimes(1);
+    });
+
+    it('a replica that finds the lease held skips: no census, no sweep, no job run', async () => {
+      const { svc, reindex, jobs, queries } = guarded({
+        census: { 'knowledge_fact.embedding': [{ width: 1536, count: 39 }] },
+        held: true,
+      });
+      svc.noteTenant('co_x');
+      await flush();
+      expect(queries).toEqual([]);
+      expect(reindex.run).not.toHaveBeenCalled();
+      expect(jobs.start).not.toHaveBeenCalled();
+    });
+
+    it('a deferred repair re-enters through the same lease once the embedder is warm', async () => {
+      jest.useFakeTimers();
+      try {
+        let ready = false;
+        const { svc, reindex, calls } = guarded({
+          census: { 'knowledge_fact.embedding': [{ width: 1536, count: 39 }] },
+          afterRepair: { 'knowledge_fact.embedding': [{ width: 1024, count: 39 }] },
+        });
+        (svc as unknown as { embedder: { isReady: () => boolean } }).embedder.isReady = () => ready;
+        svc.noteTenant('co_x');
+        await jest.advanceTimersByTimeAsync(0);
+        // Deferred under the lease, and the lease was released with it.
+        expect(calls).toHaveLength(1);
+        expect(reindex.run).not.toHaveBeenCalled();
+        ready = true;
+        await jest.advanceTimersByTimeAsync(60_000);
+        await jest.advanceTimersByTimeAsync(0);
+        expect(calls).toEqual([
+          { key: 'vector_corpus_startup_co_x', ttl: 30 * 60 },
+          { key: 'vector_corpus_startup_co_x', ttl: 30 * 60 },
+        ]);
+        expect(reindex.run).toHaveBeenCalledTimes(1);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+  });
 });


### PR DESCRIPTION
## What

Makes the service safe for N identical replicas along the three paths the replica-safety audit found unguarded or under-guarded. No new flags or env knobs; the guard's existing `run(key, fn, ttl)` API and `LeaderLeaseService.tryAcquire` are the only primitives used. `src/jobs/*` and `src/main.ts` are untouched; the `knownCompanyIds()` roster lines are left byte-identical for #548.

**A. Boot hooks (S1).** `VectorCorpusService` and `HnswProvisionService` take the schema-ready hook on every replica, so a tenant's first request triggered N full re-embeds of its corpus and N concurrent `DEFINE INDEX … CONCURRENTLY` builds. The per-tenant hook body now runs under `guard.run('vector_corpus_startup_<tenant>' | 'hnsw_provision_startup_<tenant>', …, 1800)`; a replica that finds the lease held skips silently. The deferred-repair poller (`retryWhenReady`) is untouched and re-enters through the same lease once the embedder is warm. Tenant ids are folded to `[A-Za-z0-9_]` (`tenantLeaseKey`) because lease names are composed into a `leader_lease:` record id — a `:` in the key would fail to parse and every replica would silently skip.

**B. Sweeps that ran raw on every replica (S2/S3).** The inline compaction fallback, `OutcomePruneService`, the strategy `deprecateSweep` and the `MemoryQualityService` snapshot each get `@Optional() guard?: DistributedLeaseGuard` and run their cron body under `compaction_all` (60 min), `outcome_prune` (60 min), `strategy_sweep` (30 min), `memory_quality` (30 min). The process-local single-flight flags stay as the reentrancy layer. A fixture without the guard runs unguarded exactly as before, with one warning per process (`noteUnguarded`). The memory-quality header now states the per-pod gauge contract (aggregate with `max()`; non-leaders export nothing for the labelled series).

**C. Per-minute consumers (S1).** `ChangefeedConsumerService.tick` and `EpisodeSubscriptionService.dispatchTick` held a 180 s lease they never renewed across the tenant walk, and advanced cursors unconditionally. Both now renew the lease mid-walk (a same-identity `tryAcquire` is the lease's renew branch; the DB is hit only once less than half the TTL remains) and stop the walk when the renewal fails. The changefeed cursor advance is a CAS inside the existing drain transaction — `LET $cur = (SELECT VALUE lastVersionstamp FROM changefeed_state:[$source])[0]; IF $cur IS NONE OR $cur < $vs { INSERT IGNORE …; UPSERT …; RETURN true } ELSE { RETURN false }` — read by record id (no table scan in the SSI read-set), BigInt end-to-end; a lost race writes nothing and stops the walk (`cursorRaceLost`), including from the admin `drainNow`. The episode watermark advance becomes `UPDATE $id SET watermark = … WHERE watermark < <datetime> $new` with the zero-row result treated as "another dispatcher is ahead — stop". A batch whose newest row floors to the stored millisecond watermark (`recordedAt` is `time::now()` at ns precision, the watermark is a JS ISO ms string) is deliberately not treated as a race: no advance is attempted and it is re-delivered next tick, as before.

## Why

Replica-safety audit findings S1 (boot hooks bypass the guard; per-minute consumers hold an unrenewed 180 s lease and advance cursors blindly — a drain longer than 180 s let a second replica acquire mid-walk and the slower drain's unconditional `UPSERT changefeed_state` rewound the cursor, producing duplicate `audit_event` rows / duplicate webhook pushes) and S2/S3 (nightly sweeps guarded only by a process-local flag).

## How verified

- `pnpm typecheck` — exit 0
- `pnpm lint:ci` — exit 0 (0 problems, after rebasing onto `e0c5854` which carries the #544 fix for `test/capability-probe.unit-spec.ts`)
- `pnpm format:check` — exit 0
- `pnpm jest --config ./test/jest-unit.json --testPathIgnorePatterns='/node_modules/' --modulePathIgnorePatterns='/__none__/' --testPathPatterns 'lease-guard-sweeps|vector-corpus|hnsw-provisioning|changefeed-consumer|episode-subscription|memory-outcome|memory-quality|compaction\.unit|strategy-revision|strategy-memory\.unit|contracts-admin-changefeed-state|health-components|flag-budget|config-catalog-truth'` — **Test Suites: 15 passed, 15 total; Tests: 178 passed, 178 total**
  - new `test/lease-guard-sweeps.unit-spec.ts`: each sweep body runs under its key/TTL via a fake guard; "lease held" → skip with the empty result; unguarded fixtures unchanged; same-pod overlap still refused
  - `test/vector-corpus.unit-spec.ts` / `test/hnsw-provisioning.unit-spec.ts`: hook under `*_startup_<tenant>` (1800 s); held → no census/sweep/DDL/registry write; the deferred-repair poller re-enters through the same lease; the nightly keeps `hnsw_provision_all`
  - `test/changefeed-consumer.unit-spec.ts`: the drain fake now mirrors the CAS; a slower drain writes nothing and reports `cursorRaceLost` (cursor stays at 20, a cursor exactly at the high-water mark counts as past); the consumer renews at half TTL, stops on renewal failure and on a lost race, `drainNow` stops the same way
  - `test/episode-subscription.unit-spec.ts`: forward-only CAS shape and params; 0 rows stops the walk; the same-millisecond batch is re-delivered rather than treated as a race; lease renewal/stop
- `pnpm jest --config ./test/jest-e2e.json --testPathIgnorePatterns='/node_modules/' --modulePathIgnorePatterns='/__none__/' --testPathPatterns 'changefeed-drain'` (testcontainers SurrealDB) — **Test Suites: 1 passed, 1 total; Tests: 2 passed, 2 total**
  - new case "a slower drain cannot rewind the cursor past a faster one": drain B reads its window, then (interposed inside its `fetchChanges`) drain A sees one more change and advances the cursor; B's commit loses the CAS, reports `cursorRaceLost`, the cursor stays at A's value and the `audit_event` count is unchanged

## Not done / deliberately left out

- `LeaderLeaseService` has no `renew()`; per the brief `src/jobs/*` is another agent's, so renewal uses `tryAcquire` with the same identity (its CAS branch already renews). If the fencing-epoch work changes `tryAcquire`'s return type, the two `acquireLease()` helpers are the only call sites to touch.
- The brief's key spelling `vector_corpus_startup:<tenant>` was changed to `_` — see A.
- The admin `drainNow` path still takes no lease (it now stops on a lost race, which the CAS makes safe); a leased manual drain is out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhrQxeisXJZEt4sg3PGyU6
