### PR TITLE
feat(evidence): give evidence blobs a shared object store, so a read does not depend on which replica took the upload

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -771,6 +771,21 @@ PRIVACY_COMPOSER_USER_SCOPE=1
 #EVIDENCE_SUBSTRATE_ENABLED=0
 #EVIDENCE_INGEST_ENABLED=0
 #EVIDENCE_FS_ROOT=
+# Blob store selection: fs (default, local disk — correct only with ONE
+# replica or a volume every replica mounts) or s3 (the shared object
+# store every replica sees). Setting EVIDENCE_S3_BUCKET is what registers
+# the s3 adapter at boot; the credential pair is set together or not at
+# all (the SDK default chain). Reads resolve by each row's own storageRef
+# scheme, so switching fs→s3 moves only NEW uploads.
+# See docs/operations.md § Evidence blob storage.
+#EVIDENCE_STORAGE_SCHEME=fs
+#EVIDENCE_S3_BUCKET=
+#EVIDENCE_S3_ENDPOINT=
+#EVIDENCE_S3_REGION=us-east-1
+#EVIDENCE_S3_PREFIX=
+#EVIDENCE_S3_ACCESS_KEY_ID=
+#EVIDENCE_S3_SECRET_ACCESS_KEY=
+#EVIDENCE_S3_FORCE_PATH_STYLE=0
 #EVIDENCE_MAX_BYTES=1073741824
 #EVIDENCE_PROCESSOR_BROKER=0
 #EVIDENCE_QUARANTINE=0

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -124,7 +124,9 @@ overview — one line per flag, plus the orderings that matter.
 | Flag                                     | Default  | Purpose                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
 | ---------------------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `EVIDENCE_SUBSTRATE_ENABLED`             | `0`      | Master switch for the multimodal evidence substrate writers (evidence_asset / evidence_fragment / derived_representation, 0109); off = every write 503s. GDPR cascade + retention run regardless.                                                                                                                                                                                                                                                                                                                                                              |
-| `EVIDENCE_FS_ROOT`                       | unset    | Directory root for the `fs://` storage adapter; unset = the adapter throws a clear unconfigured error.                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
+| `EVIDENCE_STORAGE_SCHEME`                | `fs`     | Which blob adapter NEW uploads land in: `fs` (local disk) or `s3` (the shared object store every replica sees). Reads always resolve by the row's own `storageRef` scheme. See [Evidence blob storage](#evidence-blob-storage-fs-vs-s3).                                                                                                                                                                                                                                                                                                                       |
+| `EVIDENCE_S3_*` (7 keys)                 | unset    | Bucket / endpoint / region / prefix / credentials / path-style for the `s3://` storage adapter. Setting `EVIDENCE_S3_BUCKET` is what REGISTERS it at boot. See [Evidence blob storage](#evidence-blob-storage-fs-vs-s3).                                                                                                                                                                                                                                                                                                                                       |
+| `EVIDENCE_FS_ROOT`                       | unset    | Directory root for the `fs://` storage adapter; unset = the adapter throws a clear unconfigured error. Local disk — correct only with ONE replica or a volume every replica mounts.                                                                                                                                                                                                                                                                                                                                                                            |
 | `EVIDENCE_MAX_BYTES`                     | 1 GiB    | Sanity cap on a registered asset's DECLARED byteLength, and the transfer bound of the blob upload surface — applied there as `min(this, 64 MiB)`, so raising it past that memory-storage ceiling raises nothing.                                                                                                                                                                                                                                                                                                                                               |
 | `EVIDENCE_BLOB_UPLOAD_ENABLED`           | `0`      | The byte surface: `POST /v1/ingest/evidence-blob` (multipart) — bytes into the content-addressed storage adapter, server-computed `byteHash`/`byteLength`/`storageRef`, asset registered `hot` and SCANNED before it is dispatchable. Media types are a conservative allowlist checked against the declared modality (no SVG/HTML/archives/octet-stream). Off = a bare 404 raised BEFORE the body is parsed. Requires `EVIDENCE_FS_ROOT`, the substrate flag, and `EVIDENCE_QUARANTINE` (uploaded bytes are external ingest — see the quarantine order below). |
 | `EVIDENCE_PROCESSOR_BROKER`              | `0`      | Trusted platform-owned processor adapters over registered assets, each run an idempotent `processing_run` row (0121). Requires the substrate flag.                                                                                                                                                                                                                                                                                                                                                                                                             |
@@ -323,6 +325,41 @@ The queue is on by default. Every var has a safe default; tune below.
 | `JOB_RUN_PERSIST`              | `1`                    | Set `0` only in unit tests to disable job_run persistence entirely. Never in prod.                                                                                                                                                                                                                                                                                                             |
 | `WORKER_LOOP_MAX_CONCURRENT`   | `1`                    | In-flight dispatch bound per job type on this pod. Override per type with `WORKER_LOOP_MAX_CONCURRENT_<JOBTYPE>` (job type upper-cased, e.g. `WORKER_LOOP_MAX_CONCURRENT_DREAMS=2`, `WORKER_LOOP_MAX_CONCURRENT_INDEX_DOCUMENT=2`). `WORKER_LOOP_TENANT_MAX_CONCURRENT` (default 1) bounds per-tenant fan-out; `WORKER_LOOP_GLOBAL_MAX_CONCURRENT` (default 0 = unbounded) caps the pod total. |
 | `PROCESS_ROLE`                 | `all`                  | One-env role split: `all` / `api` / `worker`. Maps to the flag bundle described in [Splitting API and worker roles](#splitting-api-and-worker-roles). Explicitly-set flags always win over the role defaults.                                                                                                                                                                                  |
+
+## Evidence blob storage (`fs` vs `s3`)
+
+Evidence bytes never live in the DB — an `evidence_asset` row points at
+its blob through a `storageRef` (`<scheme>://<companyId>/<byteHash>`),
+and `EVIDENCE_STORAGE_SCHEME` picks which store NEW uploads land in:
+`fs` (the default) writes `<EVIDENCE_FS_ROOT>/<companyId>/<hash[0..1]>/<hash>`
+on the local disk of the process that took the upload, which is correct
+only for a SINGLE replica or a volume every replica mounts — with
+per-pod roots a blob uploaded through one pod is a bare 404 on every
+other, and the leader-elected orphan sweep only ever sees the leader's
+disk. Choose `s3` for anything else (more than one replica, an autoscaled
+or rolling deployment, or a pod whose disk is ephemeral): it needs
+`EVIDENCE_S3_BUCKET` (which is what REGISTERS the adapter at boot, so a
+deployment that never mentions S3 has nothing that could throw), plus
+`EVIDENCE_S3_ENDPOINT` for a non-AWS store, `EVIDENCE_S3_REGION`
+(default `us-east-1`), an optional `EVIDENCE_S3_PREFIX` key namespace so
+one bucket can host several environments,
+`EVIDENCE_S3_ACCESS_KEY_ID` + `EVIDENCE_S3_SECRET_ACCESS_KEY` together
+(or neither, for the instance role / SDK credential chain), and
+`EVIDENCE_S3_FORCE_PATH_STYLE=1` for MinIO-class hosts. Object key is
+`<prefix>/<companyId>/<byteHash>`; bucket, prefix and endpoint are NOT
+part of the ref, so relocating the store is configuration and never a
+row rewrite — but rows written under an old prefix are unreachable until
+it is restored. Reads resolve by each row's own `storageRef` scheme, so a
+store switched `fs`→`s3` keeps serving its existing `fs://` rows and only
+new uploads move; nothing migrates the old bytes for you. The orphan-blob
+GC lists THROUGH the adapter (`ListObjectsV2` under the tenant prefix,
+plus abandoned multipart uploads), so with `s3` the leader sweeps the
+shared bucket instead of one pod's disk — the same per-tenant fence, cap
+and grace window apply. `/ready` and the `evidence_store` capability
+probe run a live `HeadBucket` while `s3` is selected (`fs` reports
+`disabled` — local disk has nothing remote to ask), and boot refuses
+`s3` without a bucket, a malformed bucket name or endpoint, and half a
+credential pair.
 
 ## Splitting API and worker roles
 

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.124.0",
+    "@aws-sdk/client-s3": "^3.1130.0",
     "@modelcontextprotocol/sdk": "^1.30.0",
     "@nestjs/common": "^11.2.3",
     "@nestjs/config": "^4.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@anthropic-ai/sdk':
         specifier: ^0.124.0
         version: 0.124.0(zod@4.5.4)
+      '@aws-sdk/client-s3':
+        specifier: ^3.1130.0
+        version: 3.1130.0
       '@modelcontextprotocol/sdk':
         specifier: ^1.30.0
         version: 1.30.0(zod@4.5.4)
@@ -109,7 +112,7 @@ importers:
         version: 1.0.21
       openai:
         specifier: ^7.10.0
-        version: 7.10.0(undici@7.29.0)(zod@4.5.4)
+        version: 7.10.0(@aws-sdk/credential-provider-node@3.972.83)(@smithy/signature-v4@5.7.3)(undici@7.29.0)(zod@4.5.4)
       pdf2json:
         specifier: 4.0.3
         version: 4.0.3
@@ -255,6 +258,78 @@ packages:
     peerDependenciesMeta:
       zod:
         optional: true
+
+  '@aws-sdk/checksums@3.1001.0':
+    resolution: {integrity: sha512-6uTniZc87q+B5eXouGTl+7Tmc482rEeCcvxpsvREP8EfF0gvloRZ41UOA9sbSJlyy8TbqIBXb3kKfKarEArUQA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/client-s3@3.1130.0':
+    resolution: {integrity: sha512-TUe0hgQi3RtuccmTgpUsRIuPk07ZtJE6s3vpOeWCM8sibLNXPVKweemNEz5gwaRYTor8MAGgjlyVZfKGuu1ZOQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.978.0':
+    resolution: {integrity: sha512-2yX9LUmxPklVjSGTb8dfnWRJSiFQ3TeH2nn7G1mdKHTfnabzF0+gfrS8rYfLWmZrQ8A3mEcxMJjRc51dL5KWaA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.71':
+    resolution: {integrity: sha512-JN+JHruYZw3GUZB8YGAlDk4wTDPOEAEEdEzj5nS0xodWR4smzHsN7PnK2j6IeOsDIj2aqua5DSbhXl9Gtf90FQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.73':
+    resolution: {integrity: sha512-uyYYnJOnlis8uQzaYGPd7N1JoioCoNpXgnkXYixsWJXHXgXyYi8WXJSDfofxJeWfQIGWLe2Nwyq60Uc7MZdVOg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.973.16':
+    resolution: {integrity: sha512-i++ly+0Uxa+u3ebSSyr0S/3CFhFJDxCXT3+Zj+mW2bXenEx5bKGCdTIKFu39SgXBNhWDjex/8cXUx9MUTMCrTw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.78':
+    resolution: {integrity: sha512-eUtswnXu0+Ii9ieRK+0L7aPFV3Z/dnW2VntJzjBP9xs8s+8p5nBNuymIXtXwZ+5r5+XJP3e32nMkuZ/r0HozEA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.83':
+    resolution: {integrity: sha512-jdso7ejzfRnatxMUZK4S/U6KbaDPCvfIV4XL+IQAPFDBt5rj5Fq595euqlK8Le4lNCMFR9oUpt+1l0aMgaayOQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.71':
+    resolution: {integrity: sha512-lYmXJa4gvq4xN1lrT5NiP5vIYYKcGWAdj8y+8o6dlcateB5eF3Dn8DtmjjHKfMBrTPAMr2pebIiX/UOj8c1/UA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-sso@3.973.15':
+    resolution: {integrity: sha512-6Jhcf4v0pSFdjk1EW2kvzuEBKD+UZ2uNcHUIglKKLndD20YhvkL2kdmDOV5/j4mYuWWwe/a1FQ1aomU86/Cg5Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.77':
+    resolution: {integrity: sha512-uylIQSUWpfLuH2LovxEEfwzJGM/SabLOfLMg6YXu/E8jJEKUdpdILCVCQCdFvHyu/7dLJOHPMfrSwduxO56NkQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-sdk-s3@3.972.76':
+    resolution: {integrity: sha512-NfnTkVUTBKTBuBgqaapFK9r3YdkKt1b2oRvgLzZq91bwNKh6ZS0S7sEcheguttREaL4iyfs/xQnqD7Z7AsWSsA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.45':
+    resolution: {integrity: sha512-mooq9Q+jLa18VoM7HouczmslZU60iiB0aKc/Ztnq/luIL1ud0z4DnYprLR/ZO1gp331S9tJctM1HZr7u6YKBXQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.46':
+    resolution: {integrity: sha512-L+2xZTye/2T96f3lwCws0Zw6GG2JHZW9e8FpVgGBeeExSKyeoZ6CWRpBml/7DNiK/O26jrgPM9F+Ay8VkgzUWQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/token-providers@3.1129.0':
+    resolution: {integrity: sha512-Sbl3rpzQdsG4ZK2zh0JWUYyZPKKorJlVOddA2T0DVbKJFrsW8J6wgnslxxUH04+WaBMr4A1HzJZvZX0xUvkniA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.974.5':
+    resolution: {integrity: sha512-LkwLL2BLbC6wNNm4JaH9mbEqBMdOZCct6VAYqhdN4U1xrWM+fUJQEfbHwQgDypapOWTRtlk25akb5afM0P8CIQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.40':
+    resolution: {integrity: sha512-wlFmCIGUlwF4zx/kncw+bmxTQh1HeSJq4mYV/V5cZUSJadDP3kXvGW8Rn21cimj/7y9ju+47oYWXi97vF7czaA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws/lambda-invoke-store@0.3.0':
+    resolution: {integrity: sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==}
+    engines: {node: '>=18.0.0'}
 
   '@babel/code-frame@7.29.7':
     resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
@@ -1692,6 +1767,30 @@ packages:
   '@sinonjs/fake-timers@15.4.0':
     resolution: {integrity: sha512-DsG+8/LscQIQg68J6Ef3dv10u6nVyetYn923s3/sus5eaGfTo1of5WMZSLf0UJc9KDuKPilPH0UDJCjvNbDNCA==}
 
+  '@smithy/core@3.33.3':
+    resolution: {integrity: sha512-CsOeKq/9kA3y6VJHt+/+VTCtBaxJ4OTFpgrjIUhPpDIKxBci1k2bJaQASF2h/ELWrulGp+t97DZ0mevfAD8idg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.5.2':
+    resolution: {integrity: sha512-A9uSdn72ozbRUSit0eib0TW7nXuNPlaeM0zcGkJ+nE6tFcSDbnmtwoxbTCFBukVQcszDAyvsd7+rTduPTXpygg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.8.0':
+    resolution: {integrity: sha512-ycSJu3tFAQ4v04CBB0agqFMVsSQ1iG3yw+SpgxRqKfaURpQD4CZ8Wn0zPMmSnOuTpTh65Vz+EA0rMrw089wvkA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.12.1':
+    resolution: {integrity: sha512-ThMkboGeONWXAelq9FvGsuJC4rOi+qyC4/zhUF58xYpxUg5sQKx2VXZYJmtNjr4dSuBJ1HeJXETQILCz3wOHvw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.7.3':
+    resolution: {integrity: sha512-7ImGm+FkHRLcBaRttIAMZ6bzJZWb2cJGoYjq46F2UjycujWzrL9GEN9h4w7eQyXJYnltrUhxbbieBAIRrdqpow==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.18.0':
+    resolution: {integrity: sha512-CgB6HHWer/vrKps24ulRIbpcpb7K4xAU7SkZ7YHzBPlwHsvsrCJFEXK421s+cJzX+ZrqtA/TuU5w1HzI7k9N8A==}
+    engines: {node: '>=18.0.0'}
+
   '@stablelib/base64@1.0.1':
     resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
 
@@ -2371,6 +2470,9 @@ packages:
   body-parser@2.3.0:
     resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
+
+  bowser@2.14.1:
+    resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
   brace-expansion@1.1.18:
     resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
@@ -4140,6 +4242,7 @@ packages:
     resolution: {integrity: sha512-QErPemxRHDI2RUli3+9/mv4V6Ib9VWI+UoP2S82yXEQtoXzWvu9NSjjo3vyiUiVJv+CJFuzNiKUI+UFFUdv8Lg==}
     engines: {node: '>=20.18.0'}
     hasBin: true
+    bundledDependencies: []
 
   pg-int8@1.0.1:
     resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
@@ -5151,6 +5254,171 @@ snapshots:
       standardwebhooks: 1.1.1
     optionalDependencies:
       zod: 4.5.4
+
+  '@aws-sdk/checksums@3.1001.0':
+    dependencies:
+      '@aws-sdk/core': 3.978.0
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@aws-sdk/client-s3@3.1130.0':
+    dependencies:
+      '@aws-sdk/checksums': 3.1001.0
+      '@aws-sdk/core': 3.978.0
+      '@aws-sdk/credential-provider-node': 3.972.83
+      '@aws-sdk/middleware-sdk-s3': 3.972.76
+      '@aws-sdk/signature-v4-multi-region': 3.996.46
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/fetch-http-handler': 5.8.0
+      '@smithy/node-http-handler': 4.12.1
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@aws-sdk/core@3.978.0':
+    dependencies:
+      '@aws-sdk/types': 3.974.5
+      '@aws-sdk/xml-builder': 3.972.40
+      '@aws/lambda-invoke-store': 0.3.0
+      '@smithy/core': 3.33.3
+      '@smithy/signature-v4': 5.7.3
+      '@smithy/types': 4.18.0
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.71':
+    dependencies:
+      '@aws-sdk/core': 3.978.0
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.73':
+    dependencies:
+      '@aws-sdk/core': 3.978.0
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/fetch-http-handler': 5.8.0
+      '@smithy/node-http-handler': 4.12.1
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-ini@3.973.16':
+    dependencies:
+      '@aws-sdk/core': 3.978.0
+      '@aws-sdk/credential-provider-env': 3.972.71
+      '@aws-sdk/credential-provider-http': 3.972.73
+      '@aws-sdk/credential-provider-login': 3.972.78
+      '@aws-sdk/credential-provider-process': 3.972.71
+      '@aws-sdk/credential-provider-sso': 3.973.15
+      '@aws-sdk/credential-provider-web-identity': 3.972.77
+      '@aws-sdk/nested-clients': 3.997.45
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/credential-provider-imds': 4.5.2
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.78':
+    dependencies:
+      '@aws-sdk/core': 3.978.0
+      '@aws-sdk/nested-clients': 3.997.45
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-node@3.972.83':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.71
+      '@aws-sdk/credential-provider-http': 3.972.73
+      '@aws-sdk/credential-provider-ini': 3.973.16
+      '@aws-sdk/credential-provider-process': 3.972.71
+      '@aws-sdk/credential-provider-sso': 3.973.15
+      '@aws-sdk/credential-provider-web-identity': 3.972.77
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/credential-provider-imds': 4.5.2
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.71':
+    dependencies:
+      '@aws-sdk/core': 3.978.0
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-sso@3.973.15':
+    dependencies:
+      '@aws-sdk/core': 3.978.0
+      '@aws-sdk/nested-clients': 3.997.45
+      '@aws-sdk/token-providers': 3.1129.0
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.77':
+    dependencies:
+      '@aws-sdk/core': 3.978.0
+      '@aws-sdk/nested-clients': 3.997.45
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-sdk-s3@3.972.76':
+    dependencies:
+      '@aws-sdk/core': 3.978.0
+      '@aws-sdk/signature-v4-multi-region': 3.996.46
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.997.45':
+    dependencies:
+      '@aws-sdk/core': 3.978.0
+      '@aws-sdk/signature-v4-multi-region': 3.996.46
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/fetch-http-handler': 5.8.0
+      '@smithy/node-http-handler': 4.12.1
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.46':
+    dependencies:
+      '@aws-sdk/types': 3.974.5
+      '@smithy/signature-v4': 5.7.3
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@aws-sdk/token-providers@3.1129.0':
+    dependencies:
+      '@aws-sdk/core': 3.978.0
+      '@aws-sdk/nested-clients': 3.997.45
+      '@aws-sdk/types': 3.974.5
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.974.5':
+    dependencies:
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.40':
+    dependencies:
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@aws/lambda-invoke-store@0.3.0': {}
 
   '@babel/code-frame@7.29.7':
     dependencies:
@@ -6900,6 +7168,39 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
+  '@smithy/core@3.33.3':
+    dependencies:
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.5.2':
+    dependencies:
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.8.0':
+    dependencies:
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.12.1':
+    dependencies:
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.7.3':
+    dependencies:
+      '@smithy/core': 3.33.3
+      '@smithy/types': 4.18.0
+      tslib: 2.8.1
+
+  '@smithy/types@4.18.0':
+    dependencies:
+      tslib: 2.8.1
+
   '@stablelib/base64@1.0.1': {}
 
   '@surrealdb/cbor@2.0.0-alpha.4': {}
@@ -7673,6 +7974,8 @@ snapshots:
       type-is: 2.1.0
     transitivePeerDependencies:
       - supports-color
+
+  bowser@2.14.1: {}
 
   brace-expansion@1.1.18:
     dependencies:
@@ -9604,8 +9907,10 @@ snapshots:
       onnxruntime-common: 1.14.0
       platform: 1.3.6
 
-  openai@7.10.0(undici@7.29.0)(zod@4.5.4):
+  openai@7.10.0(@aws-sdk/credential-provider-node@3.972.83)(@smithy/signature-v4@5.7.3)(undici@7.29.0)(zod@4.5.4):
     optionalDependencies:
+      '@aws-sdk/credential-provider-node': 3.972.83
+      '@smithy/signature-v4': 5.7.3
       undici: 7.29.0
       zod: 4.5.4
 

--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -1445,7 +1445,82 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
     runtimeMutable: true,
     isBooleanFlag: false,
     description:
-      'Directory root for the fs:// evidence storage adapter (<root>/<companyId>/<hash[0..1]>/<hash>). NO default on purpose — unset means the adapter throws a clear unconfigured error instead of silently accumulating tenant media in an unmanaged path.',
+      'Directory root for the fs:// evidence storage adapter (<root>/<companyId>/<hash[0..1]>/<hash>). NO default on purpose — unset means the adapter throws a clear unconfigured error instead of silently accumulating tenant media in an unmanaged path. Local disk: correct only for ONE replica or a volume every replica mounts — with per-pod roots a blob uploaded through one pod is a 404 on the others (select EVIDENCE_STORAGE_SCHEME=s3 for a shared store).',
+  },
+  {
+    key: 'EVIDENCE_STORAGE_SCHEME',
+    category: 'pipeline',
+    defaultValue: 'fs',
+    runtimeMutable: true,
+    isBooleanFlag: false,
+    description:
+      'Which blob adapter NEW evidence uploads land in, and which one /ready and the evidence_store capability probe exercise: fs (default — local disk, unchanged behaviour) or s3 (the shared object store every replica sees; needs EVIDENCE_S3_BUCKET at boot or validation refuses). Reads resolve by each row’s own storageRef scheme, so a store switched fs→s3 keeps serving its fs:// rows. Read per call, but a flip can only select an adapter that was REGISTERED at boot.',
+  },
+  {
+    key: 'EVIDENCE_S3_BUCKET',
+    category: 'pipeline',
+    defaultValue: '',
+    runtimeMutable: false,
+    isBooleanFlag: false,
+    description:
+      'Bucket for the s3:// evidence storage adapter (object key <EVIDENCE_S3_PREFIX>/<companyId>/<byteHash>). Setting it REGISTERS the s3 adapter at boot; unset = the adapter does not exist and a deployment that never mentions S3 has nothing that could throw. The client is built on first use and kept — restart to change. Readiness runs a HeadBucket against it while s3 is the selected scheme.',
+  },
+  {
+    key: 'EVIDENCE_S3_ENDPOINT',
+    category: 'pipeline',
+    defaultValue: '',
+    runtimeMutable: false,
+    isBooleanFlag: false,
+    description:
+      'http(s) endpoint of an S3-compatible store (MinIO, Ceph RGW, R2, …). Unset = the AWS regional endpoint for EVIDENCE_S3_REGION. Restart to change.',
+  },
+  {
+    key: 'EVIDENCE_S3_REGION',
+    category: 'pipeline',
+    defaultValue: 'us-east-1',
+    runtimeMutable: false,
+    isBooleanFlag: false,
+    description:
+      'Signing region for the s3 adapter. us-east-1 is what MinIO-class hosts expect; set the real region for AWS. Restart to change.',
+  },
+  {
+    key: 'EVIDENCE_S3_PREFIX',
+    category: 'pipeline',
+    defaultValue: '',
+    runtimeMutable: false,
+    isBooleanFlag: false,
+    description:
+      'Key namespace inside the bucket (<prefix>/<companyId>/<byteHash>; surrounding slashes stripped) so one bucket can host several environments. Empty = the bucket root. NOT part of the storageRef, so moving the prefix is configuration, not a row rewrite — but rows written under the old prefix are then unreachable until it is restored. Restart to change.',
+  },
+  {
+    key: 'EVIDENCE_S3_ACCESS_KEY_ID',
+    category: 'pipeline',
+    defaultValue: '',
+    runtimeMutable: false,
+    isBooleanFlag: false,
+    description:
+      'Static credential for the s3 adapter — set together with EVIDENCE_S3_SECRET_ACCESS_KEY (validation refuses one without the other). Both unset = the SDK default credential chain (instance role, AWS_* env, profile). Restart to change.',
+  },
+  {
+    key: 'EVIDENCE_S3_SECRET_ACCESS_KEY',
+    category: 'pipeline',
+    defaultValue: '',
+    runtimeMutable: false,
+    isBooleanFlag: false,
+    secret: true,
+    description:
+      'The secret half of the static credential pair for the s3 adapter. Masked here; never logged, never part of a probe message. Restart to change.',
+  },
+  {
+    key: 'EVIDENCE_S3_FORCE_PATH_STYLE',
+    category: 'pipeline',
+    defaultValue: '0',
+    runtimeMutable: false,
+    // Boolean-valued, and labelled so: the flag budget scopes itself to
+    // the ENGINE_ prefixes, so the honest label costs nothing there.
+    isBooleanFlag: true,
+    description:
+      'Path-style addressing (https://host/bucket/key) instead of virtual-hosted (https://bucket.host/key) for the s3 adapter. MinIO-class hosts need 1; AWS S3 wants 0. Store configuration, not an engine fork: boot hard-errors on a value outside 1/0/true/false rather than letting it read as OFF. Restart to change.',
   },
   {
     key: 'EVIDENCE_MAX_BYTES',

--- a/src/admin/health-components.service.ts
+++ b/src/admin/health-components.service.ts
@@ -44,6 +44,7 @@ export class HealthComponentsService {
       this.database(readiness),
       this.scopedPool(readiness, last.scoped_read),
       this.embedderRow(readiness, last.embed),
+      this.evidenceStoreRow(readiness, last.evidence_store),
       this.intentRow(),
       this.openAiKeyRow(),
       this.changefeedRow(),
@@ -122,6 +123,48 @@ export class HealthComponentsService {
       name,
       status: probeFailed ? 'degraded' : 'ok',
       message: joinParts(`cache size ${stats.size}`, probeSummary(probe)),
+    };
+  }
+
+  /**
+   * The SELECTED blob store (EVIDENCE_STORAGE_SCHEME). `disabled` is the
+   * honest word for fs — local disk, nothing remote to probe, and correct
+   * only with one replica or a shared volume — not a green that proves
+   * nothing. For s3 the row is /ready's live HeadBucket plus the probe's
+   * last outcome; `unreachable` carries the probe's own message (which
+   * bucket, which endpoint, what the store said), and a selected scheme
+   * with no adapter registered reads the same way.
+   */
+  private evidenceStoreRow(
+    r: ReadinessReport,
+    probe: LastProbeReport | undefined,
+  ): HealthComponent {
+    const store = r.detail.evidenceStore;
+    const name = `evidence store (${store.scheme})`;
+    if (store.error !== null) {
+      return {
+        name,
+        status: 'unreachable',
+        ...(store.probed ? { latencyMs: store.latencyMs } : {}),
+        message: joinParts(store.error, probeSummary(probe)),
+      };
+    }
+    if (!store.probed) {
+      return {
+        name,
+        status: 'disabled',
+        message:
+          `EVIDENCE_STORAGE_SCHEME=${store.scheme}: local disk — correct only with one ` +
+          `replica or a shared volume; select s3 for a shared store`,
+      };
+    }
+    const probeFailed =
+      probe !== undefined && isConclusive(probe.outcome) && probe.outcome !== 'serving';
+    return {
+      name,
+      status: probeFailed ? 'degraded' : 'ok',
+      latencyMs: store.latencyMs,
+      message: joinParts('bucket answers', probeSummary(probe)),
     };
   }
 

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -1,5 +1,10 @@
 import { Logger } from '@nestjs/common';
 import { validateEvidenceOrphanGcEnv, validateOcrEnvValues } from './evidence-flags';
+// Its own statement, deliberately: this file sits at the 800-line
+// god-file ceiling, and folding a third name into the import above makes
+// prettier expand it to five lines. The blob-store family validates
+// beside its readers like every other EVIDENCE_ knob.
+import { validateEvidenceStorageEnv } from './evidence-flags';
 import { isProcessRole, normalizeProcessRole } from './process-role';
 
 const log = new Logger('EnvValidation');
@@ -274,6 +279,11 @@ export function validateEnv(env: NodeJS.ProcessEnv = process.env): void {
   // Local OCR processor knobs, same clamp contract (the validator lives
   // beside its readers in evidence-flags.ts — see the note there).
   validateOcrEnvValues(env, errors);
+  // Store selection + the S3 object store (multi-replica): a scheme
+  // outside fs/s3, s3 without a bucket, or half a credential pair is an
+  // upload path with nowhere to put bytes — errors, validated beside the
+  // readers in evidence-flags.ts.
+  validateEvidenceStorageEnv(env, errors);
 
   // ── Retrieval profile (per-tenant genre configuration) ─────────────
   validateRetrievalProfileEnv(env, errors);
@@ -1396,6 +1406,10 @@ const KNOWN_BOOLEAN_FLAGS = [
   // warns on the inconsistent pair). EVIDENCE_ family sits off the
   // ENGINE flag budget by design (see above).
   'EVIDENCE_GRANTS_API_ENABLED',
+  // EVIDENCE_S3_FORCE_PATH_STYLE is deliberately NOT here: it is
+  // configuration for the object store, and validateEvidenceStorageEnv
+  // hard-ERRORS on a value outside 1/0/true/false alongside the rest of
+  // the EVIDENCE_S3_ family, rather than warning like an engine flag.
   // Outcome telemetry master (0107): writers append memory_outcome rows
   // + fold memory_outcome_stat counters; the nightly raw-log prune runs.
   // Default off = byte-identical (every writer is a guarded no-op).

--- a/src/common/evidence-flags.ts
+++ b/src/common/evidence-flags.ts
@@ -121,6 +121,139 @@ export function evidenceFsRoot(): string | null {
   return raw.trim();
 }
 
+/**
+ * The blob stores an upload may land in. Deliberately named without the
+ * env key as a substring: the catalogue truth gate reads a module-scope
+ * const that mentions a key as "captured at boot", and the selector
+ * below is genuinely per-call.
+ */
+export const BLOB_STORE_SCHEMES = ['fs', 's3'] as const;
+export type EvidenceStorageScheme = (typeof BLOB_STORE_SCHEMES)[number];
+
+/**
+ * Upload-side store selection — EVIDENCE_STORAGE_SCHEME (fs | s3).
+ *
+ * Which registered adapter NEW uploads land in, and which one `/ready`
+ * and the evidence_store probe exercise. READS resolve by the row's own
+ * storageRef scheme, so a deployment switched from fs to s3 keeps
+ * serving its fs:// rows. `fs` (the default — unchanged behaviour) is
+ * correct only for a single replica or a shared volume; `s3` is the
+ * object store every replica sees. A value outside the set fails boot
+ * (validateEvidenceStorageEnv); read at call time, so a flip is
+ * runtime-mutable — towards an adapter that was REGISTERED at boot (s3
+ * registers only with EVIDENCE_S3_BUCKET set).
+ */
+export function evidenceStorageScheme(): EvidenceStorageScheme {
+  return normalizeScheme(process.env.EVIDENCE_STORAGE_SCHEME) === 's3' ? 's3' : 'fs';
+}
+
+function normalizeScheme(raw: string | undefined): string {
+  return (raw ?? '').trim().toLowerCase();
+}
+
+/** Trimmed value, or null for unset/blank — the fs-root idiom. */
+function trimmed(raw: string | undefined): string | null {
+  if (raw === undefined || raw.trim() === '') return null;
+  return raw.trim();
+}
+
+/** AWS's default region when the region knob is unset — what MinIO-class hosts expect too. */
+const DEFAULT_S3_REGION = 'us-east-1';
+/** Bucket naming per the S3 rules: 3-63 chars of lowercase letters, digits, dots, hyphens. */
+const S3_BUCKET_RE = /^[a-z0-9][a-z0-9.-]{1,61}[a-z0-9]$/;
+
+export interface EvidenceS3Config {
+  bucket: string;
+  region: string;
+  /** null = the AWS regional endpoint. */
+  endpoint: string | null;
+  /** Key namespace inside the bucket, surrounding slashes stripped; '' = the bucket root. */
+  prefix: string;
+  /** null = the SDK default credential chain (instance role, env, profile). */
+  credentials: { accessKeyId: string; secretAccessKey: string } | null;
+  forcePathStyle: boolean;
+}
+
+/**
+ * S3-compatible object-store configuration — EVIDENCE_S3_* (strings,
+ * plus the boolean FORCE_PATH_STYLE). null while EVIDENCE_S3_BUCKET is
+ * unset: the s3 adapter then does not register at all, so a deployment
+ * that never mentions S3 has no adapter that could throw. Endpoint unset
+ * = the AWS regional endpoint; credentials unset = the SDK default chain
+ * — set BOTH keys or neither. The prefix namespaces keys
+ * (`<prefix>/<companyId>/<byteHash>`), so one bucket can host several
+ * environments. Read per call here; the adapter binds its client on
+ * first use and keeps it, so a live change needs a restart.
+ */
+export function evidenceS3Config(): EvidenceS3Config | null {
+  const bucket = trimmed(process.env.EVIDENCE_S3_BUCKET);
+  if (bucket === null) return null;
+  const accessKeyId = trimmed(process.env.EVIDENCE_S3_ACCESS_KEY_ID);
+  const secretAccessKey = trimmed(process.env.EVIDENCE_S3_SECRET_ACCESS_KEY);
+  return {
+    bucket,
+    region: trimmed(process.env.EVIDENCE_S3_REGION) ?? DEFAULT_S3_REGION,
+    endpoint: trimmed(process.env.EVIDENCE_S3_ENDPOINT),
+    prefix: (trimmed(process.env.EVIDENCE_S3_PREFIX) ?? '').replace(/^\/+|\/+$/g, ''),
+    credentials:
+      accessKeyId !== null && secretAccessKey !== null ? { accessKeyId, secretAccessKey } : null,
+    forcePathStyle: envFlagEnabled(process.env.EVIDENCE_S3_FORCE_PATH_STYLE),
+  };
+}
+
+/**
+ * Boot validation for the store selection + S3 configuration, beside
+ * its readers (the orphan-GC validator's rule). ERRORS, not warnings:
+ * each inconsistency here is an upload path with nowhere to put bytes,
+ * or a store the operator believes is shared and is not.
+ */
+export function validateEvidenceStorageEnv(env: NodeJS.ProcessEnv, errors: string[]): void {
+  const scheme = env.EVIDENCE_STORAGE_SCHEME;
+  const normalized = normalizeScheme(scheme);
+  if (scheme !== undefined && !(BLOB_STORE_SCHEMES as readonly string[]).includes(normalized)) {
+    errors.push(`EVIDENCE_STORAGE_SCHEME must be one of fs/s3 (got "${scheme}")`);
+  }
+  const bucket = trimmed(env.EVIDENCE_S3_BUCKET);
+  if (normalized === 's3' && bucket === null) {
+    errors.push(
+      'EVIDENCE_STORAGE_SCHEME=s3 requires EVIDENCE_S3_BUCKET — without it the s3 adapter ' +
+        'does not register and every upload answers 503.',
+    );
+  }
+  if (bucket !== null && !S3_BUCKET_RE.test(bucket)) {
+    errors.push(
+      'EVIDENCE_S3_BUCKET must be an S3 bucket name (3-63 chars: lowercase letters, digits, ' +
+        'dots, hyphens)',
+    );
+  }
+  const endpoint = trimmed(env.EVIDENCE_S3_ENDPOINT);
+  if (endpoint !== null && !/^https?:\/\/[^\s/]+/.test(endpoint)) {
+    errors.push('EVIDENCE_S3_ENDPOINT must be an http(s) URL');
+  }
+  const hasId = trimmed(env.EVIDENCE_S3_ACCESS_KEY_ID) !== null;
+  const hasSecret = trimmed(env.EVIDENCE_S3_SECRET_ACCESS_KEY) !== null;
+  if (hasId !== hasSecret) {
+    errors.push(
+      'EVIDENCE_S3_ACCESS_KEY_ID and EVIDENCE_S3_SECRET_ACCESS_KEY must be set together ' +
+        '(or neither, for the SDK default credential chain)',
+    );
+  }
+  // Addressing style is parsed with envFlagEnabled, so an unrecognised
+  // value reads as virtual-hosted and every request 404s against a
+  // MinIO-class host. An error here, not the engine flags' warning: this
+  // is store configuration, and the fail-open shape is the whole point.
+  const pathStyle = env.EVIDENCE_S3_FORCE_PATH_STYLE;
+  if (pathStyle !== undefined && !FLAG_LITERALS.has(pathStyle.trim().toLowerCase())) {
+    errors.push(
+      `EVIDENCE_S3_FORCE_PATH_STYLE must be one of 1/0/true/false (got "${pathStyle}") — ` +
+        'unrecognized values parse as OFF (virtual-hosted addressing).',
+    );
+  }
+}
+
+/** Values envFlagEnabled recognises; anything else parses as OFF. */
+const FLAG_LITERALS = new Set(['1', '0', 'true', 'false']);
+
 /** Default declared-byteLength sanity cap: 1 GiB. (Named WITHOUT the
  *  full env-key substring so the W6 boot-capture truth gate doesn't
  *  mistake this module-scope default for a boot-captured read.) */

--- a/src/common/health.controller.ts
+++ b/src/common/health.controller.ts
@@ -47,8 +47,10 @@ export class HealthController {
   @Get('ready')
   @HttpCode(HttpStatus.OK)
   async ready() {
-    const { dbOk, scopedOk, embedderReady, ready } = await this.healthService.readiness();
+    const { dbOk, scopedOk, embedderReady, evidenceStoreOk, ready, detail } =
+      await this.healthService.readiness();
     if (!ready) {
+      const store = detail.evidenceStore;
       throw new ServiceUnavailableException({
         ready: false,
         checks: {
@@ -58,12 +60,18 @@ export class HealthController {
           // the failure /ready used to miss.
           scopedPool: scopedOk ? 'ok' : 'unauthorized',
           embedder: embedderReady ? 'ok' : 'warming',
+          // The SELECTED blob store: fs is local disk and always ok here;
+          // s3 is a live HeadBucket. Its own message rides along below so
+          // the 503 names WHICH bucket and WHY instead of sending the
+          // operator to the logs.
+          evidenceStore: evidenceStoreOk ? 'ok' : 'unreachable',
         },
+        ...(evidenceStoreOk ? {} : { evidenceStore: { scheme: store.scheme, error: store.error } }),
       });
     }
     return {
       ready: true,
-      checks: { surrealdb: 'ok', scopedPool: 'ok', embedder: 'ok' },
+      checks: { surrealdb: 'ok', scopedPool: 'ok', embedder: 'ok', evidenceStore: 'ok' },
     };
   }
 }

--- a/src/common/health.service.ts
+++ b/src/common/health.service.ts
@@ -1,6 +1,18 @@
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable, Optional } from '@nestjs/common';
 import { SurrealService } from '../db/surreal.service';
 import { EmbedderService, type EmbedderWarmupStatus } from '../ai/embedder.service';
+import { evidenceStorageScheme } from './evidence-flags';
+import {
+  EVIDENCE_STORAGE_ADAPTERS,
+  type EvidenceStorageRegistry,
+} from '../evidence/storage/storage-adapter';
+
+/**
+ * Bound on the live blob-store probe inside one readiness poll. Shorter
+ * than the adapter's own request abort (10s): a wedged endpoint must not
+ * hold /ready open past what a balancer waits for.
+ */
+const STORE_PROBE_DEADLINE_MS = 5_000;
 
 export interface LivenessReport {
   dbOk: boolean;
@@ -20,6 +32,30 @@ export interface ReadinessChecks {
   /** The caller-facing read path (scoped pool) can still authorize a query. */
   scopedOk: boolean;
   embedderReady: boolean;
+  /**
+   * The SELECTED blob store (EVIDENCE_STORAGE_SCHEME) can serve: a live
+   * HeadBucket for s3; vacuously true for fs, which is local disk with
+   * nothing remote to ask. False also when the selected scheme has no
+   * adapter registered — uploads would 503, so the deploy must not go
+   * green.
+   */
+  evidenceStoreOk: boolean;
+}
+
+/** The selected blob store's probe, as `/ready` and the cockpit show it. */
+export interface EvidenceStoreDetail {
+  /** EVIDENCE_STORAGE_SCHEME — which adapter NEW uploads land in. */
+  scheme: string;
+  /**
+   * The selected adapter has a remote store and was asked. When false
+   * `evidenceStoreOk` is vacuous (fs = local disk) unless `error` names
+   * a missing adapter — a surface must say "local", not "ok", for the
+   * vacuous case.
+   */
+  probed: boolean;
+  latencyMs: number;
+  /** The probe's own message when the check failed; null otherwise. */
+  error: string | null;
 }
 
 /** Measurements behind the checks — what the cockpit shows next to them. */
@@ -34,6 +70,8 @@ export interface ReadinessDetail {
   scopedLatencyMs: number;
   /** Warmup bookkeeping behind `embedderReady`: attempts, last error, next retry. */
   embedder: EmbedderWarmupStatus;
+  /** The live probe behind `evidenceStoreOk`: which store, whether asked, what it said. */
+  evidenceStore: EvidenceStoreDetail;
 }
 
 /**
@@ -59,6 +97,12 @@ export class HealthService {
   constructor(
     private readonly surreal: SurrealService,
     private readonly embedder: EmbedderService,
+    // @Optional: unit fixtures construct this positionally, and a process
+    // without the storage registry wired gets a vacuous store check
+    // rather than a DI failure. In production the registry is @Global.
+    @Optional()
+    @Inject(EVIDENCE_STORAGE_ADAPTERS)
+    private readonly storage?: EvidenceStorageRegistry,
   ) {}
 
   /** Liveness — is the DB connection reachable right now. */
@@ -88,12 +132,70 @@ export class HealthService {
     const scopedLatencyMs = Date.now() - scopedStarted;
     const embedderReady = this.embedder.isReady();
     const embedder = this.embedder.warmupStatus();
+    const evidenceStore = await this.evidenceStore();
+    const evidenceStoreOk = evidenceStore.error === null;
     return {
       dbOk,
       scopedOk,
       embedderReady,
-      ready: dbOk && scopedOk && embedderReady,
-      detail: { dbLatencyMs, scopedEnabled, scopedLatencyMs, embedder },
+      evidenceStoreOk,
+      ready: dbOk && scopedOk && embedderReady && evidenceStoreOk,
+      detail: { dbLatencyMs, scopedEnabled, scopedLatencyMs, embedder, evidenceStore },
     };
   }
+
+  /**
+   * The SELECTED blob store (EVIDENCE_STORAGE_SCHEME), probed live — a
+   * HeadBucket for s3 — under a deadline, so a wedged endpoint cannot
+   * hold /ready open. fs has no remote dependency: not probed, vacuously
+   * ok. A selected scheme whose adapter is not registered (s3 with
+   * EVIDENCE_S3_BUCKET unset at boot) is NOT ok: every upload would 503,
+   * and the deploy must hear that here rather than from the first caller.
+   * No registry at all (a process without the storage module) is vacuous,
+   * the same rule as the scoped pool when it is not configured.
+   */
+  private async evidenceStore(): Promise<EvidenceStoreDetail> {
+    const scheme = evidenceStorageScheme();
+    if (!this.storage) return { scheme, probed: false, latencyMs: 0, error: null };
+    const adapter = this.storage.get(scheme);
+    if (!adapter) {
+      return {
+        scheme,
+        probed: false,
+        latencyMs: 0,
+        error:
+          `no '${scheme}' evidence storage adapter is registered — ` +
+          `EVIDENCE_STORAGE_SCHEME=${scheme} needs its store configured at boot ` +
+          `(EVIDENCE_S3_BUCKET); uploads answer 503 until then`,
+      };
+    }
+    if (!adapter.probe) return { scheme, probed: false, latencyMs: 0, error: null };
+    const started = Date.now();
+    try {
+      await withDeadline(adapter.probe(), STORE_PROBE_DEADLINE_MS);
+      return { scheme, probed: true, latencyMs: Date.now() - started, error: null };
+    } catch (e) {
+      return {
+        scheme,
+        probed: true,
+        latencyMs: Date.now() - started,
+        error: e instanceof Error ? e.message : String(e),
+      };
+    }
+  }
+}
+
+/**
+ * Bound a probe's wall-clock. `Promise.race` attaches a handler to `p`
+ * immediately, so a rejection arriving after the deadline is still
+ * handled and cannot surface as an unhandled rejection.
+ */
+function withDeadline<T>(p: Promise<T>, ms: number): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  const deadline = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => reject(new Error(`evidence store probe timed out after ${ms}ms`)), ms);
+  });
+  return Promise.race([p, deadline]).finally(() => {
+    if (timer) clearTimeout(timer);
+  });
 }

--- a/src/evidence/evidence-upload.service.ts
+++ b/src/evidence/evidence-upload.service.ts
@@ -8,7 +8,11 @@ import {
   UnprocessableEntityException,
 } from '@nestjs/common';
 import { createHash } from 'node:crypto';
-import { evidenceMaxBytes, processorBrokerEnabled } from '../common/evidence-flags';
+import {
+  evidenceMaxBytes,
+  evidenceStorageScheme,
+  processorBrokerEnabled,
+} from '../common/evidence-flags';
 import type { EvidenceModality } from '../common/evidence-taxonomy';
 import type { MediaPiiClass } from '../common/media-pii';
 import type { UploadedEvidenceBlob } from './blob-upload.interceptor';
@@ -21,14 +25,6 @@ import {
   type EvidenceStorageRegistry,
 } from './storage/storage-adapter';
 import { normalizeUploadMediaType, uploadMediaTypeError } from './upload-media-types';
-
-/**
- * The scheme uploads are stored under. v1 registers exactly one adapter
- * (fs://); resolving by SCHEME rather than by concrete class keeps the
- * seam the rest of the substrate uses — an s3-class adapter is a registry
- * entry plus this constant, never a rewrite of the upload path.
- */
-export const EVIDENCE_UPLOAD_SCHEME = 'fs';
 
 export interface UploadEvidenceBlobInput {
   modality: EvidenceModality;
@@ -191,12 +187,20 @@ export class EvidenceUploadService {
     return normalizeUploadMediaType(mediaType);
   }
 
-  /** The upload-scheme adapter, or a loud retryable operator error. */
+  /**
+   * The adapter for the SELECTED scheme (EVIDENCE_STORAGE_SCHEME, read
+   * per call), or a loud retryable operator error. Resolving by scheme
+   * rather than by concrete class keeps the seam the rest of the
+   * substrate uses; s3 selected with no s3 adapter registered
+   * (EVIDENCE_S3_BUCKET unset at boot) is a 503, never a silent
+   * fall-back to local disk.
+   */
   private adapter(): EvidenceStorageAdapter {
-    const adapter = this.adapters.get(EVIDENCE_UPLOAD_SCHEME);
+    const scheme = evidenceStorageScheme();
+    const adapter = this.adapters.get(scheme);
     if (!adapter) {
       throw new ServiceUnavailableException(
-        `no '${EVIDENCE_UPLOAD_SCHEME}' storage adapter is registered — ` +
+        `no '${scheme}' storage adapter is registered — ` +
           'the blob upload surface has nowhere to put bytes',
       );
     }

--- a/src/evidence/evidence.module.ts
+++ b/src/evidence/evidence.module.ts
@@ -23,18 +23,13 @@ import {
 } from './processing/processor-adapter';
 import { ProcessingRunService } from './processing/processing-run.service';
 import { AllowAllScanHook, EVIDENCE_SCAN_HOOK } from './processing/scan-hook';
-import { FsEvidenceStorageAdapter } from './storage/fs-storage.adapter';
-import {
-  EVIDENCE_STORAGE_ADAPTERS,
-  EvidenceStorageAdapter,
-  EvidenceStorageRegistry,
-} from './storage/storage-adapter';
+import { EvidenceStorageModule } from './storage/evidence-storage.module';
 
 /**
  * Evidence substrate (migration 0109): the multimodal Evidence Plane
- * write seam (EvidenceStoreService) + the blob storage-adapter registry.
- * v1 registers ONE adapter (fs://); an s3-class adapter is a new
- * provider + one more Map entry — consumers resolve by storageRef
+ * write seam (EvidenceStoreService) over the blob storage-adapter
+ * registry, which lives in the global EvidenceStorageModule (fs always;
+ * s3 when EVIDENCE_S3_BUCKET is set) — consumers resolve by storageRef
  * scheme, never by concrete class. EvidenceIngestController owns both
  * write-side HTTP surfaces — the metadata-only registration (POST
  * /v1/ingest/evidence-asset, EVIDENCE_INGEST_ENABLED) and the MM-7 byte
@@ -99,6 +94,7 @@ import {
  * provider so Nest resolves it by class in @UseGuards.
  */
 @Module({
+  imports: [EvidenceStorageModule],
   controllers: [
     EvidenceIngestController,
     EvidenceReadController,
@@ -108,13 +104,6 @@ import {
   providers: [
     EvidenceGrantsEnabledGuard,
     EvidenceGrantService,
-    FsEvidenceStorageAdapter,
-    {
-      provide: EVIDENCE_STORAGE_ADAPTERS,
-      useFactory: (fs: EvidenceStorageAdapter): EvidenceStorageRegistry =>
-        new Map([[fs.scheme, fs]]),
-      inject: [FsEvidenceStorageAdapter],
-    },
     EvidenceStoreService,
     EvidenceReadService,
     TextExtractionPassthroughAdapter,

--- a/src/evidence/storage/content-ref.ts
+++ b/src/evidence/storage/content-ref.ts
@@ -1,0 +1,35 @@
+/**
+ * The content-addressed storageRef grammar every blob adapter shares:
+ * `<scheme>://<companyId>/<byteHash>`. The tenant id must match the
+ * conservative shape the fixture/auth layer mints (co_…) and the hash
+ * must be 64 lowercase hex chars, so neither segment can carry a path
+ * escape or a key delimiter — one fence for a directory tree and for a
+ * bucket key, so a second adapter cannot relax it by accident. The
+ * store's own location (root directory, bucket, prefix) is NEVER part of
+ * the ref: an operator relocates a store by changing configuration, not
+ * by rewriting rows.
+ */
+export const HASH_RE = /^[0-9a-f]{64}$/;
+export const TENANT_RE = /^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$/;
+
+/** Parsed, validated pieces of a content-addressed storageRef. */
+export interface ParsedContentRef {
+  companyId: string;
+  byteHash: string;
+}
+
+/**
+ * Parse + validate `<scheme>://<companyId>/<byteHash>`. Pure and
+ * unit-testable. Returns null on ANY deviation (wrong scheme, extra
+ * segment, empty tenant, a hash that is not 64 lowercase hex); callers
+ * treat null as a hard error, never a guess.
+ */
+export function parseContentRef(scheme: string, storageRef: string): ParsedContentRef | null {
+  const prefix = `${scheme}://`;
+  if (!storageRef.startsWith(prefix)) return null;
+  const parts = storageRef.slice(prefix.length).split('/');
+  if (parts.length !== 2) return null;
+  const [companyId, byteHash] = parts as [string, string];
+  if (!TENANT_RE.test(companyId) || !HASH_RE.test(byteHash)) return null;
+  return { companyId, byteHash };
+}

--- a/src/evidence/storage/evidence-storage.module.ts
+++ b/src/evidence/storage/evidence-storage.module.ts
@@ -1,0 +1,42 @@
+import { Global, Module } from '@nestjs/common';
+import { evidenceS3Config } from '../../common/evidence-flags';
+import { FsEvidenceStorageAdapter } from './fs-storage.adapter';
+import { S3EvidenceStorageAdapter } from './s3-storage.adapter';
+import {
+  EVIDENCE_STORAGE_ADAPTERS,
+  type EvidenceStorageAdapter,
+  type EvidenceStorageRegistry,
+} from './storage-adapter';
+
+/**
+ * EvidenceStorageModule — the blob-adapter registry, @Global so the
+ * readiness report (HealthService) and the capability probe can reach
+ * the SELECTED store without importing the whole evidence module. fs is
+ * always registered (its methods throw the clear unconfigured error
+ * while EVIDENCE_FS_ROOT is unset); s3 registers only when
+ * EVIDENCE_S3_BUCKET is set, so a deployment that never mentions S3 has
+ * no adapter that could throw — the orphan sweep walks EVERY registered
+ * adapter. Which one takes uploads is EVIDENCE_STORAGE_SCHEME; reads
+ * resolve by the row's own ref scheme, so both can serve at once.
+ */
+@Global()
+@Module({
+  providers: [
+    FsEvidenceStorageAdapter,
+    S3EvidenceStorageAdapter,
+    {
+      provide: EVIDENCE_STORAGE_ADAPTERS,
+      useFactory: (
+        fs: FsEvidenceStorageAdapter,
+        s3: S3EvidenceStorageAdapter,
+      ): EvidenceStorageRegistry => {
+        const registry = new Map<string, EvidenceStorageAdapter>([[fs.scheme, fs]]);
+        if (evidenceS3Config() !== null) registry.set(s3.scheme, s3);
+        return registry;
+      },
+      inject: [FsEvidenceStorageAdapter, S3EvidenceStorageAdapter],
+    },
+  ],
+  exports: [FsEvidenceStorageAdapter, S3EvidenceStorageAdapter, EVIDENCE_STORAGE_ADAPTERS],
+})
+export class EvidenceStorageModule {}

--- a/src/evidence/storage/fs-storage.adapter.ts
+++ b/src/evidence/storage/fs-storage.adapter.ts
@@ -1,51 +1,50 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger, type OnApplicationBootstrap } from '@nestjs/common';
 import { createReadStream, type Stats } from 'node:fs';
 import { mkdir, readdir, rename, rm, stat, writeFile } from 'node:fs/promises';
 import { join, resolve, sep } from 'node:path';
 import { createHash, randomUUID } from 'node:crypto';
 import type { Readable } from 'node:stream';
-import { evidenceFsRoot } from '../../common/evidence-flags';
+import { evidenceFsRoot, evidenceStorageScheme } from '../../common/evidence-flags';
+import { normalizeProcessRole } from '../../common/process-role';
+import { HASH_RE, TENANT_RE, parseContentRef, type ParsedContentRef } from './content-ref';
 import { EvidenceStorageAdapter, StoredBlobEntry } from './storage-adapter';
 
-const HASH_RE = /^[0-9a-f]{64}$/;
 /** Prefix put() gives a blob mid-write, before the atomic rename. */
 const TMP_PREFIX = '.tmp-';
 /** The two-char fan-out directory a blob's content address lives under. */
 const SHARD_RE = /^[0-9a-f]{2}$/;
-// Tenant ids as the fixture/auth layer mints them (co_…): a conservative
-// shape that keeps every path segment traversal-free by construction.
-const TENANT_RE = /^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$/;
 
 /** Parsed, validated pieces of an fs:// storageRef. */
-export interface ParsedFsRef {
-  companyId: string;
-  byteHash: string;
-}
+export type ParsedFsRef = ParsedContentRef;
 
 /**
- * Parse + validate an `fs://<companyId>/<byteHash>` storageRef. Pure and
- * unit-testable: hash must be 64 lowercase hex chars, the tenant id must
- * match the conservative shape above — both segments are therefore
+ * Parse + validate an `fs://<companyId>/<byteHash>` storageRef — the
+ * shared content-ref grammar (content-ref.ts): both segments are
  * incapable of path escape ('..', separators, drive letters all fail the
- * regexes). Returns null on ANY deviation; callers treat null as a
- * hard error, never a guess.
+ * regexes). Returns null on ANY deviation; callers treat null as a hard
+ * error, never a guess.
  */
 export function parseStorageRef(storageRef: string): ParsedFsRef | null {
-  const m = /^fs:\/\/([^/]+)\/([^/]+)$/.exec(storageRef);
-  if (!m) return null;
-  const companyId = m[1]!;
-  const byteHash = m[2]!;
-  if (!TENANT_RE.test(companyId) || !HASH_RE.test(byteHash)) return null;
-  return { companyId, byteHash };
+  return parseContentRef('fs', storageRef);
 }
 
 /**
- * FsEvidenceStorageAdapter — the v1 blob store: a local directory tree
+ * FsEvidenceStorageAdapter — the local-disk blob store: a directory tree
  * under EVIDENCE_FS_ROOT, layout `<root>/<companyId>/<hash[0..1]>/<hash>`
  * (two-char fan-out keeps per-directory entry counts sane at scale).
  * storageRef is `fs://<companyId>/<byteHash>` — the ROOT IS NOT part of
  * the ref, so an operator can relocate the tree by changing the env var
  * without rewriting rows.
+ *
+ * CORRECT ONLY FOR ONE REPLICA, OR A SHARED VOLUME. The tree lives on
+ * the disk of the process that wrote it: with N replicas and per-pod
+ * roots a blob uploaded through one pod is `head() → null` (a 404) on
+ * every other, and the orphan sweep — leader-elected — only ever sees
+ * the leader's disk. Either mount EVIDENCE_FS_ROOT as one volume every
+ * replica shares, or select the object store (EVIDENCE_STORAGE_SCHEME=s3,
+ * S3EvidenceStorageAdapter). onApplicationBootstrap warns once when a
+ * split-role deployment (PROCESS_ROLE=api|worker — more than one process
+ * by definition) is running on this adapter.
  *
  * put() is temp-file-then-rename atomic: a crash mid-write leaves a
  * `.tmp-…` straggler, never a half-written blob under its content
@@ -53,8 +52,28 @@ export function parseStorageRef(storageRef: string): ParsedFsRef | null {
  * (evidence-flags contract) — no silent default path.
  */
 @Injectable()
-export class FsEvidenceStorageAdapter implements EvidenceStorageAdapter {
+export class FsEvidenceStorageAdapter implements EvidenceStorageAdapter, OnApplicationBootstrap {
   readonly scheme = 'fs';
+  private readonly logger = new Logger(FsEvidenceStorageAdapter.name);
+
+  /**
+   * The one multi-replica warning, no knob: silent unless this adapter
+   * is actually in use (root set, scheme fs) on a split-role process.
+   */
+  onApplicationBootstrap(): void {
+    const root = evidenceFsRoot();
+    if (root === null || evidenceStorageScheme() !== 'fs') return;
+    const role = normalizeProcessRole(process.env.PROCESS_ROLE);
+    if (role !== 'api' && role !== 'worker') return;
+    this.logger.warn(
+      `EVIDENCE_STORAGE_SCHEME=fs with PROCESS_ROLE=${role}: the fs evidence adapter keeps ` +
+        `blobs on THIS process's local disk (${root}). A split-role deployment is more than ` +
+        `one process — unless EVIDENCE_FS_ROOT is a volume every replica mounts, a blob ` +
+        `uploaded through one replica is a 404 on the others and the orphan sweep only ` +
+        `sees the leader's disk. Select EVIDENCE_STORAGE_SCHEME=s3 for a shared store ` +
+        `(docs/operations.md § Evidence storage).`,
+    );
+  }
 
   /** Resolved root, or a loud error — never a default path. */
   private root(): string {

--- a/src/evidence/storage/s3-storage.adapter.ts
+++ b/src/evidence/storage/s3-storage.adapter.ts
@@ -1,0 +1,369 @@
+import { Injectable, Logger, type OnApplicationBootstrap } from '@nestjs/common';
+import {
+  AbortMultipartUploadCommand,
+  DeleteObjectCommand,
+  GetObjectCommand,
+  HeadBucketCommand,
+  HeadObjectCommand,
+  ListMultipartUploadsCommand,
+  ListObjectsV2Command,
+  PutObjectCommand,
+  S3Client,
+  S3ServiceException,
+} from '@aws-sdk/client-s3';
+import { createHash } from 'node:crypto';
+import type { Readable } from 'node:stream';
+import {
+  evidenceS3Config,
+  evidenceStorageScheme,
+  type EvidenceS3Config,
+} from '../../common/evidence-flags';
+import { HASH_RE, TENANT_RE, parseContentRef, type ParsedContentRef } from './content-ref';
+import { EvidenceStorageAdapter, StoredBlobEntry } from './storage-adapter';
+
+/** Wall-clock bound on the readiness probe's single round trip. */
+const PROBE_TIMEOUT_MS = 10_000;
+
+/** Parse + validate an `s3://<companyId>/<byteHash>` storageRef (content-ref grammar). */
+export function parseS3StorageRef(storageRef: string): ParsedContentRef | null {
+  return parseContentRef('s3', storageRef);
+}
+
+interface Bound {
+  client: S3Client;
+  config: EvidenceS3Config;
+}
+
+/**
+ * S3EvidenceStorageAdapter — the shared blob store for N replicas: one
+ * bucket every pod reads and writes, object key
+ * `<EVIDENCE_S3_PREFIX>/<companyId>/<byteHash>`. storageRef is
+ * `s3://<companyId>/<byteHash>` — bucket, prefix and endpoint are NOT
+ * part of the ref (the fs adapter's rule), so an operator moves the
+ * store by changing configuration, never by rewriting rows. Same
+ * tenant/hash grammar as fs (content-ref.ts), so the tenant fence the
+ * store service and the orphan sweep lean on is identical.
+ *
+ * Semantics mirror the fs adapter point for point: put() is
+ * content-addressed and idempotent (a HEAD first, then ONE PutObject —
+ * S3 commits an object atomically, so there is no temp-then-rename and
+ * no half-written blob is ever visible); head()/exists() answer null /
+ * false on a missing key; delete() reports whether a key existed; get()
+ * hands back the response body stream, so a large blob is never
+ * materialised. listBlobs pages ListObjectsV2 under the tenant prefix
+ * and yields only well-formed content addresses; sweepIncompleteWrites
+ * aborts abandoned multipart uploads under the same prefix (this adapter
+ * never starts one, but a bucket shared with other writers may hold
+ * them). The client is built from EVIDENCE_S3_* on first use and kept —
+ * a live change of those keys is not picked up (restart). Bucket unset
+ * ⇒ every method throws the clear unconfigured error.
+ *
+ * Checksums are sent only WHEN_REQUIRED: the SDK's default of a CRC32
+ * trailer on every PUT is refused by several S3-compatible stores, and
+ * integrity is already pinned by the content address (put() verifies
+ * the sha256 before sending).
+ */
+@Injectable()
+export class S3EvidenceStorageAdapter implements EvidenceStorageAdapter, OnApplicationBootstrap {
+  readonly scheme = 's3';
+  private readonly logger = new Logger(S3EvidenceStorageAdapter.name);
+  private bound: Bound | undefined;
+
+  /**
+   * One boot-time line when this is the selected store — the probe's
+   * verdict, so a misconfigured bucket is in the log before the first
+   * /ready poll. Fire-and-forget: boot never waits on S3; readiness is
+   * the gate.
+   */
+  onApplicationBootstrap(): void {
+    if (evidenceStorageScheme() !== 's3') return;
+    void this.probe().then(
+      () => {
+        const { config } = this.bind();
+        this.logger.log(`evidence s3 store serving: bucket '${config.bucket}' at ${where(config)}`);
+      },
+      (e: unknown) => this.logger.error((e as Error).message),
+    );
+  }
+
+  /** Bound client + config, or a loud error — never a default bucket. */
+  private bind(): Bound {
+    if (this.bound) return this.bound;
+    const config = evidenceS3Config();
+    if (!config) {
+      throw new Error(
+        'EVIDENCE_S3_BUCKET is not set — the s3 evidence storage adapter is ' +
+          'unconfigured. Set EVIDENCE_S3_BUCKET (plus EVIDENCE_S3_ENDPOINT / ' +
+          'EVIDENCE_S3_REGION / credentials as the store requires).',
+      );
+    }
+    const client = new S3Client({
+      region: config.region,
+      ...(config.endpoint !== null ? { endpoint: config.endpoint } : {}),
+      ...(config.credentials !== null ? { credentials: config.credentials } : {}),
+      forcePathStyle: config.forcePathStyle,
+      requestChecksumCalculation: 'WHEN_REQUIRED',
+      responseChecksumValidation: 'WHEN_REQUIRED',
+    });
+    this.bound = { client, config };
+    return this.bound;
+  }
+
+  /** Client + bucket + key for a validated ref; throws on a malformed ref. */
+  private locate(storageRef: string): { client: S3Client; bucket: string; key: string } {
+    const parsed = parseS3StorageRef(storageRef);
+    if (!parsed) throw new Error(`malformed s3 storageRef: ${storageRef}`);
+    const { client, config } = this.bind();
+    return {
+      client,
+      bucket: config.bucket,
+      key: `${tenantPrefix(config, parsed.companyId)}${parsed.byteHash}`,
+    };
+  }
+
+  async put(
+    companyId: string,
+    byteHash: string,
+    data: Buffer,
+  ): Promise<{ storageRef: string; byteLength: number }> {
+    if (!TENANT_RE.test(companyId)) throw new Error(`invalid companyId for s3 put: ${companyId}`);
+    if (!HASH_RE.test(byteHash)) throw new Error(`invalid byteHash for s3 put: ${byteHash}`);
+    const actualHash = createHash('sha256').update(data).digest('hex');
+    if (actualHash !== byteHash) {
+      throw new Error(`byteHash does not match the supplied bytes`);
+    }
+    const storageRef = `s3://${companyId}/${byteHash}`;
+    const existing = await this.head(storageRef);
+    if (existing) return { storageRef, byteLength: existing.byteLength }; // content-addressed no-op
+    const { client, bucket, key } = this.locate(storageRef);
+    await client.send(
+      new PutObjectCommand({
+        Bucket: bucket,
+        Key: key,
+        Body: data,
+        ContentLength: data.byteLength,
+        ContentType: 'application/octet-stream',
+      }),
+    );
+    return { storageRef, byteLength: data.byteLength };
+  }
+
+  belongsToTenant(companyId: string, storageRef: string): boolean {
+    return parseS3StorageRef(storageRef)?.companyId === companyId;
+  }
+
+  async get(storageRef: string): Promise<Readable> {
+    const { client, bucket, key } = this.locate(storageRef);
+    let body: unknown;
+    try {
+      body = (await client.send(new GetObjectCommand({ Bucket: bucket, Key: key }))).Body;
+    } catch (e) {
+      if (isMissing(e)) throw new Error(`s3 blob not found: ${storageRef}`);
+      throw e;
+    }
+    if (!isReadable(body))
+      throw new Error(`s3 GetObject returned no byte stream for ${storageRef}`);
+    return body;
+  }
+
+  async head(storageRef: string): Promise<{ byteLength: number } | null> {
+    const { client, bucket, key } = this.locate(storageRef);
+    try {
+      const out = await client.send(new HeadObjectCommand({ Bucket: bucket, Key: key }));
+      return { byteLength: out.ContentLength ?? 0 };
+    } catch (e) {
+      if (isMissing(e)) return null;
+      throw e;
+    }
+  }
+
+  async exists(storageRef: string): Promise<boolean> {
+    return (await this.head(storageRef)) !== null;
+  }
+
+  /**
+   * DeleteObject answers 204 whether or not the key existed, so the HEAD
+   * first is what makes the boolean honest (the GDPR cascade and the
+   * sweeps log real counts). A blob that vanishes between the two calls
+   * is reported as deleted — the outcome the caller wanted anyway.
+   */
+  async delete(storageRef: string): Promise<boolean> {
+    const { client, bucket, key } = this.locate(storageRef);
+    if ((await this.head(storageRef)) === null) return false;
+    await client.send(new DeleteObjectCommand({ Bucket: bucket, Key: key }));
+    return true;
+  }
+
+  /**
+   * Enumerate one tenant's blobs — the orphan-GC contract in
+   * storage-adapter.ts. Pages ListObjectsV2 under `<prefix>/<companyId>/`
+   * and yields ONLY keys whose remainder is a well-formed 64-hex content
+   * address: anything else under the prefix is not a blob this adapter
+   * wrote and is never offered to a deleter. Every yielded ref is
+   * `s3://<companyId>/<hash>`, so belongsToTenant holds by construction;
+   * a tenant with no objects is an empty iteration.
+   */
+  async *listBlobs(companyId: string): AsyncGenerator<StoredBlobEntry> {
+    if (!TENANT_RE.test(companyId)) return;
+    const { client, config } = this.bind();
+    const prefix = tenantPrefix(config, companyId);
+    let token: string | undefined;
+    do {
+      const page = await client.send(
+        new ListObjectsV2Command({
+          Bucket: config.bucket,
+          Prefix: prefix,
+          ...(token !== undefined ? { ContinuationToken: token } : {}),
+        }),
+      );
+      for (const object of page.Contents ?? []) {
+        const name = object.Key?.slice(prefix.length);
+        if (name === undefined || !HASH_RE.test(name)) continue;
+        yield {
+          storageRef: `s3://${companyId}/${name}`,
+          byteLength: object.Size ?? 0,
+          // LastModified is the PUT that wrote these bytes — the honest
+          // write time. A store that omits it reads as written NOW: err
+          // younger, per the contract.
+          modifiedAtMs: object.LastModified?.getTime() ?? Date.now(),
+        };
+      }
+      token = page.IsTruncated === true ? page.NextContinuationToken : undefined;
+    } while (token !== undefined);
+  }
+
+  /**
+   * Abort multipart uploads under this tenant's prefix that were started
+   * before the cutoff — the object-store shape of the fs adapter's
+   * `.tmp-…` stragglers: parts a writer paid for and never completed,
+   * addressable by no ref, invisible to listBlobs. `dryRun` counts
+   * without aborting; per-upload failures are swallowed and rediscovered
+   * next run.
+   */
+  async sweepIncompleteWrites(
+    companyId: string,
+    opts: { olderThanMs: number; dryRun: boolean },
+  ): Promise<{ found: number; removed: number }> {
+    if (!TENANT_RE.test(companyId)) return { found: 0, removed: 0 };
+    const { client, config } = this.bind();
+    const prefix = tenantPrefix(config, companyId);
+    const cutoff = Date.now() - Math.max(0, opts.olderThanMs);
+    let found = 0;
+    let removed = 0;
+    let keyMarker: string | undefined;
+    let uploadIdMarker: string | undefined;
+    do {
+      const page = await client.send(
+        new ListMultipartUploadsCommand({
+          Bucket: config.bucket,
+          Prefix: prefix,
+          ...(keyMarker !== undefined ? { KeyMarker: keyMarker } : {}),
+          ...(uploadIdMarker !== undefined ? { UploadIdMarker: uploadIdMarker } : {}),
+        }),
+      );
+      for (const upload of page.Uploads ?? []) {
+        if (upload.Key === undefined || upload.UploadId === undefined) continue;
+        if ((upload.Initiated?.getTime() ?? Date.now()) > cutoff) continue;
+        found++;
+        if (opts.dryRun) continue;
+        try {
+          await client.send(
+            new AbortMultipartUploadCommand({
+              Bucket: config.bucket,
+              Key: upload.Key,
+              UploadId: upload.UploadId,
+            }),
+          );
+          removed++;
+        } catch {
+          // Best effort, like every other delete leg in the substrate.
+        }
+      }
+      keyMarker = page.IsTruncated === true ? page.NextKeyMarker : undefined;
+      uploadIdMarker = page.IsTruncated === true ? page.NextUploadIdMarker : undefined;
+    } while (keyMarker !== undefined || uploadIdMarker !== undefined);
+    return { found, removed };
+  }
+
+  /**
+   * HeadBucket — reachable, authorized, and the bucket exists; the
+   * readiness-contract method. The message names the bucket and endpoint
+   * (never a credential) and turns the store's status into the operator's
+   * next move.
+   */
+  async probe(): Promise<void> {
+    const { client, config } = this.bind();
+    try {
+      await client.send(new HeadBucketCommand({ Bucket: config.bucket }), {
+        abortSignal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+      });
+    } catch (e) {
+      throw new Error(
+        `evidence s3 store is not serving: bucket '${config.bucket}' at ${where(config)} — ` +
+          `${explain(e)}. Check EVIDENCE_S3_BUCKET / EVIDENCE_S3_ENDPOINT / EVIDENCE_S3_REGION ` +
+          `and the credentials` +
+          (config.forcePathStyle ? '' : ' (MinIO-class hosts need EVIDENCE_S3_FORCE_PATH_STYLE=1)'),
+      );
+    }
+  }
+
+  /** The KMS key S3 reports for the object (SSE-KMS); null for SSE-S3 / none. */
+  async encryptionContext(storageRef: string): Promise<{ kmsKeyRef: string } | null> {
+    const { client, bucket, key } = this.locate(storageRef);
+    try {
+      const out = await client.send(new HeadObjectCommand({ Bucket: bucket, Key: key }));
+      return out.SSEKMSKeyId ? { kmsKeyRef: out.SSEKMSKeyId } : null;
+    } catch (e) {
+      if (isMissing(e)) return null;
+      throw e;
+    }
+  }
+
+  /** Explicit null: raw serving stays in-process behind the gate ladder
+   *  (raw-evidence-gate.ts); a presigned bucket URL would hand out bytes
+   *  the per-call gate never saw. null = unsupported, callers must not
+   *  fall back to a raw path. */
+  signedGetUrl(_storageRef: string, _ttlSeconds: number): Promise<string | null> {
+    return Promise.resolve(null);
+  }
+}
+
+/** `<prefix>/<companyId>/` — the key namespace one tenant's blobs live under. */
+function tenantPrefix(config: EvidenceS3Config, companyId: string): string {
+  return config.prefix ? `${config.prefix}/${companyId}/` : `${companyId}/`;
+}
+
+function where(config: EvidenceS3Config): string {
+  return config.endpoint ?? `the AWS endpoint for region '${config.region}'`;
+}
+
+/**
+ * "This key is not here" — HeadObject answers `NotFound`, GetObject
+ * `NoSuchKey`, and the status covers stores that name it differently. A
+ * MISSING BUCKET is deliberately excluded even though it is also a 404:
+ * head() must not report a whole misconfigured store as one absent blob,
+ * which is exactly the silent 404 this adapter exists to end.
+ */
+function isMissing(e: unknown): boolean {
+  if (!(e instanceof S3ServiceException)) return false;
+  if (e.name === 'NoSuchBucket') return false;
+  return e.name === 'NotFound' || e.name === 'NoSuchKey' || e.$metadata.httpStatusCode === 404;
+}
+
+function isReadable(x: unknown): x is Readable {
+  return typeof (x as { pipe?: unknown } | null)?.pipe === 'function';
+}
+
+/** What the store (or the network) said, as one greppable clause. */
+function explain(e: unknown): string {
+  if (e instanceof S3ServiceException) {
+    const status = e.$metadata.httpStatusCode;
+    if (status === 403) return `HTTP 403 ${e.name}: the credentials do not authorize this bucket`;
+    if (status === 404) return `HTTP 404 ${e.name}: the bucket does not exist at this endpoint`;
+    if (status === 301) return `HTTP 301 ${e.name}: the bucket lives in another region`;
+    return `HTTP ${status ?? '?'} ${e.name}: ${e.message}`;
+  }
+  const err = e as { name?: string; message?: string; code?: string } | null;
+  const code = err?.code ? ` ${err.code}` : '';
+  return `${err?.name ?? 'Error'}${code}: ${err?.message ?? String(e)}`;
+}

--- a/src/evidence/storage/storage-adapter.ts
+++ b/src/evidence/storage/storage-adapter.ts
@@ -5,8 +5,9 @@ import type { Readable } from 'node:stream';
  * substrate (Brain v2.1 M1). Bytes NEVER live in the DB (0109 doctrine);
  * an evidence_asset row points at its blob through `storageRef`, an
  * adapter-scheme URI (`<scheme>://…`) resolved against the registry
- * below. v1 ships ONE adapter (fs); an s3-class adapter is a new scheme
- * + registry entry, zero row changes.
+ * below. Two adapters ship — fs (local disk) and s3 (the shared object
+ * store for N replicas); a further adapter is a new scheme + registry
+ * entry, zero row changes.
  *
  * Contract points:
  *   * put() is CONTENT-ADDRESSED and idempotent: the blob's location is a
@@ -104,6 +105,17 @@ export interface EvidenceStorageAdapter {
     companyId: string,
     opts: { olderThanMs: number; dryRun: boolean },
   ): Promise<{ found: number; removed: number }>;
+  /**
+   * OPTIONAL (multi-replica readiness): one round trip proving the
+   * backing store is reachable, the credentials authorize, and the
+   * configured partition exists — HeadBucket for an s3-class adapter.
+   * Resolves when the store can serve; throws an operator-actionable
+   * message otherwise. `/ready` and the `evidence_store` capability
+   * probe call it on the SELECTED adapter (EVIDENCE_STORAGE_SCHEME); an
+   * adapter with no remote dependency leaves it undefined and readiness
+   * treats the check as vacuously satisfied.
+   */
+  probe?(): Promise<void>;
 }
 
 /**

--- a/src/metrics/capability-probe.service.ts
+++ b/src/metrics/capability-probe.service.ts
@@ -1,4 +1,5 @@
 import {
+  Inject,
   Injectable,
   Logger,
   OnApplicationBootstrap,
@@ -11,6 +12,11 @@ import { TenantRegistryService } from '../auth/tenant-registry.service';
 import { EmbedderService } from '../ai/embedder.service';
 import { MetricsService } from './metrics.service';
 import { envFlagNotDisabled } from '../common/env-validation';
+import { evidenceStorageScheme } from '../common/evidence-flags';
+import {
+  EVIDENCE_STORAGE_ADAPTERS,
+  type EvidenceStorageRegistry,
+} from '../evidence/storage/storage-adapter';
 import {
   CAPABILITY_NAMES,
   classifyProbeFailure,
@@ -91,8 +97,9 @@ const REMEDY =
  * `min by (capability)` — one bad pod is enough to page.
  *
  * ── Cost ─────────────────────────────────────────────────────────────────
- * Per pod per minute: one indexless `LIMIT 1` read, and one embed of a
- * four-word string. On `EMBEDDER_PROVIDER=bge-m3` the embed is local CPU;
+ * Per pod per minute: one indexless `LIMIT 1` read, one embed of a
+ * four-word string, and — with EVIDENCE_STORAGE_SCHEME=s3 — one HeadBucket.
+ * On `EMBEDDER_PROVIDER=bge-m3` the embed is local CPU;
  * on `openai` it is a real (tiny) API call that shows up in
  * `brain_openai_calls_total` — raise `CAPABILITY_PROBE_INTERVAL_MS` if that
  * matters more than a 60s detection floor.
@@ -128,6 +135,11 @@ export class CapabilityProbeService implements OnApplicationBootstrap, OnApplica
     // The production roster. Optional for the same unit fixtures; without
     // it the canary comes from the static key set alone.
     @Optional() private readonly registry?: TenantRegistryService,
+    // The blob-adapter registry (global EvidenceStorageModule). Optional
+    // for the same fixtures; without it the store probe reports `skipped`.
+    @Optional()
+    @Inject(EVIDENCE_STORAGE_ADAPTERS)
+    private readonly storage?: EvidenceStorageRegistry,
   ) {}
 
   onApplicationBootstrap(): void {
@@ -189,7 +201,11 @@ export class CapabilityProbeService implements OnApplicationBootstrap, OnApplica
    * could disagree with the one being monitored.
    */
   async runOnce(): Promise<ProbeReport[]> {
-    const reports = [await this.probeScopedRead(), await this.probeEmbed()];
+    const reports = [
+      await this.probeScopedRead(),
+      await this.probeEmbed(),
+      await this.probeEvidenceStore(),
+    ];
     for (const report of reports) this.publish(report);
     return reports;
   }
@@ -372,6 +388,55 @@ export class CapabilityProbeService implements OnApplicationBootstrap, OnApplica
               `The primary is not warm (see its warmup status on /ready and the admin health ` +
               `grid); it retries on its own`
             : `embedder: ${probeErrorDetail(e)}`,
+      };
+    }
+  }
+
+  /**
+   * Exercise the SELECTED blob store (EVIDENCE_STORAGE_SCHEME): one
+   * HeadBucket against s3 under the probe deadline. The fs adapter has no
+   * remote dependency, so a local-disk deployment reports `skipped`, not
+   * a green that proves nothing. s3 selected with no adapter registered
+   * (bucket unset at boot) is a conclusive `error` — the verdict /ready
+   * gives — and a 403 from the store classifies `unauthorized`: alive,
+   * but the credentials no longer authorize, the scoped-pool incident's
+   * shape on a different component.
+   */
+  private async probeEvidenceStore(): Promise<ProbeReport> {
+    const scheme = evidenceStorageScheme();
+    if (!this.storage) {
+      return {
+        capability: 'evidence_store',
+        outcome: 'skipped',
+        detail: 'no evidence storage registry in this process',
+      };
+    }
+    const adapter = this.storage.get(scheme);
+    if (!adapter) {
+      return {
+        capability: 'evidence_store',
+        outcome: 'error',
+        detail:
+          `no '${scheme}' evidence storage adapter is registered — EVIDENCE_STORAGE_SCHEME=` +
+          `${scheme} needs its store configured at boot (EVIDENCE_S3_BUCKET); uploads answer ` +
+          `503 until then`,
+      };
+    }
+    if (!adapter.probe) {
+      return {
+        capability: 'evidence_store',
+        outcome: 'skipped',
+        detail: `EVIDENCE_STORAGE_SCHEME=${scheme}: local disk, nothing remote to exercise`,
+      };
+    }
+    try {
+      await withDeadline(adapter.probe(), PROBE_DEADLINE_MS);
+      return { capability: 'evidence_store', outcome: 'serving' };
+    } catch (e) {
+      return {
+        capability: 'evidence_store',
+        outcome: classifyProbeFailure(e),
+        detail: `evidence store (${scheme}): ${probeErrorDetail(e)}`,
       };
     }
   }

--- a/src/metrics/capability-probe.ts
+++ b/src/metrics/capability-probe.ts
@@ -38,7 +38,7 @@ import type { ReadinessChecks } from '../common/health.service';
  * continuously exercises, and `keyof ReadinessReport` makes that link a
  * COMPILE error if a check is renamed (test/capability-probe.unit-spec.ts
  * fails if one is ADDED without a probe). That is the whole generalisation:
- * the service's own readiness contract — three checks — must have a
+ * the service's own readiness contract — four checks — must have a
  * continuous counterpart. Enumerating every "capability" brain claims (145
  * flags, every route) and asserting each is exercised by something is NOT
  * built here: that inventory is what per-surface flag-set specs (#510) and
@@ -49,7 +49,7 @@ import type { ReadinessChecks } from '../common/health.service';
 /** The checks `/ready` reports, minus its own roll-up field. */
 export type ReadinessCheck = keyof ReadinessChecks;
 
-export const CAPABILITY_NAMES = ['scoped_read', 'embed'] as const;
+export const CAPABILITY_NAMES = ['scoped_read', 'embed', 'evidence_store'] as const;
 export type CapabilityName = (typeof CAPABILITY_NAMES)[number];
 
 /**
@@ -66,7 +66,8 @@ export type CapabilityName = (typeof CAPABILITY_NAMES)[number];
  *   error        — anything else: DB unreachable, statement threw, the
  *                  probe's own deadline expired.
  *   skipped      — nothing to exercise (no tenant in the roster, no
- *                  embedder in this process). Also not a failure.
+ *                  embedder in this process, a local-disk evidence store
+ *                  with nothing remote to ask). Also not a failure.
  */
 export const PROBE_OUTCOMES = [
   'serving',
@@ -96,6 +97,11 @@ export interface ProbeReport {
 export const CAPABILITY_COVERAGE: Record<CapabilityName, readonly ReadinessCheck[]> = {
   scoped_read: ['dbOk', 'scopedOk'],
   embed: ['embedderReady'],
+  // The SELECTED blob store: a live HeadBucket against s3 every tick
+  // (skipped on fs, which is local disk) — the continuous counterpart of
+  // /ready's evidenceStoreOk, so a bucket that stops authorizing an hour
+  // after deploy is seen, not just a bucket that was wrong at deploy.
+  evidence_store: ['evidenceStoreOk'],
 };
 
 /**
@@ -121,10 +127,12 @@ const BUSY = /pool acquire timed out/i;
  * anonymous session (incident 1); the third is brain's own fail-closed
  * wrapper when the scoped signin cannot be renewed at all — a rotated
  * secret or a dropped `brain_caller` — which is the same operator problem
- * with a different first line.
+ * with a different first line. The last clause is the s3 adapter's probe
+ * translating a 403 from the object store (S3EvidenceStorageAdapter.probe):
+ * the bucket is alive, the credentials no longer authorize it.
  */
 const UNAUTHORIZED =
-  /Anonymous access not allowed|Not enough permissions|IAM error|scoped DB signin unavailable|Invalid credentials|There was a problem with authentication/i;
+  /Anonymous access not allowed|Not enough permissions|IAM error|scoped DB signin unavailable|Invalid credentials|There was a problem with authentication|credentials do not authorize/i;
 
 /**
  * Classify a thrown probe failure. Order matters: saturation is checked

--- a/test/capability-probe.unit-spec.ts
+++ b/test/capability-probe.unit-spec.ts
@@ -539,7 +539,12 @@ describe('capability coverage gate', () => {
   }
 
   it('finds the readiness checks it is supposed to gate', () => {
-    expect(readinessChecks().sort()).toEqual(['dbOk', 'embedderReady', 'scopedOk']);
+    expect(readinessChecks().sort()).toEqual([
+      'dbOk',
+      'embedderReady',
+      'evidenceStoreOk',
+      'scopedOk',
+    ]);
   });
 
   it('every readiness check is continuously exercised by some probe', () => {

--- a/test/config-catalog-truth.unit-spec.ts
+++ b/test/config-catalog-truth.unit-spec.ts
@@ -154,9 +154,13 @@ describe('credential masking', () => {
    * is opt-in and forgetting it fails open.
    *
    * The rule is deliberately name-shaped rather than a hand-kept allowlist:
-   * an allowlist has the same failure mode as the flag it guards.
+   * an allowlist has the same failure mode as the flag it guards. It is
+   * therefore extended by SHAPE, never by key: `_SECRET_ACCESS_KEY` is the
+   * AWS-family name for a secret and does not end in any suffix above, so
+   * the anchored alternation alone would have let EVIDENCE_S3_SECRET_ACCESS_KEY
+   * ship unmasked — the exact failure this gate exists to catch.
    */
-  const CREDENTIAL_NAME = /(SECRET|_API_KEY|_TOKEN|PASSWORD|PRIVATE_KEY)$/;
+  const CREDENTIAL_NAME = /(SECRET|_API_KEY|_TOKEN|PASSWORD|PRIVATE_KEY|_SECRET_ACCESS_KEY)$/;
 
   it('every credential-shaped catalogue key is masked', () => {
     const unmasked = CONFIG_CATALOG.filter(

--- a/test/contracts-admin-health-components.unit-spec.ts
+++ b/test/contracts-admin-health-components.unit-spec.ts
@@ -25,12 +25,14 @@ function makeController(): AdminInfraController {
       dbOk: true,
       scopedOk: true,
       embedderReady: true,
+      evidenceStoreOk: true,
       ready: true,
       detail: {
         dbLatencyMs: 1,
         scopedEnabled: true,
         scopedLatencyMs: 2,
         embedder: { ready: true, failures: 0, inFlight: false },
+        evidenceStore: { scheme: 'fs', probed: false, latencyMs: 0, error: null },
       },
     }),
   } as unknown as HealthService;

--- a/test/evidence-blob-upload.unit-spec.ts
+++ b/test/evidence-blob-upload.unit-spec.ts
@@ -22,7 +22,6 @@ import type { CallHandler, ExecutionContext } from '@nestjs/common';
 import { EvidenceBlobUploadInterceptor } from '../src/evidence/blob-upload.interceptor';
 import { EvidenceIngestController } from '../src/evidence/evidence-ingest.controller';
 import {
-  EVIDENCE_UPLOAD_SCHEME,
   EvidenceUploadService,
   type UploadEvidenceBlobInput,
 } from '../src/evidence/evidence-upload.service';
@@ -41,6 +40,9 @@ import type { EvidenceQuarantineService } from '../src/evidence/quarantine.servi
 import type { EvidenceStorageAdapter } from '../src/evidence/storage/storage-adapter';
 
 const COMPANY = 'co_blob_unit';
+// The default EVIDENCE_STORAGE_SCHEME: uploads resolve their adapter by
+// scheme, so the fixture registers itself under the one the service asks for.
+const UPLOAD_SCHEME = 'fs';
 const BYTES = Buffer.from('hello upload', 'utf8');
 // sha256('hello upload') — pinned so a change to what the server hashes
 // (the received bytes, never a caller assertion) fails loudly here.
@@ -88,9 +90,9 @@ function harness(
   const dispatches: Array<{ packId: string; assetId: string }> = [];
   const stored = new Map<string, Buffer>();
   const adapter = {
-    scheme: EVIDENCE_UPLOAD_SCHEME,
+    scheme: UPLOAD_SCHEME,
     put: (companyId: string, byteHash: string, data: Buffer) => {
-      const storageRef = `${EVIDENCE_UPLOAD_SCHEME}://${companyId}/${byteHash}`;
+      const storageRef = `${UPLOAD_SCHEME}://${companyId}/${byteHash}`;
       stored.set(storageRef, data);
       return Promise.resolve({ storageRef, byteLength: data.byteLength });
     },
@@ -126,7 +128,7 @@ function harness(
       return opts.dispatch ? opts.dispatch() : Promise.resolve({ runs: [], denied: [] });
     },
   } as unknown as EvidenceProcessorBrokerService;
-  const adapters = opts.adapters ?? new Map([[EVIDENCE_UPLOAD_SCHEME, adapter]]);
+  const adapters = opts.adapters ?? new Map([[UPLOAD_SCHEME, adapter]]);
   return {
     service: new EvidenceUploadService(store, adapters, quarantine, broker),
     registered,
@@ -238,7 +240,7 @@ describe('blob upload pipeline', () => {
     // Server-owned identity, not caller-asserted.
     expect(spec.byteHash).toBe(BYTES_HASH);
     expect(spec.byteLength).toBe(BYTES.byteLength);
-    expect(spec.storageRef).toBe(`${EVIDENCE_UPLOAD_SCHEME}://${COMPANY}/${BYTES_HASH}`);
+    expect(spec.storageRef).toBe(`${UPLOAD_SCHEME}://${COMPANY}/${BYTES_HASH}`);
     expect(spec.originUri).toBeUndefined();
     // Bytes over HTTP are external ingest — the MM-6 fence must apply.
     expect(spec.origin).toBe('external_ingest');
@@ -279,14 +281,54 @@ describe('blob upload pipeline', () => {
       h.service.upload(COMPANY, blob({ mimetype: 'image/svg+xml' }), input({ modality: 'image' })),
     ).rejects.toMatchObject({ status: 400 });
     expect(h.registered).toHaveLength(0);
-    expect(await h.adapter.exists(`${EVIDENCE_UPLOAD_SCHEME}://${COMPANY}/${BYTES_HASH}`)).toBe(
-      false,
-    );
+    expect(await h.adapter.exists(`${UPLOAD_SCHEME}://${COMPANY}/${BYTES_HASH}`)).toBe(false);
   });
 
   it('503s when no adapter owns the upload scheme', async () => {
     const h = harness({ adapters: new Map() });
     await expect(h.service.upload(COMPANY, blob(), input())).rejects.toMatchObject({ status: 503 });
+  });
+
+  describe('EVIDENCE_STORAGE_SCHEME picks the store', () => {
+    afterEach(() => delete process.env.EVIDENCE_STORAGE_SCHEME);
+
+    /** An adapter under a different scheme, remembering what it was handed. */
+    function objectStore(): { adapter: EvidenceStorageAdapter; refs: string[] } {
+      const refs: string[] = [];
+      const adapter = {
+        scheme: 's3',
+        put: (companyId: string, byteHash: string, data: Buffer) => {
+          const storageRef = `s3://${companyId}/${byteHash}`;
+          refs.push(storageRef);
+          return Promise.resolve({ storageRef, byteLength: data.byteLength });
+        },
+        belongsToTenant: () => true,
+        head: () => Promise.resolve(null),
+        exists: () => Promise.resolve(false),
+        get: () => Promise.reject(new Error('unused')),
+        delete: () => Promise.resolve(true),
+      } as unknown as EvidenceStorageAdapter;
+      return { adapter, refs };
+    }
+
+    it('writes the bytes through the selected adapter and records ITS ref on the row', async () => {
+      process.env.EVIDENCE_STORAGE_SCHEME = 's3';
+      const s3 = objectStore();
+      const h = harness({ adapters: new Map([['s3', s3.adapter]]) });
+      await h.service.upload(COMPANY, blob(), input());
+      expect(s3.refs).toEqual([`s3://${COMPANY}/${BYTES_HASH}`]);
+      expect(h.registered[0]!.storageRef).toBe(`s3://${COMPANY}/${BYTES_HASH}`);
+    });
+
+    it('503s rather than silently falling back to local disk when s3 is unregistered', async () => {
+      process.env.EVIDENCE_STORAGE_SCHEME = 's3';
+      // The fs adapter IS registered — the point is that it is not used.
+      const h = harness();
+      await expect(h.service.upload(COMPANY, blob(), input())).rejects.toMatchObject({
+        status: 503,
+      });
+      expect(h.registered).toHaveLength(0);
+    });
   });
 });
 
@@ -296,7 +338,7 @@ describe('scan before serve', () => {
       scan: () => Promise.resolve({ assetId: 'evidence_asset:up1', quarantineStatus: 'rejected' }),
     });
     await expect(h.service.upload(COMPANY, blob(), input())).rejects.toMatchObject({ status: 422 });
-    expect(h.deleted).toEqual([`${EVIDENCE_UPLOAD_SCHEME}://${COMPANY}/${BYTES_HASH}`]);
+    expect(h.deleted).toEqual([`${UPLOAD_SCHEME}://${COMPANY}/${BYTES_HASH}`]);
   });
 
   it('a throwing scan hook leaves the asset scanning — it never fails open', async () => {

--- a/test/evidence-storage-adapter-contract.e2e-spec.ts
+++ b/test/evidence-storage-adapter-contract.e2e-spec.ts
@@ -1,0 +1,379 @@
+/**
+ * ONE contract, both stores. Every assertion below is run twice — once
+ * against the local-disk adapter and once against a real S3-compatible
+ * server (MinIO in a pinned container) — because the whole value of the
+ * scheme registry is that consumers cannot tell which adapter they got.
+ * A semantic that holds for fs and not for s3 is a bug that would only
+ * surface in production, on the pod that did not take the upload.
+ *
+ * The last describe is the finding itself: with per-pod roots the fs
+ * adapter answers `head() → null` for a blob a sibling replica holds
+ * (which the read path turns into a bare 404), while two independent s3
+ * adapter instances over one bucket serve each other's bytes.
+ *
+ * Nothing here reaches the network beyond pulling the pinned image.
+ */
+import { createHash, randomBytes, randomUUID } from 'node:crypto';
+import { mkdtemp, rm, utimes, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { Readable } from 'node:stream';
+import { CreateBucketCommand, S3Client } from '@aws-sdk/client-s3';
+import { GenericContainer, Wait, type StartedTestContainer } from 'testcontainers';
+import { FsEvidenceStorageAdapter } from '../src/evidence/storage/fs-storage.adapter';
+import { S3EvidenceStorageAdapter } from '../src/evidence/storage/s3-storage.adapter';
+import type { EvidenceStorageAdapter } from '../src/evidence/storage/storage-adapter';
+
+// Pinned: an object store's compatibility surface is exactly what this
+// suite is measuring, so `latest` would make a green run unrepeatable.
+const MINIO_IMAGE = 'minio/minio:RELEASE.2025-01-20T14-49-07Z';
+const ACCESS_KEY = 'minioadmin';
+const SECRET_KEY = 'minioadmin';
+const BUCKET = 'brain-evidence-contract';
+const PREFIX = 'contract';
+
+let minio: StartedTestContainer | undefined;
+let endpoint = '';
+let fsRoot = '';
+const savedEnv: Record<string, string | undefined> = {};
+
+const ENV_KEYS = [
+  'EVIDENCE_FS_ROOT',
+  'EVIDENCE_STORAGE_SCHEME',
+  'EVIDENCE_S3_BUCKET',
+  'EVIDENCE_S3_ENDPOINT',
+  'EVIDENCE_S3_REGION',
+  'EVIDENCE_S3_PREFIX',
+  'EVIDENCE_S3_ACCESS_KEY_ID',
+  'EVIDENCE_S3_SECRET_ACCESS_KEY',
+  'EVIDENCE_S3_FORCE_PATH_STYLE',
+] as const;
+
+beforeAll(async () => {
+  for (const k of ENV_KEYS) savedEnv[k] = process.env[k];
+
+  fsRoot = await mkdtemp(join(tmpdir(), 'evidence-contract-fs-'));
+  process.env.EVIDENCE_FS_ROOT = fsRoot;
+
+  minio = await new GenericContainer(MINIO_IMAGE)
+    .withEnvironment({ MINIO_ROOT_USER: ACCESS_KEY, MINIO_ROOT_PASSWORD: SECRET_KEY })
+    .withCommand(['server', '/data'])
+    .withExposedPorts(9000)
+    .withWaitStrategy(Wait.forHttp('/minio/health/live', 9000).forStatusCode(200))
+    .withStartupTimeout(120_000)
+    .start();
+  endpoint = `http://${minio.getHost()}:${minio.getMappedPort(9000)}`;
+
+  process.env.EVIDENCE_S3_ENDPOINT = endpoint;
+  process.env.EVIDENCE_S3_BUCKET = BUCKET;
+  process.env.EVIDENCE_S3_REGION = 'us-east-1';
+  process.env.EVIDENCE_S3_PREFIX = PREFIX;
+  process.env.EVIDENCE_S3_ACCESS_KEY_ID = ACCESS_KEY;
+  process.env.EVIDENCE_S3_SECRET_ACCESS_KEY = SECRET_KEY;
+  // MinIO-class hosts have no per-bucket DNS.
+  process.env.EVIDENCE_S3_FORCE_PATH_STYLE = '1';
+
+  const client = new S3Client({
+    region: 'us-east-1',
+    endpoint,
+    forcePathStyle: true,
+    credentials: { accessKeyId: ACCESS_KEY, secretAccessKey: SECRET_KEY },
+  });
+  await client.send(new CreateBucketCommand({ Bucket: BUCKET }));
+  client.destroy();
+}, 180_000);
+
+afterAll(async () => {
+  if (minio) await minio.stop();
+  if (fsRoot) await rm(fsRoot, { recursive: true, force: true });
+  for (const k of ENV_KEYS) {
+    if (savedEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = savedEnv[k];
+  }
+});
+
+/** A fresh tenant per test, so no case can see another's blobs. */
+function tenant(): string {
+  return `co_${randomUUID().replace(/-/g, '').slice(0, 16)}`;
+}
+
+function sha256(data: Buffer): string {
+  return createHash('sha256').update(data).digest('hex');
+}
+
+async function collect(stream: Readable): Promise<Buffer> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of stream) chunks.push(Buffer.from(chunk as Buffer));
+  return Buffer.concat(chunks);
+}
+
+const CASES: Array<{ scheme: string; make: () => EvidenceStorageAdapter }> = [
+  { scheme: 'fs', make: () => new FsEvidenceStorageAdapter() },
+  { scheme: 's3', make: () => new S3EvidenceStorageAdapter() },
+];
+
+describe.each(CASES)('evidence storage adapter contract — $scheme', ({ scheme, make }) => {
+  let adapter: EvidenceStorageAdapter;
+  let company: string;
+
+  beforeEach(() => {
+    adapter = make();
+    company = tenant();
+  });
+
+  const HASH_OF_NOTHING_STORED = 'b'.repeat(64);
+
+  it('put is content-addressed, idempotent, and reports the length', async () => {
+    const bytes = Buffer.from('one contract, two stores', 'utf8');
+    const hash = sha256(bytes);
+    const first = await adapter.put(company, hash, bytes);
+    expect(first).toEqual({
+      storageRef: `${scheme}://${company}/${hash}`,
+      byteLength: bytes.byteLength,
+    });
+    // Re-putting identical bytes lands on the same ref and is a no-op.
+    expect(await adapter.put(company, hash, bytes)).toEqual(first);
+    expect(await adapter.head(first.storageRef)).toEqual({ byteLength: bytes.byteLength });
+    expect(await adapter.exists(first.storageRef)).toBe(true);
+  });
+
+  it('put refuses bytes whose hash the caller got wrong, and a hostile tenant id', async () => {
+    const bytes = Buffer.from('payload', 'utf8');
+    await expect(adapter.put(company, HASH_OF_NOTHING_STORED, bytes)).rejects.toThrow(
+      /byteHash does not match/,
+    );
+    await expect(adapter.put('../escape', sha256(bytes), bytes)).rejects.toThrow(/invalid/);
+    await expect(adapter.put(company, 'not-a-hash', bytes)).rejects.toThrow(/invalid/);
+  });
+
+  it('head and exists answer absence rather than throwing', async () => {
+    const ref = `${scheme}://${company}/${HASH_OF_NOTHING_STORED}`;
+    expect(await adapter.head(ref)).toBeNull();
+    expect(await adapter.exists(ref)).toBe(false);
+  });
+
+  it('get streams the exact bytes back — a large blob is never materialised twice', async () => {
+    // Bigger than a single default chunk, so the read really is a stream.
+    const bytes = randomBytes(5 * 1024 * 1024);
+    const hash = sha256(bytes);
+    const { storageRef } = await adapter.put(company, hash, bytes);
+    const stream = await adapter.get(storageRef);
+    const readBack = await collect(stream);
+    expect(readBack.byteLength).toBe(bytes.byteLength);
+    expect(sha256(readBack)).toBe(hash);
+  });
+
+  it('get rejects for a blob that is not there, and for a malformed ref', async () => {
+    await expect(adapter.get(`${scheme}://${company}/${HASH_OF_NOTHING_STORED}`)).rejects.toThrow();
+    await expect(adapter.get(`${scheme}://${company}/nope`)).rejects.toThrow();
+    await expect(adapter.head(`${scheme}://${company}/nope`)).rejects.toThrow();
+  });
+
+  it('delete reports honestly whether a blob existed', async () => {
+    const bytes = Buffer.from('to be erased', 'utf8');
+    const { storageRef } = await adapter.put(company, sha256(bytes), bytes);
+    expect(await adapter.delete(storageRef)).toBe(true);
+    expect(await adapter.head(storageRef)).toBeNull();
+    // The GDPR cascade and the sweeps log these counts, so the second
+    // answer must be false, not a throw and not another true.
+    expect(await adapter.delete(storageRef)).toBe(false);
+  });
+
+  it('belongsToTenant is structural — another tenant’s ref and a malformed one are refused', async () => {
+    const other = tenant();
+    expect(
+      adapter.belongsToTenant(company, `${scheme}://${company}/${HASH_OF_NOTHING_STORED}`),
+    ).toBe(true);
+    expect(adapter.belongsToTenant(company, `${scheme}://${other}/${HASH_OF_NOTHING_STORED}`)).toBe(
+      false,
+    );
+    expect(adapter.belongsToTenant(company, `${scheme}://${company}/short`)).toBe(false);
+    expect(adapter.belongsToTenant(company, 'nonsense')).toBe(false);
+  });
+
+  it('listBlobs yields this tenant’s blobs with size and write time, and nobody else’s', async () => {
+    const other = make();
+    const otherCompany = tenant();
+    const mine = Buffer.from('mine', 'utf8');
+    const theirs = Buffer.from('theirs', 'utf8');
+    const before = Date.now();
+    const put = await adapter.put(company, sha256(mine), mine);
+    await other.put(otherCompany, sha256(theirs), theirs);
+
+    const entries = [];
+    for await (const entry of adapter.listBlobs!(company)) entries.push(entry);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.storageRef).toBe(put.storageRef);
+    expect(entries[0]!.byteLength).toBe(mine.byteLength);
+    // The write time, so the orphan sweep's grace window protects an
+    // upload whose row does not exist yet. Allow a second of clock skew
+    // between this process and the store.
+    expect(entries[0]!.modifiedAtMs).toBeGreaterThanOrEqual(before - 1_000);
+    expect(entries[0]!.modifiedAtMs).toBeLessThanOrEqual(Date.now() + 1_000);
+    // Every yielded ref satisfies the sweep's fence by construction.
+    for (const entry of entries) {
+      expect(adapter.belongsToTenant(company, entry.storageRef)).toBe(true);
+    }
+  });
+
+  it('listBlobs is an empty iteration for a tenant that never uploaded', async () => {
+    const entries = [];
+    for await (const entry of adapter.listBlobs!(tenant())) entries.push(entry);
+    expect(entries).toEqual([]);
+  });
+
+  it('the partial-write broom never touches a complete blob', async () => {
+    const bytes = Buffer.from('complete', 'utf8');
+    const { storageRef } = await adapter.put(company, sha256(bytes), bytes);
+    const swept = await adapter.sweepIncompleteWrites!(company, {
+      olderThanMs: 0,
+      dryRun: false,
+    });
+    expect(swept.removed).toBe(0);
+    expect(await adapter.head(storageRef)).not.toBeNull();
+  });
+});
+
+describe('the fs adapter only holds together on one disk', () => {
+  it('a blob written on one replica’s root is absent on another’s — the 404 the finding describes', async () => {
+    const podA = await mkdtemp(join(tmpdir(), 'evidence-pod-a-'));
+    const podB = await mkdtemp(join(tmpdir(), 'evidence-pod-b-'));
+    const company = tenant();
+    const bytes = Buffer.from('uploaded through pod A', 'utf8');
+    try {
+      // The root is read per call, so pointing it at a second pod's
+      // volume is exactly what a sibling replica sees.
+      process.env.EVIDENCE_FS_ROOT = podA;
+      const a = new FsEvidenceStorageAdapter();
+      const { storageRef } = await a.put(company, sha256(bytes), bytes);
+      expect(await a.head(storageRef)).not.toBeNull();
+
+      process.env.EVIDENCE_FS_ROOT = podB;
+      const b = new FsEvidenceStorageAdapter();
+      expect(await b.head(storageRef)).toBeNull();
+      expect(await b.exists(storageRef)).toBe(false);
+      // And the leader-elected orphan sweep would only ever see its own.
+      const seen = [];
+      for await (const entry of b.listBlobs!(company)) seen.push(entry);
+      expect(seen).toEqual([]);
+    } finally {
+      process.env.EVIDENCE_FS_ROOT = fsRoot;
+      await rm(podA, { recursive: true, force: true });
+      await rm(podB, { recursive: true, force: true });
+    }
+  });
+
+  it('a shared volume is the other correct fs deployment', async () => {
+    const shared = await mkdtemp(join(tmpdir(), 'evidence-shared-'));
+    const company = tenant();
+    const bytes = Buffer.from('one volume, two pods', 'utf8');
+    try {
+      process.env.EVIDENCE_FS_ROOT = shared;
+      const a = new FsEvidenceStorageAdapter();
+      const b = new FsEvidenceStorageAdapter();
+      const { storageRef } = await a.put(company, sha256(bytes), bytes);
+      expect(await b.head(storageRef)).toEqual({ byteLength: bytes.byteLength });
+    } finally {
+      process.env.EVIDENCE_FS_ROOT = fsRoot;
+      await rm(shared, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('the object store crosses the replica boundary', () => {
+  it('a blob written through one adapter instance is served by a second over the same bucket', async () => {
+    // Two instances, each with its own S3 client — the closest a test
+    // gets to two pods behind a round-robin balancer.
+    const podA = new S3EvidenceStorageAdapter();
+    const podB = new S3EvidenceStorageAdapter();
+    const company = tenant();
+    const bytes = randomBytes(2 * 1024 * 1024);
+    const hash = sha256(bytes);
+
+    const { storageRef } = await podA.put(company, hash, bytes);
+    expect(await podB.head(storageRef)).toEqual({ byteLength: bytes.byteLength });
+    expect(sha256(await collect(await podB.get(storageRef)))).toBe(hash);
+
+    // The sweep runs on whichever pod holds the lease, and sees the
+    // shared store rather than one pod's disk.
+    const seen = [];
+    for await (const entry of podB.listBlobs!(company)) seen.push(entry.storageRef);
+    expect(seen).toEqual([storageRef]);
+
+    // A delete on either pod is a delete for both.
+    expect(await podB.delete(storageRef)).toBe(true);
+    expect(await podA.head(storageRef)).toBeNull();
+  });
+
+  it('the readiness probe passes against the live bucket and names the problem when it cannot', async () => {
+    await expect(new S3EvidenceStorageAdapter().probe!()).resolves.toBeUndefined();
+
+    const savedBucket = process.env.EVIDENCE_S3_BUCKET;
+    process.env.EVIDENCE_S3_BUCKET = 'brain-evidence-does-not-exist';
+    try {
+      await expect(new S3EvidenceStorageAdapter().probe!()).rejects.toThrow(
+        /evidence s3 store is not serving: bucket 'brain-evidence-does-not-exist'/,
+      );
+    } finally {
+      process.env.EVIDENCE_S3_BUCKET = savedBucket;
+    }
+  });
+
+  it('the prefix namespaces the keys without appearing in any ref', async () => {
+    const company = tenant();
+    const bytes = Buffer.from('prefixed', 'utf8');
+    const hash = sha256(bytes);
+    const { storageRef } = await new S3EvidenceStorageAdapter().put(company, hash, bytes);
+    // The ref carries tenant + hash only, so relocating the store is
+    // configuration and never a row rewrite.
+    expect(storageRef).toBe(`s3://${company}/${hash}`);
+
+    // Under a different prefix the same ref addresses nothing — and the
+    // bytes are still there under the original one.
+    process.env.EVIDENCE_S3_PREFIX = 'somewhere-else';
+    try {
+      expect(await new S3EvidenceStorageAdapter().head(storageRef)).toBeNull();
+    } finally {
+      process.env.EVIDENCE_S3_PREFIX = PREFIX;
+    }
+    expect(await new S3EvidenceStorageAdapter().head(storageRef)).not.toBeNull();
+  });
+
+  it('an unconfigured bucket is a loud error, never a default one', async () => {
+    const savedBucket = process.env.EVIDENCE_S3_BUCKET;
+    delete process.env.EVIDENCE_S3_BUCKET;
+    try {
+      await expect(
+        new S3EvidenceStorageAdapter().head(`s3://${tenant()}/${'c'.repeat(64)}`),
+      ).rejects.toThrow(/EVIDENCE_S3_BUCKET is not set/);
+    } finally {
+      process.env.EVIDENCE_S3_BUCKET = savedBucket;
+    }
+  });
+});
+
+/** Keeps the fs branch honest about tmp debris, which s3 cannot have. */
+describe('the fs partial-write broom', () => {
+  it('removes a straggler left by a process killed between write and rename', async () => {
+    const company = tenant();
+    const adapter = new FsEvidenceStorageAdapter();
+    const bytes = Buffer.from('debris', 'utf8');
+    const hash = sha256(bytes);
+    await adapter.put(company, hash, bytes);
+    const shard = join(fsRoot, company, hash.slice(0, 2));
+    const straggler = join(shard, `.tmp-${randomUUID()}`);
+    await writeFile(straggler, 'half a blob');
+    // Aged past the grace window: a tmp file written seconds ago may be
+    // an upload writing right now, and the broom must leave it alone.
+    const anHourAgo = new Date(Date.now() - 3_600_000);
+    await utimes(straggler, anHourAgo, anHourAgo);
+
+    const grace = { olderThanMs: 60_000 };
+    const dry = await adapter.sweepIncompleteWrites!(company, { ...grace, dryRun: true });
+    expect(dry).toEqual({ found: 1, removed: 0 });
+    const wet = await adapter.sweepIncompleteWrites!(company, { ...grace, dryRun: false });
+    expect(wet).toEqual({ found: 1, removed: 1 });
+    // The complete blob is untouched, and no ref ever addressed the debris.
+    expect(await adapter.head(`fs://${company}/${hash}`)).not.toBeNull();
+  });
+});

--- a/test/evidence-storage-selection.unit-spec.ts
+++ b/test/evidence-storage-selection.unit-spec.ts
@@ -1,0 +1,351 @@
+/**
+ * Store SELECTION and its configuration — the pure half of the
+ * multi-replica fix (the byte-level adapter contract is exercised against
+ * a real MinIO in evidence-storage-adapter-contract.e2e-spec.ts).
+ *
+ * The finding: only the fs adapter was ever registered, so evidence blobs
+ * lived on the local disk of whichever replica took the upload and every
+ * other replica answered a bare 404. These specs pin the seam that ends
+ * that — which adapter uploads resolve to, what refuses at boot, and the
+ * readiness/probe verdicts an operator sees when the selected store is
+ * missing or unreachable.
+ */
+import { Logger } from '@nestjs/common';
+import {
+  evidenceS3Config,
+  evidenceStorageScheme,
+  validateEvidenceStorageEnv,
+} from '../src/common/evidence-flags';
+import { HealthService } from '../src/common/health.service';
+import { CapabilityProbeService } from '../src/metrics/capability-probe.service';
+import { MetricsService } from '../src/metrics/metrics.service';
+import { FsEvidenceStorageAdapter } from '../src/evidence/storage/fs-storage.adapter';
+import { parseS3StorageRef } from '../src/evidence/storage/s3-storage.adapter';
+import type {
+  EvidenceStorageAdapter,
+  EvidenceStorageRegistry,
+} from '../src/evidence/storage/storage-adapter';
+
+const S3_KEYS = [
+  'EVIDENCE_STORAGE_SCHEME',
+  'EVIDENCE_S3_BUCKET',
+  'EVIDENCE_S3_ENDPOINT',
+  'EVIDENCE_S3_REGION',
+  'EVIDENCE_S3_PREFIX',
+  'EVIDENCE_S3_ACCESS_KEY_ID',
+  'EVIDENCE_S3_SECRET_ACCESS_KEY',
+  'EVIDENCE_S3_FORCE_PATH_STYLE',
+  'EVIDENCE_FS_ROOT',
+  'PROCESS_ROLE',
+] as const;
+
+let saved: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  saved = {};
+  for (const k of S3_KEYS) {
+    saved[k] = process.env[k];
+    delete process.env[k];
+  }
+});
+
+afterEach(() => {
+  for (const k of S3_KEYS) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+});
+
+const HASH = 'a'.repeat(64);
+
+describe('EVIDENCE_STORAGE_SCHEME — which store takes new uploads', () => {
+  it('defaults to fs, so an untouched deployment keeps writing where it always did', () => {
+    expect(evidenceStorageScheme()).toBe('fs');
+  });
+
+  it('selects s3 case- and whitespace-insensitively', () => {
+    process.env.EVIDENCE_STORAGE_SCHEME = ' S3 ';
+    expect(evidenceStorageScheme()).toBe('s3');
+  });
+
+  it('reads as fs for anything else — and boot refuses that value separately', () => {
+    process.env.EVIDENCE_STORAGE_SCHEME = 'gcs';
+    expect(evidenceStorageScheme()).toBe('fs');
+    const errors: string[] = [];
+    validateEvidenceStorageEnv(process.env, errors);
+    expect(errors.join('\n')).toContain('EVIDENCE_STORAGE_SCHEME must be one of fs/s3');
+  });
+
+  it('is read per call, so a flip needs no restart', () => {
+    expect(evidenceStorageScheme()).toBe('fs');
+    process.env.EVIDENCE_STORAGE_SCHEME = 's3';
+    expect(evidenceStorageScheme()).toBe('s3');
+  });
+});
+
+describe('EVIDENCE_S3_* configuration', () => {
+  it('is null while the bucket is unset — the adapter then does not register at all', () => {
+    process.env.EVIDENCE_S3_REGION = 'eu-central-1';
+    expect(evidenceS3Config()).toBeNull();
+  });
+
+  it('defaults region to us-east-1 and takes the SDK credential chain when no keys are given', () => {
+    process.env.EVIDENCE_S3_BUCKET = 'brain-evidence';
+    expect(evidenceS3Config()).toEqual({
+      bucket: 'brain-evidence',
+      region: 'us-east-1',
+      endpoint: null,
+      prefix: '',
+      credentials: null,
+      forcePathStyle: false,
+    });
+  });
+
+  it('strips surrounding slashes from the prefix and carries the credential pair', () => {
+    process.env.EVIDENCE_S3_BUCKET = 'brain-evidence';
+    process.env.EVIDENCE_S3_PREFIX = '/preprod/blobs/';
+    process.env.EVIDENCE_S3_ENDPOINT = 'http://minio:9000';
+    process.env.EVIDENCE_S3_ACCESS_KEY_ID = 'key';
+    process.env.EVIDENCE_S3_SECRET_ACCESS_KEY = 'secret';
+    process.env.EVIDENCE_S3_FORCE_PATH_STYLE = '1';
+    expect(evidenceS3Config()).toEqual({
+      bucket: 'brain-evidence',
+      region: 'us-east-1',
+      endpoint: 'http://minio:9000',
+      prefix: 'preprod/blobs',
+      credentials: { accessKeyId: 'key', secretAccessKey: 'secret' },
+      forcePathStyle: true,
+    });
+  });
+});
+
+describe('boot validation', () => {
+  function errorsFor(env: Record<string, string>): string {
+    const errors: string[] = [];
+    validateEvidenceStorageEnv(env as NodeJS.ProcessEnv, errors);
+    return errors.join('\n');
+  }
+
+  it('accepts the untouched deployment (nothing set at all)', () => {
+    expect(errorsFor({})).toBe('');
+  });
+
+  it('refuses s3 without a bucket — every upload would answer 503', () => {
+    expect(errorsFor({ EVIDENCE_STORAGE_SCHEME: 's3' })).toContain(
+      'EVIDENCE_STORAGE_SCHEME=s3 requires EVIDENCE_S3_BUCKET',
+    );
+  });
+
+  it('refuses a bucket name S3 could not accept', () => {
+    expect(errorsFor({ EVIDENCE_S3_BUCKET: 'Not_A_Bucket' })).toContain(
+      'EVIDENCE_S3_BUCKET must be an S3 bucket name',
+    );
+  });
+
+  it('refuses an endpoint that is not an http(s) URL', () => {
+    expect(errorsFor({ EVIDENCE_S3_BUCKET: 'b-1', EVIDENCE_S3_ENDPOINT: 'minio:9000' })).toContain(
+      'EVIDENCE_S3_ENDPOINT must be an http(s) URL',
+    );
+  });
+
+  it('refuses half a credential pair — the other half silently falling back is the trap', () => {
+    expect(errorsFor({ EVIDENCE_S3_BUCKET: 'b-1', EVIDENCE_S3_ACCESS_KEY_ID: 'key' })).toContain(
+      'must be set together',
+    );
+    expect(
+      errorsFor({
+        EVIDENCE_S3_BUCKET: 'b-1',
+        EVIDENCE_S3_ACCESS_KEY_ID: 'key',
+        EVIDENCE_S3_SECRET_ACCESS_KEY: 'secret',
+      }),
+    ).toBe('');
+  });
+});
+
+describe('s3 storageRef grammar', () => {
+  it('accepts a tenant + 64-hex content address and nothing else', () => {
+    expect(parseS3StorageRef(`s3://co_acme/${HASH}`)).toEqual({
+      companyId: 'co_acme',
+      byteHash: HASH,
+    });
+    expect(parseS3StorageRef(`fs://co_acme/${HASH}`)).toBeNull();
+    expect(parseS3StorageRef(`s3://co_acme/${HASH}/extra`)).toBeNull();
+    expect(parseS3StorageRef(`s3://../${HASH}`)).toBeNull();
+    expect(parseS3StorageRef(`s3://co_acme/${HASH.toUpperCase()}`)).toBeNull();
+    expect(parseS3StorageRef('s3://co_acme/short')).toBeNull();
+  });
+});
+
+describe('readiness gates on the SELECTED store', () => {
+  const surreal = {
+    ping: async () => true,
+    scopedPoolEnabled: () => true,
+    pingScoped: async () => true,
+  } as never;
+  const embedder = {
+    isReady: () => true,
+    warmupStatus: () => ({ ready: true, failures: 0, inFlight: false }),
+  } as never;
+
+  const adapter = (probe?: () => Promise<void>): EvidenceStorageAdapter =>
+    ({ scheme: 's3', ...(probe ? { probe } : {}) }) as unknown as EvidenceStorageAdapter;
+
+  it('is vacuously ok on fs — local disk has nothing remote to ask', async () => {
+    const fs = { scheme: 'fs' } as unknown as EvidenceStorageAdapter;
+    const r = await new HealthService(surreal, embedder, new Map([['fs', fs]])).readiness();
+    expect(r.evidenceStoreOk).toBe(true);
+    expect(r.ready).toBe(true);
+    expect(r.detail.evidenceStore).toEqual({
+      scheme: 'fs',
+      probed: false,
+      latencyMs: 0,
+      error: null,
+    });
+  });
+
+  it('is vacuous in a process with no storage registry wired at all', async () => {
+    const r = await new HealthService(surreal, embedder).readiness();
+    expect(r.evidenceStoreOk).toBe(true);
+    expect(r.detail.evidenceStore).toMatchObject({ probed: false, error: null });
+  });
+
+  it('is NOT ready when the selected scheme has no adapter registered', async () => {
+    process.env.EVIDENCE_STORAGE_SCHEME = 's3';
+    const r = await new HealthService(surreal, embedder, new Map()).readiness();
+    expect(r.evidenceStoreOk).toBe(false);
+    expect(r.ready).toBe(false);
+    expect(r.detail.evidenceStore.error).toContain("no 's3' evidence storage adapter");
+  });
+
+  it('reports the probe’s own message when the store refuses', async () => {
+    process.env.EVIDENCE_STORAGE_SCHEME = 's3';
+    const registry = new Map([
+      [
+        's3',
+        adapter(() => Promise.reject(new Error('HTTP 403: the credentials do not authorize'))),
+      ],
+    ]);
+    const r = await new HealthService(surreal, embedder, registry).readiness();
+    expect(r.ready).toBe(false);
+    expect(r.detail.evidenceStore).toMatchObject({ scheme: 's3', probed: true });
+    expect(r.detail.evidenceStore.error).toContain('do not authorize');
+  });
+
+  it('goes green — and says it probed — when the bucket answers', async () => {
+    process.env.EVIDENCE_STORAGE_SCHEME = 's3';
+    const registry = new Map([['s3', adapter(() => Promise.resolve())]]);
+    const r = await new HealthService(surreal, embedder, registry).readiness();
+    expect(r.evidenceStoreOk).toBe(true);
+    expect(r.ready).toBe(true);
+    expect(r.detail.evidenceStore).toMatchObject({ scheme: 's3', probed: true, error: null });
+  });
+
+  it('does not hold /ready open on a wedged endpoint', async () => {
+    process.env.EVIDENCE_STORAGE_SCHEME = 's3';
+    jest.useFakeTimers();
+    try {
+      const registry = new Map([['s3', adapter(() => new Promise<void>(() => {}))]]);
+      const pending = new HealthService(surreal, embedder, registry).readiness();
+      await jest.advanceTimersByTimeAsync(6_000);
+      const r = await pending;
+      expect(r.ready).toBe(false);
+      expect(r.detail.evidenceStore.error).toContain('timed out');
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});
+
+describe('the store is exercised continuously, not only at deploy time', () => {
+  function probe(registry?: EvidenceStorageRegistry): CapabilityProbeService {
+    return new CapabilityProbeService(
+      { withScopedCompany: jest.fn().mockResolvedValue([[]]) } as never,
+      { knownCompanyIds: () => ['acme'] } as never,
+      new MetricsService(),
+      undefined,
+      undefined,
+      registry,
+    );
+  }
+
+  async function evidenceStoreReport(registry?: EvidenceStorageRegistry) {
+    const reports = await probe(registry).runOnce();
+    return reports.find((r) => r.capability === 'evidence_store')!;
+  }
+
+  it('reports skipped on fs rather than a green that proves nothing', async () => {
+    const fs = { scheme: 'fs' } as unknown as EvidenceStorageAdapter;
+    expect(await evidenceStoreReport(new Map([['fs', fs]]))).toMatchObject({
+      outcome: 'skipped',
+    });
+  });
+
+  it('classifies a 403 from the object store as unauthorized, not as a dead store', async () => {
+    process.env.EVIDENCE_STORAGE_SCHEME = 's3';
+    const s3 = {
+      scheme: 's3',
+      probe: () =>
+        Promise.reject(
+          new Error(
+            "bucket 'b' at http://minio:9000 — the credentials do not authorize this bucket",
+          ),
+        ),
+    } as unknown as EvidenceStorageAdapter;
+    expect(await evidenceStoreReport(new Map([['s3', s3]]))).toMatchObject({
+      outcome: 'unauthorized',
+    });
+  });
+
+  it('is a conclusive error when the selected scheme is not registered', async () => {
+    process.env.EVIDENCE_STORAGE_SCHEME = 's3';
+    expect(await evidenceStoreReport(new Map())).toMatchObject({ outcome: 'error' });
+  });
+
+  it('serves when the bucket answers', async () => {
+    process.env.EVIDENCE_STORAGE_SCHEME = 's3';
+    const s3 = {
+      scheme: 's3',
+      probe: () => Promise.resolve(),
+    } as unknown as EvidenceStorageAdapter;
+    expect(await evidenceStoreReport(new Map([['s3', s3]]))).toMatchObject({
+      outcome: 'serving',
+    });
+  });
+});
+
+describe('the fs adapter says out loud that it is local disk', () => {
+  function warnings(): string[] {
+    const captured: string[] = [];
+    const spy = jest.spyOn(Logger.prototype, 'warn').mockImplementation((m) => {
+      captured.push(String(m));
+    });
+    try {
+      new FsEvidenceStorageAdapter().onApplicationBootstrap();
+    } finally {
+      spy.mockRestore();
+    }
+    return captured;
+  }
+
+  it('warns once on a split-role deployment, which is more than one process by definition', () => {
+    process.env.EVIDENCE_FS_ROOT = '/var/lib/brain/evidence';
+    process.env.PROCESS_ROLE = 'worker';
+    const lines = warnings();
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain('local disk');
+    expect(lines[0]).toContain('EVIDENCE_STORAGE_SCHEME=s3');
+  });
+
+  it('stays silent on the single-process default and when s3 is the selected store', () => {
+    process.env.EVIDENCE_FS_ROOT = '/var/lib/brain/evidence';
+    expect(warnings()).toEqual([]);
+    process.env.PROCESS_ROLE = 'api';
+    process.env.EVIDENCE_STORAGE_SCHEME = 's3';
+    expect(warnings()).toEqual([]);
+  });
+
+  it('stays silent when the adapter is not configured at all', () => {
+    process.env.PROCESS_ROLE = 'api';
+    expect(warnings()).toEqual([]);
+  });
+});

--- a/test/health-components.unit-spec.ts
+++ b/test/health-components.unit-spec.ts
@@ -26,12 +26,15 @@ const READY: ReadinessReport = {
   dbOk: true,
   scopedOk: true,
   embedderReady: true,
+  evidenceStoreOk: true,
   ready: true,
   detail: {
     dbLatencyMs: 3,
     scopedEnabled: true,
     scopedLatencyMs: 4,
     embedder: { ready: true, failures: 0, inFlight: false },
+    // The default store: local disk, nothing remote to ask.
+    evidenceStore: { scheme: 'fs', probed: false, latencyMs: 0, error: null },
   },
 };
 
@@ -280,6 +283,7 @@ describe('health grid — wire contract and provenance', () => {
       'surrealdb',
       'scoped pool (brain_caller)',
       'embedder (bge-m3)',
+      'evidence store (fs)',
       'intent classifier',
       'openai key',
       'changefeed consumer',


### PR DESCRIPTION
## What

An S3-compatible evidence blob store under scheme `s3`, selected by
`EVIDENCE_STORAGE_SCHEME=fs|s3` (default `fs` — nothing changes for the
current deployment).

- **`S3EvidenceStorageAdapter`** (`@aws-sdk/client-s3` `^3.1130.0`) implements the
  whole `EvidenceStorageAdapter` contract with the fs adapter's semantics point
  for point: content-addressed idempotent `put` (HEAD first, then one atomic
  `PutObject` — no temp-then-rename and no half-written object is ever visible),
  `head`/`exists` answering absence rather than throwing, streaming `get` (the
  response body stream, so a large blob is never materialised), an honest
  `delete` boolean, tenant-scoped `listBlobs` (paged `ListObjectsV2` under
  `<prefix>/<companyId>/`, yielding only well-formed content addresses) for the
  orphan GC, and `sweepIncompleteWrites` aborting abandoned multipart uploads as
  the object-store shape of the fs `.tmp-…` broom. Object key is
  `<EVIDENCE_S3_PREFIX>/<companyId>/<byteHash>`; the `storageRef` stays
  `s3://<companyId>/<byteHash>`, so bucket/prefix/endpoint are configuration and
  never a row rewrite.
- **Configuration, not flags.** `EVIDENCE_STORAGE_SCHEME` and the seven
  `EVIDENCE_S3_*` keys are registered the way `EVIDENCE_FS_ROOT` is — in
  `config-catalog.data.ts` (with `EVIDENCE_S3_SECRET_ACCESS_KEY` masked) and
  validated at boot in `env-validation.ts`, which now refuses `s3` without a
  bucket, a malformed bucket name or endpoint, half a credential pair, and an
  unparseable `EVIDENCE_S3_FORCE_PATH_STYLE`.
- **Readiness through the existing vocabulary.** One new check
  (`evidenceStoreOk` + `detail.evidenceStore`) on `ReadinessReport`, backed by
  `HeadBucket` under a 5s deadline, surfaced on `/ready`, in the admin health
  grid, and as a fourth capability (`evidence_store`) on the continuous probe. On
  `fs` it reports `disabled` — local disk has nothing remote to ask — rather than
  a green that proves nothing; a selected scheme with no adapter registered is
  NOT ready, because every upload would 503.
- **The fs adapter is honest now**: its docstring says it is correct only with a
  single replica or a shared volume, and it warns once at boot when
  `PROCESS_ROLE=api|worker` (a split-role deployment is more than one process by
  definition). No new knob for that.
- **Reads are unaffected**: they resolve by each row's own `storageRef` scheme, so
  a store switched `fs`→`s3` keeps serving its existing `fs://` rows.

The blob-adapter registry moved into a `@Global EvidenceStorageModule` so
readiness and the capability probe can reach the selected store without
importing the whole evidence module. `fs` is always registered; `s3` registers
only when `EVIDENCE_S3_BUCKET` is set, so a deployment that never mentions S3
has no adapter that could throw.

## Why

Audit finding (review wave #501): only `FsEvidenceStorageAdapter` was ever
registered (`src/evidence/evidence.module.ts`), and it writes
`<EVIDENCE_FS_ROOT>/<companyId>/<hash>` on the local disk of the process that
took the upload. A blob uploaded through one replica is `head() → null` on every
other (`evidence-read.service.ts:275-278`), and the read path turns that into a
bare 404 (`:287-293`) — so with N replicas behind a round-robin load balancer
uploads succeed and reads fail (N-1)/N of the time. The `scheme` registry under
`src/evidence/storage/` was built for exactly this second adapter. Related: the
lease-guarded `orphan-blob-gc.service.ts` only ever swept the leader's disk.

**No GC change was needed** — it already enumerates through
`adapter.listBlobs(companyId)` over every registered adapter, so registering
`s3` makes the leader sweep the shared bucket, under the same per-tenant fence,
deletion cap and grace window.

**Flag budget**: `test/flag-budget.unit-spec.ts` counts a key only when it
matches `ENGINE_PREFIX` (`SEARCH|SYNTHESIZE|MULTI_HOP|EXTRACTOR|EXTRACTION|INGEST|EPISODE|EPISODES|DERIVER|AGENT_QA|HNSW`),
so the `EVIDENCE_` family is out of scope by construction — as the
`env-validation.ts` comments already state for the rest of it. Nothing was
bypassed and no golden was touched. `EVIDENCE_S3_FORCE_PATH_STYLE` is catalogued
with `isBooleanFlag: true` (its honest classification) and still isn't counted.
Two gate tests needed a real edit rather than a fixture bump:
`capability-probe.unit-spec.ts`'s readiness-coverage gate had to learn the fourth
check, and `config-catalog-truth.unit-spec.ts`'s credential-shape regex was
anchored to `SECRET$|_API_KEY$|_TOKEN$|PASSWORD$|PRIVATE_KEY$` — which would have
let `EVIDENCE_S3_SECRET_ACCESS_KEY` ship unmasked, the exact failure that gate
exists to catch — so it was extended by SHAPE (`_SECRET_ACCESS_KEY$`), not by key.

## How verified

```
pnpm typecheck                                          clean
pnpm lint:ci                                            clean (0 errors, 0 warnings)
pnpm format:check                                       All matched files use Prettier code style!
pnpm audit --audit-level=high --ignore-workspace        0 high/critical (3 moderate, pre-existing)
pnpm openapi:build                                      no drift (57 paths, 138 schemas)
```

Unit (touched areas + every doctrine/truth gate):

```
pnpm jest --config ./test/jest-unit.json --testPathPatterns \
  'evidence|health|capability-probe|truth|flag-budget|engine-gates|engine-layering|env-validation|contracts-admin'
→ Test Suites: 58 passed, 58 total
  Tests:       484 passed, 484 total
```

e2e (Docker; includes the whole existing evidence suite, unchanged and green):

```
pnpm jest --config ./test/jest-e2e.json --testPathPatterns 'evidence'
→ Test Suites: 11 passed, 11 total
  Tests:       111 passed, 111 total

pnpm jest --config ./test/jest-e2e.json --testPathPatterns 'capability|health|admin-infra'
→ Test Suites: 4 passed, 4 total
  Tests:       10 passed, 10 total
```

New tests:

- `test/evidence-storage-adapter-contract.e2e-spec.ts` — ONE parametrised contract
  suite run twice, against the fs adapter and against a real S3 server (pinned
  `minio/minio:RELEASE.2025-01-20T14-49-07Z` via testcontainers; nothing else is
  fetched): put idempotence, hash/tenant refusals, absence semantics, a 5 MiB
  streaming round-trip, honest delete, `belongsToTenant`, tenant-scoped
  `listBlobs` with write times, and the partial-write broom. Plus the finding
  itself, both directions: two fs adapters over per-pod roots → `head() → null`
  and an empty sweep, two fs adapters over ONE volume → served; and two
  independent `S3EvidenceStorageAdapter` instances over one bucket serving each
  other's bytes, sweeping the same store and observing each other's deletes.
  Also the live `HeadBucket` probe (pass, and the operator-actionable failure for
  a missing bucket), prefix namespacing, and the loud unconfigured-bucket error.
- `test/evidence-storage-selection.unit-spec.ts` — scheme selection, `EVIDENCE_S3_*`
  parsing, every boot-validation refusal, the ref grammar, the readiness verdicts
  (vacuous on fs, not-ready with the adapter unregistered, the probe's own message
  on refusal, and the deadline on a wedged endpoint), the four `evidence_store`
  probe outcomes, and the fs adapter's one boot warning.
- `test/evidence-blob-upload.unit-spec.ts` — the upload path writes through the
  SELECTED adapter and records its ref, and 503s rather than silently falling
  back to local disk when `s3` is selected but unregistered.

## Operator note

This ships the mechanism, not a switched deployment. Preprod/prod stay on `fs`
until an operator supplies a real bucket and credentials
(`EVIDENCE_S3_BUCKET` / `EVIDENCE_S3_ENDPOINT` / `EVIDENCE_S3_REGION` /
`EVIDENCE_S3_ACCESS_KEY_ID` / `EVIDENCE_S3_SECRET_ACCESS_KEY`, plus
`EVIDENCE_S3_FORCE_PATH_STYLE=1` for a MinIO-class host) and flips
`EVIDENCE_STORAGE_SCHEME=s3`. Existing `fs://` blobs are NOT migrated by this
PR — they keep serving from the disk that holds them, which is why the fs root
should be a shared volume for as long as any `fs://` row remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhrQxeisXJZEt4sg3PGyU6
