### PR TITLE
fix(jobs): one identity per process, a fencing epoch on every claim, and a shutdown that drains

### DIFF
--- a/.github/workflows/deploy-brain.yml
+++ b/.github/workflows/deploy-brain.yml
@@ -697,9 +697,10 @@ jobs:
               # pool / native deps and forwards signals so SIGTERM reaches
               # Node cleanly.
               init: true
-              # The app's graceful shutdown drains in-flight work for up to
-              # 15s (main.ts); Docker's default 10s SIGKILLs mid-drain, so
-              # give it headroom past that budget.
+              # The app's shutdown budget (GracefulShutdownService): 6s
+              # readiness drain (/health answers 503, so traefik pulls this
+              # replica), then up to 12s for in-flight jobs, then a 25s hard
+              # stop. Docker's default 10s SIGKILLs mid-drain.
               stop_grace_period: 30s
               expose:
                 - "${PORT}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,9 +69,9 @@ services:
     # worker_threads / native processes, and without an init the Node
     # PID-1 doesn't reap them. Also forwards signals correctly.
     init: true
-    # The app's graceful shutdown gives in-flight work up to 15s before a
-    # forced exit (main.ts). Docker's default 10s SIGKILLs mid-drain; give
-    # it headroom so SIGTERM handling actually completes.
+    # The app's shutdown budget (GracefulShutdownService): 6s readiness
+    # drain, then up to 12s for in-flight jobs, then a 25s hard stop.
+    # Docker's default 10s SIGKILLs mid-drain; give it headroom past that.
     stop_grace_period: 30s
     # Mirror the prod ceilings so local OOMs surface here, not in deploy.
     mem_limit: 2g

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -894,9 +894,23 @@ This is intentional — better to refuse to start than to dribble out
 
 ## Graceful shutdown
 
-`SIGTERM` and `SIGINT` close the SurrealDB connection and drain in-
-flight requests. A 15s deadline guards against a hung shutdown so
-docker / fly / k8s don't `SIGKILL` you with no log line.
+`SIGTERM` and `SIGINT` run Nest's shutdown lifecycle exactly once —
+there is no second signal handler, and adding one races `app.close()`
+with itself. `GracefulShutdownService` owns the sequence:
+
+1. `/health` and `/ready` answer 503 immediately. Traefik health-checks
+   `/health`, so this is what takes the replica out of rotation.
+2. The process keeps serving for 6s while the balancer notices.
+3. The worker loop stops claiming, waits up to 12s for in-flight
+   dispatches, hands any claim that outlived that back to the queue
+   (`status='pending'`, visible now, `error.name='PodShutdown'`) rather
+   than leaving it `running` until its lease expires, then releases the
+   `worker_loop` lease.
+4. HTTP close, OTel flush, SurrealDB pool close.
+
+A 25s deadline forces `exit(1)` if any of that hangs, inside compose's
+`stop_grace_period: 30s`, so docker / fly / k8s never `SIGKILL` you with
+no log line.
 
 ## Deploys, and how to undo one
 

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,6 +5,7 @@ import { ScheduleModule } from '@nestjs/schedule';
 import { APP_GUARD } from '@nestjs/core';
 import { CommonModule } from './common/common.module';
 import { HealthController } from './common/health.controller';
+import { GracefulShutdownService } from './common/graceful-shutdown.service';
 import { TenantThrottlerGuard } from './common/tenant-throttler.guard';
 import { SurrealThrottlerStorage } from './common/surreal-throttler.storage';
 import { SurrealModule } from './db/surreal.module';
@@ -120,6 +121,10 @@ import { MriModule } from './mri/mri.module';
       provide: APP_GUARD,
       useClass: TenantThrottlerGuard,
     },
+    // On the root module on purpose: Nest calls each shutdown phase
+    // root-module-first, so the readiness flip and drain precede every
+    // feature module's own hook.
+    GracefulShutdownService,
   ],
 })
 export class AppModule {}

--- a/src/common/graceful-shutdown.service.ts
+++ b/src/common/graceful-shutdown.service.ts
@@ -1,0 +1,65 @@
+import {
+  Injectable,
+  Logger,
+  type BeforeApplicationShutdown,
+  type OnApplicationShutdown,
+  type OnModuleDestroy,
+} from '@nestjs/common';
+import { HealthService } from './health.service';
+import { shutdownTracing } from './tracing';
+
+/**
+ * Shutdown budget, inside compose `stop_grace_period: 30s`:
+ *   0 s    /health and /ready answer 503 (onModuleDestroy, the first hook
+ *          of the lifecycle) — the balancer stops routing here within one
+ *          health-check interval
+ *   6 s    READINESS_DRAIN_MS: keep serving while it notices (signal-driven only)
+ *   ≤12 s  WorkerLoopService drains in-flight dispatches, hands back any
+ *          claim that outlived the budget, then releases its lease
+ *   then   HTTP close, OTel flush, pool close
+ *   25 s   HARD_STOP_MS: process.exit(1) if any of that hangs, ahead of
+ *          docker's SIGKILL
+ */
+const READINESS_DRAIN_MS = 6_000;
+const HARD_STOP_MS = 25_000;
+
+/**
+ * Owns the process-level shutdown sequence so it runs exactly once, through
+ * Nest's lifecycle (enableShutdownHooks) rather than a second signal
+ * listener racing app.close() with itself. Registered on the root module:
+ * Nest calls each shutdown phase root-module-first, so the readiness flip
+ * and the drain precede every feature module's own hook.
+ */
+@Injectable()
+export class GracefulShutdownService
+  implements OnModuleDestroy, BeforeApplicationShutdown, OnApplicationShutdown
+{
+  private readonly logger = new Logger(GracefulShutdownService.name);
+  private hardStop: NodeJS.Timeout | null = null;
+
+  constructor(private readonly health: HealthService) {}
+
+  onModuleDestroy(): void {
+    this.health.markShuttingDown();
+    this.hardStop = setTimeout(() => {
+      this.logger.error(`Shutdown still running after ${HARD_STOP_MS} ms; forcing exit`);
+      process.exit(1);
+    }, HARD_STOP_MS);
+    this.hardStop.unref();
+  }
+
+  async beforeApplicationShutdown(signal?: string): Promise<void> {
+    // A programmatic close (tests, tooling) has no balancer to drain for.
+    if (!signal) return;
+    this.logger.log(
+      `${signal} received — /health and /ready are 503; serving ${READINESS_DRAIN_MS} ms more`,
+    );
+    await new Promise<void>((resolve) => setTimeout(resolve, READINESS_DRAIN_MS).unref());
+  }
+
+  async onApplicationShutdown(signal?: string): Promise<void> {
+    await shutdownTracing();
+    // Signal-driven: the deadline stays armed until the process is gone.
+    if (!signal && this.hardStop) clearTimeout(this.hardStop);
+  }
+}

--- a/src/common/health.controller.ts
+++ b/src/common/health.controller.ts
@@ -27,6 +27,19 @@ export class HealthController {
   @Get('health')
   async health() {
     const { dbOk } = await this.healthService.liveness();
+    if (this.healthService.isShuttingDown()) {
+      // The balancer health-checks THIS path (traefik loadbalancer
+      // healthcheck.path=/health, deliberately not /ready), so a leaving
+      // replica has to fail it: answering 200 until the socket closes
+      // costs a whole check interval of 502s.
+      throw new ServiceUnavailableException({
+        status: 'shutting_down',
+        service: 'inite-brain-service',
+        version: SERVICE_VERSION,
+        timestamp: new Date().toISOString(),
+        checks: { surrealdb: dbOk ? 'ok' : 'unreachable' },
+      });
+    }
     return {
       status: dbOk ? 'ok' : 'degraded',
       service: 'inite-brain-service',
@@ -53,6 +66,9 @@ export class HealthController {
       const store = detail.evidenceStore;
       throw new ServiceUnavailableException({
         ready: false,
+        // Set from the first shutdown hook on: the checks may all be fine,
+        // the replica is simply leaving the pool.
+        shuttingDown: this.healthService.isShuttingDown(),
         checks: {
           surrealdb: dbOk ? 'ok' : 'unreachable',
           // Distinct from `surrealdb`: the socket can be perfectly healthy

--- a/src/common/health.service.ts
+++ b/src/common/health.service.ts
@@ -94,6 +94,8 @@ export interface ReadinessReport extends ReadinessChecks {
  */
 @Injectable()
 export class HealthService {
+  private shuttingDown = false;
+
   constructor(
     private readonly surreal: SurrealService,
     private readonly embedder: EmbedderService,
@@ -104,6 +106,22 @@ export class HealthService {
     @Inject(EVIDENCE_STORAGE_ADAPTERS)
     private readonly storage?: EvidenceStorageRegistry,
   ) {}
+
+  /**
+   * Called the moment shutdown begins: from here `/health` and `/ready`
+   * both answer 503 so the balancer drains this replica within one
+   * health-check interval while it still serves in-flight requests.
+   * Traefik health-checks `/health` (deploy-brain.yml), which is why
+   * liveness has to say it too. One-way — a shutting-down process never
+   * becomes ready again.
+   */
+  markShuttingDown(): void {
+    this.shuttingDown = true;
+  }
+
+  isShuttingDown(): boolean {
+    return this.shuttingDown;
+  }
 
   /** Liveness — is the DB connection reachable right now. */
   async liveness(): Promise<LivenessReport> {
@@ -139,7 +157,8 @@ export class HealthService {
       scopedOk,
       embedderReady,
       evidenceStoreOk,
-      ready: dbOk && scopedOk && embedderReady && evidenceStoreOk,
+      // A shutting-down replica is not ready however green its checks are.
+      ready: !this.shuttingDown && dbOk && scopedOk && embedderReady && evidenceStoreOk,
       detail: { dbLatencyMs, scopedEnabled, scopedLatencyMs, embedder, evidenceStore },
     };
   }

--- a/src/common/tracing.ts
+++ b/src/common/tracing.ts
@@ -71,16 +71,15 @@ export function initTracing(): void {
     ],
   });
   sdk.start();
-
-  process.on('SIGTERM', () => {
-    void shutdownTracing();
-  });
 }
 
 /**
- * Flush + shut down the OTel SDK. Called from the app's graceful
- * shutdown (main.ts onTerm) so spans are exported before exit, and from
- * the SIGTERM listener above. Idempotent no-op when tracing is disabled.
+ * Flush + shut down the OTel SDK. Called from GracefulShutdownService's
+ * onApplicationShutdown so spans are exported before exit. No signal
+ * listener of its own: Nest re-raises the signal after its lifecycle, and
+ * a listener still registered at that point swallows the default exit and
+ * hangs the pod until the hard-stop deadline. Idempotent no-op when
+ * tracing is disabled.
  */
 export async function shutdownTracing(): Promise<void> {
   const s = sdk;

--- a/src/db/migrations/0142_lease_epoch_claim_fence.surql
+++ b/src/db/migrations/0142_lease_epoch_claim_fence.surql
@@ -1,0 +1,13 @@
+-- 0142: fencing token for leader leases and the claims taken under them.
+--
+-- leader_lease.epoch counts fresh acquisitions of a lease name: it goes up
+-- by one whenever the holder changes (or the row was missing), and is kept
+-- while the same holder renews. job_run.claimEpoch records the worker_loop
+-- epoch the claiming pod held when it won the row. The renew and the
+-- terminal complete / fail / cancelled / release writes require the row's
+-- claimEpoch to still equal the one the claim was taken under, so a pod
+-- whose leadership lapsed cannot overwrite a row that was claimed again in
+-- a later epoch. Both tables are SCHEMAFULL; without these definitions the
+-- writes would be rejected.
+DEFINE FIELD IF NOT EXISTS epoch ON leader_lease TYPE int DEFAULT 0;
+DEFINE FIELD IF NOT EXISTS claimEpoch ON job_run TYPE option<int>;

--- a/src/jobs/job-claim.service.ts
+++ b/src/jobs/job-claim.service.ts
@@ -1,16 +1,15 @@
 import { Injectable, Logger, Optional } from '@nestjs/common';
-import { hostname } from 'node:os';
 import { randomUUID } from 'node:crypto';
 import { context, propagation } from '@opentelemetry/api';
 import {
   SurrealService,
-  runTransaction,
   retryOnUniqueViolation,
   isUniqueViolation,
   queryRows,
   queryFirst,
 } from '../db/surreal.service';
 import { withSpan } from '../common/tracing';
+import { PROCESS_IDENTITY } from '../common/process-identity';
 import type { JobType, JobStatus } from './job-run.service';
 
 /** SurrealDB returns datetimes as a Date on 3.x and an ISO string via JSON. */
@@ -45,6 +44,12 @@ export interface JobClaim {
   /** Lease deadline. Handler MUST renew before this passes. */
   leaseUntil: string;
   /**
+   * Epoch of the worker_loop lease the claim was taken under (null when
+   * no lease was involved). Every later write on the claim is fenced on
+   * the row still carrying it.
+   */
+  claimEpoch: number | null;
+  /**
    * W3C traceparent injected at enqueue time by the producer's span
    * context. Used by WorkerLoopService.dispatch to link the consumer
    * span as a child of the producer, so trace viewers stitch the
@@ -62,9 +67,10 @@ export interface JobClaim {
  *   complete / fail → terminal state, optional requeue with backoff.
  *   reapZombies → recycle rows whose lease lapsed (worker crashed).
  *
- * The actor identity (claimedBy) is `hostname#pid` — same convention
- * as LeaderLeaseService so an operator can correlate which pod
- * holds which claim against `/admin/leases`.
+ * The actor identity (claimedBy) is PROCESS_IDENTITY — the same string
+ * LeaderLeaseService presents, so an operator can correlate which pod
+ * holds which claim against `/admin/leases`, and unique per process, so
+ * the `claimedBy = $me` guard on every write names exactly one claimer.
  *
  * Per-tenant placement: the `job_run` table lives in each tenant's
  * `co_<companyId>` database (migration 0025). All methods take a
@@ -79,11 +85,9 @@ export interface JobClaim {
 @Injectable()
 export class JobClaimService {
   private readonly logger = new Logger(JobClaimService.name);
-  private readonly workerId: string;
+  private readonly workerId: string = PROCESS_IDENTITY;
 
-  constructor(@Optional() private readonly surreal?: SurrealService) {
-    this.workerId = `${hostname()}#${process.pid}`;
-  }
+  constructor(@Optional() private readonly surreal?: SurrealService) {}
 
   identity(): string {
     return this.workerId;
@@ -108,7 +112,6 @@ export class JobClaimService {
       return { runId: randomUUID(), created: true };
     }
     const runId = randomUUID();
-    const visibleAfterIso = (input.visibleAfter ?? new Date()).toISOString();
     // Capture the active W3C trace context (if any) so the consumer
     // span can attach as a child. Empty carrier outside an active
     // span — that's fine, the field stays unset and the consumer
@@ -129,14 +132,22 @@ export class JobClaimService {
       `startedAt: time::now()`,
       `cancelRequested: false`,
       `attempts: 0`,
-      `visibleAfter: type::datetime($visibleAfter)`,
     ];
     const params: Record<string, unknown> = {
       runId,
       jobType: input.jobType,
       triggeredBy: input.triggeredBy,
-      visibleAfter: visibleAfterIso,
     };
+    // An unscheduled job takes visibleAfter from the schema DEFAULT
+    // (time::now(), migration 0028) rather than this process's clock: the
+    // claim filter is `visibleAfter <= time::now()`, so a row stamped from
+    // a clock running ahead of the datastore's is unclaimable until the
+    // difference elapses. Only a deliberately delayed job carries a
+    // caller-supplied instant.
+    if (input.visibleAfter !== undefined) {
+      fields.push(`visibleAfter: type::datetime($visibleAfter)`);
+      params.visibleAfter = input.visibleAfter.toISOString();
+    }
     if (input.triggeredByActor !== undefined) {
       fields.push(`triggeredByActor: $actor`);
       params.actor = input.triggeredByActor;
@@ -191,66 +202,71 @@ export class JobClaimService {
   }
 
   /**
-   * Find the oldest pending row for a (companyId, jobType) and CAS it
-   * to running. Returns null when nothing is claimable (queue empty,
-   * scheduled-future, or another pod grabbed it first).
+   * Claim the oldest visible pending row for a (companyId, jobType): pick
+   * the candidate with an index-backed read (job_run_claim_idx) outside
+   * any transaction, then compare-and-set that ONE record pending→running.
+   * A lost CAS (0 rows — another claimer got there first) moves on to the
+   * next candidate, up to three per call. The previous shape ran the
+   * SELECT and the UPDATE inside one transaction, which put the whole
+   * table in the SSI read-set: two claimers aborted each other instead of
+   * one of them winning. Returns null when nothing is claimable. `epoch`
+   * is the worker_loop lease epoch the caller holds — stamped on the row,
+   * it fences every later write on the claim.
    */
   async claimNext(input: {
     companyId: string;
     jobType: JobType;
     ttlSeconds: number;
+    epoch?: number | null;
   }): Promise<JobClaim | null> {
     if (!this.surreal) return null;
+    const claimEpoch = input.epoch ?? null;
     try {
       // JS-computed deadline + type::datetime: parses on SurrealDB 2.x
       // and 3.x alike, unlike the duration::from_* function path (see
-      // LeaderLeaseService.tryAcquire).
+      // LeaderLeaseService.acquire).
       const until = new Date(Date.now() + input.ttlSeconds * 1000).toISOString();
       return await retryOnUniqueViolation(() =>
         this.surreal!.withCompany(input.companyId, async (db) => {
-          const claimed = await runTransaction<unknown>(db, (tx) => {
-            tx.bind('jobType', input.jobType)
-              .bind('me', this.workerId)
-              .bind('until', until)
-              .add(
-                `LET $row = (SELECT * FROM job_run
-                              WHERE jobType = $jobType
-                                AND status = 'pending'
-                                AND visibleAfter <= time::now()
-                              ORDER BY visibleAfter ASC
-                              LIMIT 1)[0]`,
-              )
-              .add(
-                `IF $row IS NONE { RETURN NONE }
-                 ELSE {
-                   LET $updated = (UPDATE $row.id
-                       SET status = 'running',
-                           claimedBy = $me,
-                           claimedAt = time::now(),
-                           leaseUntil = type::datetime($until),
-                           heartbeatAt = time::now(),
-                           attempts = ($row.attempts OR 0) + 1
-                     WHERE status = 'pending'
-                     RETURN AFTER)[0];
-                   RETURN $updated;
-                 }`,
-              );
-          });
-          if (!claimed || typeof claimed !== 'object') return null;
-          const row = claimed as Record<string, unknown>;
-          const recordId = String(row.id ?? '');
-          const runId = String(row.runId ?? '');
-          if (!recordId || !runId) return null;
-          return {
-            recordId,
-            runId,
-            jobType: row.jobType as JobType,
-            companyId: input.companyId,
-            attempts: Number(row.attempts ?? 1),
-            payload: (row.payload as Record<string, unknown> | null) ?? null,
-            leaseUntil: new Date(row.leaseUntil as string).toISOString(),
-            traceparent: typeof row.traceparent === 'string' ? row.traceparent : undefined,
-          } satisfies JobClaim;
+          for (let attempt = 0; attempt < 3; attempt++) {
+            const candidate = await queryFirst<{ id: unknown }>(
+              db,
+              // visibleAfter is PROJECTED, not just ordered on: SurrealDB 3.x
+              // rejects an ORDER BY over an idiom missing from the selection
+              // ("Missing order idiom `visibleAfter` in statement selection").
+              `SELECT id, visibleAfter FROM job_run
+                 WHERE status = 'pending'
+                   AND visibleAfter <= time::now()
+                   AND jobType = $jobType
+                 ORDER BY visibleAfter ASC
+                 LIMIT 1`,
+              { jobType: input.jobType },
+            );
+            const rid = candidate ? String(candidate.id ?? '') : '';
+            if (!rid) return null;
+            const rows = await queryRows<Record<string, unknown>>(
+              db,
+              `UPDATE type::record($rid) SET
+                  status = 'running',
+                  claimedBy = $me,
+                  claimedAt = time::now(),
+                  leaseUntil = type::datetime($until),
+                  heartbeatAt = time::now(),
+                  attempts = (attempts OR 0) + 1,
+                  claimEpoch = ${claimEpoch === null ? 'NONE' : '$epoch'}
+                WHERE status = 'pending' AND visibleAfter <= time::now()
+                RETURN AFTER`,
+              {
+                rid,
+                me: this.workerId,
+                until,
+                ...(claimEpoch === null ? {} : { epoch: claimEpoch }),
+              },
+            );
+            const row = rows[0];
+            if (row) return this.toClaim(row, input.companyId, claimEpoch);
+          }
+          return null;
         }),
       );
     } catch (e) {
@@ -269,22 +285,24 @@ export class JobClaimService {
   async renew(input: {
     companyId: string;
     recordId: string;
+    claimEpoch: number | null;
     ttlSeconds: number;
   }): Promise<{ stillOwned: boolean; cancelRequested: boolean }> {
     if (!this.surreal) return { stillOwned: true, cancelRequested: false };
     try {
+      const guard = this.ownerGuard(input.claimEpoch);
       return await this.surreal.withCompany(input.companyId, async (db) => {
         const rows = await queryRows<{ cancelRequested?: boolean }>(
           db,
           `UPDATE type::record($rid) SET
               leaseUntil = type::datetime($until),
               heartbeatAt = time::now()
-            WHERE claimedBy = $me AND status = 'running'
+            WHERE ${guard.where}
             RETURN cancelRequested`,
           {
             rid: input.recordId,
-            me: this.workerId,
             until: new Date(Date.now() + input.ttlSeconds * 1000).toISOString(),
+            ...guard.params,
           },
         );
         if (rows.length === 0) {
@@ -322,10 +340,12 @@ export class JobClaimService {
   async complete(input: {
     companyId: string;
     recordId: string;
+    claimEpoch: number | null;
     result?: Record<string, unknown>;
   }): Promise<void> {
     if (!this.surreal) return;
     try {
+      const guard = this.ownerGuard(input.claimEpoch);
       await this.surreal.withCompany(input.companyId, async (db) => {
         const rows = await queryRows<IdRow>(
           db,
@@ -340,13 +360,13 @@ export class JobClaimService {
               status = 'succeeded',
               finishedAt = time::now(),
               result = $result,
-              claimedBy = NONE, leaseUntil = NONE
-            WHERE claimedBy = $me AND status = 'running'
+              claimedBy = NONE, leaseUntil = NONE, claimEpoch = NONE
+            WHERE ${guard.where}
             RETURN id`,
           {
             rid: input.recordId,
-            me: this.workerId,
             result: input.result ?? null,
+            ...guard.params,
           },
         );
         if (rows.length === 0) {
@@ -369,6 +389,7 @@ export class JobClaimService {
   async fail(input: {
     companyId: string;
     recordId: string;
+    claimEpoch: number | null;
     attempts: number;
     error: { message: string; name?: string };
     requeue?: boolean;
@@ -384,6 +405,7 @@ export class JobClaimService {
       // Ownership guard on both arms: a zombie-reaped, re-claimed row
       // must not be requeued or terminal-failed out from under the new
       // owner. 0 rows affected ⇒ claim lost; report requeued: false.
+      const guard = this.ownerGuard(input.claimEpoch);
       const affected = await this.surreal.withCompany(input.companyId, async (db) => {
         if (willRequeue) {
           const baseMs = input.backoffBaseMs ?? 30_000;
@@ -398,15 +420,15 @@ export class JobClaimService {
             `UPDATE type::record($rid) SET
                   status = 'pending',
                   error = $err,
-                  claimedBy = NONE, leaseUntil = NONE,
+                  claimedBy = NONE, leaseUntil = NONE, claimEpoch = NONE,
                   visibleAfter = type::datetime($visibleAfter)
-                WHERE claimedBy = $me AND status = 'running'
+                WHERE ${guard.where}
                 RETURN id`,
             {
               rid: input.recordId,
-              me: this.workerId,
               err: input.error,
               visibleAfter,
+              ...guard.params,
             },
           );
           return rows.length;
@@ -418,14 +440,14 @@ export class JobClaimService {
                 finishedAt = time::now(),
                 error = $err,
                 result = $result,
-                claimedBy = NONE, leaseUntil = NONE
-              WHERE claimedBy = $me AND status = 'running'
+                claimedBy = NONE, leaseUntil = NONE, claimEpoch = NONE
+              WHERE ${guard.where}
               RETURN id`,
           {
             rid: input.recordId,
-            me: this.workerId,
             err: input.error,
             result: input.result ?? null,
+            ...guard.params,
           },
         );
         return rows.length;
@@ -451,10 +473,12 @@ export class JobClaimService {
   async cancelled(input: {
     companyId: string;
     recordId: string;
+    claimEpoch: number | null;
     result?: Record<string, unknown>;
   }): Promise<void> {
     if (!this.surreal) return;
     try {
+      const guard = this.ownerGuard(input.claimEpoch);
       await this.surreal.withCompany(input.companyId, async (db) => {
         const rows = await queryRows<IdRow>(
           db,
@@ -463,10 +487,10 @@ export class JobClaimService {
               status = 'cancelled',
               finishedAt = time::now(),
               result = $result,
-              claimedBy = NONE, leaseUntil = NONE
-            WHERE claimedBy = $me AND status = 'running'
+              claimedBy = NONE, leaseUntil = NONE, claimEpoch = NONE
+            WHERE ${guard.where}
             RETURN id`,
-          { rid: input.recordId, me: this.workerId, result: input.result ?? null },
+          { rid: input.recordId, result: input.result ?? null, ...guard.params },
         );
         if (rows.length === 0) {
           this.logger.warn(
@@ -477,6 +501,93 @@ export class JobClaimService {
     } catch (e) {
       this.logger.warn(`cancelled(${input.recordId}) failed: ${(e as Error).message}`);
     }
+  }
+
+  /**
+   * Hand a running claim back to the queue at once, without the failure
+   * backoff: the pod is shutting down and the handler did not stop inside
+   * the drain budget. attempts stays as claimed (a restart mid-job counts,
+   * as it does for the reaper's ZombieReclaim). True iff the row was ours.
+   */
+  async release(input: {
+    companyId: string;
+    recordId: string;
+    claimEpoch: number | null;
+    reason: string;
+  }): Promise<boolean> {
+    if (!this.surreal) return false;
+    try {
+      const guard = this.ownerGuard(input.claimEpoch);
+      const rows = await this.surreal.withCompany(input.companyId, (db) =>
+        queryRows<IdRow>(
+          db,
+          `UPDATE type::record($rid) SET
+              status = 'pending',
+              error = $err,
+              claimedBy = NONE, leaseUntil = NONE, claimEpoch = NONE,
+              visibleAfter = time::now()
+            WHERE ${guard.where}
+            RETURN id`,
+          {
+            rid: input.recordId,
+            err: { name: 'PodShutdown', message: input.reason },
+            ...guard.params,
+          },
+        ),
+      );
+      if (rows.length === 0) {
+        this.logger.warn(
+          `release(${input.recordId}) no-op — claim no longer owned by ${this.workerId}`,
+        );
+      }
+      return rows.length > 0;
+    } catch (e) {
+      this.logger.warn(`release(${input.recordId}) failed: ${(e as Error).message}`);
+      return false;
+    }
+  }
+
+  /**
+   * WHERE clause naming a claim exactly: our identity, still running, and
+   * the epoch it was taken under. A row claimed again — by another pod, or
+   * by this pod in a later epoch — matches zero rows, so a stale writer
+   * cannot touch it.
+   */
+  private ownerGuard(claimEpoch: number | null): {
+    where: string;
+    params: Record<string, unknown>;
+  } {
+    return claimEpoch === null
+      ? {
+          where: `claimedBy = $me AND status = 'running' AND claimEpoch IS NONE`,
+          params: { me: this.workerId },
+        }
+      : {
+          where: `claimedBy = $me AND status = 'running' AND claimEpoch = $epoch`,
+          params: { me: this.workerId, epoch: claimEpoch },
+        };
+  }
+
+  /** Shape one claimed `RETURN AFTER` row into a JobClaim. */
+  private toClaim(
+    row: Record<string, unknown>,
+    companyId: string,
+    claimEpoch: number | null,
+  ): JobClaim | null {
+    const recordId = String(row.id ?? '');
+    const runId = String(row.runId ?? '');
+    if (!recordId || !runId) return null;
+    return {
+      recordId,
+      runId,
+      jobType: row.jobType as JobType,
+      companyId,
+      attempts: Number(row.attempts ?? 1),
+      payload: (row.payload as Record<string, unknown> | null) ?? null,
+      leaseUntil: new Date(row.leaseUntil as string).toISOString(),
+      claimEpoch,
+      traceparent: typeof row.traceparent === 'string' ? row.traceparent : undefined,
+    } satisfies JobClaim;
   }
 
   /**

--- a/src/jobs/job-dispatcher.service.ts
+++ b/src/jobs/job-dispatcher.service.ts
@@ -102,6 +102,7 @@ export class JobDispatcherService {
         const r = await this.claim.renew({
           companyId: claim.companyId,
           recordId: claim.recordId,
+          claimEpoch: claim.claimEpoch,
           ttlSeconds: reg.ttlSeconds,
         });
         if (!r.stillOwned) {
@@ -141,6 +142,7 @@ export class JobDispatcherService {
         await this.claim.cancelled({
           companyId: claim.companyId,
           recordId: claim.recordId,
+          claimEpoch: claim.claimEpoch,
           result: (result as Record<string, unknown>) ?? undefined,
         });
       } else if (lostClaim) {
@@ -162,6 +164,7 @@ export class JobDispatcherService {
         await this.claim.cancelled({
           companyId: claim.companyId,
           recordId: claim.recordId,
+          claimEpoch: claim.claimEpoch,
           result: { reason: 'cancel_requested', message: e.message },
         });
       } else if (lostClaim) {
@@ -175,6 +178,7 @@ export class JobDispatcherService {
         await this.claim.fail({
           companyId: claim.companyId,
           recordId: claim.recordId,
+          claimEpoch: claim.claimEpoch,
           attempts: claim.attempts,
           error: { message: e.message, name: e.name },
           requeue: true,
@@ -210,6 +214,7 @@ export class JobDispatcherService {
       await this.claim.fail({
         companyId: claim.companyId,
         recordId: claim.recordId,
+        claimEpoch: claim.claimEpoch,
         attempts: claim.attempts,
         error: { message, name: 'BatchFailed' },
         requeue: true,
@@ -222,6 +227,7 @@ export class JobDispatcherService {
     await this.claim.complete({
       companyId: claim.companyId,
       recordId: claim.recordId,
+      claimEpoch: claim.claimEpoch,
       result: (result as Record<string, unknown>) ?? undefined,
     });
     return 'succeeded';

--- a/src/jobs/leader-lease.service.ts
+++ b/src/jobs/leader-lease.service.ts
@@ -1,10 +1,11 @@
 import { Injectable, Logger, Optional } from '@nestjs/common';
-import { hostname } from 'node:os';
+import { PROCESS_IDENTITY } from '../common/process-identity';
 import {
   SurrealService,
   runTransaction,
   retryOnUniqueViolation,
   queryRows,
+  queryFirst,
 } from '../db/surreal.service';
 
 /** SurrealDB returns datetimes as a Date on 3.x and an ISO string via JSON. */
@@ -19,6 +20,13 @@ interface LeaseRow {
   acquiredAt: RawDateTime;
 }
 
+/** Point-read projection behind isHeld(). */
+interface HeldRow {
+  leaderId: string;
+  leaseUntil: RawDateTime;
+  epoch?: number | bigint;
+}
+
 /**
  * Acquire / renew / release named leases in `leader_lease` (migration
  * 0029). Replaces process-local InFlightGuard for cron methods on
@@ -29,6 +37,14 @@ interface LeaseRow {
  * the abort. The aspirant either wins (rows returned with our
  * leaderId) or sees a still-valid lease (we back off).
  *
+ * Every lease carries an `epoch` (migration 0142): the number of fresh
+ * acquisitions of that name. It goes up when the holder changes or the row
+ * was missing, and stays put while the same holder renews, so work done
+ * under a lease can be stamped with the epoch and refused once a later
+ * holder exists — the holder identity alone cannot say WHEN it was taken,
+ * which is what a lost lease table (a restart on a non-durable volume, an
+ * operator deleting rows) otherwise hides.
+ *
  * Defaults: ttl=90s (long enough to survive GC pauses, short enough
  * that a crashed leader's lease expires before the next cron fires).
  * Heartbeat optional — short cron jobs just acquire-then-release, no
@@ -37,11 +53,9 @@ interface LeaseRow {
 @Injectable()
 export class LeaderLeaseService {
   private readonly logger = new Logger(LeaderLeaseService.name);
-  private readonly leaderId: string;
+  private readonly leaderId: string = PROCESS_IDENTITY;
 
-  constructor(@Optional() private readonly surreal?: SurrealService) {
-    this.leaderId = `${hostname()}#${process.pid}`;
-  }
+  constructor(@Optional() private readonly surreal?: SurrealService) {}
 
   identity(): string {
     return this.leaderId;
@@ -52,16 +66,25 @@ export class LeaderLeaseService {
    * it after the call, false if another pod does.
    */
   async tryAcquire(name: string, ttlSeconds = 90): Promise<boolean> {
-    if (!this.surreal) return true; // dev / unit tests — single process
+    return (await this.acquire(name, ttlSeconds)) !== null;
+  }
+
+  /**
+   * tryAcquire that also returns the lease's fencing epoch, or null when
+   * another pod holds the lease. Without a datastore (dev / unit tests) the
+   * lease is always ours, at epoch 0.
+   */
+  async acquire(name: string, ttlSeconds = 90): Promise<number | null> {
+    if (!this.surreal) return 0; // dev / unit tests — single process
     try {
       // Deadline computed in JS and bound as an ISO string: the
       // duration::from_* / duration::from::* function paths differ
       // between SurrealDB 2.x and 3.x (prod hit a parse error on the
       // 3.x spelling), while type::datetime($iso) parses on both.
       const until = new Date(Date.now() + ttlSeconds * 1000).toISOString();
-      return await retryOnUniqueViolation(() =>
-        this.surreal!.withAdminDb(async (db) => {
-          const out = await runTransaction<unknown>(db, (tx) => {
+      const out = await retryOnUniqueViolation(() =>
+        this.surreal!.withAdminDb((db) =>
+          runTransaction<unknown>(db, (tx) => {
             tx.bind('name', name)
               .bind('me', this.leaderId)
               .bind('until', until)
@@ -81,28 +104,56 @@ export class LeaderLeaseService {
               // and constructs on both generations; lease names are
               // code-controlled [a-z_]+ so no id-escaping concerns.
               .add(`LET $row = (SELECT * FROM type::record('leader_lease:' + $name))[0]`)
+              // A missing row, a lapsed lease, or our own lease is ours to
+              // take; only a change of holder (or a missing row) bumps the
+              // epoch, so a renew by the same holder keeps its token.
               .add(
                 `IF $row IS NONE OR $row.leaseUntil < time::now() OR $row.leaderId = $me {
+                   LET $epoch = IF $row.leaderId = $me { $row.epoch OR 0 } ELSE { ($row.epoch OR 0) + 1 };
                    UPSERT type::record('leader_lease:' + $name) CONTENT {
                      name: $name,
                      leaderId: $me,
                      leaseUntil: type::datetime($until),
                      heartbeatAt: time::now(),
-                     acquiredAt: $row.acquiredAt OR time::now()
+                     acquiredAt: $row.acquiredAt OR time::now(),
+                     epoch: $epoch
                    };
-                   RETURN true;
+                   RETURN $epoch;
                  } ELSE {
-                   RETURN false;
+                   RETURN NONE;
                  }`,
               );
-          });
-          return out === true;
-        }),
+          }),
+        ),
       );
+      return typeof out === 'number' || typeof out === 'bigint' ? Number(out) : null;
     } catch (e) {
-      this.logger.warn(
-        `tryAcquire(${name}) failed: ${(e as Error).message}; treating as not-leader`,
-      );
+      this.logger.warn(`acquire(${name}) failed: ${(e as Error).message}; treating as not-leader`);
+      return null;
+    }
+  }
+
+  /**
+   * Point read: does this process hold `name` right now — our leaderId,
+   * not expired, and (when given) still at the epoch it was acquired
+   * under. A failed read answers false: not knowing is not holding.
+   */
+  async isHeld(name: string, epoch?: number): Promise<boolean> {
+    if (!this.surreal) return true; // dev / unit tests — single process
+    try {
+      return await this.surreal.withAdminDb(async (db) => {
+        // Point read on the record id, same reason acquire() point-reads.
+        const row = await queryFirst<HeldRow>(
+          db,
+          `SELECT leaderId, leaseUntil, epoch FROM type::record('leader_lease:' + $name)`,
+          { name },
+        );
+        if (!row || row.leaderId !== this.leaderId) return false;
+        if (new Date(row.leaseUntil).getTime() <= Date.now()) return false;
+        return epoch === undefined || Number(row.epoch ?? 0) === epoch;
+      });
+    } catch (e) {
+      this.logger.warn(`isHeld(${name}) failed: ${(e as Error).message}; treating as not held`);
       return false;
     }
   }

--- a/src/jobs/worker-loop.service.ts
+++ b/src/jobs/worker-loop.service.ts
@@ -15,6 +15,13 @@ import { envFlagNotDisabled } from '../common/env-validation';
 export type { JobContext, JobHandler } from './worker-loop.types';
 
 /**
+ * How long shutdown waits for in-flight dispatches before handing their
+ * claims back to the queue. Sits after the readiness drain and inside the
+ * hard stop (GracefulShutdownService), under compose's stop_grace_period.
+ */
+const DISPATCH_DRAIN_MS = 12_000;
+
+/**
  * WorkerLoopService — leader election + handler registry + lifecycle for
  * the job_run queue worker. Holds the @Cron-less lease loop: it acquires
  * the worker_loop lease, and while leader spins up one WorkerPollerService
@@ -38,7 +45,11 @@ export class WorkerLoopService implements OnModuleInit, BeforeApplicationShutdow
   private readonly abortController = new AbortController();
   private leaseTimer: NodeJS.Timeout | null = null;
   private isLeader = false;
+  /** Fencing epoch of the worker_loop lease we hold; null when not leader. */
+  private epoch: number | null = null;
   private loopsStarted = false;
+  /** The running poll loops; each settles after its own dispatches do. */
+  private loops: Promise<void>[] = [];
 
   constructor(
     private readonly poller: WorkerPollerService,
@@ -119,6 +130,7 @@ export class WorkerLoopService implements OnModuleInit, BeforeApplicationShutdow
     this.poller.stopDecay();
     this.abortController.abort();
     this.metrics?.setWorkerLeader(false);
+    await this.drainDispatches();
     if (this.isLeader && this.lease) {
       try {
         await this.lease.release('worker_loop');
@@ -129,45 +141,110 @@ export class WorkerLoopService implements OnModuleInit, BeforeApplicationShutdow
     this.logger.log('Worker loop shut down');
   }
 
+  /**
+   * Wait for the poll loops — and the dispatches they own — to settle.
+   * Past the budget, hand every still-running claim back to the queue so
+   * the next leader can take it now instead of waiting out a lease this
+   * dying pod will never renew. Runs BEFORE the lease release: the claims
+   * are ours until then.
+   */
+  private async drainDispatches(): Promise<void> {
+    if (this.loops.length === 0) return;
+    let timer: NodeJS.Timeout | undefined;
+    const budget = new Promise<false>((resolve) => {
+      timer = setTimeout(() => resolve(false), DISPATCH_DRAIN_MS);
+      timer.unref();
+    });
+    const drained = await Promise.race([
+      Promise.allSettled(this.loops).then(() => true as const),
+      budget,
+    ]);
+    if (timer) clearTimeout(timer);
+    if (drained) return;
+    const stuck = this.poller.activeClaims().length;
+    const released = await this.poller.releaseActiveClaims(
+      'pod shutdown: handler did not stop within the drain budget',
+    );
+    this.logger.warn(
+      `${stuck} dispatch(es) still running after ${DISPATCH_DRAIN_MS} ms; ` +
+        `released ${released} claim(s) back to the queue`,
+    );
+  }
+
   private async tryBecomeLeader(): Promise<void> {
     if (this.abortController.signal.aborted) return;
     if (!this.lease) {
       // No lease service — assume single-pod dev/test. Start loops
       // immediately if we have handlers registered.
       this.isLeader = true;
+      this.epoch = null;
     } else {
       try {
-        const got = await this.lease.tryAcquire(
+        const epoch = await this.lease.acquire(
           'worker_loop',
           Math.ceil((this.leaseRenewIntervalMs * 3) / 1000),
         );
+        const got = epoch !== null;
         if (got !== this.isLeader) {
           this.logger.log(
             got
-              ? 'Acquired worker_loop lease — starting poll loops'
+              ? `Acquired worker_loop lease (epoch ${epoch}) — starting poll loops`
               : 'Lost worker_loop lease — pausing poll loops',
           );
         }
         this.isLeader = got;
+        this.epoch = epoch;
       } catch (e) {
         this.logger.warn(`worker_loop lease acquire failed: ${(e as Error).message}`);
         this.isLeader = false;
+        this.epoch = null;
       }
     }
     this.metrics?.setWorkerLeader(this.isLeader);
-    if (this.isLeader && !this.loopsStarted) {
-      this.loopsStarted = true;
-      const control: PollControl = {
-        isLeader: () => this.isLeader,
-        signal: this.abortController.signal,
-        onInFlight: (jobType, inFlight) => this.metrics?.setWorkerJobsInFlight(jobType, inFlight),
-      };
-      for (const reg of this.handlers.values()) {
-        void this.poller.runLoop(reg, control);
-      }
-    }
+    if (this.isLeader && !this.loopsStarted) this.startLoops();
     if (!this.abortController.signal.aborted) {
       this.leaseTimer = setTimeout(() => void this.tryBecomeLeader(), this.leaseRenewIntervalMs);
     }
+  }
+
+  /**
+   * Point-read the lease before a claim: a pod that lost it must stop
+   * claiming now, not at the next renew tick up to a full interval away.
+   */
+  private async confirmLeader(): Promise<boolean> {
+    if (!this.lease) return this.isLeader;
+    if (!this.isLeader) return false;
+    const held = await this.lease.isHeld('worker_loop', this.epoch ?? undefined);
+    if (!held) {
+      this.logger.log('worker_loop lease no longer ours — stopping poll loops');
+      this.isLeader = false;
+      this.epoch = null;
+      this.metrics?.setWorkerLeader(false);
+    }
+    return held;
+  }
+
+  /**
+   * One loop per registered jobType. Loops end when leadership is lost;
+   * the renew tick starts a fresh set once the lease is ours again. The
+   * promises are kept so shutdown can await the dispatches they own.
+   */
+  private startLoops(): void {
+    this.loopsStarted = true;
+    const control: PollControl = {
+      isLeader: () => this.isLeader,
+      confirmLeader: () => this.confirmLeader(),
+      epoch: () => this.epoch,
+      signal: this.abortController.signal,
+      onInFlight: (jobType, inFlight) => this.metrics?.setWorkerJobsInFlight(jobType, inFlight),
+    };
+    this.loops = [...this.handlers.values()].map((reg) =>
+      this.poller.runLoop(reg, control).catch((e: unknown) => {
+        this.logger.warn(`poll loop (${reg.jobType}) died: ${(e as Error).message}`);
+      }),
+    );
+    void Promise.allSettled(this.loops).then(() => {
+      this.loopsStarted = false;
+    });
   }
 }

--- a/src/jobs/worker-loop.types.ts
+++ b/src/jobs/worker-loop.types.ts
@@ -39,7 +39,12 @@ export interface RegisteredHandler {
 
 /** Leader/lifecycle control surface the poller reads on each cycle. */
 export interface PollControl {
+  /** Cached leadership — refreshed by the renew tick and by confirmLeader(). */
   isLeader: () => boolean;
+  /** Point-read the lease before taking a claim; false means end the loop. */
+  confirmLeader: () => Promise<boolean>;
+  /** Fencing epoch of the worker_loop lease, stamped on every claim. */
+  epoch: () => number | null;
   signal: AbortSignal;
   /**
    * Observability hook: invoked with the number of in-flight dispatches

--- a/src/jobs/worker-poller.service.ts
+++ b/src/jobs/worker-poller.service.ts
@@ -68,6 +68,8 @@ export class WorkerPollerService {
   private readonly inFlightByTenant = new Map<string, number>();
   /** In-flight dispatches across all runLoops in this process (global cap). */
   private globalInFlight = 0;
+  /** Claims dispatched by this process that have not reached their terminal write. */
+  private readonly active = new Set<JobClaim>();
 
   constructor(
     private readonly dispatcher: JobDispatcherService,
@@ -97,6 +99,29 @@ export class WorkerPollerService {
     this.decayTimer = null;
   }
 
+  /** Claims this process is still running a handler for. */
+  activeClaims(): JobClaim[] {
+    return [...this.active];
+  }
+
+  /**
+   * Hand every still-running claim back to the queue — the shutdown drain
+   * ran out before their handlers stopped. Returns how many rows were ours.
+   */
+  async releaseActiveClaims(reason: string): Promise<number> {
+    let released = 0;
+    for (const c of this.activeClaims()) {
+      const ok = await this.claim?.release({
+        companyId: c.companyId,
+        recordId: c.recordId,
+        claimEpoch: c.claimEpoch,
+        reason,
+      });
+      if (ok) released += 1;
+    }
+    return released;
+  }
+
   /**
    * Per-jobType polling loop. Runs while the pod holds the lease (per
    * control.isLeader). On empty queue across all tenants, backs off.
@@ -117,11 +142,11 @@ export class WorkerPollerService {
   private async runLoopSerial(reg: RegisteredHandler, control: PollControl): Promise<void> {
     this.logger.log(`Poll loop started for jobType=${reg.jobType}`);
     while (!control.signal.aborted) {
-      if (!control.isLeader()) {
-        // Lost leadership mid-loop; sleep until renew tick reinstates us.
-        await sleep(this.pollIntervalMs, control.signal);
-        continue;
-      }
+      // The cached flag is refreshed every renew tick; the point read
+      // catches a lease lost in between, before this cycle claims
+      // alongside the new leader. Either way the loop ends here —
+      // WorkerLoopService starts a fresh one once it is leader again.
+      if (!control.isLeader() || !(await control.confirmLeader())) break;
       let claimed: JobClaim | null = null;
       try {
         const tenants = this.sampleByFairness(reg.jobType, this.apiKeys?.fanOutRoster() ?? []);
@@ -131,6 +156,7 @@ export class WorkerPollerService {
             companyId,
             jobType: reg.jobType,
             ttlSeconds: reg.ttlSeconds,
+            epoch: control.epoch(),
           });
           if (claimed) {
             this.recordClaim(reg.jobType, companyId);
@@ -141,9 +167,14 @@ export class WorkerPollerService {
         this.logger.warn(`claim cycle (${reg.jobType}) failed: ${(e as Error).message}`);
       }
       if (claimed) {
-        await withSpan('jobs.dispatch', () =>
-          this.dispatcher.dispatch(claimed!, reg, control.signal),
-        );
+        this.active.add(claimed);
+        try {
+          await withSpan('jobs.dispatch', () =>
+            this.dispatcher.dispatch(claimed!, reg, control.signal),
+          );
+        } finally {
+          this.active.delete(claimed);
+        }
       } else {
         await sleep(this.emptyPollBackoffMs, control.signal);
       }
@@ -173,11 +204,8 @@ export class WorkerPollerService {
     );
     const inFlight = new Set<Promise<void>>();
     while (!control.signal.aborted) {
-      if (!control.isLeader()) {
-        // Lost leadership mid-loop; sleep until renew tick reinstates us.
-        await sleep(this.pollIntervalMs, control.signal);
-        continue;
-      }
+      // Same leadership contract as the serial loop: confirm, or end.
+      if (!control.isLeader() || !(await control.confirmLeader())) break;
       if (this.saturated(inFlight.size, limits)) {
         // All slots busy — wake on the first finished dispatch or the
         // poll tick (the tick matters for the global cap: a slot may
@@ -240,6 +268,7 @@ export class WorkerPollerService {
           companyId,
           jobType: reg.jobType,
           ttlSeconds: reg.ttlSeconds,
+          epoch: control.epoch(),
         });
         if (claimed) {
           this.recordClaim(reg.jobType, companyId);
@@ -268,12 +297,14 @@ export class WorkerPollerService {
     const { claimed, reg, control, inFlight } = args;
     const tenantKey = `${reg.jobType}::${claimed.companyId}`;
     this.inFlightByTenant.set(tenantKey, (this.inFlightByTenant.get(tenantKey) ?? 0) + 1);
+    this.active.add(claimed);
     const p: Promise<void> = withSpan('jobs.dispatch', () =>
       this.dispatcher.dispatch(claimed, reg, control.signal),
     )
       .catch(() => undefined)
       .finally(() => {
         inFlight.delete(p);
+        this.active.delete(claimed);
         const n = (this.inFlightByTenant.get(tenantKey) ?? 1) - 1;
         if (n <= 0) this.inFlightByTenant.delete(tenantKey);
         else this.inFlightByTenant.set(tenantKey, n);

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,7 @@
 // `express`, or other auto-instrumented modules. The instrumentations
 // patch via require-hooks; late init silently misses every prior
 // require. No-op when OTEL_ENABLED!=1.
-import { initTracing, shutdownTracing } from './common/tracing';
+import { initTracing } from './common/tracing';
 initTracing();
 
 import { NestFactory } from '@nestjs/core';
@@ -53,6 +53,12 @@ async function bootstrap() {
   });
 
   const app = await NestFactory.create<NestExpressApplication>(AppModule);
+  // The ONLY signal handling in the process: Nest runs its shutdown
+  // lifecycle once per signal and re-raises the signal when it is done.
+  // GracefulShutdownService (root module) owns the readiness flip, the
+  // drain, the hard-stop deadline and the OTel flush inside that
+  // lifecycle — a second SIGTERM listener here ran app.close()
+  // concurrently with Nest's own run of the same hooks.
   app.enableShutdownHooks();
   const configService = app.get(ConfigService);
   const logger = new Logger('Bootstrap');
@@ -117,33 +123,6 @@ async function bootstrap() {
 
   logger.log(`INITE Brain Service running on port ${port}`);
   logger.log(`SurrealDB: ${configService.get<string>('SURREALDB_URL')}`);
-
-  // Hard-stop guard: if a hung SurrealDB close blocks shutdown, force exit
-  // after 15s rather than have docker SIGKILL us with no log line.
-  const onTerm = async () => {
-    logger.log('SIGTERM received — closing app');
-    const t = setTimeout(() => {
-      logger.error('Graceful shutdown timed out; forcing exit');
-      process.exit(1);
-    }, 15_000).unref();
-    await app.close().catch((err) => {
-      logger.error(`Error during shutdown: ${(err as Error).message}`);
-    });
-    await shutdownTracing(); // flush OTel spans before exit
-    clearTimeout(t);
-    process.exit(0);
-  };
-  // process.on's listener type is (...args) => void, but onTerm is async.
-  // Wrap it so a rejection (e.g. shutdownTracing throwing) is logged and
-  // forces exit instead of surfacing as an unhandledRejection mid-shutdown.
-  const onTermListener = () => {
-    void onTerm().catch((err) => {
-      logger.error(`Shutdown handler failed: ${(err as Error).message}`);
-      process.exit(1);
-    });
-  };
-  process.on('SIGTERM', onTermListener);
-  process.on('SIGINT', onTermListener);
 }
 
 bootstrap().catch((err) => {

--- a/test/admin-jobs-stream-replica.e2e-spec.ts
+++ b/test/admin-jobs-stream-replica.e2e-spec.ts
@@ -33,6 +33,15 @@ describe('/admin/jobs/stream across replicas', () => {
   beforeAll(async () => {
     f = await createApp();
     surreal = f.app.get(SurrealService);
+    // Touch the tenant database before any stream subscribes to it. The
+    // stream anchors its cursor on the database clock inside its FIRST
+    // poll tick, and that tick pays this tenant's schema bootstrap when it
+    // is the first caller through the door — over a second, during which
+    // this spec's write lands and ends up BEHIND the anchor, invisible for
+    // good. Whether boot warms it is incidental: CalibrationService warms
+    // `hostTenant()`, which is the roster's first entry, so in a long shard
+    // it is some earlier spec's tenant rather than this one's.
+    await surreal.withCompany(f.companyId, (db) => db.query(`RETURN time::now()`));
   });
 
   afterAll(async () => {

--- a/test/graceful-shutdown.unit-spec.ts
+++ b/test/graceful-shutdown.unit-spec.ts
@@ -1,0 +1,101 @@
+/**
+ * GracefulShutdownService — the one owner of the process shutdown
+ * sequence: readiness flips to 503 first, a signal-driven shutdown keeps
+ * serving for the readiness drain, the hard-stop deadline forces exit if
+ * the lifecycle hangs, and the whole budget fits compose's grace period.
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { GracefulShutdownService } from '../src/common/graceful-shutdown.service';
+
+const ROOT = join(__dirname, '..');
+
+function constant(file: string, name: string): number {
+  const src = readFileSync(join(ROOT, file), 'utf8');
+  const m = new RegExp(`const ${name} = ([\\d_]+);`).exec(src);
+  if (!m) throw new Error(`${name} not found in ${file}`);
+  return Number(m[1]!.replace(/_/g, ''));
+}
+
+describe('GracefulShutdownService', () => {
+  let exit: jest.SpyInstance;
+  beforeEach(() => {
+    jest.useFakeTimers();
+    exit = jest.spyOn(process, 'exit').mockImplementation((() => undefined) as never);
+  });
+  afterEach(() => {
+    exit.mockRestore();
+    jest.useRealTimers();
+  });
+
+  function mk() {
+    const health = { markShuttingDown: jest.fn(), isShuttingDown: () => true };
+    return { svc: new GracefulShutdownService(health as never), health };
+  }
+
+  it('flips readiness in the first lifecycle phase, before anything else closes', () => {
+    const { svc, health } = mk();
+    svc.onModuleDestroy();
+    expect(health.markShuttingDown).toHaveBeenCalledTimes(1);
+  });
+
+  it('holds a signal-driven shutdown for the readiness drain; a programmatic close does not wait', async () => {
+    const { svc } = mk();
+    let resolved = false;
+    const held = svc.beforeApplicationShutdown('SIGTERM').then(() => {
+      resolved = true;
+    });
+    await jest.advanceTimersByTimeAsync(5_999);
+    expect(resolved).toBe(false);
+    await jest.advanceTimersByTimeAsync(1);
+    await held;
+    expect(resolved).toBe(true);
+
+    let quick = false;
+    await svc.beforeApplicationShutdown().then(() => {
+      quick = true;
+    });
+    expect(quick).toBe(true);
+  });
+
+  it('forces exit 25 s after a signal-driven shutdown began if the lifecycle is still running', async () => {
+    const { svc } = mk();
+    svc.onModuleDestroy();
+    await svc.onApplicationShutdown('SIGTERM');
+    await jest.advanceTimersByTimeAsync(24_999);
+    expect(exit).not.toHaveBeenCalled();
+    await jest.advanceTimersByTimeAsync(1);
+    expect(exit).toHaveBeenCalledWith(1);
+  });
+
+  it('a programmatic close disarms the deadline once the lifecycle has run', async () => {
+    const { svc } = mk();
+    svc.onModuleDestroy();
+    await svc.onApplicationShutdown();
+    await jest.advanceTimersByTimeAsync(60_000);
+    expect(exit).not.toHaveBeenCalled();
+  });
+
+  it('the budget nests: readiness drain + dispatch drain < hard stop < compose stop_grace_period', () => {
+    const readiness = constant('src/common/graceful-shutdown.service.ts', 'READINESS_DRAIN_MS');
+    const hardStop = constant('src/common/graceful-shutdown.service.ts', 'HARD_STOP_MS');
+    const dispatch = constant('src/jobs/worker-loop.service.ts', 'DISPATCH_DRAIN_MS');
+    const compose = readFileSync(join(ROOT, 'docker-compose.yml'), 'utf8');
+    const graces = [...compose.matchAll(/stop_grace_period:\s*(\d+)s/g)].map((m) => Number(m[1]));
+    expect(graces.length).toBeGreaterThan(0);
+    expect(readiness + dispatch).toBeLessThan(hardStop);
+    for (const grace of graces) expect(hardStop).toBeLessThan(grace * 1000);
+  });
+
+  it('signal handling belongs to Nest alone, and the service sits on the root module', () => {
+    const main = readFileSync(join(ROOT, 'src/main.ts'), 'utf8');
+    const tracing = readFileSync(join(ROOT, 'src/common/tracing.ts'), 'utf8');
+    const appModule = readFileSync(join(ROOT, 'src/app.module.ts'), 'utf8');
+    // A second SIGTERM listener ran app.close() concurrently with Nest's
+    // own; a lingering one would swallow the exit Nest re-raises.
+    expect(main).not.toMatch(/process\.(on|once)\(\s*'SIG/);
+    expect(tracing).not.toMatch(/process\.(on|once)\(\s*'SIG/);
+    expect(main).toContain('app.enableShutdownHooks()');
+    expect(appModule).toMatch(/providers:\s*\[[\s\S]*GracefulShutdownService[\s\S]*\]/);
+  });
+});

--- a/test/health-ready.unit-spec.ts
+++ b/test/health-ready.unit-spec.ts
@@ -15,6 +15,11 @@ import { HealthController } from '../src/common/health.controller';
 import { HealthService } from '../src/common/health.service';
 import { ServiceUnavailableException } from '@nestjs/common';
 
+/** The HealthService the controller was built with — the shutdown flag lives there. */
+function shuttingDownService(controller: HealthController): HealthService {
+  return (controller as unknown as { healthService: HealthService }).healthService;
+}
+
 describe('HealthController', () => {
   function mk(opts: { db: boolean; embedderReady: boolean; scoped?: boolean }) {
     const surreal = {
@@ -48,6 +53,23 @@ describe('HealthController', () => {
       // compose healthcheck from looping the container.
       const res = await mk({ db: true, embedderReady: false }).health();
       expect(res.status).toBe('ok');
+    });
+
+    /**
+     * Traefik load-balances on /health (deploy-brain.yml sets
+     * healthcheck.path=/health, deliberately not /ready), so a leaving
+     * replica has to fail THIS path to be drained.
+     */
+    it('answers 503 with status shutting_down once shutdown begins', async () => {
+      const controller = mk({ db: true, embedderReady: true });
+      await expect(controller.health()).resolves.toMatchObject({ status: 'ok' });
+      shuttingDownService(controller).markShuttingDown();
+      const err = await controller.health().catch((e: ServiceUnavailableException) => e);
+      expect(err).toBeInstanceOf(ServiceUnavailableException);
+      expect((err as ServiceUnavailableException).getResponse()).toMatchObject({
+        status: 'shutting_down',
+        checks: { surrealdb: 'ok' },
+      });
     });
   });
 
@@ -88,6 +110,28 @@ describe('HealthController', () => {
       await expect(mk({ db: true, embedderReady: false }).ready()).rejects.toBeInstanceOf(
         ServiceUnavailableException,
       );
+    });
+
+    /**
+     * The balancer health-checks on an interval; a replica that keeps
+     * answering 200 until its socket closes takes 502s for a whole interval.
+     * From the first shutdown hook on, /ready must say 503 while every
+     * dependency is still green — the replica is leaving, not broken.
+     */
+    it('answers 503 with shuttingDown: true from the moment shutdown begins, every check still green', async () => {
+      const controller = mk({ db: true, embedderReady: true });
+      await expect(controller.ready()).resolves.toMatchObject({ ready: true });
+
+      shuttingDownService(controller).markShuttingDown();
+      const err = await controller.ready().catch((e: ServiceUnavailableException) => e);
+      expect(err).toBeInstanceOf(ServiceUnavailableException);
+      expect((err as ServiceUnavailableException).getResponse()).toMatchObject({
+        ready: false,
+        shuttingDown: true,
+        checks: { surrealdb: 'ok', scopedPool: 'ok', embedder: 'ok' },
+      });
+      // One-way: a replica that started leaving never reports ready again.
+      await expect(controller.ready()).rejects.toBeInstanceOf(ServiceUnavailableException);
     });
 
     it('throws 503 when DB is unreachable', async () => {

--- a/test/job-claim.unit-spec.ts
+++ b/test/job-claim.unit-spec.ts
@@ -1,12 +1,13 @@
 /**
  * Unit coverage for JobClaimService — CAS enqueue / claimNext / renew
- * / complete / fail / reapZombies. We mock the SurrealService at the
- * withCompany boundary and assert what SQL it issued and how the
+ * / complete / fail / release / reapZombies. We mock the SurrealService
+ * at the withCompany boundary and assert what SQL it issued and how the
  * service reacted to driver-level errors (unique violation collapse,
  * read conflict retry).
  */
 import { Logger } from '@nestjs/common';
 import { JobClaimService } from '../src/jobs/job-claim.service';
+import { PROCESS_IDENTITY } from '../src/common/process-identity';
 
 interface QueryCall {
   sql: string;
@@ -35,13 +36,18 @@ function mkSurreal(db: { query: (s: string, p?: any) => Promise<any> }) {
   } as any;
 }
 
+const CLAIMED_ROW = {
+  id: 'job_run:abc',
+  runId: 'run-uuid-1',
+  jobType: 'dreams',
+  attempts: 1,
+  payload: { operations: ['dedup'] },
+  leaseUntil: '2030-01-01T00:05:00Z',
+};
+
 describe('JobClaimService', () => {
-  it('claimNext returns null when the transaction yields no row', async () => {
-    // Real SurrealDB 3.x shape for the 2-statement claim tx: one slot
-    // per statement INCLUDING BEGIN and COMMIT → [BEGIN, LET,
-    // RETURN NONE, COMMIT]. runTransaction detects the stmts+2 shape
-    // and reads the slot before COMMIT.
-    const { db } = mkDbScript([() => [null, null, null, null]]);
+  it('claimNext returns null when no candidate is pending', async () => {
+    const { db, calls } = mkDbScript([() => [[]]]);
     const svc = new JobClaimService(mkSurreal(db));
     const got = await svc.claimNext({
       companyId: 'co_x',
@@ -49,63 +55,83 @@ describe('JobClaimService', () => {
       ttlSeconds: 300,
     });
     expect(got).toBeNull();
+    // One index-backed read; no CAS attempted, no transaction opened.
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.sql).toContain('SELECT id, visibleAfter FROM job_run');
+    expect(calls[0]!.sql).not.toContain('BEGIN');
   });
 
-  it('claimNext returns a typed JobClaim when the tx yields a row', async () => {
-    // 3.x shape: [BEGIN, LET, RETURN row, COMMIT] — row sits right
-    // before the trailing COMMIT null.
-    const { db } = mkDbScript([
-      () => [
-        null,
-        null,
-        {
-          id: 'job_run:abc',
-          runId: 'run-uuid-1',
-          jobType: 'dreams',
-          attempts: 1,
-          payload: { operations: ['dedup'] },
-          leaseUntil: '2030-01-01T00:05:00Z',
-        },
-        null,
-      ],
-    ]);
+  it('claimNext selects the candidate outside any transaction, then CAS-updates that one record', async () => {
+    const { db, calls } = mkDbScript([() => [[{ id: 'job_run:abc' }]], () => [[CLAIMED_ROW]]]);
     const svc = new JobClaimService(mkSurreal(db));
     const got = await svc.claimNext({
       companyId: 'co_x',
       jobType: 'dreams',
       ttlSeconds: 300,
+      epoch: 7,
     });
     expect(got).not.toBeNull();
     expect(got?.runId).toBe('run-uuid-1');
     expect(got?.recordId).toBe('job_run:abc');
     expect(got?.payload).toEqual({ operations: ['dedup'] });
     expect(got?.attempts).toBe(1);
+    expect(got?.claimEpoch).toBe(7);
+
+    expect(calls).toHaveLength(2);
+    const [select, cas] = calls as [QueryCall, QueryCall];
+    expect(select.sql).toMatch(/status = 'pending'\s+AND visibleAfter <= time::now\(\)/);
+    expect(select.sql).toContain('LIMIT 1');
+    // The CAS is a point write on the candidate's id, guarded on the
+    // state the candidate was read in, and stamps the lease epoch.
+    expect(cas.sql).toContain('UPDATE type::record($rid)');
+    expect(cas.sql).toContain("WHERE status = 'pending' AND visibleAfter <= time::now()");
+    expect(cas.sql).toContain('claimEpoch = $epoch');
+    expect(cas.sql).not.toContain('BEGIN');
+    expect(cas.params).toMatchObject({ rid: 'job_run:abc', me: PROCESS_IDENTITY, epoch: 7 });
   });
 
-  it('claimNext reads the last slot on the 2.x response shape', async () => {
-    // 2.x shape: BEGIN/COMMIT emit no slots and LETs collapse — the
-    // RETURN row is simply the LAST (often only) slot. Regression for
-    // prod v2.3.10, where blind arr[length-2] silently discarded every
-    // committed claim.
-    const { db } = mkDbScript([
-      () => [
-        {
-          id: 'job_run:abc2',
-          runId: 'run-uuid-2',
-          jobType: 'dreams',
-          attempts: 1,
-          payload: null,
-          leaseUntil: '2030-01-01T00:05:00Z',
-        },
-      ],
+  it('claimNext without a lease epoch stamps claimEpoch = NONE', async () => {
+    const { db, calls } = mkDbScript([() => [[{ id: 'job_run:abc' }]], () => [[CLAIMED_ROW]]]);
+    const svc = new JobClaimService(mkSurreal(db));
+    const got = await svc.claimNext({ companyId: 'co_x', jobType: 'dreams', ttlSeconds: 300 });
+    expect(got?.claimEpoch).toBeNull();
+    expect(calls[1]!.sql).toContain('claimEpoch = NONE');
+    expect(calls[1]!.params).not.toHaveProperty('epoch');
+  });
+
+  it('claimNext moves on to the next candidate when the CAS loses the race', async () => {
+    const { db, calls } = mkDbScript([
+      () => [[{ id: 'job_run:a' }]],
+      () => [[]], // another claimer flipped job_run:a between our read and our write
+      () => [[{ id: 'job_run:b' }]],
+      () => [[{ ...CLAIMED_ROW, id: 'job_run:b', runId: 'run-b' }]],
     ]);
     const svc = new JobClaimService(mkSurreal(db));
-    const got = await svc.claimNext({
-      companyId: 'co_x',
-      jobType: 'dreams',
-      ttlSeconds: 300,
-    });
-    expect(got?.runId).toBe('run-uuid-2');
+    const got = await svc.claimNext({ companyId: 'co_x', jobType: 'dreams', ttlSeconds: 300 });
+    expect(got?.recordId).toBe('job_run:b');
+    expect(got?.runId).toBe('run-b');
+    expect(calls.map((c) => c.params?.rid)).toEqual([
+      undefined,
+      'job_run:a',
+      undefined,
+      'job_run:b',
+    ]);
+  });
+
+  it('claimNext gives up after three lost races', async () => {
+    const { db, calls } = mkDbScript([
+      () => [[{ id: 'job_run:a' }]],
+      () => [[]],
+      () => [[{ id: 'job_run:b' }]],
+      () => [[]],
+      () => [[{ id: 'job_run:c' }]],
+      () => [[]],
+      () => [[{ id: 'job_run:d' }]], // never read
+    ]);
+    const svc = new JobClaimService(mkSurreal(db));
+    const got = await svc.claimNext({ companyId: 'co_x', jobType: 'dreams', ttlSeconds: 300 });
+    expect(got).toBeNull();
+    expect(calls).toHaveLength(6);
   });
 
   it('claimNext returns null and swallows transient driver errors', async () => {
@@ -125,6 +151,28 @@ describe('JobClaimService', () => {
       ttlSeconds: 300,
     });
     expect(got).toBeNull();
+  });
+
+  it('enqueue leaves visibleAfter to the datastore unless the job is deliberately delayed', async () => {
+    // The claim filter is `visibleAfter <= time::now()`, evaluated by the
+    // datastore: a row stamped from a process clock running ahead of it is
+    // unclaimable until the difference elapses.
+    const { db, calls } = mkDbScript([() => [[{ id: 'job_run:new' }]]]);
+    const svc = new JobClaimService(mkSurreal(db));
+    await svc.enqueue({ jobType: 'dreams', companyId: 'co_x', triggeredBy: 'cron' });
+    expect(calls[0]!.sql).not.toContain('visibleAfter');
+    expect(calls[0]!.params).not.toHaveProperty('visibleAfter');
+
+    const at = new Date('2030-01-01T00:00:00.000Z');
+    const scheduled = mkDbScript([() => [[{ id: 'job_run:later' }]]]);
+    await new JobClaimService(mkSurreal(scheduled.db)).enqueue({
+      jobType: 'dreams',
+      companyId: 'co_x',
+      triggeredBy: 'cron',
+      visibleAfter: at,
+    });
+    expect(scheduled.calls[0]!.sql).toContain('visibleAfter: type::datetime($visibleAfter)');
+    expect(scheduled.calls[0]!.params).toMatchObject({ visibleAfter: at.toISOString() });
   });
 
   it('enqueue collapses a dedup collision onto the existing row', async () => {
@@ -167,6 +215,7 @@ describe('JobClaimService', () => {
     const out = await svc.renew({
       companyId: 'co_x',
       recordId: 'job_run:abc',
+      claimEpoch: null,
       ttlSeconds: 300,
     });
     expect(out.stillOwned).toBe(false);
@@ -179,6 +228,7 @@ describe('JobClaimService', () => {
     const out = await svc.renew({
       companyId: 'co_x',
       recordId: 'job_run:abc',
+      claimEpoch: null,
       ttlSeconds: 300,
     });
     expect(out.stillOwned).toBe(true);
@@ -198,6 +248,7 @@ describe('JobClaimService', () => {
     const out = await svc.fail({
       companyId: 'co_x',
       recordId: 'job_run:abc',
+      claimEpoch: null,
       attempts: 1,
       error: { message: 'boom' },
       maxAttempts: 3,
@@ -206,7 +257,7 @@ describe('JobClaimService', () => {
     expect(updateSql).toContain("status = 'pending'");
     expect(updateSql).toContain('visibleAfter');
     // Ownership guard present so a re-claimed row can't be stomped.
-    expect(updateSql).toContain("claimedBy = $me AND status = 'running'");
+    expect(updateSql).toContain("claimedBy = $me AND status = 'running' AND claimEpoch IS NONE");
   });
 
   it('fail terminal-fails at maxAttempts', async () => {
@@ -221,13 +272,14 @@ describe('JobClaimService', () => {
     const out = await svc.fail({
       companyId: 'co_x',
       recordId: 'job_run:abc',
+      claimEpoch: null,
       attempts: 3,
       error: { message: 'boom' },
       maxAttempts: 3,
     });
     expect(out.requeued).toBe(false);
     expect(updateSql).toContain("status = 'failed'");
-    expect(updateSql).toContain("claimedBy = $me AND status = 'running'");
+    expect(updateSql).toContain("claimedBy = $me AND status = 'running' AND claimEpoch IS NONE");
   });
 
   it('fail reports requeued=false when the guarded UPDATE matches no row (claim lost to a re-claim)', async () => {
@@ -238,6 +290,7 @@ describe('JobClaimService', () => {
     const out = await svc.fail({
       companyId: 'co_x',
       recordId: 'job_run:abc',
+      claimEpoch: null,
       attempts: 1,
       error: { message: 'boom' },
       maxAttempts: 3,
@@ -254,21 +307,21 @@ describe('JobClaimService', () => {
       },
     };
     const svc = new JobClaimService(mkSurreal(db));
-    await svc.complete({ companyId: 'co_x', recordId: 'job_run:abc' });
-    await svc.cancelled({ companyId: 'co_x', recordId: 'job_run:abc' });
+    await svc.complete({ companyId: 'co_x', recordId: 'job_run:abc', claimEpoch: null });
+    await svc.cancelled({ companyId: 'co_x', recordId: 'job_run:abc', claimEpoch: null });
     expect(sqls).toHaveLength(2);
     expect(sqls[0]).toContain("status = 'succeeded'");
-    expect(sqls[0]).toContain("claimedBy = $me AND status = 'running'");
+    expect(sqls[0]).toContain("claimedBy = $me AND status = 'running' AND claimEpoch IS NONE");
     expect(sqls[1]).toContain("status = 'cancelled'");
-    expect(sqls[1]).toContain("claimedBy = $me AND status = 'running'");
+    expect(sqls[1]).toContain("claimedBy = $me AND status = 'running' AND claimEpoch IS NONE");
   });
 
   it('complete()/cancelled() no-op + warn when the guarded UPDATE matches no row', async () => {
     const warn = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined as any);
     const db = { query: async () => [[]] }; // 0 rows ⇒ claim lost
     const svc = new JobClaimService(mkSurreal(db));
-    await svc.complete({ companyId: 'co_x', recordId: 'job_run:abc' });
-    await svc.cancelled({ companyId: 'co_x', recordId: 'job_run:abc' });
+    await svc.complete({ companyId: 'co_x', recordId: 'job_run:abc', claimEpoch: null });
+    await svc.cancelled({ companyId: 'co_x', recordId: 'job_run:abc', claimEpoch: null });
     expect(warn).toHaveBeenCalledWith(expect.stringContaining('no-op'));
     expect(warn.mock.calls.filter((c) => String(c[0]).includes('no-op')).length).toBe(2);
     warn.mockRestore();
@@ -304,9 +357,79 @@ describe('JobClaimService', () => {
     });
   });
 
-  it('identity is hostname#pid format', () => {
+  it('identity is the one process identity — hostname#pid#uuid', () => {
     const svc = new JobClaimService();
-    expect(svc.identity()).toMatch(/^.+#\d+$/);
+    expect(svc.identity()).toBe(PROCESS_IDENTITY);
+    expect(svc.identity()).toMatch(/^.+#\d+#[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$/);
+  });
+
+  it('renew is fenced on the claim epoch, so a dispatch from a lapsed leadership loses its claim', async () => {
+    const { db, calls } = mkDbScript([() => [[]]]);
+    const svc = new JobClaimService(mkSurreal(db));
+    const out = await svc.renew({
+      companyId: 'co_x',
+      recordId: 'job_run:abc',
+      claimEpoch: 4,
+      ttlSeconds: 300,
+    });
+    expect(out.stillOwned).toBe(false);
+    expect(calls[0]!.sql).toContain(
+      "claimedBy = $me AND status = 'running' AND claimEpoch = $epoch",
+    );
+    expect(calls[0]!.params).toMatchObject({ me: PROCESS_IDENTITY, epoch: 4 });
+  });
+
+  it('terminal writes taken under an epoch require the row to still carry it — a stale epoch is a no-op', async () => {
+    const warn = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined as any);
+    const { db, calls } = mkDbScript([() => [[]], () => [[]], () => [[]]]);
+    const svc = new JobClaimService(mkSurreal(db));
+    await svc.complete({ companyId: 'co_x', recordId: 'job_run:abc', claimEpoch: 5 });
+    const failed = await svc.fail({
+      companyId: 'co_x',
+      recordId: 'job_run:abc',
+      claimEpoch: 5,
+      attempts: 1,
+      error: { message: 'boom' },
+    });
+    await svc.cancelled({ companyId: 'co_x', recordId: 'job_run:abc', claimEpoch: 5 });
+    expect(failed.requeued).toBe(false);
+    for (const call of calls) {
+      expect(call.sql).toContain("claimedBy = $me AND status = 'running' AND claimEpoch = $epoch");
+      expect(call.params).toMatchObject({ me: PROCESS_IDENTITY, epoch: 5 });
+      // The row leaves the claim state clean for the next claimer.
+      expect(call.sql).toContain('claimEpoch = NONE');
+    }
+    expect(warn.mock.calls.filter((c) => String(c[0]).includes('no-op')).length).toBe(3);
+    warn.mockRestore();
+  });
+
+  it('release hands the row back as pending, visible now, under the same ownership guard', async () => {
+    const { db, calls } = mkDbScript([() => [[{ id: 'job_run:abc' }]], () => [[]]]);
+    const svc = new JobClaimService(mkSurreal(db));
+    const released = await svc.release({
+      companyId: 'co_x',
+      recordId: 'job_run:abc',
+      claimEpoch: 2,
+      reason: 'pod shutdown',
+    });
+    expect(released).toBe(true);
+    expect(calls[0]!.sql).toContain("status = 'pending'");
+    expect(calls[0]!.sql).toContain('visibleAfter = time::now()');
+    expect(calls[0]!.sql).toContain(
+      "claimedBy = $me AND status = 'running' AND claimEpoch = $epoch",
+    );
+    expect(calls[0]!.params).toMatchObject({
+      err: { name: 'PodShutdown', message: 'pod shutdown' },
+    });
+    // A row we no longer own matches nothing — nothing to hand back.
+    expect(
+      await svc.release({
+        companyId: 'co_x',
+        recordId: 'job_run:abc',
+        claimEpoch: 2,
+        reason: 'pod shutdown',
+      }),
+    ).toBe(false);
   });
 
   it('listActiveClaims aggregates rows across tenants', async () => {

--- a/test/jobs-otel.unit-spec.ts
+++ b/test/jobs-otel.unit-spec.ts
@@ -136,23 +136,24 @@ describe('Jobs OTel handoff — wire contract', () => {
   it('claimNext returns claim.traceparent when the row has one', async () => {
     const traceparent = '00-cccccccccccccccccccccccccccccccc-3333333333333333-01';
     const db = {
-      // Real 3.x shape for the 2-statement claim tx: [BEGIN, LET,
-      // RETURN row, COMMIT] — runTransaction reads the slot before the
-      // trailing COMMIT when the response has stmts+2 slots.
-      query: async () => [
-        null,
-        null,
-        {
-          id: 'job_run:withtp',
-          runId: 'run-with-tp',
-          jobType: 'dreams',
-          attempts: 1,
-          payload: null,
-          leaseUntil: '2030-01-01T00:05:00Z',
-          traceparent,
-        },
-        null,
-      ],
+      // claimNext is two single statements: the candidate SELECT, then the
+      // CAS UPDATE … RETURN AFTER whose row carries the traceparent.
+      query: async (sql: string) =>
+        sql.includes('SELECT id, visibleAfter FROM job_run')
+          ? [[{ id: 'job_run:withtp' }]]
+          : [
+              [
+                {
+                  id: 'job_run:withtp',
+                  runId: 'run-with-tp',
+                  jobType: 'dreams',
+                  attempts: 1,
+                  payload: null,
+                  leaseUntil: '2030-01-01T00:05:00Z',
+                  traceparent,
+                },
+              ],
+            ],
     };
     const surreal = {
       withCompany: async <T>(_c: string, fn: (d: any) => Promise<T>) => fn(db),

--- a/test/jobs.real-e2e-spec.ts
+++ b/test/jobs.real-e2e-spec.ts
@@ -86,6 +86,7 @@ describe('JobClaimService — real Surreal end-to-end', () => {
     await claim.complete({
       companyId: TENANT,
       recordId: claimed!.recordId,
+      claimEpoch: claimed!.claimEpoch,
       result: { ok: true, summarized: 42 },
     });
     const afterComplete = await surreal.withCompany(TENANT, async (db) => {
@@ -125,6 +126,7 @@ describe('JobClaimService — real Surreal end-to-end', () => {
     const r1 = await claim.renew({
       companyId: TENANT,
       recordId: claimed!.recordId,
+      claimEpoch: claimed!.claimEpoch,
       ttlSeconds: 60,
     });
     expect(r1.stillOwned).toBe(true);
@@ -137,6 +139,7 @@ describe('JobClaimService — real Surreal end-to-end', () => {
     const r2 = await claim.renew({
       companyId: TENANT,
       recordId: claimed!.recordId,
+      claimEpoch: claimed!.claimEpoch,
       ttlSeconds: 60,
     });
     expect(r2.stillOwned).toBe(true);
@@ -145,6 +148,7 @@ describe('JobClaimService — real Surreal end-to-end', () => {
     await claim.cancelled({
       companyId: TENANT,
       recordId: claimed!.recordId,
+      claimEpoch: claimed!.claimEpoch,
     });
   }, 60_000);
 
@@ -183,6 +187,7 @@ describe('JobClaimService — real Surreal end-to-end', () => {
     const out = await claim.fail({
       companyId: TENANT,
       recordId: claimed!.recordId,
+      claimEpoch: claimed!.claimEpoch,
       attempts: 1,
       error: { message: 'transient boom' },
       maxAttempts: 3,
@@ -286,6 +291,150 @@ describe('JobClaimService — real Surreal end-to-end', () => {
     expect(row.errName).toBe('ZombieAbandoned');
     expect(row.finishedAt).toBeTruthy();
   }, 60_000);
+  it('claim race: eight concurrent claimers on one pending row — exactly one wins, attempts = 1', async () => {
+    const jobType = 'changefeed_drain';
+    const { runId } = await claim.enqueue({
+      jobType,
+      companyId: TENANT,
+      triggeredBy: 'cron',
+      dedupKey: 'race_one_row',
+    });
+    const results = await Promise.all(
+      Array.from({ length: 8 }, () =>
+        claim.claimNext({ companyId: TENANT, jobType, ttlSeconds: 60 }),
+      ),
+    );
+    const winners = results.filter((r) => r !== null);
+    expect(winners).toHaveLength(1);
+    expect(winners[0]!.runId).toBe(runId);
+
+    const row = await surreal.withCompany(TENANT, async (db) => {
+      const [rows] = await db.query<[any[]]>(
+        `SELECT status, attempts, claimedBy FROM job_run WHERE runId = $r`,
+        { r: runId },
+      );
+      return (rows as any[])[0];
+    });
+    expect(row.status).toBe('running');
+    expect(row.attempts).toBe(1);
+    expect(row.claimedBy).toBe(claim.identity());
+
+    await claim.complete({
+      companyId: TENANT,
+      recordId: winners[0]!.recordId,
+      claimEpoch: winners[0]!.claimEpoch,
+    });
+  }, 60_000);
+
+  it('claim epoch fence: a write under a stale epoch is refused, the current epoch goes through', async () => {
+    // A jobType of its own: the earlier tests leave pending rows behind, and
+    // claimNext takes the oldest visible one for the type, not ours.
+    const jobType = 'candidate_sweeper';
+    const { runId } = await claim.enqueue({
+      jobType,
+      companyId: TENANT,
+      triggeredBy: 'cron',
+      dedupKey: 'epoch_fence',
+    });
+    const claimed = await claim.claimNext({ companyId: TENANT, jobType, ttlSeconds: 60, epoch: 5 });
+    expect(claimed?.runId).toBe(runId);
+    expect(claimed?.claimEpoch).toBe(5);
+
+    // The row was claimed again under a later leadership epoch — by a pod
+    // that may even present the same identity (a restart that kept it).
+    await surreal.withCompany(TENANT, async (db) => {
+      await db.query(`UPDATE type::record($rid) SET claimEpoch = 6`, { rid: claimed!.recordId });
+    });
+
+    const stale = await claim.renew({
+      companyId: TENANT,
+      recordId: claimed!.recordId,
+      claimEpoch: 5,
+      ttlSeconds: 60,
+    });
+    expect(stale.stillOwned).toBe(false);
+    await claim.complete({
+      companyId: TENANT,
+      recordId: claimed!.recordId,
+      claimEpoch: 5,
+      result: { stale: true },
+    });
+    const after = await surreal.withCompany(TENANT, async (db) => {
+      const [rows] = await db.query<[any[]]>(
+        `SELECT status, claimEpoch, result FROM job_run WHERE runId = $r`,
+        { r: runId },
+      );
+      return (rows as any[])[0];
+    });
+    expect(after.status).toBe('running');
+    expect(after.claimEpoch).toBe(6);
+    expect(after.result).toBeFalsy();
+
+    await claim.complete({
+      companyId: TENANT,
+      recordId: claimed!.recordId,
+      claimEpoch: 6,
+      result: { current: true },
+    });
+    const done = await surreal.withCompany(TENANT, async (db) => {
+      const [rows] = await db.query<[any[]]>(
+        `SELECT status, claimEpoch, result FROM job_run WHERE runId = $r`,
+        { r: runId },
+      );
+      return (rows as any[])[0];
+    });
+    expect(done.status).toBe('succeeded');
+    expect(done.claimEpoch).toBeFalsy();
+    expect(done.result).toEqual({ current: true });
+  }, 60_000);
+
+  it('release hands a running claim back as pending and visible now', async () => {
+    const jobType = 'recompose';
+    const { runId } = await claim.enqueue({
+      jobType,
+      companyId: TENANT,
+      triggeredBy: 'cron',
+      dedupKey: 'release_on_shutdown',
+    });
+    const claimed = await claim.claimNext({ companyId: TENANT, jobType, ttlSeconds: 60, epoch: 2 });
+    expect(claimed?.runId).toBe(runId);
+
+    expect(
+      await claim.release({
+        companyId: TENANT,
+        recordId: claimed!.recordId,
+        claimEpoch: 2,
+        reason: 'pod shutdown',
+      }),
+    ).toBe(true);
+    const row = await surreal.withCompany(TENANT, async (db) => {
+      const [rows] = await db.query<[any[]]>(
+        `SELECT status, claimedBy, claimEpoch, attempts, error.name AS errName, visibleAfter FROM job_run WHERE runId = $r`,
+        { r: runId },
+      );
+      return (rows as any[])[0];
+    });
+    expect(row.status).toBe('pending');
+    expect(row.claimedBy).toBeFalsy();
+    expect(row.claimEpoch).toBeFalsy();
+    expect(row.attempts).toBe(1);
+    expect(row.errName).toBe('PodShutdown');
+    expect(Date.parse(row.visibleAfter)).toBeLessThanOrEqual(Date.now());
+
+    // Claimable again at once; a second release of a row we no longer hold is a no-op.
+    const again = await claim.claimNext({ companyId: TENANT, jobType, ttlSeconds: 60, epoch: 3 });
+    expect(again?.runId).toBe(runId);
+    expect(again?.attempts).toBe(2);
+    expect(
+      await claim.release({
+        companyId: TENANT,
+        recordId: claimed!.recordId,
+        claimEpoch: 2,
+        reason: 'stale',
+      }),
+    ).toBe(false);
+    await claim.complete({ companyId: TENANT, recordId: again!.recordId, claimEpoch: 3 });
+  }, 60_000);
 });
 
 describe('LeaderLeaseService — real Surreal end-to-end', () => {
@@ -345,5 +494,41 @@ describe('LeaderLeaseService — real Surreal end-to-end', () => {
         name: 'test_lease_b',
       });
     });
+  }, 60_000);
+  it('acquire returns the fencing epoch: kept while the same holder renews, bumped on a takeover', async () => {
+    const name = 'test_lease_epoch';
+    await surreal.withAdminDb(async (db) => {
+      await db.query(`DELETE FROM leader_lease WHERE name = $name`, { name });
+    });
+    expect(await leader.acquire(name, 60)).toBe(1);
+    expect(await leader.acquire(name, 60)).toBe(1);
+    expect(await leader.isHeld(name, 1)).toBe(true);
+    expect(await leader.isHeld(name, 2)).toBe(false);
+
+    // Another pod took the lease, and its own lease has since lapsed.
+    await surreal.withAdminDb(async (db) => {
+      await db.query(
+        `UPDATE leader_lease SET leaderId = 'other-pod#1#00000000-0000-0000-0000-000000000000',
+            leaseUntil = type::datetime($t)
+          WHERE name = $name`,
+        { name, t: new Date(Date.now() - 1_000).toISOString() },
+      );
+    });
+    expect(await leader.isHeld(name, 1)).toBe(false);
+    expect(await leader.tryAcquire(name, 60)).toBe(true);
+    expect(await leader.isHeld(name, 1)).toBe(false);
+    expect(await leader.isHeld(name, 2)).toBe(true);
+    const row = await surreal.withAdminDb(async (db) => {
+      const [rows] = await db.query<[any[]]>(
+        `SELECT epoch, leaderId FROM leader_lease WHERE name = $name`,
+        { name },
+      );
+      return (rows as any[])[0];
+    });
+    expect(row.epoch).toBe(2);
+    expect(row.leaderId).toBe(leader.identity());
+
+    await leader.release(name);
+    expect(await leader.isHeld(name, 2)).toBe(false);
   }, 60_000);
 });

--- a/test/leader-lease.unit-spec.ts
+++ b/test/leader-lease.unit-spec.ts
@@ -1,0 +1,109 @@
+/**
+ * LeaderLeaseService against a scripted SurrealService: the fencing epoch
+ * acquire() returns, the boolean tryAcquire() wrapper over it, and the
+ * point read behind isHeld().
+ */
+import { LeaderLeaseService } from '../src/jobs/leader-lease.service';
+import { PROCESS_IDENTITY } from '../src/common/process-identity';
+
+interface QueryCall {
+  sql: string;
+  params?: Record<string, unknown> | undefined;
+}
+
+function mkSurreal(steps: Array<(call: QueryCall) => unknown[] | Error>) {
+  const calls: QueryCall[] = [];
+  let i = 0;
+  const db = {
+    query: async (sql: string, params?: Record<string, unknown>) => {
+      const call = { sql, params };
+      calls.push(call);
+      const step = steps[i++] ?? (() => [[]]);
+      const out = step(call);
+      if (out instanceof Error) throw out;
+      return out;
+    },
+  };
+  const surreal = { withAdminDb: async <T>(fn: (d: any) => Promise<T>) => fn(db) } as any;
+  return { surreal, calls };
+}
+
+describe('LeaderLeaseService', () => {
+  it('acquire returns the epoch the transaction committed; tryAcquire is its boolean', async () => {
+    // 3.x slot shape for the 2-statement tx: [BEGIN, LET, IF/RETURN, COMMIT].
+    const { surreal, calls } = mkSurreal([
+      () => [null, null, 4, null],
+      () => [null, null, 4, null],
+    ]);
+    const svc = new LeaderLeaseService(surreal);
+    expect(await svc.acquire('worker_loop', 90)).toBe(4);
+    expect(await svc.tryAcquire('worker_loop', 90)).toBe(true);
+    expect(calls[0]!.params).toMatchObject({ name: 'worker_loop', me: PROCESS_IDENTITY });
+    // A change of holder bumps the epoch; the same holder keeps it.
+    expect(calls[0]!.sql).toContain(
+      'IF $row.leaderId = $me { $row.epoch OR 0 } ELSE { ($row.epoch OR 0) + 1 }',
+    );
+    expect(calls[0]!.sql).toContain('epoch: $epoch');
+  });
+
+  it('acquire returns null (tryAcquire false) while another holder has an unexpired lease', async () => {
+    const { surreal } = mkSurreal([() => [null, null, null, null], () => [null, null, null, null]]);
+    const svc = new LeaderLeaseService(surreal);
+    expect(await svc.acquire('worker_loop', 90)).toBeNull();
+    expect(await svc.tryAcquire('worker_loop', 90)).toBe(false);
+  });
+
+  it('acquire treats a datastore failure as not-leader', async () => {
+    const { surreal } = mkSurreal([() => new Error('connection reset')]);
+    const svc = new LeaderLeaseService(surreal);
+    expect(await svc.acquire('worker_loop', 90)).toBeNull();
+  });
+
+  it('isHeld is true only for our identity, an unexpired lease, and the epoch we hold', async () => {
+    const future = new Date(Date.now() + 60_000).toISOString();
+    const past = new Date(Date.now() - 1_000).toISOString();
+    const rows: unknown[][] = [
+      [{ leaderId: PROCESS_IDENTITY, leaseUntil: future, epoch: 2 }],
+      [
+        {
+          leaderId: 'other-host#7#00000000-0000-0000-0000-000000000000',
+          leaseUntil: future,
+          epoch: 3,
+        },
+      ],
+      [{ leaderId: PROCESS_IDENTITY, leaseUntil: past, epoch: 2 }],
+      [{ leaderId: PROCESS_IDENTITY, leaseUntil: future, epoch: 3 }],
+      [], // row wiped
+    ];
+    const { surreal, calls } = mkSurreal(rows.map((r) => () => [r]));
+    const svc = new LeaderLeaseService(surreal);
+    expect(await svc.isHeld('worker_loop', 2)).toBe(true);
+    expect(await svc.isHeld('worker_loop', 2)).toBe(false);
+    expect(await svc.isHeld('worker_loop', 2)).toBe(false);
+    expect(await svc.isHeld('worker_loop', 2)).toBe(false);
+    expect(await svc.isHeld('worker_loop', 2)).toBe(false);
+    // A point read on the record id, not a table scan.
+    expect(calls[0]!.sql).toContain("FROM type::record('leader_lease:' + $name)");
+    expect(calls[0]!.sql).not.toContain('WHERE');
+  });
+
+  it('isHeld without an epoch checks holder and expiry only', async () => {
+    const future = new Date(Date.now() + 60_000).toISOString();
+    const { surreal } = mkSurreal([
+      () => [[{ leaderId: PROCESS_IDENTITY, leaseUntil: future, epoch: 9 }]],
+    ]);
+    expect(await new LeaderLeaseService(surreal).isHeld('worker_loop')).toBe(true);
+  });
+
+  it('isHeld answers false when the read fails — not knowing is not holding', async () => {
+    const { surreal } = mkSurreal([() => new Error('pool closed')]);
+    expect(await new LeaderLeaseService(surreal).isHeld('worker_loop', 1)).toBe(false);
+  });
+
+  it('without a datastore the lease is always ours at epoch 0', async () => {
+    const svc = new LeaderLeaseService();
+    expect(await svc.acquire('worker_loop')).toBe(0);
+    expect(await svc.tryAcquire('worker_loop')).toBe(true);
+    expect(await svc.isHeld('worker_loop', 0)).toBe(true);
+  });
+});

--- a/test/process-identity.unit-spec.ts
+++ b/test/process-identity.unit-spec.ts
@@ -2,6 +2,8 @@ import { hostname } from 'node:os';
 import type { Request, Response } from 'express';
 import { PROCESS_IDENTITY } from '../src/common/process-identity';
 import { requestLogger } from '../src/common/request-logger';
+import { LeaderLeaseService } from '../src/jobs/leader-lease.service';
+import { JobClaimService } from '../src/jobs/job-claim.service';
 
 /**
  * One identity across metrics, logs and traces. Correlating a metric spike
@@ -12,6 +14,32 @@ import { requestLogger } from '../src/common/request-logger';
 describe('per-replica identity', () => {
   it('starts from the OS hostname, which Docker sets to the container id', () => {
     expect(PROCESS_IDENTITY.startsWith(`${hostname()}#${process.pid}#`)).toBe(true);
+  });
+
+  /**
+   * `hostname#pid` alone is not unique by construction: a restart of the
+   * same container (prod pins `container_name` + `restart: unless-stopped`,
+   * and `init: true` makes the app's pid deterministic) reproduces both
+   * halves exactly, and an orchestrator pinning hostnames repeats the pair
+   * across replicas — where the lease's own `leaderId = $me` branch would
+   * then grant it twice. The uuid is what names exactly one live process.
+   */
+  it('two processes with the same hostname and pid still present distinct identities', async () => {
+    const identities: string[] = [];
+    for (let i = 0; i < 2; i++) {
+      await jest.isolateModulesAsync(async () => {
+        const mod = await import('../src/common/process-identity');
+        identities.push(mod.PROCESS_IDENTITY);
+      });
+    }
+    const [a, b] = identities as [string, string];
+    expect(a.split('#').slice(0, 2)).toEqual(b.split('#').slice(0, 2));
+    expect(a).not.toBe(b);
+  });
+
+  it('is the owner stamp on both the leader lease and the job claim', () => {
+    expect(new LeaderLeaseService().identity()).toBe(PROCESS_IDENTITY);
+    expect(new JobClaimService().identity()).toBe(PROCESS_IDENTITY);
   });
 });
 

--- a/test/worker-loop-leadership.unit-spec.ts
+++ b/test/worker-loop-leadership.unit-spec.ts
@@ -1,0 +1,207 @@
+/**
+ * Leadership and shutdown on the worker trio:
+ *   - WorkerPollerService confirms the lease (point read) before every
+ *     claim and ends the loop the moment it is gone — not at the next
+ *     renew tick up to 30 s later — and stamps the lease epoch on claims;
+ *   - WorkerLoopService drains in-flight dispatches for ≤12 s at shutdown
+ *     and hands still-running claims back BEFORE releasing the lease.
+ */
+import { WorkerLoopService } from '../src/jobs/worker-loop.service';
+import { WorkerPollerService } from '../src/jobs/worker-poller.service';
+import type { JobClaim } from '../src/jobs/job-claim.service';
+import type { JobType } from '../src/jobs/job-run.service';
+import type { PollControl, RegisteredHandler } from '../src/jobs/worker-loop.types';
+
+function makeJobClaim(opts: { recordId: string; jobType?: JobType; companyId?: string }): JobClaim {
+  return {
+    recordId: opts.recordId,
+    runId: `run-${opts.recordId}`,
+    jobType: opts.jobType ?? 'dreams',
+    companyId: opts.companyId ?? 'co_a',
+    attempts: 1,
+    payload: null,
+    leaseUntil: '2030-01-01T00:05:00Z',
+    claimEpoch: null,
+  };
+}
+
+describe('WorkerPollerService.runLoop — leadership is confirmed before every claim', () => {
+  const ENV = ['WORKER_LOOP_POLL_MS', 'WORKER_LOOP_EMPTY_BACKOFF_MS', 'WORKER_LOOP_MAX_CONCURRENT'];
+  let saved: Record<string, string | undefined> = {};
+  beforeEach(() => {
+    saved = {};
+    for (const k of ENV) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+    process.env.WORKER_LOOP_POLL_MS = '5';
+    process.env.WORKER_LOOP_EMPTY_BACKOFF_MS = '5';
+  });
+  afterEach(() => {
+    for (const k of ENV) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  function harness(confirms: boolean[], leader = true) {
+    let seq = 0;
+    const claimNext = jest.fn(
+      async (input: { companyId: string; jobType: JobType; epoch?: number | null }) =>
+        makeJobClaim({
+          recordId: `job_run:${++seq}`,
+          jobType: input.jobType,
+          companyId: input.companyId,
+        }),
+    );
+    const dispatch = jest.fn(async () => undefined);
+    const poller = new WorkerPollerService(
+      { dispatch } as never,
+      { claimNext } as never,
+      { fanOutRoster: () => ['co_a'] } as never,
+    );
+    let i = 0;
+    const confirmLeader = jest.fn(async () => confirms[i++] ?? false);
+    const control: PollControl = {
+      isLeader: () => leader,
+      confirmLeader,
+      epoch: () => 9,
+      signal: new AbortController().signal,
+    };
+    const reg: RegisteredHandler = {
+      jobType: 'dreams',
+      handler: async () => ({}),
+      ttlSeconds: 3,
+      maxAttempts: 3,
+    };
+    return { poller, control, reg, claimNext, dispatch, confirmLeader };
+  }
+
+  it('serial loop: a false confirmation ends the loop before the next claim; every claim carries the lease epoch', async () => {
+    const { poller, control, reg, claimNext, dispatch, confirmLeader } = harness([true, false]);
+    await poller.runLoop(reg, control);
+    expect(confirmLeader).toHaveBeenCalledTimes(2);
+    expect(claimNext).toHaveBeenCalledTimes(1);
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    expect(claimNext.mock.calls[0]![0]).toMatchObject({ companyId: 'co_a', epoch: 9 });
+  });
+
+  it('bounded-concurrency loop: same contract', async () => {
+    process.env.WORKER_LOOP_MAX_CONCURRENT = '2';
+    const { poller, control, reg, claimNext, confirmLeader } = harness([true, false]);
+    await poller.runLoop(reg, control);
+    expect(confirmLeader).toHaveBeenCalledTimes(2);
+    expect(claimNext).toHaveBeenCalledTimes(1);
+    expect(claimNext.mock.calls[0]![0]).toMatchObject({ epoch: 9 });
+  });
+
+  it('a loop whose cached flag is already false ends without a read or a claim', async () => {
+    const { poller, control, reg, claimNext, confirmLeader } = harness([true], false);
+    await poller.runLoop(reg, control);
+    expect(confirmLeader).not.toHaveBeenCalled();
+    expect(claimNext).not.toHaveBeenCalled();
+  });
+});
+
+describe('WorkerLoopService — shutdown drains dispatches before releasing the lease', () => {
+  const OLD = process.env.WORKER_LOOP_LEASE_RENEW_MS;
+  beforeEach(() => {
+    jest.useFakeTimers();
+    // First acquire fires at renew/6 = 100 ms.
+    process.env.WORKER_LOOP_LEASE_RENEW_MS = '600';
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+    if (OLD === undefined) delete process.env.WORKER_LOOP_LEASE_RENEW_MS;
+    else process.env.WORKER_LOOP_LEASE_RENEW_MS = OLD;
+  });
+
+  function boot(opts: { stuck: boolean }) {
+    const order: string[] = [];
+    const claim = makeJobClaim({ recordId: 'job_run:stuck' });
+    const poller = {
+      hasClaim: true,
+      startDecay: jest.fn(),
+      stopDecay: jest.fn(),
+      // A stuck loop stands in for a handler ignoring the shutdown abort.
+      runLoop: jest.fn(
+        (_reg: RegisteredHandler, control: PollControl) =>
+          new Promise<void>((resolve) => {
+            if (!opts.stuck) {
+              control.signal.addEventListener('abort', () => resolve(), { once: true });
+            }
+          }),
+      ),
+      activeClaims: () => (opts.stuck ? [claim] : []),
+      releaseActiveClaims: jest.fn(async () => {
+        order.push('release-claims');
+        return 1;
+      }),
+    };
+    const lease = {
+      acquire: jest.fn(async () => 3),
+      isHeld: jest.fn(async () => true),
+      release: jest.fn(async () => {
+        order.push('release-lease');
+      }),
+    };
+    const svc = new WorkerLoopService(poller as never, lease as never);
+    svc.register('dreams', async () => ({}));
+    return { svc, poller, lease, order };
+  }
+
+  async function becomeLeader(svc: WorkerLoopService) {
+    await svc.onModuleInit();
+    await jest.advanceTimersByTimeAsync(100);
+    for (let i = 0; i < 5; i++) await Promise.resolve();
+    expect(svc.leader()).toBe(true);
+  }
+
+  it('loops that stop on the abort signal drain at once and no claim is handed back', async () => {
+    const { svc, poller, lease, order } = boot({ stuck: false });
+    await becomeLeader(svc);
+    expect(poller.runLoop).toHaveBeenCalledTimes(1);
+    let done = false;
+    const closing = svc.beforeApplicationShutdown().then(() => {
+      done = true;
+    });
+    await jest.advanceTimersByTimeAsync(1);
+    await closing;
+    expect(done).toBe(true);
+    expect(poller.releaseActiveClaims).not.toHaveBeenCalled();
+    expect(lease.release).toHaveBeenCalledWith('worker_loop');
+    expect(order).toEqual(['release-lease']);
+  });
+
+  it('a handler still running after the 12 s budget has its claim handed back BEFORE the lease is released', async () => {
+    const { svc, poller, order } = boot({ stuck: true });
+    await becomeLeader(svc);
+    let done = false;
+    const closing = svc.beforeApplicationShutdown().then(() => {
+      done = true;
+    });
+    await jest.advanceTimersByTimeAsync(11_999);
+    expect(done).toBe(false);
+    expect(poller.releaseActiveClaims).not.toHaveBeenCalled();
+    await jest.advanceTimersByTimeAsync(1);
+    await closing;
+    expect(poller.releaseActiveClaims).toHaveBeenCalledTimes(1);
+    expect(order).toEqual(['release-claims', 'release-lease']);
+  });
+
+  it('confirmLeader() drops leadership as soon as the point read says the lease moved on', async () => {
+    const { svc, poller, lease } = boot({ stuck: false });
+    await becomeLeader(svc);
+    const control = poller.runLoop.mock.calls[0]![1] as PollControl;
+    expect(control.epoch()).toBe(3);
+    expect(await control.confirmLeader()).toBe(true);
+    expect(lease.isHeld).toHaveBeenLastCalledWith('worker_loop', 3);
+    lease.isHeld.mockResolvedValueOnce(false);
+    expect(await control.confirmLeader()).toBe(false);
+    expect(svc.leader()).toBe(false);
+    expect(control.isLeader()).toBe(false);
+    expect(control.epoch()).toBeNull();
+    // Abort so the parked loop and the renew timer go away.
+    await svc.beforeApplicationShutdown();
+  });
+});

--- a/test/worker-loop.unit-spec.ts
+++ b/test/worker-loop.unit-spec.ts
@@ -62,6 +62,7 @@ function makeJobClaim(
     companyId?: string;
     attempts?: number;
     payload?: Record<string, unknown> | null;
+    claimEpoch?: number | null;
   } = {},
 ): JobClaim {
   return {
@@ -72,6 +73,7 @@ function makeJobClaim(
     attempts: opts.attempts ?? 1,
     payload: opts.payload ?? null,
     leaseUntil: '2030-01-01T00:05:00Z',
+    claimEpoch: opts.claimEpoch ?? null,
   };
 }
 
@@ -135,6 +137,29 @@ describe('JobDispatcherService.dispatch', () => {
     expect(claimSvc.calls.completed[0]!.recordId).toBe('job_run:abc');
     expect(claimSvc.calls.completed[0]!.result).toEqual({ ok: true });
     expect(claimSvc.calls.failed).toHaveLength(0);
+  });
+
+  it('every write on the claim carries the lease epoch it was taken under', async () => {
+    // The epoch is the fence: a dispatch whose leadership lapsed must not
+    // be able to renew or terminally write a row claimed again since.
+    const claim = makeJobClaim({ claimEpoch: 4 });
+    const claimSvc = makeClaimSvc();
+    const reg = {
+      jobType: 'dreams' as JobType,
+      handler: async () => ({ ok: true }),
+      ttlSeconds: 3,
+      maxAttempts: 3,
+    };
+    await callDispatch(mkDispatcher(claimSvc), claim, reg);
+    expect(claimSvc.complete.mock.calls[0]![0]).toMatchObject({ claimEpoch: 4 });
+    const throwing = makeClaimSvc();
+    await callDispatch(mkDispatcher(throwing), claim, {
+      ...reg,
+      handler: async () => {
+        throw new Error('boom');
+      },
+    });
+    expect(throwing.fail.mock.calls[0]![0]).toMatchObject({ claimEpoch: 4 });
   });
 
   it('a returned FAILED batch outcome is treated like a throw: fail(), result persisted', async () => {

--- a/test/worker-poller-concurrency.unit-spec.ts
+++ b/test/worker-poller-concurrency.unit-spec.ts
@@ -62,7 +62,12 @@ function makeReg(jobType: JobType = 'dreams'): RegisteredHandler {
 function makeControl(): { control: PollControl; abort: () => void } {
   const ac = new AbortController();
   return {
-    control: { isLeader: () => true, signal: ac.signal },
+    control: {
+      isLeader: () => true,
+      confirmLeader: async () => true,
+      epoch: () => null,
+      signal: ac.signal,
+    },
     abort: () => ac.abort(),
   };
 }


### PR DESCRIPTION
## What

Makes the leader-lease primitive and the shutdown path sound for N identical replicas.

- **One identity per process, everywhere an owner is stamped.** `LeaderLeaseService.leaderId` and `JobClaimService.workerId` now both take `PROCESS_IDENTITY` (`hostname#pid#uuid`) — the constant #559 added for the metrics `instance` label, the JSON request line and `service.instance.id`. This PR does not add its own copy; it adopts that one and extends its spec.
- **A fencing epoch.** `leader_lease.epoch` is bumped on a fresh acquire and preserved on a renew. `acquire()` returns it, `claimNext` stamps it on `job_run.claimEpoch`, and `renew` / `complete` / `fail` / `cancelled` / `release` all require the row to still carry it.
- **Leadership is confirmed before every claim.** `PollControl` gained `confirmLeader()` (a point read on the lease record, epoch-checked) and `epoch()`. A loop that finds the lease gone ends immediately; the renew tick starts a fresh set once the lease is ours again.
- **`claimNext` is no longer a scan inside a transaction.** The candidate is selected outside any transaction (index-backed on `job_run_claim_idx`), then one record is compare-and-set `pending → running`; a lost CAS takes the next candidate, up to three per call.
- **One shutdown, and it drains.** The manual `SIGTERM`/`SIGINT` handler in `main.ts` and the one in `tracing.ts` are gone; `GracefulShutdownService` (root module) owns the sequence: `/health` + `/ready` answer 503 → 6 s readiness drain → the worker loop awaits in-flight dispatches for ≤12 s and hands back any claim that outlived that (`status='pending'`, visible now, `error.name='PodShutdown'`) → lease release → OTel flush → pool close, under a 25 s unref'd hard stop.
- **Migration `0142_lease_epoch_claim_fence.surql`** defines `leader_lease.epoch` (`int DEFAULT 0`) and `job_run.claimEpoch` (`option<int>`); both tables are SCHEMAFULL.

Two adjacent fixes the above depends on:

- `/health` (not `/ready`) is the path Traefik load-balances on, so the readiness flip has to make liveness answer 503 too — otherwise nothing drains.
- An unscheduled `enqueue` no longer stamps `visibleAfter` from the enqueueing process's clock. The claim filter `visibleAfter <= time::now()` is evaluated by the datastore, so a row written by a replica running ahead of it was unclaimable until the difference elapsed; the schema DEFAULT (`time::now()`, migration 0028) is the same clock the filter uses. A deliberately delayed job still carries the caller's instant.

## Why

Audit wave #501, findings S1 (lease identity collides) / S2 (no fencing token) / S2 (leadership up to 30 s stale) / S2 (`claimNext` table-scans inside a transaction) / S2 (SIGTERM handled twice, no drain).

Verified rather than assumed:

- **Identity.** `hostname#pid` is not unique by construction. Measured with Docker 29.7.2: two fresh containers get distinct hostnames (the container id), but the **same** container started twice reports the identical hostname *and* pid 7 under `init: true` — which is the prod shape (`container_name` + `restart: unless-stopped`). A restarted process presented its dead predecessor's identity, passed every `claimedBy = $me` guard on rows it never claimed, and could take the lease through `tryAcquire`'s own `OR $row.leaderId = $me` branch.
- **Double shutdown.** `enableShutdownHooks()` registers Nest's own signal listener (destroy → beforeShutdown → dispose → shutdown); the manual listener called `app.close()`, which runs those same four phases again, concurrently. Nest re-raises the signal at the end of its run, and `tracing.ts` had a listener still registered at that point, which would have swallowed the default exit.
- **Hook ordering.** Nest 11.1.29 sorts modules by distance descending and then `.reverse()`s for all three shutdown phases, so the root module's hooks run first in each phase — which is what makes the readiness flip precede the drain.
- **SurrealQL.** Every new statement was run against a real SurrealDB 3.x container before being trusted. The first shape of the candidate read (`SELECT id … ORDER BY visibleAfter`) was rejected — *"Missing order idiom `visibleAfter` in statement selection"* — so the ordering key is projected.

## The `admin-jobs-stream-replica` failure this PR hit in CI

It was not caused by this PR's DDL or by the `enqueue` change, and the diagnosis is not a shrug at a flake — the mechanism reproduces on demand, on `main`:

The job stream anchors its cursor on the database clock **inside its first poll tick** (`initialCursor: () => surreal.withCompany(companyId, dbNow)`), and that tick pays the tenant's schema bootstrap when it is the first caller through the door. A probe that runs the spec's own sequence twice, once against a warm tenant and once against a cold one:

```
PROBE warm {"seen":true,"insertMs":6}    cold {"seen":false,"insertMs":893}   # this branch
PROBE warm {"seen":true,"insertMs":9}    cold {"seen":false,"insertMs":875}   # origin/main, unchanged
```

Cold, the insert itself queues behind the bootstrap, the anchor lands *after* it, and `WHERE updatedAt >= $since` excludes that row for good — "timed out waiting for the inserted row". A fresh tenant costs 1.3–3.2 s to bootstrap locally (measured over 40 of them), more on a loaded runner.

Whether the spec's tenant is warm at subscribe time was incidental: `CalibrationService.onModuleInit` warms `hostTenant()`, which since #548 is `fanOutRoster()[0]` — the registry-active roster — so run alone it warms this spec's tenant, and inside a long shard it warms an earlier spec's tenant instead (the registry is in the shared admin database and accumulates every spec's tenant). Hence a failure that appears only in a shard, and only sometimes.

Fixed by touching the tenant database in `beforeAll`, before anything subscribes, with the reason in a comment. Shard 2/4 — the exact CI invocation, `jest --config ./test/jest-e2e.json --shard=2/4` — reproduced the failure on this branch before the fix and passes twice after it; it also passes on `origin/main`, which is what said the fault was not in this PR's code.

**For #553's owner (not fixed here):** the same anchoring means a transition written while a stream is starting up on a cold tenant is lost, not delayed. Anchoring the cursor before the tenant round-trip (or on a stored watermark) would close it; it is a product hole, not a test artefact.

## How verified

Rebased onto `main` @ a1f3345 (#556), i.e. on top of #548, #552, #553, #555, #556, #557, #558, #559, #561. Conflicts resolved: `src/common/process-identity.ts` (add/add — kept main's file, dropped this PR's duplicate, call sites unchanged since the shape is identical), `test/process-identity.unit-spec.ts` (add/add — kept main's and appended the uniqueness and owner-stamp assertions), and earlier `HealthService.readiness()` where #555's `evidenceStoreOk` met the shutdown flag (`ready: !shuttingDown && dbOk && scopedOk && embedderReady && evidenceStoreOk`).

Also checked for cross-PR interference rather than assumed:

- #553's `job_run.updatedAt` is `option<datetime> VALUE time::now()`, stamped by the database on every write, and this PR's migration only adds `claimEpoch` — no duplicate or conflicting definition, and the claim / terminal / release writes bump the change marker the stream polls with no code in this PR.
- #548 moved the poller's tenant sampling from `knownCompanyIds()` to `fanOutRoster()` on the two lines this PR edits; both sides are present after the merge, and `test/worker-loop-leadership.unit-spec.ts` now stubs `fanOutRoster` (its `knownCompanyIds` stub would have made those tests vacuous).

```
pnpm typecheck                                  → clean (exit 0)
pnpm lint:ci                                    → clean, 0 warnings (exit 0)
pnpm format:check                               → all matched files use Prettier code style
pnpm jest --config ./test/jest-unit.json        → 451 suites, 5483 tests, all passed
  (includes test/flag-budget, test/*truth*, test/*doctrine*, test/engine-layering)
jobs real-DB e2e (testcontainers Surreal)       → 1 suite, 13 tests, all passed
e2e shard 2/4 (the CI invocation), twice        → 40 suites, 210 tests, all passed
belief-revision-chain e2e                       → 1 suite, 11 tests, all passed
```

(In a worktree the jest calls need `--testPathIgnorePatterns='/node_modules/' --modulePathIgnorePatterns='/__none__/'`; the configs ignore `/.claude/worktrees/`. A `pnpm install` is required after rebasing onto #555, which adds `@aws-sdk/client-s3`.)

New / extended tests:

- `test/process-identity.unit-spec.ts` — two isolated module registries with the same hostname and pid still present distinct identities, and both the lease and the claim stamp that one string.
- `test/leader-lease.unit-spec.ts` — the epoch `acquire()` commits, `tryAcquire` as its boolean, and `isHeld` (wrong holder / expired / wrong epoch / missing row / failed read all answer false).
- `test/worker-loop-leadership.unit-spec.ts` — both poll loops end on a false confirmation and stamp the epoch on every claim; shutdown drains, and a handler still running at 12 s has its claim handed back **before** the lease release.
- `test/graceful-shutdown.unit-spec.ts` — readiness flips in the first phase, a signal-driven close holds for the drain while a programmatic one does not, the hard stop fires at 25 s, the budget nests inside compose's `stop_grace_period`, and no `process.on('SIG…')` remains in `main.ts` or `tracing.ts`.
- `test/job-claim.unit-spec.ts` — the point-claim, the lost-race path and its three-candidate bound, a stale epoch making every terminal write a no-op, `release`, and the enqueue `visibleAfter` contract.
- `test/health-ready.unit-spec.ts` — `/health` answers `shutting_down` and `/ready` answers `shuttingDown: true` from the moment shutdown begins, with every dependency still green.
- `test/jobs.real-e2e-spec.ts` — eight concurrent claimers on one pending row yield exactly one winner with `attempts = 1`; the epoch fence refuses a stale write and accepts the current one; `release` returns the row as pending and visible now; the lease epoch is kept across renews and bumped on a takeover.

Not done, deliberately: `fn::reap_zombies` does not clear `claimEpoch` on the rows it recycles. It does not have to — the status guard already refuses a stale writer and the next claim overwrites the field — and touching it would mean another migration over a stored function this PR does not otherwise change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhrQxeisXJZEt4sg3PGyU6
