### PR TITLE
feat(batch): one terminal status for batch operations, failed keys, retry-only-failed

### DIFF
--- a/brain-landing/public/openapi.json
+++ b/brain-landing/public/openapi.json
@@ -153,6 +153,75 @@
         ],
         "type": "object"
       },
+      "BatchOutcome": {
+        "additionalProperties": false,
+        "properties": {
+          "degradedBy": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "error": {
+                  "type": "string"
+                },
+                "key": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "key",
+                "error"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "failed": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "error": {
+                  "type": "string"
+                },
+                "key": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "key",
+                "error"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "status": {
+            "enum": [
+              "complete",
+              "degraded",
+              "failed"
+            ],
+            "type": "string"
+          },
+          "succeeded": {
+            "maximum": 9007199254740991,
+            "minimum": -9007199254740991,
+            "type": "integer"
+          },
+          "total": {
+            "maximum": 9007199254740991,
+            "minimum": -9007199254740991,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "status",
+          "total",
+          "succeeded",
+          "failed",
+          "degradedBy"
+        ],
+        "type": "object"
+      },
       "BeliefReadResponse": {
         "additionalProperties": false,
         "properties": {
@@ -3891,6 +3960,12 @@
           "force": {
             "type": "boolean"
           },
+          "keys": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
           "version": {
             "type": "string"
           }
@@ -3912,6 +3987,9 @@
             "maximum": 9007199254740991,
             "minimum": -9007199254740991,
             "type": "integer"
+          },
+          "outcome": {
+            "$ref": "#/components/schemas/BatchOutcome"
           },
           "previousVersion": {
             "type": [
@@ -3969,7 +4047,8 @@
           "unresolvedSubjects",
           "skipped",
           "status",
-          "failed"
+          "failed",
+          "outcome"
         ],
         "type": "object"
       },

--- a/docs/api.md
+++ b/docs/api.md
@@ -108,7 +108,7 @@ All routes 404 until their flag is on.
 | `GET /v1/episodes/subscriptions` | Registered endpoints (secrets never included). |
 | `DELETE /v1/episodes/subscriptions/:id` | Remove an endpoint (`brain:admin`). |
 | `GET /v1/projections` | Derived surfaces as first-class records (migration 0076): status `building/built/live/residual/failed`, watermark, builder, stats, plus the live read pin (`RETRIEVAL_DERIVED_VERSION`). Flag `PROJECTIONS_API_ENABLED`. |
-| `POST /v1/projections/:name/rebuild` | The public rebuild verb over the maintenance batch engine (`brain:admin`; v1 rebuilds `facts` via the session-window deriver). Body: `version` / `conversation` / `activate` / `force`. Flag `PROJECTIONS_API_ENABLED`. |
+| `POST /v1/projections/:name/rebuild` | The public rebuild verb over the maintenance batch engine (`brain:admin`; v1 rebuilds `facts` via the session-window deriver). Body: `version` / `conversation` / `keys` (retry selector: exactly these conversation ids) / `activate` / `force`. The response carries `outcome` (see [batch outcome](#batch-outcome)). Flag `PROJECTIONS_API_ENABLED`. |
 
 ## Evidence raw-read gateway
 
@@ -176,6 +176,18 @@ user-enumeration oracle either.
 |---|---|
 | `POST /v1/dreams/run` | Off-hours self-improvement: dedup / resolve / summarize (admin scope). |
 
+### Batch outcome
+
+Batch operations (scene compose and its scheduled pass, the derive / projection rebuild, aggregates and arcs, the evidence processing sweep, the embedding reindex) return one shared terminal status alongside their counters:
+
+```json
+{ "status": "complete | degraded | failed", "total": 12, "succeeded": 11,
+  "failed": [{ "key": "<unit id>", "error": "…" }],
+  "degradedBy": [{ "key": "post-pass:<name>", "error": "…" }] }
+```
+
+`complete` — every unit landed and every post-pass ran clean; `degraded` — some units failed, or a post-pass over landed units failed (`degradedBy`); `failed` — units were attempted and none succeeded, or the operation could not run (key `*`). `failed[].key` is the unit's retry key (conversation id, `evidence_asset` id, table name, `knowledge_entity` id): pass those back as the entrypoint's `keys` to retry only the failed units. A job-backed batch (`job_run.result.outcome`) with a `failed` outcome fails the job row.
+
 ## Domain Packs (admin)
 
 Manifest format + install semantics: [domain-packs.md](domain-packs.md).
@@ -232,14 +244,14 @@ in [source-reputation.md](source-reputation.md).
 | `GET /v1/admin/scheduler` | Registered cron entries with last/next fire timestamps. |
 | `POST /v1/admin/maintenance/dreams/run` | Fire-and-forget kick of dreams; returns `{accepted, jobType, companyId}` (no runId — poll `GET /v1/admin/maintenance/dreams/runs/:runId/emits` for a specific run). |
 | `POST /v1/admin/maintenance/calibration-refit` | Async kick of calibration + source-trust refit. |
-| `POST /v1/admin/maintenance/reindex` | Async re-embed `knowledge_fact`, optionally per tenant. |
+| `POST /v1/admin/maintenance/reindex` | Async re-embed `knowledge_fact`, optionally per tenant. Body `keys` (retry selector) sweeps exactly the named tables (`knowledge_fact`, `knowledge_entity`, `knowledge_predicate`, `episode`, `episode_segment`, `memory_episode`, `strategy_memory`). The job_run `result` carries `outcome`; a `failed` outcome fails the job row. |
 | `POST /v1/admin/maintenance/compaction` | Fire-and-forget kick of the compaction (+promotion) pass. |
 | `GET /v1/admin/maintenance/hnsw/roster` | Which tenants have a ready HNSW index, read from `tenant_registry` alone — no tenant database is opened and no DDL is emitted. Each row carries `state` (`ready` \| `building` \| `partial` \| `absent` \| `mismatch` \| `unknown`), `detail` (per-index `name=state`), `embeddingSpace` and `observedAt`. A row with no `observedAt` has never been looked at, and reads as `unknown` rather than as ready. Scoped like every cross-tenant admin read: a plain `brain:admin` sees its own tenant, a platform operator (`brain:platform_admin` + gate) sees the roster. |
 | `POST /v1/admin/maintenance/hnsw/reconcile` | Run the provisioning sweep NOW instead of waiting for 05:10 UTC: `{dryRun?, tenant?}`. `dryRun: true` probes and records without emitting any DDL — the right first call on a deployment that has never provisioned. Honours `HNSW_PROVISION_MAX_BUILDS_PER_RUN` and the wall-clock budget; tenants held back by the cap are still probed and recorded. Inert while `HNSW_PROVISION_ENABLED` is off. Cross-tenant, so the platform scope gates the roster-wide form. |
 | `POST /v1/admin/maintenance/hnsw` | Per-tenant HNSW vector-index lifecycle: `{action: 'create' \| 'drop' \| 'status' \| 'ensure', tenant?, waitMs?}`. Every build is `CONCURRENTLY`; `waitMs` (create only, default `60000`, `0`–`600000`) is how long this call holds for the builds before answering with the state it reached. **`ensure`** is the idempotent action automation uses — it defines only the indexes that are ABSENT, always `CONCURRENTLY`, never `REMOVE`s and never waits, so it is safe on every pass; `create` is the destructive repair. All actions report `mismatched`: indexes that exist at a `DIMENSION` other than the embedder's, which are `ready` to the engine and reject every write — a tenant in that state can never read as `ready` here, and `ensure` will not attempt the repair (reindex embeddings, then `create`). `create` RECREATES unconditionally at the primary embedder's width (`REMOVE` then `DEFINE`), so a stale-width index cannot survive; run the embedding reindex BEFORE `create` so the rewrites are not rejected by an existing index. Every response carries `builds[]` (per index `state`: `ready` \| `building` \| `absent` \| `unknown`, plus the engine's `initial`/`pending` counts) and a single `ready` boolean — **do not flip `SEARCH_HNSW_ENABLED` for a tenant while `ready` is false**: an index that exists but is still building answers KNN with the same unranked rows a missing index does. `status` re-reads that state and emits no DDL. The builds run `CONCURRENTLY` and the call waits up to `waitMs` before answering with the progress it reached; the build continues server-side. |
 | `POST /v1/admin/maintenance/segments` | L0 segment composer (embedding-only, no LLM); idempotent per conversation. Enable the read lane afterwards with `SEARCH_SEGMENT_LANE_ENABLED`. |
 | `POST /v1/admin/maintenance/segments/backfill-user-ids` | 0117 backfill: stamp `userIds` on legacy segment rows so `PRIVACY_SEGMENT_USER_FENCE` (fail-closed on `userIds IS NONE`) can be enabled without hiding pre-0117 windows. Run once per tenant BEFORE the first fence enable (order: migrate → backfill → flip). Scenes are not covered — re-run `…/maintenance/scenes` instead. |
-| `POST /v1/admin/maintenance/scenes` | Scene composer over the shadow `memory_episode` substrate (0106) — LLM-free, idempotent per (conversation × segmenterVersion), atomic swap. 404 unless `SCENES_SEGMENTATION_ENABLED`. Optional body: `{tenant?, conversationId?}`. |
+| `POST /v1/admin/maintenance/scenes` | Scene composer over the shadow `memory_episode` substrate (0106) — LLM-free, idempotent per (conversation × segmenterVersion), atomic swap. 404 unless `SCENES_SEGMENTATION_ENABLED`. Optional body: `{tenant?, conversationId?, keys?}` — `keys` is the retry selector (exactly these conversation ids, no enumeration). The response carries `outcome`; a post-swap pass that failed degrades it under `post-pass:<name>`. |
 | `POST /v1/admin/maintenance/scenes/enrich` | Standalone re-enrichment: ONE structured LLM call per scene of the current segmenter version; idempotent per enrichmentVersion composite (unchanged config = zero paid calls). 404 unless the master flag AND `SCENES_LLM_ENRICHMENT` are on. |
 | `POST /v1/admin/maintenance/scenes/backlink` | Standalone fact backlink: reconciles `source.memoryEpisodeIds` to exactly the scenes of the effective version whose membership intersects the fact's episodes — stale pointers to purged or rebuilt scenes are removed (`stalePointersRemoved` in the result). 404 unless the master flag AND `SCENES_FACT_BACKLINK` are on. |
 | `POST /v1/admin/maintenance/scenes/beliefs` | Belief promotion (Belief-A, 0120): folds ENRICHED scenes into `semantic_belief` upserts keyed by free-text (subject, field); replay-idempotent. 404 unless the master flag AND `SCENES_BELIEF_PROMOTION` are on. Read the result via the [beliefs API](#read). |

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -153,6 +153,75 @@
         ],
         "type": "object"
       },
+      "BatchOutcome": {
+        "additionalProperties": false,
+        "properties": {
+          "degradedBy": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "error": {
+                  "type": "string"
+                },
+                "key": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "key",
+                "error"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "failed": {
+            "items": {
+              "additionalProperties": false,
+              "properties": {
+                "error": {
+                  "type": "string"
+                },
+                "key": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "key",
+                "error"
+              ],
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "status": {
+            "enum": [
+              "complete",
+              "degraded",
+              "failed"
+            ],
+            "type": "string"
+          },
+          "succeeded": {
+            "maximum": 9007199254740991,
+            "minimum": -9007199254740991,
+            "type": "integer"
+          },
+          "total": {
+            "maximum": 9007199254740991,
+            "minimum": -9007199254740991,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "status",
+          "total",
+          "succeeded",
+          "failed",
+          "degradedBy"
+        ],
+        "type": "object"
+      },
       "BeliefReadResponse": {
         "additionalProperties": false,
         "properties": {
@@ -3891,6 +3960,12 @@
           "force": {
             "type": "boolean"
           },
+          "keys": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
           "version": {
             "type": "string"
           }
@@ -3912,6 +3987,9 @@
             "maximum": 9007199254740991,
             "minimum": -9007199254740991,
             "type": "integer"
+          },
+          "outcome": {
+            "$ref": "#/components/schemas/BatchOutcome"
           },
           "previousVersion": {
             "type": [
@@ -3969,7 +4047,8 @@
           "unresolvedSubjects",
           "skipped",
           "status",
-          "failed"
+          "failed",
+          "outcome"
         ],
         "type": "object"
       },

--- a/scripts/build-openapi.ts
+++ b/scripts/build-openapi.ts
@@ -164,6 +164,7 @@ import {
   RebuildProjectionRequestSchema,
   RebuildProjectionResponseSchema,
 } from '../src/contracts/episodes/driver.schema';
+import { BatchOutcomeSchema } from '../src/contracts/common/batch-outcome.schema';
 import {
   FactProvenanceEpisodeSchema,
   FactProvenanceResponseSchema,
@@ -337,6 +338,8 @@ const ZOD_COMPONENTS: Record<string, z.ZodType> = {
   ProjectionsListResponse: ProjectionsListResponseSchema,
   RebuildProjectionRequest: RebuildProjectionRequestSchema,
   RebuildProjectionResponse: RebuildProjectionResponseSchema,
+  // --- shared batch terminal status (src/contracts/common/batch-outcome.schema.ts)
+  BatchOutcome: BatchOutcomeSchema,
   CreateEpisodeSubscriptionRequest: CreateEpisodeSubscriptionRequestSchema,
   CreateEpisodeSubscriptionResponse: CreateEpisodeSubscriptionResponseSchema,
   EpisodeSubscriptionRow: EpisodeSubscriptionRowSchema,

--- a/src/admin/admin-aggregates.controller.ts
+++ b/src/admin/admin-aggregates.controller.ts
@@ -5,6 +5,19 @@ import { ApiKeyService } from '../auth/api-key.service';
 import { resolvePlatformTenant } from '../auth/tenant-scope';
 import { AggregateComposerService, AggregateRunResult } from './aggregate-composer.service';
 import { ArcComposerService, ArcRunResult } from './arc-composer.service';
+import { parseBatchKeys } from '../common/batch-outcome';
+
+/** Retry-selector belt: the composers' own entity cap, as record ids. */
+const KEYS_MAX = 50;
+const ENTITY_ID_MAX_CHARS = 256;
+
+interface ComposerBody {
+  tenant?: string;
+  entities?: number;
+  version?: string;
+  /** Retry selector: `outcome.failed[].key` (knowledge_entity ids) of a previous run. */
+  keys?: string[];
+}
 
 /**
  * Explicit triggers for the write-time insight composers (each costs one
@@ -31,28 +44,26 @@ export class AdminAggregatesController {
   @RequireScopes('brain:admin')
   async run(
     @Req() req: AuthenticatedRequest,
-    @Body()
-    body: { tenant?: string; entities?: number; version?: string } = {},
+    @Body() body: ComposerBody = {},
   ): Promise<AggregateRunResult> {
-    const { tenant, version } = this.validate(req, body);
-    return this.composer.run(tenant, { entities: body.entities, version });
+    const { tenant, version, entityIds } = this.validate(req, body);
+    return this.composer.run(tenant, { entities: body.entities, version, entityIds });
   }
 
   @Post('maintenance/arcs')
   @RequireScopes('brain:admin')
   async runArcs(
     @Req() req: AuthenticatedRequest,
-    @Body()
-    body: { tenant?: string; entities?: number; version?: string } = {},
+    @Body() body: ComposerBody = {},
   ): Promise<ArcRunResult> {
-    const { tenant, version } = this.validate(req, body);
-    return this.arcs.run(tenant, { entities: body.entities, version });
+    const { tenant, version, entityIds } = this.validate(req, body);
+    return this.arcs.run(tenant, { entities: body.entities, version, entityIds });
   }
 
   private validate(
     req: AuthenticatedRequest,
-    body: { tenant?: string; version?: string },
-  ): { tenant: string; version?: string | undefined } {
+    body: ComposerBody,
+  ): { tenant: string; version?: string | undefined; entityIds?: string[] | undefined } {
     const tenant = resolvePlatformTenant(req, body.tenant, {
       knownTenants: () => this.apiKeys.knownCompanyIds(),
     });
@@ -60,6 +71,11 @@ export class AdminAggregatesController {
     if (version && !/^[a-z0-9-]{2,32}$/.test(version)) {
       throw new BadRequestException('version must be a short kebab-case tag (e.g. wd-v2)');
     }
-    return { tenant, version };
+    const entityIds = parseBatchKeys(body.keys, {
+      maxKeys: KEYS_MAX,
+      maxLength: ENTITY_ID_MAX_CHARS,
+      accept: (key) => key.startsWith('knowledge_entity:'),
+    });
+    return { tenant, version, entityIds };
   }
 }

--- a/src/admin/admin-derive.controller.ts
+++ b/src/admin/admin-derive.controller.ts
@@ -17,6 +17,33 @@ import {
   DeriveRunResult,
   WINDOW_DERIVER_VERSION,
 } from './window-deriver.service';
+import { parseBatchKeys } from '../common/batch-outcome';
+
+/** Retry-selector belt: conversation ids. */
+const KEYS_MAX = 1000;
+const CONVERSATION_ID_MAX_CHARS = 128;
+
+/**
+ * The derive body's conversation selector: `conversation` (one id) or
+ * `keys` (the `outcome.failed[].key` of a previous run), never both.
+ */
+export function parseDeriveTargets(body: { conversation?: string; keys?: string[] }): {
+  conversationId: string | undefined;
+  conversationIds: string[] | undefined;
+} {
+  const conversationId = body.conversation?.trim() || undefined;
+  if (conversationId && conversationId.length > CONVERSATION_ID_MAX_CHARS) {
+    throw new BadRequestException('conversation id too long');
+  }
+  const conversationIds = parseBatchKeys(body.keys, {
+    maxKeys: KEYS_MAX,
+    maxLength: CONVERSATION_ID_MAX_CHARS,
+  });
+  if (conversationId !== undefined && conversationIds !== undefined) {
+    throw new BadRequestException('pass either conversation or keys, not both');
+  }
+  return { conversationId, conversationIds };
+}
 
 /**
  * A derive where every attempted conversation failed produced nothing:
@@ -63,6 +90,8 @@ export class AdminDeriveController {
       tenant?: string;
       version?: string;
       conversation?: string;
+      /** Retry selector: re-derive exactly these conversation ids. */
+      keys?: string[];
       /** Flip the live read pin to this version after a successful run. */
       activate?: boolean;
       /** Allow rewriting the currently pinned world in place (eval only). */
@@ -76,15 +105,13 @@ export class AdminDeriveController {
     if (!/^[a-z0-9-]{2,32}$/.test(version)) {
       throw new BadRequestException('version must be a short kebab-case tag (e.g. wd-v2)');
     }
-    const conversationId = body.conversation?.trim() || undefined;
-    if (conversationId && conversationId.length > 128) {
-      throw new BadRequestException('conversation id too long');
-    }
+    const { conversationId, conversationIds } = parseDeriveTargets(body);
     try {
       return throwIfDeriveFailed(
         await this.deriver.run(tenant, {
           version,
           conversationId,
+          conversationIds,
           activate: body.activate === true,
           force: body.force === true,
         }),

--- a/src/admin/admin-jobs.controller.ts
+++ b/src/admin/admin-jobs.controller.ts
@@ -34,6 +34,8 @@ import {
 import { ConfigService } from '@nestjs/config';
 import { HttpCode } from '@nestjs/common';
 import { ReindexEmbeddingsService } from '../ai/embedder/reindex-embeddings.service';
+import { REINDEX_SWEPT_COLUMNS } from '../ai/embedder/reindex-engine.service';
+import { describeBatchOutcome, parseBatchKeys } from '../common/batch-outcome';
 import { ScenarioRunnerService, ScenarioRunOutcome } from './scenario-runner.service';
 import type { LeasesResponse } from '../contracts/admin/leases.schema';
 import type { SchedulerResponse } from '../contracts/admin/scheduler.schema';
@@ -331,7 +333,10 @@ export class AdminJobsController {
    * synchronous /v1/admin/reindex/embeddings handler so an operator
    * triggering a full re-embed doesn't have to keep their browser tab
    * open for the duration. Result lands in job_run with the same shape
-   * the sync endpoint returned (tenantsScanned, factsScanned, factsUpdated).
+   * the sync endpoint returned (tenantsScanned, factsScanned, factsUpdated)
+   * plus `outcome`; a `failed` outcome fails the job row. `keys` is the
+   * retry selector: sweep exactly these tables (the `failed[].key` of a
+   * previous run) instead of the default knowledge_fact-only pass.
    */
   @Post('maintenance/reindex')
   @HttpCode(202)
@@ -339,8 +344,14 @@ export class AdminJobsController {
   async triggerReindex(
     @Req() req: AuthenticatedRequest,
     @Body()
-    body: { tenant?: string; dryRun?: boolean; maxFacts?: number } = {},
+    body: { tenant?: string; dryRun?: boolean; maxFacts?: number; keys?: string[] } = {},
   ): Promise<AcceptedReindexResponse> {
+    const sweptTables = new Set(REINDEX_SWEPT_COLUMNS.map((c) => c.table));
+    const tables = parseBatchKeys(body.keys, {
+      maxKeys: sweptTables.size,
+      maxLength: 64,
+      accept: (key) => sweptTables.has(key),
+    });
     // Tenant isolation: a specific tenant resolves through the platform
     // gate (own tenant always ok; a foreign one is a 403 without the
     // platform scope + gate). Omitted → a platform operator re-embeds
@@ -373,6 +384,7 @@ export class AdminJobsController {
         tenantFilter: reindexTenant ?? null,
         dryRun: body.dryRun === true,
         maxFacts: body.maxFacts ?? null,
+        tables: tables ?? null,
       },
     });
     void (async () => {
@@ -381,10 +393,17 @@ export class AdminJobsController {
           ...(reindexTenant !== undefined ? { tenant: reindexTenant } : {}),
           dryRun: body.dryRun === true,
           ...(body.maxFacts !== undefined ? { maxFacts: body.maxFacts } : {}),
+          ...(tables !== undefined ? { tables } : {}),
         });
+        const persisted = JSON.parse(JSON.stringify(result)) as Record<string, unknown>;
+        // The terminal status follows the outcome: a sweep where nothing
+        // succeeded is a failed job, not a succeeded one with sad numbers.
         await this.jobs.finish(row, {
-          status: 'succeeded',
-          result: JSON.parse(JSON.stringify(result)) as Record<string, unknown>,
+          status: result.outcome.status === 'failed' ? 'failed' : 'succeeded',
+          result: persisted,
+          ...(result.outcome.status === 'failed'
+            ? { error: { message: describeBatchOutcome(result.outcome), name: 'BatchFailed' } }
+            : {}),
         });
       } catch (e) {
         await this.jobs.finish(row, {

--- a/src/admin/admin-scenes.controller.ts
+++ b/src/admin/admin-scenes.controller.ts
@@ -30,6 +30,11 @@ import {
   SceneEvidenceLinkResult,
 } from './scene-evidence-linker.service';
 import { SceneGistEmbeddingService, SceneGistEmbedResult } from './scene-gist-embedding.service';
+import { parseBatchKeys } from '../common/batch-outcome';
+
+/** Retry-selector belt: conversation ids, bounded like the nightly page. */
+const KEYS_MAX = 1000;
+const CONVERSATION_ID_MAX_CHARS = 128;
 
 /** Purge param belt: DB stamps are short version slugs, not free text. */
 // 128 (was 64): pack scene worlds (0110) are versioned
@@ -103,14 +108,27 @@ export class AdminScenesController {
     private readonly apiKeys: ApiKeyService,
   ) {}
 
+  /**
+   * `keys` — retry selector: compose exactly these conversation ids (the
+   * `outcome.failed[].key` of a previous run), skipping the full
+   * enumeration. Mutually exclusive with `conversationId`.
+   */
   @Post('maintenance/scenes')
   @RequireScopes('brain:admin')
   async run(
     @Req() req: AuthenticatedRequest,
-    @Body() body: { tenant?: string; conversationId?: string } = {},
+    @Body() body: { tenant?: string; conversationId?: string; keys?: string[] } = {},
   ): Promise<SceneRunResult> {
     if (!sceneSegmentationEnabled()) throw new NotFoundException();
+    const keys = parseBatchKeys(body.keys, {
+      maxKeys: KEYS_MAX,
+      maxLength: CONVERSATION_ID_MAX_CHARS,
+    });
+    if (keys !== undefined && body.conversationId !== undefined) {
+      throw new BadRequestException('pass either conversationId or keys, not both');
+    }
     const tenant = this.resolveTenant(req, body.tenant);
+    if (keys !== undefined) return this.composer.run(tenant, { conversationIds: keys });
     return this.composer.run(
       tenant,
       body.conversationId !== undefined ? { conversationId: body.conversationId } : {},

--- a/src/admin/aggregate-composer.service.ts
+++ b/src/admin/aggregate-composer.service.ts
@@ -1,3 +1,4 @@
+import type { BatchOutcome } from '../common/batch-outcome';
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import OpenAI from 'openai';
@@ -47,6 +48,8 @@ export interface AggregateRunResult {
   entities: number;
   aggregatesWritten: number;
   skipped: Array<{ entityId: string; reason: string }>;
+  /** Units are entities (`failed[].key` is an entity id, retryable via `entityIds`). */
+  outcome: BatchOutcome;
 }
 
 interface AggregateProposal {
@@ -130,7 +133,11 @@ export class AggregateComposerService {
    */
   async run(
     companyId: string,
-    opts: { entities?: number | undefined; version?: string | undefined } = {},
+    opts: {
+      entities?: number | undefined;
+      version?: string | undefined;
+      entityIds?: string[] | undefined;
+    } = {},
   ): Promise<AggregateRunResult> {
     const r = await runInsightComposer(
       { surreal: this.surreal, embedding: this.embedding, logger: this.logger },
@@ -141,6 +148,7 @@ export class AggregateComposerService {
       entities: r.entities,
       aggregatesWritten: r.written,
       skipped: r.skipped,
+      outcome: r.outcome,
     };
   }
 

--- a/src/admin/arc-composer.service.ts
+++ b/src/admin/arc-composer.service.ts
@@ -1,3 +1,4 @@
+import type { BatchOutcome } from '../common/batch-outcome';
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import OpenAI from 'openai';
@@ -61,6 +62,8 @@ export interface ArcRunResult {
   entities: number;
   arcsWritten: number;
   skipped: Array<{ entityId: string; reason: string }>;
+  /** Units are entities (`failed[].key` is an entity id, retryable via `entityIds`). */
+  outcome: BatchOutcome;
 }
 
 interface ArcProposal {
@@ -169,14 +172,18 @@ export class ArcComposerService {
    */
   async run(
     companyId: string,
-    opts: { entities?: number | undefined; version?: string | undefined } = {},
+    opts: {
+      entities?: number | undefined;
+      version?: string | undefined;
+      entityIds?: string[] | undefined;
+    } = {},
   ): Promise<ArcRunResult> {
     const r = await runInsightComposer(
       { surreal: this.surreal, embedding: this.embedding, logger: this.logger },
       this.spec,
       { companyId, ...opts },
     );
-    return { entities: r.entities, arcsWritten: r.written, skipped: r.skipped };
+    return { entities: r.entities, arcsWritten: r.written, skipped: r.skipped, outcome: r.outcome };
   }
 
   private async callComposer(name: string, factLines: string[]): Promise<ArcProposal[]> {

--- a/src/admin/insight-composer-kernel.ts
+++ b/src/admin/insight-composer-kernel.ts
@@ -4,6 +4,7 @@ import { SurrealService, runTransaction } from '../db/surreal.service';
 import { FactEmbeddingService } from '../ingest/fact-embedding.service';
 import { scopeForUser } from '../auth/scope-tags';
 import { privacyComposerUserScopeEnabled } from '../common/privacy-flags';
+import { emptyBatchOutcome, foldBatchOutcome, type BatchOutcome } from '../common/batch-outcome';
 
 /**
  * The shared skeleton of the write-time insight composers (aggregates,
@@ -99,6 +100,8 @@ export interface ComposerRunResult {
    * Always 0 with the flag off.
    */
   droppedCrossUser: number;
+  /** Units are entities (`failed[].key` is an entity id, retryable via `entityIds`). */
+  outcome: BatchOutcome;
 }
 
 interface KernelDeps {
@@ -124,21 +127,38 @@ export async function runInsightComposer<P>(
     companyId: string;
     entities?: number | undefined;
     version?: string | undefined;
+    /** Retry selector: compose exactly these entity ids, not the top-N. */
+    entityIds?: string[] | undefined;
   },
 ): Promise<ComposerRunResult> {
   const { companyId } = opts;
-  const entityCap = Math.min(Math.max(opts.entities ?? 12, 1), 50);
+  const entityCap = opts.entityIds
+    ? opts.entityIds.length
+    : Math.min(Math.max(opts.entities ?? 12, 1), 50);
   const version = opts.version?.trim() || undefined;
   const versionClause = version ? 'AND derivedVersion = $version' : 'AND derivedVersion IS NONE';
-  const result: ComposerRunResult = { entities: 0, written: 0, skipped: [], droppedCrossUser: 0 };
+  const entityClause = opts.entityIds ? 'AND entityId INSIDE $entityIds' : '';
+  const result: ComposerRunResult = {
+    entities: 0,
+    written: 0,
+    skipped: [],
+    droppedCrossUser: 0,
+    outcome: emptyBatchOutcome(),
+  };
   await deps.surreal.withCompany(companyId, async (db) => {
     const [tops] = await db.query<[Array<{ entityId: unknown; n: number }>]>(
       `SELECT entityId, count() AS n FROM knowledge_fact
         WHERE status = 'active'
           ${spec.sourceExclusionSql}
           ${versionClause}
+          ${entityClause}
         GROUP BY entityId ORDER BY n DESC LIMIT $k`,
-      { k: entityCap, version, ...spec.sourceExclusionParams },
+      {
+        k: entityCap,
+        version,
+        entityIds: opts.entityIds?.map((id) => new StringRecordId(id)),
+        ...spec.sourceExclusionParams,
+      },
     );
     for (const top of tops ?? []) {
       const entityId = String(top.entityId);
@@ -159,6 +179,11 @@ export async function runInsightComposer<P>(
         );
       }
     }
+  });
+  result.outcome = foldBatchOutcome({
+    total: result.entities + result.skipped.length,
+    succeeded: result.entities,
+    failed: result.skipped.map((s) => ({ key: s.entityId, error: s.reason })),
   });
   return result;
 }

--- a/src/admin/projections.controller.ts
+++ b/src/admin/projections.controller.ts
@@ -24,7 +24,7 @@ import {
   WINDOW_DERIVER_VERSION,
   type DeriveRunResult,
 } from './window-deriver.service';
-import { throwIfDeriveFailed } from './admin-derive.controller';
+import { parseDeriveTargets, throwIfDeriveFailed } from './admin-derive.controller';
 
 /**
  * Public projections API (raw-substrate driver v1, surface 3 —
@@ -83,6 +83,8 @@ export class ProjectionsController {
     body: {
       version?: string;
       conversation?: string;
+      /** Retry selector: re-derive exactly these conversation ids. */
+      keys?: string[];
       /** Flip the live read pin to this version after a successful run. */
       activate?: boolean;
       /** Allow rewriting the currently pinned world in place (eval only). */
@@ -99,15 +101,13 @@ export class ProjectionsController {
     if (!/^[a-z0-9-]{2,32}$/.test(version)) {
       throw new BadRequestException('version must be a short kebab-case tag (e.g. wd-v2)');
     }
-    const conversationId = body.conversation?.trim() || undefined;
-    if (conversationId && conversationId.length > 128) {
-      throw new BadRequestException('conversation id too long');
-    }
+    const { conversationId, conversationIds } = parseDeriveTargets(body);
     try {
       return throwIfDeriveFailed(
         await this.deriver.run(req.brainAuth.companyId, {
           version,
           conversationId,
+          conversationIds,
           activate: body.activate === true,
           force: body.force === true,
         }),

--- a/src/admin/scene-composer.service.ts
+++ b/src/admin/scene-composer.service.ts
@@ -33,6 +33,14 @@ import { SceneEnricherService } from './scene-enricher.service';
 import { SceneBacklinkService } from './scene-backlink.service';
 import { SceneEvidenceLinkerService } from './scene-evidence-linker.service';
 import { SceneGistEmbeddingService } from './scene-gist-embedding.service';
+import {
+  POST_PASS_KEY,
+  emptyBatchOutcome,
+  errorMessage,
+  foldBatchOutcome,
+  type BatchFailure,
+  type BatchOutcome,
+} from '../common/batch-outcome';
 
 /**
  * Scene composer (Brain v2 PR1): batch-derives the SHADOW memory_episode
@@ -89,6 +97,13 @@ export interface SceneRunResult {
    * to meter it without reaching past the composer into the encoder.
    */
   gistEmbedded?: number;
+  /**
+   * Terminal status of the run. Units are conversations (`failed[].key`
+   * is a conversation id, retryable via `conversationIds`); a post-swap
+   * pass that threw or reported failures lands in `degradedBy` under
+   * `post-pass:<name>` — the swap stands, the run is `degraded`.
+   */
+  outcome: BatchOutcome;
 }
 
 /**
@@ -137,7 +152,12 @@ export class SceneComposerService {
   ) {}
 
   async run(companyId: string, opts: SceneRunOptions = {}): Promise<SceneRunResult> {
-    const result: SceneRunResult = { conversations: 0, scenes: 0, skipped: [] };
+    const result: SceneRunResult = {
+      conversations: 0,
+      scenes: 0,
+      skipped: [],
+      outcome: emptyBatchOutcome(),
+    };
     // Defense in depth: the controller already 404s with the flag off; a
     // programmatic caller must not write shadow rows past a disabled flag.
     if (!sceneSegmentationEnabled()) return result;
@@ -219,8 +239,10 @@ export class SceneComposerService {
     });
     // PR2 post-swap passes, both flag-gated (default off) and both
     // degrade-never-fail: the swap has landed and its result must not be
-    // retracted by an optional pass. The enricher/backlinker re-check
-    // their own flags too — these outer guards just skip the no-op calls.
+    // retracted by an optional pass — but a pass that threw or reported
+    // failures DEGRADES the run's outcome (a warning alone hid it). The
+    // enricher/backlinker re-check their own flags too — these outer
+    // guards just skip the no-op calls.
     //
     // The three passes take a SINGLE optional conversationId, so the
     // scheduled multi-conversation working set narrows to nothing here and
@@ -231,6 +253,7 @@ export class SceneComposerService {
     // scenes this run actually changed, not by the size of the world.
     const passOpts =
       opts.conversationId !== undefined ? { conversationId: opts.conversationId } : {};
+    const degradedBy: BatchFailure[] = [];
     // PR3 encoder pass: the producer of the 0106 `gistEmbedding` column
     // (SceneGistEmbeddingService). It runs FIRST of the post-swap chain
     // because it encodes the swap's own output — the canonical `gist` text
@@ -241,44 +264,67 @@ export class SceneComposerService {
     // touches `gist`, so the vector can never go stale relative to the
     // text it encodes.
     if (sceneGistEmbeddingEnabled()) {
-      try {
+      await this.postPass('gist-embedding', degradedBy, async () => {
         const encoded = await this.gistEncoder.run(companyId, passOpts);
         result.gistEmbedded = encoded.embedded;
         this.logger.log(
           `scene gist encoder pass: ${encoded.embedded}/${encoded.scenes} embedded, ` +
             `${encoded.skipped} unusable, ${encoded.failed} failed`,
         );
-      } catch (e) {
-        this.logger.warn(`scene gist encoder pass failed: ${(e as Error).message}`);
-      }
+        return { failed: encoded.failed, scenes: encoded.scenes };
+      });
     }
     if (sceneLlmEnrichmentEnabled()) {
-      try {
+      await this.postPass('enrich', degradedBy, async () => {
         const enrich = await this.enricher.enrich(companyId, passOpts);
         result.enriched = enrich.enriched;
         this.logger.log(
           `scene enrichment pass: ${enrich.enriched}/${enrich.scenes} enriched, ` +
             `${enrich.failed} degraded, ${enrich.skipped} already current`,
         );
-      } catch (e) {
-        this.logger.warn(`scene enrichment pass failed: ${(e as Error).message}`);
-      }
+        return { failed: enrich.failed, scenes: enrich.scenes };
+      });
     }
     if (sceneFactBacklinkEnabled()) {
-      try {
-        await this.backlinker.run(companyId, passOpts);
-      } catch (e) {
-        this.logger.warn(`scene backlink pass failed: ${(e as Error).message}`);
-      }
+      await this.postPass('backlink', degradedBy, () => this.backlinker.run(companyId, passOpts));
     }
     if (sceneEvidenceLinksEnabled()) {
-      try {
-        await this.evidenceLinker.run(companyId, passOpts);
-      } catch (e) {
-        this.logger.warn(`scene evidence links pass failed: ${(e as Error).message}`);
-      }
+      await this.postPass('evidence-links', degradedBy, () =>
+        this.evidenceLinker.run(companyId, passOpts),
+      );
     }
+    result.outcome = foldBatchOutcome({
+      total: result.conversations + result.skipped.length,
+      succeeded: result.conversations,
+      failed: result.skipped.map((s) => ({ key: s.conversationId, error: s.reason })),
+      degradedBy,
+    });
     return result;
+  }
+
+  /**
+   * Run one post-swap pass and record its failure, if any, under
+   * `post-pass:<name>`: a throw, or a pass that reports `failed > 0`
+   * scenes. Never throws — the swap stands.
+   */
+  private async postPass(
+    name: string,
+    degradedBy: BatchFailure[],
+    fn: () => Promise<{ failed: number; scenes: number } | unknown>,
+  ): Promise<void> {
+    const key = `${POST_PASS_KEY}${name}`;
+    try {
+      const counts = (await fn()) as { failed?: unknown; scenes?: unknown } | null | undefined;
+      if (typeof counts?.failed === 'number' && counts.failed > 0) {
+        degradedBy.push({
+          key,
+          error: `${counts.failed} of ${String(counts.scenes)} scene(s) failed`,
+        });
+      }
+    } catch (e) {
+      this.logger.warn(`scene ${name} pass failed: ${errorMessage(e)}`);
+      degradedBy.push({ key, error: errorMessage(e) });
+    }
   }
 
   /**

--- a/src/admin/scene-maintenance.service.ts
+++ b/src/admin/scene-maintenance.service.ts
@@ -19,6 +19,15 @@ import {
 } from '../common/scene-flags';
 import { SceneComposerService } from './scene-composer.service';
 import { BeliefPromotionService } from './belief-promotion.service';
+import {
+  POST_PASS_KEY,
+  emptyBatchOutcome,
+  errorMessage,
+  failedBatchOutcome,
+  foldBatchOutcome,
+  foldNestedOutcomes,
+  type BatchOutcome,
+} from '../common/batch-outcome';
 
 /** One tenant's slice of a nightly run. */
 export interface SceneMaintenanceTenantResult {
@@ -35,6 +44,11 @@ export interface SceneMaintenanceTenantResult {
   cleared: number;
   durationSeconds: number;
   error?: string;
+  /**
+   * The composer's outcome plus belief promotion as a post-pass; a tenant
+   * whose pass threw carries `failedBatchOutcome` (key `*`).
+   */
+  outcome: BatchOutcome;
 }
 
 /** Whole-roster summary — the cron's return value and the log line. */
@@ -44,6 +58,8 @@ export interface SceneMaintenanceRunResult {
   budgetExhausted: boolean;
   /** Tenants never started because the budget ran out. */
   skippedForBudget: number;
+  /** Roster fold: units are tenants (`failed[].key` is a companyId). */
+  outcome: BatchOutcome;
 }
 
 /** Lock key for both the local and the distributed guard. */
@@ -66,6 +82,7 @@ const EMPTY_RUN: SceneMaintenanceRunResult = {
   tenants: [],
   budgetExhausted: false,
   skippedForBudget: 0,
+  outcome: emptyBatchOutcome(),
 };
 
 /**
@@ -185,6 +202,7 @@ export class SceneMaintenanceService {
       tenants: [],
       budgetExhausted: false,
       skippedForBudget: 0,
+      outcome: emptyBatchOutcome(),
     };
     for (const companyId of roster) {
       if (Date.now() >= deadline) {
@@ -217,9 +235,13 @@ export class SceneMaintenanceService {
           cleared: 0,
           durationSeconds: (Date.now() - tenantStart) / 1000,
           error: message,
+          outcome: failedBatchOutcome(message),
         });
       }
     }
+    result.outcome = foldNestedOutcomes(
+      result.tenants.map((t) => ({ key: t.companyId, outcome: t.outcome })),
+    );
     const scenes = result.tenants.reduce((n, t) => n + t.scenes, 0);
     this.logger.log(
       `scene maintenance: ${result.tenants.length}/${roster.length} tenant(s), ` +
@@ -261,6 +283,7 @@ export class SceneMaintenanceService {
         beliefs: 0,
         cleared: 0,
         durationSeconds: (Date.now() - startedAt) / 1000,
+        outcome: emptyBatchOutcome(),
       };
     }
 
@@ -277,16 +300,25 @@ export class SceneMaintenanceService {
     // reads semantic_belief), so the promotion leg runs every pass — but it
     // degrades, never fails: the scene swap has already landed and must not
     // be retracted by a failing optional pass. Same doctrine as the
-    // composer's own post-swap chain.
+    // composer's own post-swap chain — and, like there, the failure lands
+    // in the outcome's `degradedBy` rather than only in a log line.
     let beliefs = 0;
+    const degradedBy = [...composed.outcome.degradedBy];
     if (sceneBeliefPromotionEnabled()) {
       try {
         const promoted = await this.beliefs.run(companyId, {});
         beliefs = promoted.beliefsCreated + promoted.beliefsRevised + promoted.beliefsCorroborated;
       } catch (e) {
-        this.logger.warn(`belief promotion failed for ${companyId}: ${(e as Error).message}`);
+        this.logger.warn(`belief promotion failed for ${companyId}: ${errorMessage(e)}`);
+        degradedBy.push({ key: `${POST_PASS_KEY}belief-promotion`, error: errorMessage(e) });
       }
     }
+    const outcome = foldBatchOutcome({
+      total: composed.outcome.total,
+      succeeded: composed.outcome.succeeded,
+      failed: composed.outcome.failed,
+      degradedBy,
+    });
 
     const cleared = await this.clearConsumed({
       companyId,
@@ -318,6 +350,7 @@ export class SceneMaintenanceService {
       beliefs,
       cleared,
       durationSeconds,
+      outcome,
     };
   }
 

--- a/src/admin/vector-corpus.service.ts
+++ b/src/admin/vector-corpus.service.ts
@@ -8,6 +8,7 @@ import { EmbedderService } from '../ai/embedder.service';
 import { VECTOR_COLUMNS } from '../ai/embedder/embedding-space';
 import { ReindexEmbeddingsService } from '../ai/embedder/reindex-embeddings.service';
 import { REINDEX_SWEPT_COLUMNS } from '../ai/embedder/reindex-engine.service';
+import { describeBatchOutcome } from '../common/batch-outcome';
 import { JobRunService } from '../jobs/job-run.service';
 import { MetricsService } from '../metrics/metrics.service';
 import { DistributedLeaseGuard } from '../common/distributed-lease.guard';
@@ -237,16 +238,28 @@ export class VectorCorpusService implements OnModuleInit {
     });
     try {
       const sweep = await this.reindex.run({ tenant: companyId, allTables: true });
+      const swept = {
+        factsScanned: sweep.factsScanned,
+        factsUpdated: sweep.factsUpdated,
+        tables: sweep.tables ?? [],
+        outcome: sweep.outcome,
+        nonConformingBefore: before.nonConforming,
+      };
+      // A sweep that rewrote nothing is a failed repair, whatever its
+      // counters say; the outcome (failed table keys) is persisted with it.
+      if (sweep.outcome.status === 'failed') {
+        return this.failRepair({
+          run,
+          companyId,
+          before,
+          error: { message: describeBatchOutcome(sweep.outcome), name: 'BatchFailed' },
+          result: swept,
+        });
+      }
       const after = await this.inventory(companyId);
       await this.jobs?.finish(run!, {
         status: 'succeeded',
-        result: {
-          factsScanned: sweep.factsScanned,
-          factsUpdated: sweep.factsUpdated,
-          tables: sweep.tables ?? [],
-          nonConformingBefore: before.nonConforming,
-          nonConformingAfter: after.nonConforming,
-        },
+        result: { ...swept, nonConformingAfter: after.nonConforming },
       });
       this.metrics?.countVectorCorpusRepair(after.repairable === 0 ? 'repaired' : 'partial');
       this.logger.log(
@@ -256,15 +269,32 @@ export class VectorCorpusService implements OnModuleInit {
       );
       return { companyId, before, after, outcome: 'repaired' };
     } catch (e) {
-      const message = (e as Error).message;
-      await this.jobs?.finish(run!, {
-        status: 'failed',
-        error: { message, name: (e as Error).name },
+      return this.failRepair({
+        run,
+        companyId,
+        before,
+        error: { message: (e as Error).message, name: (e as Error).name },
       });
-      this.metrics?.countVectorCorpusRepair('failed');
-      this.logger.error(`vector corpus repair for ${companyId} failed: ${message}`);
-      return { companyId, before, after: null, outcome: 'failed', error: message };
     }
+  }
+
+  /** Terminal-fail the repair's job row and report it. */
+  private async failRepair(args: {
+    run: Awaited<ReturnType<JobRunService['start']>> | undefined;
+    companyId: string;
+    before: VectorCorpusInventory;
+    error: { message: string; name?: string };
+    result?: Record<string, unknown>;
+  }): Promise<VectorCorpusRepairResult> {
+    const { run, companyId, before, error } = args;
+    await this.jobs?.finish(run!, {
+      status: 'failed',
+      error,
+      ...(args.result !== undefined ? { result: args.result } : {}),
+    });
+    this.metrics?.countVectorCorpusRepair('failed');
+    this.logger.error(`vector corpus repair for ${companyId} failed: ${error.message}`);
+    return { companyId, before, after: null, outcome: 'failed', error: error.message };
   }
 
   /** Poll the embedder's readiness and re-queue the tenant the moment it is warm. */

--- a/src/admin/window-deriver.service.ts
+++ b/src/admin/window-deriver.service.ts
@@ -67,10 +67,26 @@ import {
 } from './derive-staging';
 import { buildDerivedRows, collectRollupPool } from './derive-row-builder';
 import { LeaderLeaseService } from '../jobs/leader-lease.service';
+import {
+  POST_PASS_KEY,
+  emptyBatchOutcome,
+  errorMessage,
+  foldBatchOutcome,
+  type BatchOutcome,
+} from '../common/batch-outcome';
 
 export type DeriveRunStatus = 'ok' | 'degraded' | 'failed';
 
 export interface DeriveRunResult {
+  /**
+   * Terminal status. Units are conversations (`failed[].key` is a
+   * conversation id, retryable via `conversationIds`); a per-conversation
+   * post-pass (digest fold, aspect rollups, compose) that failed lands in
+   * `degradedBy` under `post-pass:<name>`. `status` below stays the
+   * UNIT-level verdict that governs promotion — a failed post-pass
+   * degrades the outcome but never withholds the atomic facts.
+   */
+  outcome: BatchOutcome;
   conversations: number;
   sessions: number;
   propositions: number;
@@ -149,6 +165,8 @@ export class WindowDeriverService {
     opts: {
       version?: string;
       conversationId?: string | undefined;
+      /** Retry selector: derive exactly these conversations. */
+      conversationIds?: string[] | undefined;
       activate?: boolean;
       force?: boolean;
     } = {},
@@ -205,13 +223,18 @@ export class WindowDeriverService {
     companyId: string;
     version: string;
     ns: DeriveNamespace;
-    opts: { conversationId?: string | undefined; activate?: boolean };
+    opts: {
+      conversationId?: string | undefined;
+      conversationIds?: string[] | undefined;
+      activate?: boolean;
+    };
     activePin: string | undefined;
     /** Promotion fence (audit 2026-08-21): checked before the flip. */
     lease: DeriveLease;
   }): Promise<DeriveRunResult> {
     const { companyId, version, ns, opts, activePin, lease } = args;
     const result: DeriveRunResult = {
+      outcome: emptyBatchOutcome(),
       conversations: 0,
       sessions: 0,
       propositions: 0,
@@ -220,6 +243,14 @@ export class WindowDeriverService {
       status: 'ok',
       failed: 0,
     };
+    // Targeted re-derivation: one bad conversation (or the failed keys of
+    // a previous run) should not force a full-tenant (paid) re-run.
+    const targets = opts.conversationId
+      ? [opts.conversationId]
+      : opts.conversationIds !== undefined
+        ? opts.conversationIds
+        : null;
+    const only = targets ? new Set(targets) : null;
     // Registry (driver surface 3): observes the lifecycle, never fails it —
     // every registry write degrades to a warning inside the service.
     // The row stays 'building' until the FLIP: 'built' must only ever
@@ -240,11 +271,7 @@ export class WindowDeriverService {
         const convs = await this.episodes.conversationCounts(db);
         for (const conv of convs) {
           const conversationId = conv.conversationId;
-          // Targeted re-derivation: one bad conversation should not force a
-          // full-tenant (paid) re-run.
-          if (opts.conversationId && conversationId !== opts.conversationId) {
-            continue;
-          }
+          if (only && !only.has(conversationId)) continue;
           try {
             await this.deriveConversation({ db, conversationId, ns, result });
             result.conversations += 1;
@@ -298,17 +325,25 @@ export class WindowDeriverService {
           `promotion fenced; staging left in place, world NOT flipped`,
       );
       result.status = 'failed';
+      result.outcome = {
+        ...result.outcome,
+        status: 'failed',
+        failed: [...result.outcome.failed, { key: '*', error: 'lease lost mid-run' }],
+      };
       return result;
     }
     // Atomic flip: staging → final (DELETE final + UPDATE staging,
     // facts + digests in ONE BEGIN/COMMIT). A run that attempted no
     // conversation has nothing to promote — flipping would wipe the
-    // final world with an empty staging namespace.
+    // final world with an empty staging namespace. A targeted run flips
+    // ONE conversation per transaction: the whole-world flip would wipe
+    // every conversation the run did not touch.
     if (result.conversations > 0) {
       try {
-        await this.surreal.withCompany(companyId, (db) =>
-          promoteStaging(db, ns, { conversationId: opts.conversationId }),
-        );
+        await this.surreal.withCompany(companyId, async (db) => {
+          if (!targets) return promoteStaging(db, ns);
+          for (const conversationId of targets) await promoteStaging(db, ns, { conversationId });
+        });
       } catch (e) {
         // The single-transaction flip failed whole: final world
         // untouched, staging intact. The registry marks the world
@@ -397,6 +432,12 @@ export class WindowDeriverService {
   private finalizeRunStatus(result: DeriveRunResult): DeriveRunStatus {
     result.failed = result.skipped.length;
     result.status = result.failed === 0 ? 'ok' : result.conversations > 0 ? 'degraded' : 'failed';
+    result.outcome = foldBatchOutcome({
+      total: result.conversations + result.failed,
+      succeeded: result.conversations,
+      failed: result.skipped.map((s) => ({ key: s.conversationId, error: s.reason })),
+      degradedBy: result.outcome.degradedBy,
+    });
     return result.status;
   }
 
@@ -610,6 +651,10 @@ export class WindowDeriverService {
           this.logger.warn(
             `digest fold failed (${(e as Error).message}) — keeping prior digest state`,
           );
+          result.outcome.degradedBy.push({
+            key: `${POST_PASS_KEY}digest-fold`,
+            error: `${conversationId}: ${errorMessage(e)}`,
+          });
         }
         const last = new Date(session[session.length - 1]!.occurredAt as string);
         if (!digestEventAt || last > digestEventAt) digestEventAt = last;
@@ -822,6 +867,10 @@ export class WindowDeriverService {
       this.logger.warn(
         `aspect rollup pass failed (${(e as Error).message}) — atomic facts unaffected`,
       );
+      result.outcome.degradedBy.push({
+        key: `${POST_PASS_KEY}aspect-rollups`,
+        error: `${conversationId}: ${errorMessage(e)}`,
+      });
     }
   }
 
@@ -907,6 +956,10 @@ export class WindowDeriverService {
       this.logger.log(`compose pass: ${landed}/${compositions.length} landed (${conversationId})`);
     } catch (e) {
       this.logger.warn(`compose pass failed (${(e as Error).message}) — atomic facts unaffected`);
+      result.outcome.degradedBy.push({
+        key: `${POST_PASS_KEY}compose`,
+        error: `${conversationId}: ${errorMessage(e)}`,
+      });
     }
   }
 

--- a/src/ai/embedder/reindex-embeddings.service.ts
+++ b/src/ai/embedder/reindex-embeddings.service.ts
@@ -1,6 +1,12 @@
 import { Injectable, Logger, ServiceUnavailableException } from '@nestjs/common';
 import { ApiKeyService } from '../../auth/api-key.service';
 import { ReindexEngineService, type TableReindexCount } from './reindex-engine.service';
+import {
+  errorMessage,
+  failedBatchOutcome,
+  foldNestedOutcomes,
+  type BatchOutcome,
+} from '../../common/batch-outcome';
 
 export interface ReindexResult {
   tenantsScanned: number;
@@ -12,6 +18,11 @@ export interface ReindexResult {
   /** Per-table breakdown, present ONLY when the opt-in all-tables sweep
    *  ran; absent on the default knowledge_fact-only path. */
   tables?: TableReindexCount[];
+  /**
+   * Roster fold: units are tenants (`failed[].key` is a companyId); a
+   * tenant whose sweep degraded (a table failed) degrades the whole.
+   */
+  outcome: BatchOutcome;
 }
 
 export interface ReindexOptions {
@@ -27,6 +38,8 @@ export interface ReindexOptions {
    * historical knowledge_fact-only reindex, byte-identical.
    */
   allTables?: boolean;
+  /** Retry selector: sweep exactly these tables (REINDEX_SWEPT_COLUMNS). */
+  tables?: string[];
 }
 
 /**
@@ -63,17 +76,21 @@ export class ReindexEmbeddingsService {
     const tenants = opts.tenant ? [opts.tenant] : this.apiKeys.knownCompanyIds();
 
     const allTables = opts.allTables === true;
+    const breakdown = allTables || opts.tables !== undefined;
     let factsScanned = 0;
     let factsUpdated = 0;
     // Aggregate the per-table sweep counts across tenants (all-tables only).
     const tableTotals = new Map<string, TableReindexCount>();
+    const parts: Array<{ key: string; outcome: BatchOutcome }> = [];
     for (const companyId of tenants) {
       try {
         const tenantResult = await this.engine.reindexTenant(companyId, {
           dryRun,
           remaining: maxFacts - factsScanned,
           allTables,
+          ...(opts.tables !== undefined ? { tables: opts.tables } : {}),
         });
+        parts.push({ key: companyId, outcome: tenantResult.outcome });
         factsScanned += tenantResult.factsScanned;
         factsUpdated += tenantResult.factsUpdated;
         for (const t of tenantResult.tables ?? []) {
@@ -88,7 +105,8 @@ export class ReindexEmbeddingsService {
         // signal through the tenant loop so HTTP and queued jobs see failure,
         // rather than a successful run that rewrote zero vectors.
         if (e instanceof ServiceUnavailableException) throw e;
-        this.logger.warn(`reindex failed for ${companyId}: ${(e as Error).message}`);
+        parts.push({ key: companyId, outcome: failedBatchOutcome(errorMessage(e)) });
+        this.logger.warn(`reindex failed for ${companyId}: ${errorMessage(e)}`);
       }
     }
 
@@ -99,7 +117,8 @@ export class ReindexEmbeddingsService {
       durationMs: Date.now() - started,
       dryRun,
       provider: this.engine.providerId(),
-      ...(allTables ? { tables: [...tableTotals.values()] } : {}),
+      ...(breakdown ? { tables: [...tableTotals.values()] } : {}),
+      outcome: foldNestedOutcomes(parts),
     };
     this.logger.log(
       `reindex done — provider=${result.provider} tenants=${result.tenantsScanned} scanned=${result.factsScanned} updated=${result.factsUpdated} dryRun=${dryRun}`,

--- a/src/ai/embedder/reindex-engine.service.ts
+++ b/src/ai/embedder/reindex-engine.service.ts
@@ -5,6 +5,12 @@ import { SurrealService } from '../../db/surreal.service';
 import { EmbedderService } from '../embedder.service';
 import { envFlagEnabled } from '../../common/env-validation';
 import { EMBEDDING_SPACE_FIELD } from './embedding-space';
+import {
+  errorMessage,
+  foldBatchOutcome,
+  type BatchFailure,
+  type BatchOutcome,
+} from '../../common/batch-outcome';
 
 interface FactRowForReindex {
   id: { tb: string; id: { String: string } } | string;
@@ -128,6 +134,51 @@ export interface ReindexTenantResult {
   /** Present ONLY when the all-tables sweep ran; absent on the default
    *  knowledge_fact-only path so the response stays byte-identical. */
   tables?: TableReindexCount[];
+  /**
+   * Units are the tables swept (`failed[].key` is a table name, retryable
+   * via `tables`): a table failed when any page failed to embed or any
+   * row write failed — a skipped page is not a rewritten page.
+   */
+  outcome: BatchOutcome;
+}
+
+/** Which tables one tenant sweep covers, and whether to report per table. */
+interface SweepPlan {
+  facts: boolean;
+  extra: ReindexTableSpec[];
+  breakdown: boolean;
+}
+
+/** Failure counters one table's sweep accumulates. */
+interface TableFailures {
+  failedPages: number;
+  failedRows: number;
+}
+
+/**
+ * Default: knowledge_fact only, no breakdown. `allTables`: everything, with
+ * the per-table breakdown. `tables` (the retry selector): exactly the
+ * named tables, with the breakdown.
+ */
+function sweepPlan(opts: { allTables?: boolean; tables?: string[] }): SweepPlan {
+  if (opts.tables !== undefined) {
+    const wanted = new Set(opts.tables);
+    return {
+      facts: wanted.has('knowledge_fact'),
+      extra: ADDITIONAL_TABLE_SPECS.filter((s) => wanted.has(s.table)),
+      breakdown: true,
+    };
+  }
+  const all = opts.allTables === true;
+  return { facts: true, extra: all ? ADDITIONAL_TABLE_SPECS : [], breakdown: all };
+}
+
+function tableFailure(table: string, f: TableFailures): BatchFailure | null {
+  if (f.failedPages === 0 && f.failedRows === 0) return null;
+  return {
+    key: table,
+    error: `${f.failedPages} page(s) failed to embed, ${f.failedRows} row write(s) failed`,
+  };
 }
 
 /** Per-tenant reindex context — the open DB handle, the tenant id (for log
@@ -191,22 +242,39 @@ export class ReindexEngineService {
 
   async reindexTenant(
     companyId: string,
-    opts: { dryRun: boolean; remaining: number; allTables?: boolean },
+    opts: { dryRun: boolean; remaining: number; allTables?: boolean; tables?: string[] },
   ): Promise<ReindexTenantResult> {
     return this.surreal.withCompany(companyId, async (db) => {
       const ctx: ReindexCtx = { db, companyId, spaceId: this.spaceStampId() };
-      const factResult = await this.reindexKnowledgeFacts(ctx, opts);
-      if (opts.allTables !== true) return factResult;
-
+      const plan = sweepPlan(opts);
+      const failed: BatchFailure[] = [];
+      let total = 0;
+      let factsScanned = 0;
+      let factsUpdated = 0;
+      if (plan.facts) {
+        const facts = await this.reindexKnowledgeFacts(ctx, opts);
+        factsScanned = facts.factsScanned;
+        factsUpdated = facts.factsUpdated;
+        total += 1;
+        const failure = tableFailure('knowledge_fact', facts);
+        if (failure) failed.push(failure);
+      }
       // Opt-in sweep over the remaining embedding-bearing tables. Each is
       // capped independently by `remaining` (a shared budget would make the
       // per-table numbers depend on iteration order, which is worse for
       // operator reasoning).
       const tables: TableReindexCount[] = [];
-      for (const spec of ADDITIONAL_TABLE_SPECS) {
-        tables.push(await this.reindexGenericTable(ctx, spec, opts));
+      for (const spec of plan.extra) {
+        const swept = await this.reindexGenericTable(ctx, spec, opts);
+        tables.push({ table: spec.table, scanned: swept.scanned, updated: swept.updated });
+        total += 1;
+        const failure = tableFailure(spec.table, swept);
+        if (failure) failed.push(failure);
       }
-      return { ...factResult, tables };
+      const outcome = foldBatchOutcome({ total, succeeded: total - failed.length, failed });
+      return plan.breakdown
+        ? { factsScanned, factsUpdated, tables, outcome }
+        : { factsScanned, factsUpdated, outcome };
     });
   }
 
@@ -240,10 +308,11 @@ export class ReindexEngineService {
   private async reindexKnowledgeFacts(
     ctx: ReindexCtx,
     opts: { dryRun: boolean; remaining: number },
-  ): Promise<{ factsScanned: number; factsUpdated: number }> {
+  ): Promise<{ factsScanned: number; factsUpdated: number } & TableFailures> {
     let offset = 0;
     let factsScanned = 0;
     let factsUpdated = 0;
+    const failures: TableFailures = { failedPages: 0, failedRows: 0 };
     const batch = Math.min(this.batchSize, opts.remaining);
     // Paginate until either the tenant is empty or we hit the cap.
     while (factsScanned < opts.remaining) {
@@ -265,13 +334,17 @@ export class ReindexEngineService {
         const embeddings = await this.embedPageOrNull(texts, `knowledge_fact ${ctx.companyId}`);
         if (embeddings) {
           const entries = page.map((row, i) => ({ id: row.id, vector: embeddings[i] }));
-          factsUpdated += await this.writePage(ctx, 'embedding', entries);
+          const written = await this.writePage(ctx, 'embedding', entries);
+          factsUpdated += written.updated;
+          failures.failedRows += written.failed;
+        } else {
+          failures.failedPages += 1;
         }
       }
       offset += page.length;
       if (page.length < batch) break;
     }
-    return { factsScanned, factsUpdated };
+    return { factsScanned, factsUpdated, ...failures };
   }
 
   /**
@@ -287,10 +360,11 @@ export class ReindexEngineService {
     ctx: ReindexCtx,
     spec: ReindexTableSpec,
     opts: { dryRun: boolean; remaining: number },
-  ): Promise<TableReindexCount> {
+  ): Promise<TableReindexCount & TableFailures> {
     let offset = 0;
     let scanned = 0;
     let updated = 0;
+    const failures: TableFailures = { failedPages: 0, failedRows: 0 };
     const batch = Math.min(this.batchSize, opts.remaining);
     while (scanned < opts.remaining) {
       const [rows] = await ctx.db.query<[Array<Record<string, unknown>>]>(
@@ -304,11 +378,16 @@ export class ReindexEngineService {
       const page = (rows as Array<Record<string, unknown>>) ?? [];
       if (page.length === 0) break;
       scanned += page.length;
-      if (!opts.dryRun) updated += await this.reindexGenericPage(ctx, spec, page);
+      if (!opts.dryRun) {
+        const written = await this.reindexGenericPage(ctx, spec, page);
+        updated += written.updated;
+        failures.failedPages += written.failedPages;
+        failures.failedRows += written.failedRows;
+      }
       offset += page.length;
       if (page.length < batch) break;
     }
-    return { table: spec.table, scanned, updated };
+    return { table: spec.table, scanned, updated, ...failures };
   }
 
   /** Re-embed + rewrite one page of a non-fact table. Skips rows with no
@@ -317,7 +396,7 @@ export class ReindexEngineService {
     ctx: ReindexCtx,
     spec: ReindexTableSpec,
     page: Array<Record<string, unknown>>,
-  ): Promise<number> {
+  ): Promise<{ updated: number } & TableFailures> {
     const kept: Array<Record<string, unknown>> = [];
     const texts: string[] = [];
     for (const row of page) {
@@ -327,11 +406,12 @@ export class ReindexEngineService {
         texts.push(t);
       }
     }
-    if (texts.length === 0) return 0;
+    if (texts.length === 0) return { updated: 0, failedPages: 0, failedRows: 0 };
     const embeddings = await this.embedPageOrNull(texts, `${spec.table} ${ctx.companyId}`);
-    if (!embeddings) return 0;
+    if (!embeddings) return { updated: 0, failedPages: 1, failedRows: 0 };
     const entries = kept.map((row, i) => ({ id: row.id, vector: embeddings[i] }));
-    return this.writePage(ctx, spec.vectorField, entries);
+    const written = await this.writePage(ctx, spec.vectorField, entries);
+    return { updated: written.updated, failedPages: 0, failedRows: written.failed };
   }
 
   /** Embed a page, logging + swallowing a batch failure (returns null so the
@@ -353,30 +433,32 @@ export class ReindexEngineService {
       // answers 503 and the operator learns to wait for warmup.
       if (e instanceof ServiceUnavailableException) throw e;
       this.logger.warn(
-        `reindex batch embed failed (${where}, page=${texts.length}): ${(e as Error).message}`,
+        `reindex batch embed failed (${where}, page=${texts.length}): ${errorMessage(e)}`,
       );
       return null;
     }
   }
 
   /** Write each row's vector, tolerating a per-row failure. Returns the
-   *  number of rows successfully updated. */
+   *  rows successfully updated and the rows whose write failed. */
   private async writePage(
     ctx: ReindexCtx,
     vectorField: string,
     entries: Array<{ id: unknown; vector: number[] | undefined }>,
-  ): Promise<number> {
+  ): Promise<{ updated: number; failed: number }> {
     let updated = 0;
+    let failed = 0;
     for (const entry of entries) {
       try {
         await this.writeVector(ctx, vectorField, entry);
         updated += 1;
       } catch (e) {
+        failed += 1;
         this.logger.warn(
-          `reindex ${vectorField} row update failed (${ctx.companyId}): ${(e as Error).message}`,
+          `reindex ${vectorField} row update failed (${ctx.companyId}): ${errorMessage(e)}`,
         );
       }
     }
-    return updated;
+    return { updated, failed };
   }
 }

--- a/src/common/batch-outcome.ts
+++ b/src/common/batch-outcome.ts
@@ -1,0 +1,140 @@
+import { BadRequestException } from '@nestjs/common';
+
+/**
+ * Terminal status of a batch operation. `complete` — every unit landed and
+ * every post-pass ran clean; `degraded` — some units failed, or a post-pass
+ * over landed units failed; `failed` — units were attempted and none
+ * succeeded, or the operation could not run at all. A log line never
+ * replaces this: callers branch on `status`, and `failed[].key` is what a
+ * retry selector (`keys`) accepts.
+ */
+export type BatchStatus = 'complete' | 'degraded' | 'failed';
+
+export interface BatchFailure {
+  /** The unit's retry key (conversation id, asset id, table, entity id);
+   *  `*` names the operation itself when it could not run. */
+  key: string;
+  error: string;
+}
+
+export interface BatchOutcome {
+  status: BatchStatus;
+  /** Units attempted. */
+  total: number;
+  succeeded: number;
+  /** Units that failed — retryable by key. */
+  failed: BatchFailure[];
+  /**
+   * Failures that degrade the batch without failing a unit: a post-pass
+   * over landed units, or a nested batch that itself degraded. Not
+   * retryable by unit key — re-run the named pass.
+   */
+  degradedBy: BatchFailure[];
+}
+
+/** Key prefix for post-pass entries in `degradedBy`. */
+export const POST_PASS_KEY = 'post-pass:';
+
+/** Longest error text an outcome carries per entry. */
+const ERROR_MAX = 500;
+
+export function errorMessage(e: unknown): string {
+  const raw = e instanceof Error ? e.message : String(e);
+  return raw.slice(0, ERROR_MAX);
+}
+
+/** Fold unit results and post-pass failures into a terminal status. */
+export function foldBatchOutcome(units: {
+  total: number;
+  succeeded: number;
+  failed: BatchFailure[];
+  degradedBy?: BatchFailure[];
+}): BatchOutcome {
+  const degradedBy = units.degradedBy ?? [];
+  let status: BatchStatus = 'complete';
+  if (units.failed.length > 0 && units.succeeded === 0) status = 'failed';
+  else if (units.failed.length > 0 || degradedBy.length > 0) status = 'degraded';
+  return {
+    status,
+    total: units.total,
+    succeeded: units.succeeded,
+    failed: units.failed,
+    degradedBy,
+  };
+}
+
+/** A batch that attempted nothing and failed nothing. */
+export function emptyBatchOutcome(): BatchOutcome {
+  return foldBatchOutcome({ total: 0, succeeded: 0, failed: [] });
+}
+
+/** The operation could not run at all (key `*`, no units attempted). */
+export function failedBatchOutcome(error: string, key = '*'): BatchOutcome {
+  return { status: 'failed', total: 0, succeeded: 0, failed: [{ key, error }], degradedBy: [] };
+}
+
+/**
+ * Fold nested batches (one per tenant, per asset, …) into one outcome. A
+ * failed part is a failed unit; a degraded part degrades the whole; a
+ * complete part succeeded.
+ */
+export function foldNestedOutcomes(
+  parts: ReadonlyArray<{ key: string; outcome: BatchOutcome }>,
+): BatchOutcome {
+  const failed: BatchFailure[] = [];
+  const degradedBy: BatchFailure[] = [];
+  let succeeded = 0;
+  for (const part of parts) {
+    if (part.outcome.status === 'failed') {
+      failed.push({ key: part.key, error: describeBatchOutcome(part.outcome) });
+    } else {
+      succeeded += 1;
+      if (part.outcome.status === 'degraded') {
+        degradedBy.push({ key: part.key, error: describeBatchOutcome(part.outcome) });
+      }
+    }
+  }
+  return foldBatchOutcome({ total: parts.length, succeeded, failed, degradedBy });
+}
+
+/** One-line summary for logs and job_run error messages. */
+export function describeBatchOutcome(outcome: BatchOutcome): string {
+  const head = `${outcome.status}: ${outcome.succeeded} of ${outcome.total} unit(s) succeeded`;
+  const first = outcome.failed[0] ?? outcome.degradedBy[0];
+  if (!first) return head;
+  const counts =
+    `${outcome.failed.length} failed` +
+    (outcome.degradedBy.length > 0 ? `, ${outcome.degradedBy.length} degrading` : '');
+  return `${head} (${counts}); first: ${first.key} — ${first.error}`;
+}
+
+/** The `outcome` a job handler's result carries, when it carries one. */
+export function batchOutcomeOf(result: unknown): BatchOutcome | undefined {
+  if (result === null || typeof result !== 'object') return undefined;
+  const outcome = (result as { outcome?: unknown }).outcome;
+  if (outcome === null || typeof outcome !== 'object') return undefined;
+  const o = outcome as Partial<BatchOutcome>;
+  const statusOk = o.status === 'complete' || o.status === 'degraded' || o.status === 'failed';
+  return statusOk && Array.isArray(o.failed) ? (o as BatchOutcome) : undefined;
+}
+
+/**
+ * Parse an admin body's optional `keys` retry selector: absent ⇒
+ * undefined; otherwise a non-empty, bounded array of trimmed non-empty
+ * strings, each passing `accept` (400 otherwise).
+ */
+export function parseBatchKeys(
+  raw: unknown,
+  opts: { maxKeys: number; maxLength: number; accept?: (key: string) => boolean },
+): string[] | undefined {
+  if (raw === undefined) return undefined;
+  if (!Array.isArray(raw) || raw.length === 0 || raw.length > opts.maxKeys) {
+    throw new BadRequestException(`keys must be a non-empty array of at most ${opts.maxKeys}`);
+  }
+  const keys = raw.map((k) => (typeof k === 'string' ? k.trim() : ''));
+  const bad = keys.find(
+    (k) => k === '' || k.length > opts.maxLength || (opts.accept !== undefined && !opts.accept(k)),
+  );
+  if (bad !== undefined) throw new BadRequestException(`keys contains an invalid entry`);
+  return [...new Set(keys)];
+}

--- a/src/contracts/common/batch-outcome.schema.ts
+++ b/src/contracts/common/batch-outcome.schema.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod';
+
+/** Wire mirror of src/common/batch-outcome.ts (parity: test/batch-outcome.unit-spec.ts). */
+export const BatchFailureSchema = z.object({
+  /** The unit's retry key; `*` names the operation itself. */
+  key: z.string(),
+  error: z.string(),
+});
+
+export const BatchOutcomeSchema = z.object({
+  /**
+   * `complete` — every unit landed and every post-pass ran clean;
+   * `degraded` — some units failed, or a post-pass over landed units
+   * failed; `failed` — units were attempted and none succeeded, or the
+   * operation could not run.
+   */
+  status: z.enum(['complete', 'degraded', 'failed']),
+  total: z.number().int(),
+  succeeded: z.number().int(),
+  /** Units that failed — retryable via the entrypoint's `keys`. */
+  failed: z.array(BatchFailureSchema),
+  /** Post-pass / nested-batch failures that degrade without failing a unit. */
+  degradedBy: z.array(BatchFailureSchema),
+});
+export type BatchOutcomeWire = z.infer<typeof BatchOutcomeSchema>;

--- a/src/contracts/episodes/driver.schema.ts
+++ b/src/contracts/episodes/driver.schema.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { BatchOutcomeSchema } from '../common/batch-outcome.schema';
 
 /**
  * Wire contracts for the raw-substrate driver v1
@@ -61,6 +62,11 @@ export const RebuildProjectionRequestSchema = z.object({
   version: z.string().optional(),
   /** Restrict the rebuild to one conversation. */
   conversation: z.string().optional(),
+  /**
+   * Retry selector: rebuild exactly these conversation ids (the
+   * `outcome.failed[].key` of a previous run). Not with `conversation`.
+   */
+  keys: z.array(z.string()).optional(),
   /** Flip the live read pin to this version after a successful run. */
   activate: z.boolean().optional(),
   /** Allow rewriting the currently pinned world in place (eval only). */
@@ -81,6 +87,8 @@ export const RebuildProjectionResponseSchema = z.object({
    */
   status: z.enum(['ok', 'degraded', 'failed']),
   failed: z.number().int(),
+  /** Terminal status including post-passes; `failed[].key` feeds `keys`. */
+  outcome: BatchOutcomeSchema,
   activated: z.boolean().optional(),
   previousVersion: z.string().nullable().optional(),
 });

--- a/src/evidence/evidence-admin.controller.ts
+++ b/src/evidence/evidence-admin.controller.ts
@@ -24,16 +24,21 @@ import {
   EvidenceProcessorBrokerService,
   type DispatchSweepResult,
 } from './processor-broker.service';
+import { parseBatchKeys } from '../common/batch-outcome';
 
 /** Param belt: a pack id is a short slug, not free text. */
 const PACK_ID_MAX_CHARS = 200;
 /** Param belt: an asset id is a `evidence_asset:<tail>` record id. */
 const ASSET_ID_MAX_CHARS = 256;
+/** Retry-selector belt: the sweep's own hard bound. */
+const KEYS_MAX = 1000;
 
 interface DispatchBody {
   tenant?: string;
   packId?: string;
   assetId?: string;
+  /** Retry selector: `outcome.failed[].key` of a previous sweep. */
+  keys?: string[];
   limit?: number;
 }
 
@@ -96,12 +101,21 @@ export class EvidenceAdminController {
       );
     }
     const assetId = this.assetId(body.assetId);
+    const assetIds = parseBatchKeys(body.keys, {
+      maxKeys: KEYS_MAX,
+      maxLength: ASSET_ID_MAX_CHARS,
+      accept: (key) => key.startsWith('evidence_asset:'),
+    });
+    if (assetIds !== undefined && assetId !== undefined) {
+      throw new BadRequestException('pass either assetId or keys, not both');
+    }
     const tenant = resolvePlatformTenant(req, body.tenant, {
       knownTenants: () => this.apiKeys.knownCompanyIds(),
     });
     return this.broker.dispatchSweep(tenant, {
       packId,
       assetId,
+      assetIds,
       limit: body.limit,
     });
   }

--- a/src/evidence/processing/processing-run.service.ts
+++ b/src/evidence/processing/processing-run.service.ts
@@ -46,6 +46,8 @@ export interface ExecuteRunResult {
   capability: DerivedRepresentationKind;
   status: 'succeeded' | 'failed' | 'replayed' | 'skipped_in_flight';
   representationIds: string[];
+  /** The persisted (capped, PII-redacted) error — present iff `failed`. */
+  error?: string;
 }
 
 /**
@@ -100,8 +102,14 @@ export class ProcessingRunService {
       outputs = await adapter.process(opts.input);
       this.assertOutputsWithinCap(outputs);
     } catch (e) {
-      await this.failRun(companyId, runId, e);
-      return { runId, capability: adapter.capability, status: 'failed', representationIds: [] };
+      const error = await this.failRun(companyId, runId, e);
+      return {
+        runId,
+        capability: adapter.capability,
+        status: 'failed',
+        representationIds: [],
+        error,
+      };
     }
     try {
       const written = await this.writeOutputs(companyId, { runId, opts, outputs });
@@ -113,8 +121,14 @@ export class ProcessingRunService {
         representationIds: written.representationIds,
       };
     } catch (e) {
-      await this.failRun(companyId, runId, e);
-      return { runId, capability: adapter.capability, status: 'failed', representationIds: [] };
+      const error = await this.failRun(companyId, runId, e);
+      return {
+        runId,
+        capability: adapter.capability,
+        status: 'failed',
+        representationIds: [],
+        error,
+      };
     }
   }
 
@@ -338,8 +352,8 @@ export class ProcessingRunService {
   }
 
   /** Error text is capped and PII-redacted — it can quote content
-   *  derived from personal observations. */
-  private async failRun(companyId: string, runId: string, err: unknown): Promise<void> {
+   *  derived from personal observations. Returns the persisted text. */
+  private async failRun(companyId: string, runId: string, err: unknown): Promise<string> {
     const raw = err instanceof Error ? err.message : String(err);
     const message = redactPiiWithReport(raw).text.slice(0, ERROR_MAX);
     this.logger.warn(`processing run ${runId} failed: ${message}`);
@@ -349,5 +363,6 @@ export class ProcessingRunService {
         e: message,
       }),
     );
+    return message;
   }
 }

--- a/src/evidence/processor-broker.service.ts
+++ b/src/evidence/processor-broker.service.ts
@@ -21,6 +21,12 @@ import {
 import type { ExecuteRunResult } from './processing/processing-run.service';
 import { ProcessingRunService } from './processing/processing-run.service';
 import { storageRefScheme } from './storage/storage-adapter';
+import {
+  errorMessage,
+  foldBatchOutcome,
+  type BatchFailure,
+  type BatchOutcome,
+} from '../common/batch-outcome';
 
 interface AssetRow {
   id: unknown;
@@ -46,6 +52,11 @@ interface PackRow {
 export interface DispatchResult {
   runs: ExecuteRunResult[];
   denied: Array<{ capability: string; reason: string }>;
+  /**
+   * Units are the runs the adapters executed (`failed[].key` is the
+   * capability); a denial is policy, not a unit, and stays in `denied`.
+   */
+  outcome: BatchOutcome;
 }
 
 export interface DispatchSweepResult {
@@ -59,6 +70,12 @@ export interface DispatchSweepResult {
   denied: number;
   /** Assets whose dispatch threw — logged, never fatal to the sweep. */
   failed: number;
+  /**
+   * Units are assets (`failed[].key` is an evidence_asset id, retryable
+   * via `assetIds`): an asset failed when its dispatch threw OR any of its
+   * runs recorded `failed` — a persisted failed run is not a success.
+   */
+  outcome: BatchOutcome;
 }
 
 /** Default per-call sweep bound; a maintenance verb, not a migration. */
@@ -110,7 +127,11 @@ export class EvidenceProcessorBrokerService {
     const { asset, pack } = await this.loadRows(companyId, req);
     const modality = asset.modality as EvidenceModality;
     const capabilities = this.declaredCapabilities(pack.manifest, modality);
-    const result: DispatchResult = { runs: [], denied: [] };
+    const result: DispatchResult = {
+      runs: [],
+      denied: [],
+      outcome: foldBatchOutcome({ total: 0, succeeded: 0, failed: [] }),
+    };
     for (const capability of capabilities) {
       const adapter = this.processors.find(
         (candidate) =>
@@ -144,6 +165,14 @@ export class EvidenceProcessorBrokerService {
       });
       result.runs.push(run);
     }
+    result.outcome = foldBatchOutcome({
+      total: result.runs.length,
+      succeeded: result.runs.filter((r) => r.status === 'succeeded' || r.status === 'replayed')
+        .length,
+      failed: result.runs
+        .filter((r) => r.status === 'failed')
+        .map((r) => ({ key: r.capability, error: r.error ?? 'failed' })),
+    });
     return result;
   }
 
@@ -167,34 +196,54 @@ export class EvidenceProcessorBrokerService {
    */
   async dispatchSweep(
     companyId: string,
-    req: { packId: string; assetId?: string | undefined; limit?: number | undefined },
+    req: {
+      packId: string;
+      assetId?: string | undefined;
+      /** Retry selector: exactly these assets, no candidate read. */
+      assetIds?: string[] | undefined;
+      limit?: number | undefined;
+    },
   ): Promise<DispatchSweepResult> {
     if (!processorBrokerEnabled() || !evidenceSubstrateEnabled()) {
       throw new ServiceUnavailableException(
         'EVIDENCE_PROCESSOR_BROKER (with EVIDENCE_SUBSTRATE_ENABLED) is off',
       );
     }
-    const assetIds = req.assetId
-      ? [req.assetId]
-      : await this.sweepCandidates(companyId, req.limit ?? SWEEP_DEFAULT_LIMIT);
+    const assetIds =
+      req.assetIds ??
+      (req.assetId
+        ? [req.assetId]
+        : await this.sweepCandidates(companyId, req.limit ?? SWEEP_DEFAULT_LIMIT));
     const out: DispatchSweepResult = {
       assets: assetIds.length,
       dispatched: 0,
       runs: 0,
       denied: 0,
       failed: 0,
+      outcome: foldBatchOutcome({ total: 0, succeeded: 0, failed: [] }),
     };
+    const failedAssets: BatchFailure[] = [];
     for (const assetId of assetIds) {
       try {
         const res = await this.dispatchForPack(companyId, { packId: req.packId, assetId });
         out.dispatched++;
         out.runs += res.runs.length;
         out.denied += res.denied.length;
+        const firstFailed = res.outcome.failed[0];
+        if (firstFailed) {
+          failedAssets.push({ key: assetId, error: `${firstFailed.key}: ${firstFailed.error}` });
+        }
       } catch (e) {
         out.failed++;
-        this.logger.warn(`sweep dispatch failed for ${assetId}: ${(e as Error).message}`);
+        failedAssets.push({ key: assetId, error: errorMessage(e) });
+        this.logger.warn(`sweep dispatch failed for ${assetId}: ${errorMessage(e)}`);
       }
     }
+    out.outcome = foldBatchOutcome({
+      total: assetIds.length,
+      succeeded: assetIds.length - failedAssets.length,
+      failed: failedAssets,
+    });
     return out;
   }
 

--- a/src/jobs/job-claim.service.ts
+++ b/src/jobs/job-claim.service.ts
@@ -374,6 +374,8 @@ export class JobClaimService {
     requeue?: boolean;
     maxAttempts?: number;
     backoffBaseMs?: number;
+    /** Persisted on the TERMINAL arm only (a handler's failed batch outcome). */
+    result?: Record<string, unknown>;
   }): Promise<{ requeued: boolean }> {
     if (!this.surreal) return { requeued: false };
     const maxAttempts = input.maxAttempts ?? 3;
@@ -415,10 +417,16 @@ export class JobClaimService {
                 status = 'failed',
                 finishedAt = time::now(),
                 error = $err,
+                result = $result,
                 claimedBy = NONE, leaseUntil = NONE
               WHERE claimedBy = $me AND status = 'running'
               RETURN id`,
-          { rid: input.recordId, me: this.workerId, err: input.error },
+          {
+            rid: input.recordId,
+            me: this.workerId,
+            err: input.error,
+            result: input.result ?? null,
+          },
         );
         return rows.length;
       });

--- a/src/jobs/job-dispatcher.service.ts
+++ b/src/jobs/job-dispatcher.service.ts
@@ -4,6 +4,7 @@ import { JobClaimService, type JobClaim } from './job-claim.service';
 import { JobWorkerPool } from './job-worker-pool.service';
 import { MetricsService } from '../metrics/metrics.service';
 import type { RegisteredHandler } from './worker-loop.types';
+import { batchOutcomeOf, describeBatchOutcome } from '../common/batch-outcome';
 
 /**
  * JobDispatcherService — runs a single claimed job to completion. Owns
@@ -149,13 +150,7 @@ export class JobDispatcherService {
         outcome = 'lost_claim';
         this.logger.warn(`Claim ${claim.runId} lost mid-handler; skipping terminal write`);
       } else {
-        consumerSpan.setAttribute('job.outcome', 'succeeded');
-        outcome = 'succeeded';
-        await this.claim.complete({
-          companyId: claim.companyId,
-          recordId: claim.recordId,
-          result: (result as Record<string, unknown>) ?? undefined,
-        });
+        outcome = await this.settle({ claim, reg, result, consumerSpan });
       }
     } catch (err) {
       clearInterval(renewTimer);
@@ -191,5 +186,44 @@ export class JobDispatcherService {
       const elapsed = (Date.now() - startedAt) / 1000;
       this.metrics?.recordJob(claim.jobType, outcome, elapsed);
     }
+  }
+
+  /**
+   * Terminal write for a handler that RETURNED. A result carrying a
+   * `failed` batch outcome is treated exactly like a throw — requeued
+   * under the same attempt policy, with the outcome persisted on the
+   * terminal row — because a run where no unit succeeded is not a
+   * succeeded job with sad numbers.
+   */
+  private async settle(args: {
+    claim: JobClaim;
+    reg: RegisteredHandler;
+    result: unknown;
+    consumerSpan: ReturnType<ReturnType<typeof trace.getTracer>['startSpan']>;
+  }): Promise<'succeeded' | 'failed'> {
+    const { claim, reg, result, consumerSpan } = args;
+    const failedBatch = batchOutcomeOf(result);
+    if (failedBatch?.status === 'failed') {
+      const message = describeBatchOutcome(failedBatch);
+      consumerSpan.setAttribute('job.outcome', 'failed');
+      consumerSpan.setStatus({ code: SpanStatusCode.ERROR, message });
+      await this.claim.fail({
+        companyId: claim.companyId,
+        recordId: claim.recordId,
+        attempts: claim.attempts,
+        error: { message, name: 'BatchFailed' },
+        requeue: true,
+        maxAttempts: reg.maxAttempts,
+        result: result as Record<string, unknown>,
+      });
+      return 'failed';
+    }
+    consumerSpan.setAttribute('job.outcome', 'succeeded');
+    await this.claim.complete({
+      companyId: claim.companyId,
+      recordId: claim.recordId,
+      result: (result as Record<string, unknown>) ?? undefined,
+    });
+    return 'succeeded';
   }
 }

--- a/test/batch-outcome.unit-spec.ts
+++ b/test/batch-outcome.unit-spec.ts
@@ -1,0 +1,174 @@
+/**
+ * The shared batch terminal-status contract (src/common/batch-outcome.ts):
+ * the fold rules, the roster fold, the job-result probe, the `keys`
+ * selector belt, and wire parity with the zod contract the OpenAPI
+ * document publishes.
+ */
+import { BadRequestException } from '@nestjs/common';
+import {
+  batchOutcomeOf,
+  describeBatchOutcome,
+  emptyBatchOutcome,
+  failedBatchOutcome,
+  foldBatchOutcome,
+  foldNestedOutcomes,
+  parseBatchKeys,
+  type BatchOutcome,
+} from '../src/common/batch-outcome';
+import {
+  BatchOutcomeSchema,
+  type BatchOutcomeWire,
+} from '../src/contracts/common/batch-outcome.schema';
+
+describe('foldBatchOutcome', () => {
+  it('complete: every unit landed and nothing degraded', () => {
+    expect(foldBatchOutcome({ total: 3, succeeded: 3, failed: [] })).toEqual({
+      status: 'complete',
+      total: 3,
+      succeeded: 3,
+      failed: [],
+      degradedBy: [],
+    });
+  });
+
+  it('an empty batch is complete, not failed', () => {
+    expect(emptyBatchOutcome().status).toBe('complete');
+  });
+
+  it('degraded: some units failed', () => {
+    const o = foldBatchOutcome({
+      total: 3,
+      succeeded: 2,
+      failed: [{ key: 'c2', error: 'llm down' }],
+    });
+    expect(o.status).toBe('degraded');
+    expect(o.failed.map((f) => f.key)).toEqual(['c2']);
+  });
+
+  it('degraded: every unit landed but a post-pass failed', () => {
+    const o = foldBatchOutcome({
+      total: 3,
+      succeeded: 3,
+      failed: [],
+      degradedBy: [{ key: 'post-pass:enrich', error: '2 of 3 scene(s) failed' }],
+    });
+    expect(o.status).toBe('degraded');
+    expect(o.failed).toEqual([]);
+    expect(o.degradedBy[0]?.key).toBe('post-pass:enrich');
+  });
+
+  it('failed: units were attempted and none succeeded', () => {
+    const o = foldBatchOutcome({
+      total: 2,
+      succeeded: 0,
+      failed: [
+        { key: 'c1', error: 'x' },
+        { key: 'c2', error: 'x' },
+      ],
+    });
+    expect(o.status).toBe('failed');
+  });
+
+  it('failedBatchOutcome names the operation itself under key *', () => {
+    expect(failedBatchOutcome('boom')).toEqual({
+      status: 'failed',
+      total: 0,
+      succeeded: 0,
+      failed: [{ key: '*', error: 'boom' }],
+      degradedBy: [],
+    });
+  });
+});
+
+describe('foldNestedOutcomes', () => {
+  const complete = foldBatchOutcome({ total: 1, succeeded: 1, failed: [] });
+  const degraded = foldBatchOutcome({
+    total: 2,
+    succeeded: 1,
+    failed: [{ key: 'c1', error: 'x' }],
+  });
+  const failed = failedBatchOutcome('down');
+
+  it('a failed part is a failed unit; a degraded part degrades the whole', () => {
+    const o = foldNestedOutcomes([
+      { key: 'co_a', outcome: complete },
+      { key: 'co_b', outcome: degraded },
+      { key: 'co_c', outcome: failed },
+    ]);
+    expect(o.status).toBe('degraded');
+    expect(o.total).toBe(3);
+    expect(o.succeeded).toBe(2);
+    expect(o.failed.map((f) => f.key)).toEqual(['co_c']);
+    expect(o.degradedBy.map((f) => f.key)).toEqual(['co_b']);
+  });
+
+  it('all parts failed ⇒ failed; all complete ⇒ complete', () => {
+    expect(foldNestedOutcomes([{ key: 'a', outcome: failed }]).status).toBe('failed');
+    expect(foldNestedOutcomes([{ key: 'a', outcome: complete }]).status).toBe('complete');
+    expect(foldNestedOutcomes([]).status).toBe('complete');
+  });
+});
+
+describe('describeBatchOutcome / batchOutcomeOf', () => {
+  it('summarises counts and the first failure', () => {
+    const o = foldBatchOutcome({
+      total: 3,
+      succeeded: 1,
+      failed: [{ key: 'c2', error: 'llm down' }],
+      degradedBy: [{ key: 'post-pass:compose', error: 'c1: timeout' }],
+    });
+    expect(describeBatchOutcome(o)).toBe(
+      'degraded: 1 of 3 unit(s) succeeded (1 failed, 1 degrading); first: c2 — llm down',
+    );
+    expect(describeBatchOutcome(emptyBatchOutcome())).toBe('complete: 0 of 0 unit(s) succeeded');
+  });
+
+  it('probes a job result for a well-formed outcome only', () => {
+    const outcome = failedBatchOutcome('x');
+    expect(batchOutcomeOf({ outcome })).toBe(outcome);
+    expect(batchOutcomeOf({ outcome: { status: 'nope', failed: [] } })).toBeUndefined();
+    expect(batchOutcomeOf({ outcome: { status: 'failed' } })).toBeUndefined();
+    expect(batchOutcomeOf({ marked: 3 })).toBeUndefined();
+    expect(batchOutcomeOf(undefined)).toBeUndefined();
+    expect(batchOutcomeOf(null)).toBeUndefined();
+  });
+});
+
+describe('parseBatchKeys', () => {
+  const belt = { maxKeys: 3, maxLength: 8 };
+
+  it('absent ⇒ undefined; trims and dedupes present keys', () => {
+    expect(parseBatchKeys(undefined, belt)).toBeUndefined();
+    expect(parseBatchKeys([' c1 ', 'c2', 'c1'], belt)).toEqual(['c1', 'c2']);
+  });
+
+  it('400s on a non-array, an empty array, too many, blank, too long, or rejected keys', () => {
+    for (const bad of ['c1', [], ['a', 'b', 'c', 'd'], [''], ['123456789'], [42]]) {
+      expect(() => parseBatchKeys(bad, belt)).toThrow(BadRequestException);
+    }
+    expect(() => parseBatchKeys(['x:1'], { ...belt, accept: (k) => k.startsWith('y:') })).toThrow(
+      BadRequestException,
+    );
+    expect(parseBatchKeys(['y:1'], { ...belt, accept: (k) => k.startsWith('y:') })).toEqual([
+      'y:1',
+    ]);
+  });
+});
+
+describe('wire parity with src/contracts/common/batch-outcome.schema.ts', () => {
+  it('the zod contract accepts a real outcome key-for-key, and the types agree', () => {
+    const outcome: BatchOutcome = foldBatchOutcome({
+      total: 2,
+      succeeded: 1,
+      failed: [{ key: 'c1', error: 'x' }],
+      degradedBy: [{ key: 'post-pass:enrich', error: 'y' }],
+    });
+    const parsed = BatchOutcomeSchema.parse(outcome);
+    expect(parsed).toEqual(outcome);
+    expect(Object.keys(BatchOutcomeSchema.shape).sort()).toEqual(Object.keys(outcome).sort());
+    // Compile-time parity in both directions.
+    const wire: BatchOutcomeWire = outcome;
+    const back: BatchOutcome = wire;
+    expect(back).toBe(outcome);
+  });
+});

--- a/test/processor-broker-outcome.unit-spec.ts
+++ b/test/processor-broker-outcome.unit-spec.ts
@@ -1,0 +1,169 @@
+/**
+ * Evidence processing sweep terminal status
+ * (src/evidence/processor-broker.service.ts): a processing run that
+ * recorded `failed` used to count its asset as `dispatched` and vanish
+ * into a warning. Now the asset is a failed unit of the sweep's outcome,
+ * the run's persisted error rides along, and `assetIds` (the retry
+ * selector) re-dispatches exactly those assets without the candidate read.
+ */
+import {
+  declaredModalitySection,
+  modalitiesChecksum,
+  type DomainPackManifest,
+} from '../src/ai/domain-packs';
+import type { SurrealService } from '../src/db/surreal.service';
+import type { EvidenceStoreService } from '../src/evidence/evidence-store.service';
+import { EvidenceProcessorBrokerService } from '../src/evidence/processor-broker.service';
+import type { ProcessorAdapter } from '../src/evidence/processing/processor-adapter';
+import { ProcessingRunService } from '../src/evidence/processing/processing-run.service';
+
+const PACK = {
+  id: 'proc_pack',
+  version: '1.0.0',
+  description: 'Synthetic processor pack (unit).',
+  predicates: [],
+  memoryModel: {
+    modalities: ['image'],
+    processors: [{ id: 'img_cap', modality: 'image', produces: ['caption'] }],
+  },
+} as unknown as DomainPackManifest;
+const CHECKSUM = modalitiesChecksum(declaredModalitySection(PACK));
+
+const adapterOf = (process: ProcessorAdapter['process']): ProcessorAdapter => ({
+  capability: 'caption',
+  version: 'stub-v1',
+  configParts: () => [],
+  accepts: () => true,
+  process,
+});
+
+function fixture(opts: { adapter: ProcessorAdapter; assets: string[] }) {
+  const queries: string[] = [];
+  const db = {
+    query: jest.fn((sql: string, vars?: Record<string, unknown>) => {
+      queries.push(sql);
+      if (sql.includes("type::record('evidence_asset'")) {
+        const known = opts.assets.find((id) => id.endsWith(`:${String(vars?.tail)}`));
+        if (!known) return Promise.resolve([[]]);
+        return Promise.resolve([
+          [{ id: known, modality: 'image', mediaType: 'image/png', availability: 'external' }],
+        ]);
+      }
+      if (sql.includes('FROM domain_pack')) {
+        return Promise.resolve([
+          [{ manifest: PACK, acceptedModalities: true, acceptedModalitiesChecksum: CHECKSUM }],
+        ]);
+      }
+      if (sql.includes('INSERT IGNORE INTO processing_run')) {
+        return Promise.resolve([[{ id: (vars?.row as { id: unknown }).id }]]);
+      }
+      if (sql.includes('SELECT VALUE id FROM evidence_asset')) {
+        return Promise.resolve([opts.assets]);
+      }
+      return Promise.resolve([[]]);
+    }),
+  };
+  const surreal = {
+    withCompany: (_c: string, fn: (d: typeof db) => unknown) => fn(db),
+  } as unknown as SurrealService;
+  const store = {
+    addRepresentation: jest.fn(() =>
+      Promise.resolve({ representationId: 'derived_representation:r1' }),
+    ),
+  } as unknown as EvidenceStoreService;
+  const runs = new ProcessingRunService(surreal, store, new Map());
+  const broker = new EvidenceProcessorBrokerService(surreal, [opts.adapter], runs);
+  return { broker, queries };
+}
+
+describe('EvidenceProcessorBrokerService — sweep terminal status', () => {
+  const saved: Record<string, string | undefined> = {};
+  beforeEach(() => {
+    for (const k of ['EVIDENCE_PROCESSOR_BROKER', 'EVIDENCE_SUBSTRATE_ENABLED']) {
+      saved[k] = process.env[k];
+      process.env[k] = '1';
+    }
+  });
+  afterEach(() => {
+    for (const [k, v] of Object.entries(saved)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  });
+
+  it('a clean sweep is complete, one unit per asset', async () => {
+    const f = fixture({
+      adapter: adapterOf(() => Promise.resolve([{ kind: 'caption', content: 'ok' }])),
+      assets: ['evidence_asset:a1', 'evidence_asset:a2'],
+    });
+    const res = await f.broker.dispatchSweep('co_x', { packId: 'proc_pack' });
+    expect(res).toMatchObject({ assets: 2, dispatched: 2, runs: 2, failed: 0 });
+    expect(res.outcome).toEqual({
+      status: 'complete',
+      total: 2,
+      succeeded: 2,
+      failed: [],
+      degradedBy: [],
+    });
+  });
+
+  it('a run that recorded `failed` fails its asset — every asset ⇒ failed sweep', async () => {
+    const f = fixture({
+      adapter: adapterOf(() => Promise.reject(new Error('ocr engine crashed'))),
+      assets: ['evidence_asset:a1', 'evidence_asset:a2'],
+    });
+    const res = await f.broker.dispatchSweep('co_x', { packId: 'proc_pack' });
+    // The legacy counters still say "dispatched without throwing"…
+    expect(res).toMatchObject({ dispatched: 2, runs: 2, failed: 0 });
+    // …the outcome says what actually happened.
+    expect(res.outcome.status).toBe('failed');
+    expect(res.outcome.failed).toEqual([
+      { key: 'evidence_asset:a1', error: 'caption: ocr engine crashed' },
+      { key: 'evidence_asset:a2', error: 'caption: ocr engine crashed' },
+    ]);
+  });
+
+  it('a single-asset dispatch carries its own outcome keyed by capability', async () => {
+    const f = fixture({
+      adapter: adapterOf(() => Promise.reject(new Error('boom'))),
+      assets: ['evidence_asset:a1'],
+    });
+    const res = await f.broker.dispatchForPack('co_x', {
+      packId: 'proc_pack',
+      assetId: 'evidence_asset:a1',
+    });
+    expect(res.runs[0]).toMatchObject({ status: 'failed', error: 'boom' });
+    expect(res.outcome).toMatchObject({ status: 'failed', total: 1, succeeded: 0 });
+    expect(res.outcome.failed).toEqual([{ key: 'caption', error: 'boom' }]);
+  });
+
+  it('an asset whose dispatch throws is a failed unit too; the sweep is degraded', async () => {
+    const f = fixture({
+      adapter: adapterOf(() => Promise.resolve([{ kind: 'caption', content: 'ok' }])),
+      assets: ['evidence_asset:a1'],
+    });
+    const res = await f.broker.dispatchSweep('co_x', {
+      packId: 'proc_pack',
+      assetIds: ['evidence_asset:a1', 'evidence_asset:missing'],
+    });
+    expect(res).toMatchObject({ assets: 2, dispatched: 1, failed: 1 });
+    expect(res.outcome.status).toBe('degraded');
+    expect(res.outcome.failed).toEqual([
+      { key: 'evidence_asset:missing', error: 'asset evidence_asset:missing not found' },
+    ]);
+  });
+
+  it('retry with assetIds dispatches exactly those and never reads candidates', async () => {
+    const f = fixture({
+      adapter: adapterOf(() => Promise.resolve([{ kind: 'caption', content: 'ok' }])),
+      assets: ['evidence_asset:a1', 'evidence_asset:a2', 'evidence_asset:a3'],
+    });
+    const res = await f.broker.dispatchSweep('co_x', {
+      packId: 'proc_pack',
+      assetIds: ['evidence_asset:a2'],
+    });
+    expect(f.queries.some((q) => q.includes('SELECT VALUE id FROM evidence_asset'))).toBe(false);
+    expect(res).toMatchObject({ assets: 1, dispatched: 1 });
+    expect(res.outcome).toMatchObject({ status: 'complete', total: 1, succeeded: 1 });
+  });
+});

--- a/test/reindex-outcome.unit-spec.ts
+++ b/test/reindex-outcome.unit-spec.ts
@@ -1,0 +1,179 @@
+/**
+ * Reindex terminal status (src/ai/embedder/reindex-engine.service.ts +
+ * reindex-embeddings.service.ts): a page the embedder refused, or a row
+ * whose write failed, used to be a warning and a smaller `updated` count.
+ * Now the table is a failed unit, the tenant's sweep is `degraded` or
+ * `failed`, and `tables` (the retry selector) re-sweeps exactly the named
+ * tables. The roster fold treats a tenant that threw as a failed unit.
+ */
+import { ReindexEngineService } from '../src/ai/embedder/reindex-engine.service';
+import { ReindexEmbeddingsService } from '../src/ai/embedder/reindex-embeddings.service';
+import type { ApiKeyService } from '../src/auth/api-key.service';
+
+interface QueryCall {
+  sql: string;
+  params: Record<string, unknown> | undefined;
+}
+
+function makeDb(opts: {
+  pages: Record<string, Array<Record<string, unknown>>>;
+  /** Row ids whose UPDATE throws. */
+  failingRows?: string[];
+}) {
+  const calls: QueryCall[] = [];
+  const db = {
+    query: async (sql: string, params?: Record<string, unknown>) => {
+      calls.push({ sql, params });
+      if (/^\s*UPDATE/.test(sql)) {
+        if (opts.failingRows?.includes(String(params?.id))) throw new Error('write refused');
+        return [[]];
+      }
+      const offset = Number(params?.offset ?? 0);
+      for (const [table, rows] of Object.entries(opts.pages)) {
+        if (sql.includes(`FROM ${table}`)) return [offset === 0 ? rows : []];
+      }
+      return [[]];
+    },
+  };
+  return { db, calls };
+}
+
+function makeEngine(opts: {
+  pages: Record<string, Array<Record<string, unknown>>>;
+  failingRows?: string[];
+  /** Texts whose embed batch throws (matched by inclusion). */
+  failingTexts?: string[];
+}) {
+  const { db, calls } = makeDb(opts);
+  const surreal = {
+    withCompany: async <T>(_c: string, fn: (d: typeof db) => Promise<T>) => fn(db),
+  } as never;
+  const embedder = {
+    embedManyForWrite: async (texts: string[]) => {
+      if (opts.failingTexts?.some((t) => texts.some((x) => x.includes(t)))) {
+        throw new Error('embed batch refused');
+      }
+      return texts.map(() => [1, 2, 3]);
+    },
+    activeSpaceId: () => 'openai:text-embedding-3-small:1536:l2',
+    cacheStats: () => ({ provider: 'openai:text-embedding-3-small:1536' }),
+  } as never;
+  const config = {
+    get: (k: string, def?: string) => (k === 'REINDEX_BATCH_SIZE' ? '200' : def),
+  } as never;
+  return { engine: new ReindexEngineService(surreal, embedder, config), calls };
+}
+
+const FACT_PAGE = [{ id: 'knowledge_fact:1', predicate: 'status', object: 'active' }];
+const SCENE_PAGE = [
+  { id: 'memory_episode:1', gist: 'scene one' },
+  { id: 'memory_episode:2', gist: 'scene two' },
+];
+const OPTS = { dryRun: false, remaining: 1000 };
+
+describe('ReindexEngineService — terminal status per tenant', () => {
+  it('a clean default sweep is complete with knowledge_fact as its one unit', async () => {
+    const { engine } = makeEngine({ pages: { knowledge_fact: FACT_PAGE } });
+    const res = await engine.reindexTenant('co_x', OPTS);
+    expect(res.factsUpdated).toBe(1);
+    expect(res).not.toHaveProperty('tables');
+    expect(res.outcome).toEqual({
+      status: 'complete',
+      total: 1,
+      succeeded: 1,
+      failed: [],
+      degradedBy: [],
+    });
+  });
+
+  it('an embed batch the embedder refuses fails the table — the only table ⇒ failed', async () => {
+    const { engine } = makeEngine({
+      pages: { knowledge_fact: FACT_PAGE },
+      failingTexts: ['status: active'],
+    });
+    const res = await engine.reindexTenant('co_x', OPTS);
+    expect(res.factsUpdated).toBe(0);
+    expect(res.outcome.status).toBe('failed');
+    expect(res.outcome.failed).toEqual([
+      { key: 'knowledge_fact', error: '1 page(s) failed to embed, 0 row write(s) failed' },
+    ]);
+  });
+
+  it('a row write that fails degrades the sweep and names the table', async () => {
+    const { engine } = makeEngine({
+      pages: { knowledge_fact: FACT_PAGE, memory_episode: SCENE_PAGE },
+      failingRows: ['memory_episode:2'],
+    });
+    const res = await engine.reindexTenant('co_x', { ...OPTS, allTables: true });
+    expect(res.outcome.status).toBe('degraded');
+    expect(res.outcome.total).toBe(7);
+    expect(res.outcome.failed).toEqual([
+      { key: 'memory_episode', error: '0 page(s) failed to embed, 1 row write(s) failed' },
+    ]);
+    expect(res.tables?.find((t) => t.table === 'memory_episode')).toEqual({
+      table: 'memory_episode',
+      scanned: 2,
+      updated: 1,
+    });
+  });
+
+  it('retry with `tables` sweeps exactly those tables — knowledge_fact is not touched', async () => {
+    const { engine, calls } = makeEngine({
+      pages: { knowledge_fact: FACT_PAGE, memory_episode: SCENE_PAGE },
+    });
+    const res = await engine.reindexTenant('co_x', { ...OPTS, tables: ['memory_episode'] });
+    const selects = calls.filter((c) => /^\s*SELECT/.test(c.sql)).map((c) => c.sql);
+    expect(selects.some((s) => s.includes('FROM knowledge_fact'))).toBe(false);
+    expect(selects.some((s) => s.includes('FROM memory_episode'))).toBe(true);
+    expect(res.factsScanned).toBe(0);
+    expect(res.tables).toEqual([{ table: 'memory_episode', scanned: 2, updated: 2 }]);
+    expect(res.outcome).toMatchObject({ status: 'complete', total: 1, succeeded: 1 });
+  });
+});
+
+describe('ReindexEmbeddingsService — roster fold', () => {
+  function makeRoster(
+    perTenant: Record<string, () => Promise<{ factsScanned: number; factsUpdated: number }>>,
+  ) {
+    const apiKeys = { knownCompanyIds: () => Object.keys(perTenant) } as unknown as ApiKeyService;
+    const engine = {
+      providerId: () => 'stub',
+      reindexTenant: async (companyId: string) => {
+        const r = await perTenant[companyId]!();
+        return {
+          ...r,
+          outcome: { status: 'complete', total: 1, succeeded: 1, failed: [], degradedBy: [] },
+        };
+      },
+    } as unknown as ReindexEngineService;
+    return new ReindexEmbeddingsService(apiKeys, engine);
+  }
+
+  it('a tenant that throws is a failed unit keyed by companyId; the rest still count', async () => {
+    const svc = makeRoster({
+      co_a: async () => ({ factsScanned: 2, factsUpdated: 2 }),
+      co_b: async () => {
+        throw new Error('pool exhausted');
+      },
+    });
+    const res = await svc.run({});
+    expect(res.factsUpdated).toBe(2);
+    expect(res.outcome.status).toBe('degraded');
+    expect(res.outcome.failed).toEqual([
+      {
+        key: 'co_b',
+        error: 'failed: 0 of 0 unit(s) succeeded (1 failed); first: * — pool exhausted',
+      },
+    ]);
+  });
+
+  it('every tenant throwing ⇒ failed', async () => {
+    const svc = makeRoster({
+      co_a: async () => {
+        throw new Error('down');
+      },
+    });
+    const res = await svc.run({});
+    expect(res.outcome.status).toBe('failed');
+  });
+});

--- a/test/scene-composer-outcome.unit-spec.ts
+++ b/test/scene-composer-outcome.unit-spec.ts
@@ -1,0 +1,197 @@
+/**
+ * SceneComposerService terminal status (src/admin/scene-composer.service.ts):
+ *   - a post-swap pass that throws, or reports failed scenes, DEGRADES the
+ *     run — the swap stands, but the outcome says so under post-pass:<name>;
+ *   - every conversation failing ⇒ `failed`, with the conversation ids as
+ *     retry keys;
+ *   - `conversationIds` (the retry selector) composes exactly those ids and
+ *     never runs the O(all turns) enumeration.
+ *
+ * Collaborators are positional fakes; a conversation with no turns is a
+ * clean unit (the composer counts it and touches no table), so no
+ * transaction is ever issued here.
+ */
+import { SceneComposerService } from '../src/admin/scene-composer.service';
+import type { SurrealService } from '../src/db/surreal.service';
+import type { FactEmbeddingService } from '../src/ingest/fact-embedding.service';
+import type { EpisodeReadStoreService } from '../src/episodes/episode-read-store.service';
+import type { ProjectionRegistryService } from '../src/episodes/projection-registry.service';
+import type { SceneEnricherService } from '../src/admin/scene-enricher.service';
+import type { SceneBacklinkService } from '../src/admin/scene-backlink.service';
+import type { SceneEvidenceLinkerService } from '../src/admin/scene-evidence-linker.service';
+import type { SceneVersionService } from '../src/admin/scene-version';
+import type { SceneGistEmbeddingService } from '../src/admin/scene-gist-embedding.service';
+
+const FLAGS = ['SCENES_SEGMENTATION_ENABLED', 'SCENES_LLM_ENRICHMENT', 'SCENES_FACT_BACKLINK'];
+const saved: Record<string, string | undefined> = {};
+beforeEach(() => {
+  for (const k of FLAGS) {
+    saved[k] = process.env[k];
+    delete process.env[k];
+  }
+  process.env.SCENES_SEGMENTATION_ENABLED = '1';
+});
+afterEach(() => {
+  for (const k of FLAGS) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+});
+
+interface Fakes {
+  /** Conversations the enumeration would return. */
+  enumerated: string[];
+  /** Conversations whose turn read throws (the unit failure). */
+  throwing?: Record<string, string>;
+  enrich?: () => Promise<{ scenes: number; enriched: number; failed: number; skipped: number }>;
+  backlink?: () => Promise<{ scenes: number; factsLinked: number }>;
+}
+
+function makeComposer(f: Fakes) {
+  const enumerations: number[] = [];
+  const turnReads: string[] = [];
+  const surreal = {
+    withCompany: async <T>(_c: string, fn: (db: unknown) => Promise<T>) => fn({}),
+  } as unknown as SurrealService;
+  const embedding = {
+    embedMany: async () => {
+      throw new Error('never embeds here');
+    },
+  } as unknown as FactEmbeddingService;
+  const episodes = {
+    conversationCounts: async () => {
+      enumerations.push(1);
+      return f.enumerated.map((conversationId) => ({ conversationId }));
+    },
+    conversationTurnsRaw: async (_db: unknown, conversationId: string) => {
+      turnReads.push(conversationId);
+      const reason = f.throwing?.[conversationId];
+      if (reason) throw new Error(reason);
+      return [];
+    },
+  } as unknown as EpisodeReadStoreService;
+  const registry = {
+    begin: async () => undefined,
+    complete: async () => undefined,
+    fail: async () => undefined,
+  } as unknown as ProjectionRegistryService;
+  const enricher = {
+    enrich: f.enrich ?? (async () => ({ scenes: 0, enriched: 0, failed: 0, skipped: 0 })),
+  } as unknown as SceneEnricherService;
+  const backlinker = {
+    run: f.backlink ?? (async () => ({ scenes: 0, factsLinked: 0 })),
+  } as unknown as SceneBacklinkService;
+  const evidenceLinker = { run: async () => undefined } as unknown as SceneEvidenceLinkerService;
+  const versions = {
+    resolve: () => ({
+      version: 'scene-segmenter-v1',
+      cfg: { topicBoundary: false, minCosine: 0.5, maxTurns: 40 },
+    }),
+  } as unknown as SceneVersionService;
+  const gistEncoder = { run: async () => undefined } as unknown as SceneGistEmbeddingService;
+  const svc = new SceneComposerService(
+    surreal,
+    embedding,
+    episodes,
+    registry,
+    enricher,
+    backlinker,
+    evidenceLinker,
+    versions,
+    gistEncoder,
+  );
+  return { svc, enumerations, turnReads };
+}
+
+describe('SceneComposerService — terminal status', () => {
+  it('a clean run is complete, with one unit per conversation', async () => {
+    const { svc } = makeComposer({ enumerated: ['c1', 'c2'] });
+    const res = await svc.run('co_x');
+    expect(res.outcome).toEqual({
+      status: 'complete',
+      total: 2,
+      succeeded: 2,
+      failed: [],
+      degradedBy: [],
+    });
+  });
+
+  it('a post-swap pass that THROWS degrades the run (the swap stands)', async () => {
+    process.env.SCENES_LLM_ENRICHMENT = '1';
+    const { svc } = makeComposer({
+      enumerated: ['c1'],
+      enrich: async () => {
+        throw new Error('openai 429');
+      },
+    });
+    const res = await svc.run('co_x');
+    expect(res.conversations).toBe(1);
+    expect(res.outcome.status).toBe('degraded');
+    expect(res.outcome.failed).toEqual([]);
+    expect(res.outcome.degradedBy).toEqual([{ key: 'post-pass:enrich', error: 'openai 429' }]);
+  });
+
+  it('a post-swap pass that REPORTS failed scenes degrades the run too', async () => {
+    process.env.SCENES_LLM_ENRICHMENT = '1';
+    process.env.SCENES_FACT_BACKLINK = '1';
+    const { svc } = makeComposer({
+      enumerated: ['c1'],
+      enrich: async () => ({ scenes: 4, enriched: 1, failed: 3, skipped: 0 }),
+    });
+    const res = await svc.run('co_x');
+    expect(res.enriched).toBe(1);
+    expect(res.outcome.status).toBe('degraded');
+    expect(res.outcome.degradedBy).toEqual([
+      { key: 'post-pass:enrich', error: '3 of 4 scene(s) failed' },
+    ]);
+  });
+
+  it('every conversation failing ⇒ failed, keyed by conversation id', async () => {
+    const { svc } = makeComposer({
+      enumerated: ['c1', 'c2'],
+      throwing: { c1: 'surreal timeout', c2: 'surreal timeout' },
+    });
+    const res = await svc.run('co_x');
+    expect(res.skipped).toHaveLength(2);
+    expect(res.outcome.status).toBe('failed');
+    expect(res.outcome.total).toBe(2);
+    expect(res.outcome.succeeded).toBe(0);
+    expect(res.outcome.failed).toEqual([
+      { key: 'c1', error: 'surreal timeout' },
+      { key: 'c2', error: 'surreal timeout' },
+    ]);
+  });
+
+  it('some conversations failing ⇒ degraded, only the failed ones are retry keys', async () => {
+    const { svc } = makeComposer({
+      enumerated: ['c1', 'c2', 'c3'],
+      throwing: { c2: 'boom' },
+    });
+    const res = await svc.run('co_x');
+    expect(res.outcome.status).toBe('degraded');
+    expect(res.outcome.failed.map((f) => f.key)).toEqual(['c2']);
+  });
+
+  it('retry with conversationIds composes exactly those ids and skips the enumeration', async () => {
+    const { svc, enumerations, turnReads } = makeComposer({
+      enumerated: ['c1', 'c2', 'c3'],
+      throwing: { c2: 'boom' },
+    });
+    const first = await svc.run('co_x');
+    const retry = await svc.run('co_x', {
+      conversationIds: first.outcome.failed.map((f) => f.key),
+    });
+    expect(enumerations).toHaveLength(1);
+    expect(turnReads.slice(3)).toEqual(['c2']);
+    expect(retry.outcome).toMatchObject({ status: 'failed', total: 1, succeeded: 0 });
+    expect(retry.outcome.failed).toEqual([{ key: 'c2', error: 'boom' }]);
+  });
+
+  it('with the master flag off the run is an empty complete batch', async () => {
+    delete process.env.SCENES_SEGMENTATION_ENABLED;
+    const { svc, enumerations } = makeComposer({ enumerated: ['c1'] });
+    const res = await svc.run('co_x');
+    expect(enumerations).toHaveLength(0);
+    expect(res.outcome).toMatchObject({ status: 'complete', total: 0 });
+  });
+});

--- a/test/scene-maintenance.unit-spec.ts
+++ b/test/scene-maintenance.unit-spec.ts
@@ -19,6 +19,7 @@ import type {
   BeliefPromotionResult,
 } from '../src/admin/belief-promotion.service';
 import type { MetricsService } from '../src/metrics/metrics.service';
+import { emptyBatchOutcome, foldBatchOutcome } from '../src/common/batch-outcome';
 
 const FLAGS = [
   'SCENES_SEGMENTATION_ENABLED',
@@ -112,12 +113,20 @@ function makeComposer(
   return { composer, calls };
 }
 
-const composed = (over: Partial<SceneRunResult> = {}): SceneRunResult => ({
-  conversations: 0,
-  scenes: 0,
-  skipped: [],
-  ...over,
-});
+/** A composer result whose outcome is folded from its counters, like the real one. */
+const composed = (over: Partial<SceneRunResult> = {}): SceneRunResult => {
+  const base = { conversations: 0, scenes: 0, skipped: [], ...over };
+  return {
+    ...base,
+    outcome:
+      over.outcome ??
+      foldBatchOutcome({
+        total: base.conversations + base.skipped.length,
+        succeeded: base.conversations,
+        failed: base.skipped.map((s) => ({ key: s.conversationId, error: s.reason })),
+      }),
+  };
+};
 
 function makeBeliefs(result?: Partial<BeliefPromotionResult>, throws?: string) {
   const calls: string[] = [];
@@ -171,6 +180,7 @@ describe('SceneMaintenanceService — flag gate', () => {
       tenants: [],
       budgetExhausted: false,
       skippedForBudget: 0,
+      outcome: emptyBatchOutcome(),
     });
     expect(roster).not.toHaveBeenCalled();
     expect(calls).toHaveLength(0);

--- a/test/vector-corpus.unit-spec.ts
+++ b/test/vector-corpus.unit-spec.ts
@@ -43,7 +43,12 @@ describe('VectorCorpusService', () => {
     const reindex = {
       run: jest.fn(async () => {
         if (opts.afterRepair) census = opts.afterRepair;
-        return { factsScanned: 40, factsUpdated: 39, tables: [] };
+        return {
+          factsScanned: 40,
+          factsUpdated: 39,
+          tables: [],
+          outcome: { status: 'complete', total: 7, succeeded: 7, failed: [], degradedBy: [] },
+        };
       }),
     };
     const jobs = {

--- a/test/window-deriver.unit-spec.ts
+++ b/test/window-deriver.unit-spec.ts
@@ -2,6 +2,7 @@ import { BadGatewayException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { EpisodeReadStoreService } from '../src/episodes/episode-read-store.service';
 import { throwIfDeriveFailed } from '../src/admin/admin-derive.controller';
+import { foldBatchOutcome } from '../src/common/batch-outcome';
 import {
   WindowDeriverService,
   segmentSessions,
@@ -703,14 +704,20 @@ describe('WindowDeriverService (P3 v1 batch)', () => {
         propositions: 0,
         unresolvedSubjects: 0,
       };
+      const failedSkipped = [
+        { conversationId: 'c1', reason: '429 insufficient_quota' },
+        { conversationId: 'c2', reason: '429 insufficient_quota' },
+      ];
       const failed = {
         ...base,
         status: 'failed' as const,
         failed: 2,
-        skipped: [
-          { conversationId: 'c1', reason: '429 insufficient_quota' },
-          { conversationId: 'c2', reason: '429 insufficient_quota' },
-        ],
+        skipped: failedSkipped,
+        outcome: foldBatchOutcome({
+          total: 2,
+          succeeded: 0,
+          failed: failedSkipped.map((s) => ({ key: s.conversationId, error: s.reason })),
+        }),
       };
       expect(() => throwIfDeriveFailed(failed)).toThrow(BadGatewayException);
       const degraded = {
@@ -719,6 +726,11 @@ describe('WindowDeriverService (P3 v1 batch)', () => {
         status: 'degraded' as const,
         failed: 1,
         skipped: [{ conversationId: 'c1', reason: 'x' }],
+        outcome: foldBatchOutcome({
+          total: 2,
+          succeeded: 1,
+          failed: [{ key: 'c1', error: 'x' }],
+        }),
       };
       expect(throwIfDeriveFailed(degraded)).toBe(degraded);
     });

--- a/test/worker-loop.unit-spec.ts
+++ b/test/worker-loop.unit-spec.ts
@@ -137,6 +137,53 @@ describe('JobDispatcherService.dispatch', () => {
     expect(claimSvc.calls.failed).toHaveLength(0);
   });
 
+  it('a returned FAILED batch outcome is treated like a throw: fail(), result persisted', async () => {
+    const claim = makeJobClaim({ attempts: 2 });
+    const claimSvc = makeClaimSvc();
+    const outcome = {
+      status: 'failed',
+      total: 3,
+      succeeded: 0,
+      failed: [{ key: 'conv-1', error: 'llm down' }],
+      degradedBy: [],
+    };
+    const reg = {
+      jobType: 'recompose' as JobType,
+      handler: async () => ({ marked: 3, outcome }),
+      ttlSeconds: 3,
+      maxAttempts: 5,
+    };
+    await callDispatch(mkDispatcher(claimSvc), claim, reg);
+    expect(claimSvc.calls.completed).toHaveLength(0);
+    expect(claimSvc.calls.failed).toHaveLength(1);
+    const input = claimSvc.fail.mock.calls[0]![0] as Record<string, unknown>;
+    expect(input).toMatchObject({
+      recordId: 'job_run:abc',
+      attempts: 2,
+      requeue: true,
+      maxAttempts: 5,
+      error: { name: 'BatchFailed' },
+      result: { marked: 3, outcome },
+    });
+    expect((input.error as { message: string }).message).toContain('conv-1 — llm down');
+  });
+
+  it('a returned DEGRADED batch outcome still completes (the units landed)', async () => {
+    const claim = makeJobClaim();
+    const claimSvc = makeClaimSvc();
+    const reg = {
+      jobType: 'recompose' as JobType,
+      handler: async () => ({
+        outcome: { status: 'degraded', total: 2, succeeded: 1, failed: [], degradedBy: [] },
+      }),
+      ttlSeconds: 3,
+      maxAttempts: 3,
+    };
+    await callDispatch(mkDispatcher(claimSvc), claim, reg);
+    expect(claimSvc.calls.completed).toHaveLength(1);
+    expect(claimSvc.calls.failed).toHaveLength(0);
+  });
+
   it('records a job metric with the terminal outcome and a duration', async () => {
     const claim = makeJobClaim({ jobType: 'dreams' });
     const claimSvc = makeClaimSvc();


### PR DESCRIPTION
## What

Makes the service safe for N identical replicas along the three paths the replica-safety audit found unguarded or under-guarded. No new flags or env knobs; the guard's existing `run(key, fn, ttl)` API and `LeaderLeaseService.tryAcquire` are the only primitives used. `src/jobs/*` and `src/main.ts` are untouched; the `knownCompanyIds()` roster lines are left byte-identical for #548.

**A. Boot hooks (S1).** `VectorCorpusService` and `HnswProvisionService` take the schema-ready hook on every replica, so a tenant's first request triggered N full re-embeds of its corpus and N concurrent `DEFINE INDEX … CONCURRENTLY` builds. The per-tenant hook body now runs under `guard.run('vector_corpus_startup_<tenant>' | 'hnsw_provision_startup_<tenant>', …, 1800)`; a replica that finds the lease held skips silently. The deferred-repair poller (`retryWhenReady`) is untouched and re-enters through the same lease once the embedder is warm. Tenant ids are folded to `[A-Za-z0-9_]` (`tenantLeaseKey`) because lease names are composed into a `leader_lease:` record id — a `:` in the key would fail to parse and every replica would silently skip.

**B. Sweeps that ran raw on every replica (S2/S3).** The inline compaction fallback, `OutcomePruneService`, the strategy `deprecateSweep` and the `MemoryQualityService` snapshot each get `@Optional() guard?: DistributedLeaseGuard` and run their cron body under `compaction_all` (60 min), `outcome_prune` (60 min), `strategy_sweep` (30 min), `memory_quality` (30 min). The process-local single-flight flags stay as the reentrancy layer. A fixture without the guard runs unguarded exactly as before, with one warning per process (`noteUnguarded`). The memory-quality header now states the per-pod gauge contract (aggregate with `max()`; non-leaders export nothing for the labelled series).

**C. Per-minute consumers (S1).** `ChangefeedConsumerService.tick` and `EpisodeSubscriptionService.dispatchTick` held a 180 s lease they never renewed across the tenant walk, and advanced cursors unconditionally. Both now renew the lease mid-walk (a same-identity `tryAcquire` is the lease's renew branch; the DB is hit only once less than half the TTL remains) and stop the walk when the renewal fails. The changefeed cursor advance is a CAS inside the existing drain transaction — `LET $cur = (SELECT VALUE lastVersionstamp FROM changefeed_state:[$source])[0]; IF $cur IS NONE OR $cur < $vs { INSERT IGNORE …; UPSERT …; RETURN true } ELSE { RETURN false }` — read by record id (no table scan in the SSI read-set), BigInt end-to-end; a lost race writes nothing and stops the walk (`cursorRaceLost`), including from the admin `drainNow`. The episode watermark advance becomes `UPDATE $id SET watermark = … WHERE watermark < <datetime> $new` with the zero-row result treated as "another dispatcher is ahead — stop". A batch whose newest row floors to the stored millisecond watermark (`recordedAt` is `time::now()` at ns precision, the watermark is a JS ISO ms string) is deliberately not treated as a race: no advance is attempted and it is re-delivered next tick, as before.

## Why

Replica-safety audit findings S1 (boot hooks bypass the guard; per-minute consumers hold an unrenewed 180 s lease and advance cursors blindly — a drain longer than 180 s let a second replica acquire mid-walk and the slower drain's unconditional `UPSERT changefeed_state` rewound the cursor, producing duplicate `audit_event` rows / duplicate webhook pushes) and S2/S3 (nightly sweeps guarded only by a process-local flag).

## How verified

- `pnpm typecheck` — exit 0
- `pnpm lint:ci` — exit 0 (0 problems, after rebasing onto `e0c5854` which carries the #544 fix for `test/capability-probe.unit-spec.ts`)
- `pnpm format:check` — exit 0
- `pnpm jest --config ./test/jest-unit.json --testPathIgnorePatterns='/node_modules/' --modulePathIgnorePatterns='/__none__/' --testPathPatterns 'lease-guard-sweeps|vector-corpus|hnsw-provisioning|changefeed-consumer|episode-subscription|memory-outcome|memory-quality|compaction\.unit|strategy-revision|strategy-memory\.unit|contracts-admin-changefeed-state|health-components|flag-budget|config-catalog-truth'` — **Test Suites: 15 passed, 15 total; Tests: 178 passed, 178 total**
  - new `test/lease-guard-sweeps.unit-spec.ts`: each sweep body runs under its key/TTL via a fake guard; "lease held" → skip with the empty result; unguarded fixtures unchanged; same-pod overlap still refused
  - `test/vector-corpus.unit-spec.ts` / `test/hnsw-provisioning.unit-spec.ts`: hook under `*_startup_<tenant>` (1800 s); held → no census/sweep/DDL/registry write; the deferred-repair poller re-enters through the same lease; the nightly keeps `hnsw_provision_all`
  - `test/changefeed-consumer.unit-spec.ts`: the drain fake now mirrors the CAS; a slower drain writes nothing and reports `cursorRaceLost` (cursor stays at 20, a cursor exactly at the high-water mark counts as past); the consumer renews at half TTL, stops on renewal failure and on a lost race, `drainNow` stops the same way
  - `test/episode-subscription.unit-spec.ts`: forward-only CAS shape and params; 0 rows stops the walk; the same-millisecond batch is re-delivered rather than treated as a race; lease renewal/stop
- `pnpm jest --config ./test/jest-e2e.json --testPathIgnorePatterns='/node_modules/' --modulePathIgnorePatterns='/__none__/' --testPathPatterns 'changefeed-drain'` (testcontainers SurrealDB) — **Test Suites: 1 passed, 1 total; Tests: 2 passed, 2 total**
  - new case "a slower drain cannot rewind the cursor past a faster one": drain B reads its window, then (interposed inside its `fetchChanges`) drain A sees one more change and advances the cursor; B's commit loses the CAS, reports `cursorRaceLost`, the cursor stays at A's value and the `audit_event` count is unchanged

## Not done / deliberately left out

- `LeaderLeaseService` has no `renew()`; per the brief `src/jobs/*` is another agent's, so renewal uses `tryAcquire` with the same identity (its CAS branch already renews). If the fencing-epoch work changes `tryAcquire`'s return type, the two `acquireLease()` helpers are the only call sites to touch.
- The brief's key spelling `vector_corpus_startup:<tenant>` was changed to `_` — see A.
- The admin `drainNow` path still takes no lease (it now stops on a lost race, which the CAS makes safe); a leased manual drain is out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhrQxeisXJZEt4sg3PGyU6
