### PR TITLE
fix(db): arbitrate schema migration across replicas and land each file atomically

### DIFF
--- a/src/db/migration-lock.ts
+++ b/src/db/migration-lock.ts
@@ -1,0 +1,159 @@
+import { Logger } from '@nestjs/common';
+import { randomUUID } from 'node:crypto';
+import { hostname } from 'node:os';
+import type { Surreal } from 'surrealdb';
+import { runTransaction } from './surreal.service';
+import { retryOnUniqueViolation } from './surreal-retry';
+
+/**
+ * Cross-replica lock the migrator holds while it applies schema.
+ *
+ * Contract: `tryAcquire` resolves true only if this process owns `name`
+ * for the next `ttlSeconds`; calling it again while we own it renews the
+ * lease. `release` drops a lease we still own and is idempotent. Both
+ * may reject — the caller decides whether to retry or fail closed.
+ */
+export interface MigrationLock {
+  tryAcquire(name: string, ttlSeconds: number): Promise<boolean>;
+  release(name: string): Promise<void>;
+}
+
+/**
+ * 32-bit FNV-1a. A collision guard for a readable slug, NOT a security
+ * primitive — deliberately not a crypto digest, because nothing about a
+ * lease name needs to resist an adversary.
+ */
+function fnv1a32(s: string): string {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 0x01000193) >>> 0;
+  }
+  return h.toString(16).padStart(8, '0');
+}
+
+/**
+ * Lease name for one target database. Lease names are composed into the
+ * record id `leader_lease:<name>`, so a `:` or `/` in the name breaks id
+ * parsing: everything outside [a-z0-9_] folds to `_`, and a digest of the
+ * raw pair is appended so two targets that fold alike cannot collide
+ * into one lease.
+ */
+export function migrationLeaseName(namespace: string, database: string): string {
+  const raw = `migrate:${namespace}/${database}`;
+  const slug = raw
+    .toLowerCase()
+    .replace(/[^a-z0-9_]+/g, '_')
+    .slice(0, 48);
+  return `${slug}_${fnv1a32(raw)}`;
+}
+
+/**
+ * The `leader_lease` shape from migration 0029, repeated here as
+ * idempotent bootstrap DDL. The lease table lives in the admin database,
+ * which is itself migrated, so the lock cannot wait for 0029 to have
+ * run — it defines the table it needs first. `IF NOT EXISTS` keeps this
+ * a no-op once 0029 lands, and keeps the row shape identical to what
+ * LeaderLeaseService reads and writes.
+ */
+const LEASE_TABLE_DDL = `
+DEFINE TABLE IF NOT EXISTS leader_lease SCHEMAFULL;
+DEFINE FIELD IF NOT EXISTS name        ON leader_lease TYPE string;
+DEFINE FIELD IF NOT EXISTS leaderId    ON leader_lease TYPE string;
+DEFINE FIELD IF NOT EXISTS leaseUntil  ON leader_lease TYPE datetime;
+DEFINE FIELD IF NOT EXISTS heartbeatAt ON leader_lease TYPE datetime DEFAULT time::now();
+DEFINE FIELD IF NOT EXISTS acquiredAt  ON leader_lease TYPE datetime DEFAULT time::now();
+DEFINE FIELD IF NOT EXISTS note        ON leader_lease TYPE option<string>;
+DEFINE INDEX IF NOT EXISTS leader_lease_name_idx ON leader_lease FIELDS name UNIQUE;
+`;
+
+/** Runs `fn` against a root connection pointed at the lease database. */
+export type WithLeaseDb = <T>(fn: (db: Surreal) => Promise<T>) => Promise<T>;
+
+/**
+ * Compare-and-set lock over the same `leader_lease` table (and the same
+ * row shape) as LeaderLeaseService, reimplemented here because
+ * SurrealService cannot depend on it: LeaderLeaseService injects
+ * SurrealService, so the reverse edge is a DI cycle. The CAS is a
+ * point-read plus a conditional UPSERT on the record id inside one
+ * BEGIN/COMMIT — a `WHERE name = ...` scan would put the whole table in
+ * the read-set and make unrelated lease acquires abort each other.
+ * Writes use SET rather than CONTENT so fields this module does not know
+ * about survive a takeover.
+ */
+export class SurrealMigrationLock implements MigrationLock {
+  private readonly logger = new Logger(SurrealMigrationLock.name);
+  private readonly leaderId: string;
+  private tableReady = false;
+
+  constructor(
+    private readonly withLeaseDb: WithLeaseDb,
+    identity?: string,
+  ) {
+    // Unique per PROCESS, not per host+pid: containers commonly run the
+    // app as pid 1, so a restarted replica would otherwise inherit its
+    // predecessor's lease and believe it still holds the lock.
+    this.leaderId = identity ?? `${hostname()}#${process.pid}#${randomUUID().slice(0, 8)}`;
+  }
+
+  identity(): string {
+    return this.leaderId;
+  }
+
+  async tryAcquire(name: string, ttlSeconds: number): Promise<boolean> {
+    // Deadline computed in JS and bound as an ISO string: the
+    // duration::from_* spellings differ across SurrealDB generations,
+    // type::datetime($iso) parses on both.
+    const until = new Date(Date.now() + ttlSeconds * 1000).toISOString();
+    return this.withLeaseDb(async (db) => {
+      await this.ensureTable(db);
+      return retryOnUniqueViolation(async () => {
+        const held = await runTransaction<unknown>(db, (tx) => {
+          tx.bind('name', name)
+            .bind('me', this.leaderId)
+            .bind('until', until)
+            .add(`LET $row = (SELECT * FROM type::record('leader_lease:' + $name))[0]`)
+            .add(
+              `IF $row IS NONE OR $row.leaseUntil < time::now() OR $row.leaderId = $me {
+                 UPSERT type::record('leader_lease:' + $name) SET
+                   name = $name,
+                   leaderId = $me,
+                   leaseUntil = type::datetime($until),
+                   heartbeatAt = time::now(),
+                   acquiredAt = $row.acquiredAt OR time::now();
+                 RETURN true;
+               } ELSE {
+                 RETURN false;
+               }`,
+            );
+        });
+        return held === true;
+      });
+    });
+  }
+
+  /**
+   * Drop the lease if we still own it. Never throws: a failed release
+   * only means waiters sit out the TTL instead of starting immediately.
+   */
+  async release(name: string): Promise<void> {
+    try {
+      await this.withLeaseDb(async (db) => {
+        await db.query(`DELETE type::record('leader_lease:' + $name) WHERE leaderId = $me`, {
+          name,
+          me: this.leaderId,
+        });
+      });
+    } catch (e) {
+      this.logger.warn(`release(${name}) failed: ${(e as Error).message}`);
+    }
+  }
+
+  private async ensureTable(db: Surreal): Promise<void> {
+    if (this.tableReady) return;
+    // Two replicas bootstrapping the same DDL abort each other under OCC;
+    // the guards make every attempt after the first a no-op.
+    await retryOnUniqueViolation(() => db.query(LEASE_TABLE_DDL));
+    this.tableReady = true;
+  }
+}

--- a/src/db/migrator.service.ts
+++ b/src/db/migrator.service.ts
@@ -2,8 +2,8 @@ import { Logger } from '@nestjs/common';
 import { readdir, readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import type { Surreal } from 'surrealdb';
-import { isReadConflict } from './surreal.service';
-import { isUniqueViolation } from './surreal-retry';
+import type { MigrationLock } from './migration-lock';
+import { enrichTransactionError, isReadConflict, isUniqueViolation } from './surreal-retry';
 
 /**
  * Schema migrator — versioned, append-only DDL applied per tenant DB.
@@ -26,10 +26,14 @@ import { isUniqueViolation } from './surreal-retry';
  *     appliedAt). The bootstrap DDL for that table is the only thing we
  *     run unconditionally.
  *
- * Concurrency: applications are caller-serialized through SurrealService's
- * schema queue, so we don't repeat that here. Within a single tenant, the
- * apply loop is sequential — IF NOT EXISTS DDL must be idempotent because
- * a partially-applied migration that retries shouldn't fail.
+ * Concurrency: SurrealService's schema queue only serializes appliers
+ * inside ONE process. Across replicas (N pods booting at once, or two
+ * images overlapping during a rolling deploy) the arbiter is the
+ * distributed lock passed in `MigrateOptions` — keyed per target
+ * database, so tenants still migrate in parallel. A replica that loses
+ * the race waits for the holder and then re-reads the ledger, so it
+ * applies only what is genuinely left, and each file lands together with
+ * its ledger row in one BEGIN/COMMIT.
  */
 
 export interface Migration {
@@ -42,6 +46,40 @@ export interface MigrationResult {
   applied: string[]; // migration IDs newly applied this run
   alreadyApplied: string[]; // migration IDs already present
 }
+
+export interface MigrateOptions {
+  /**
+   * Cross-replica lock. Production always passes one; unit tests and
+   * one-shot scripts driving a database nobody else touches may omit it,
+   * in which case the only arbitration left is the in-process queue.
+   */
+  lock?: MigrationLock;
+  /** Lease name for `lock` — see `migrationLeaseName`. */
+  lockName?: string;
+}
+
+/** Tunables, injected by tests; production takes the defaults. */
+export interface MigratorTiming {
+  lockTtlSeconds?: number;
+  lockWaitMs?: number;
+  sleep?: (ms: number) => Promise<void>;
+}
+
+/**
+ * Lease TTL for the migration lock. A cold apply of the whole manifest
+ * measures under 4s against SurrealDB 3.2.4, so 30s leaves an order of
+ * magnitude of headroom while bounding how long a hard-killed holder can
+ * block the rest of the fleet; the holder renews at half-life anyway, so
+ * a slow data leg does not lose the lock.
+ */
+const LOCK_TTL_SECONDS = 30;
+
+/**
+ * How long a replica that lost the race waits for the holder before it
+ * gives up. Comfortably longer than the TTL, so a crashed holder is
+ * always taken over rather than waited out forever.
+ */
+const LOCK_WAIT_MS = 120_000;
 
 const SCHEMA_MIGRATIONS_DDL = `
 DEFINE TABLE IF NOT EXISTS schema_migrations SCHEMAFULL;
@@ -56,11 +94,78 @@ const FILE_NAME = /^(\d{4})_.+\.surql$/;
 export class SchemaMigrator {
   private readonly logger = new Logger(SchemaMigrator.name);
   private cached: Migration[] | null = null;
+  private readonly lockTtlSeconds: number;
+  private readonly lockWaitMs: number;
+  private readonly sleep: (ms: number) => Promise<void>;
 
-  constructor(private readonly migrationsDir: string) {}
+  constructor(
+    private readonly migrationsDir: string,
+    timing: MigratorTiming = {},
+  ) {
+    this.lockTtlSeconds = timing.lockTtlSeconds ?? LOCK_TTL_SECONDS;
+    this.lockWaitMs = timing.lockWaitMs ?? LOCK_WAIT_MS;
+    this.sleep = timing.sleep ?? ((ms) => new Promise((r) => setTimeout(r, ms)));
+  }
 
-  /** Apply all pending migrations against `conn`. */
-  async migrate(conn: Surreal): Promise<MigrationResult> {
+  /**
+   * Apply all pending migrations against `conn`, holding `opts.lock` for
+   * the whole run so replicas booting together apply the manifest once.
+   */
+  async migrate(conn: Surreal, opts: MigrateOptions = {}): Promise<MigrationResult> {
+    const { lock, lockName } = opts;
+    if (!lock || !lockName) return this.applyPending(conn);
+    await this.acquireOrWait(lock, lockName);
+    try {
+      return await this.applyPending(conn, lock, lockName);
+    } finally {
+      await lock.release(lockName);
+    }
+  }
+
+  /**
+   * Take the lock or wait for whoever holds it. Losing the race is not a
+   * reason to proceed: we wait until the holder releases — or until its
+   * lease expires, which is how a crashed holder is taken over — and only
+   * then read the ledger, so the retry applies exactly what is left.
+   * Transient acquire failures are absorbed inside the same deadline;
+   * reaching the deadline throws, because the alternative is serving
+   * requests against a half-migrated schema.
+   */
+  private async acquireOrWait(lock: MigrationLock, name: string): Promise<void> {
+    const deadline = Date.now() + this.lockWaitMs;
+    let delayMs = 50;
+    let lastErr: unknown;
+    let waited = false;
+    for (;;) {
+      try {
+        if (await lock.tryAcquire(name, this.lockTtlSeconds)) {
+          if (waited) this.logger.log(`Took migration lock ${name} after waiting for the holder`);
+          return;
+        }
+        lastErr = undefined;
+      } catch (err) {
+        lastErr = err;
+      }
+      waited = true;
+      const left = deadline - Date.now();
+      if (left <= 0) {
+        const why = lastErr
+          ? `: ${(lastErr as Error).message}`
+          : ' — another replica is still applying schema';
+        throw new Error(
+          `Timed out after ${this.lockWaitMs}ms waiting for migration lock ${name}${why}`,
+        );
+      }
+      await this.sleep(Math.min(delayMs, left));
+      delayMs = Math.min(delayMs * 2, 2000);
+    }
+  }
+
+  private async applyPending(
+    conn: Surreal,
+    lock?: MigrationLock,
+    lockName?: string,
+  ): Promise<MigrationResult> {
     await conn.query(SCHEMA_MIGRATIONS_DDL);
 
     const manifest = await this.loadManifest();
@@ -74,55 +179,85 @@ export class SchemaMigrator {
       };
     }
 
+    let renewAt = Date.now() + (this.lockTtlSeconds * 1000) / 2;
     for (const m of pending) {
-      this.logger.log(`Applying ${m.name}`);
-      // Migrations defining NS-level objects (DEFINE USER brain_caller in
-      // 0005, function definitions in 0003/0006) race against each other
-      // when multiple tenants apply schema in parallel — SurrealDB's
-      // optimistic-concurrency aborts one with `Transaction read conflict`.
-      // Retry up to 5x with exponential backoff; the second attempt sees
-      // the racing committer's row and the IF NOT EXISTS / OVERWRITE
-      // guards make it a clean no-op.
-      let attempts = 0;
-      const maxAttempts = 5;
-
-      while (true) {
-        try {
-          await conn.query(m.sql);
-          break;
-        } catch (err) {
-          attempts++;
-          if (!isReadConflict(err) || attempts >= maxAttempts) {
-            this.logger.error(
-              `Migration ${m.name} failed after ${attempts} attempt(s): ${(err as Error).message}`,
-            );
-            throw new Error(`Migration ${m.name} failed: ${(err as Error).message}`);
-          }
-          const baseMs = 20 * Math.pow(2, attempts - 1);
-          await new Promise((r) => setTimeout(r, baseMs + Math.random() * baseMs));
+      if (lock && lockName && Date.now() >= renewAt) {
+        if (!(await lock.tryAcquire(lockName, this.lockTtlSeconds))) {
+          throw new Error(
+            `Lost migration lock ${lockName} before applying ${m.name} — another replica ` +
+              `took over; refusing to write schema behind its back`,
+          );
         }
+        renewAt = Date.now() + (this.lockTtlSeconds * 1000) / 2;
       }
-      // The ledger insert is the only non-idempotent step. Two appliers
-      // racing on a SHARED DB (the system DB under parallel e2e boots;
-      // multi-pod boots in general) both compute the same pending set —
-      // the DDL is IF-NOT-EXISTS-idempotent, so the loser of this CREATE
-      // has already applied identical schema and must treat the unique
-      // violation as "someone else recorded it first", not a failure.
-      try {
-        await conn.query(`CREATE schema_migrations CONTENT { migrationId: $id, name: $name }`, {
-          id: m.id,
-          name: m.name,
-        });
-      } catch (err) {
-        if (!isUniqueViolation(err)) throw err;
-        this.logger.log(`Ledger row for ${m.name} already written by a concurrent applier`);
-      }
+      await this.applyOne(conn, m);
     }
 
     return {
       applied: pending.map((m) => m.id),
       alreadyApplied: [...applied],
     };
+  }
+
+  /**
+   * Apply one file and write its ledger row in ONE BEGIN/COMMIT batch, so
+   * a crash mid-file leaves everything or nothing. SurrealDB 3.2.4 rolls
+   * DDL back with the transaction and every file in the manifest tolerates
+   * the wrapper; a plain multi-statement batch would NOT do, because it
+   * keeps executing after a failed statement and would record a
+   * half-applied file as done (both measured in
+   * migration-concurrency.e2e-spec).
+   */
+  private async applyOne(conn: Surreal, m: Migration): Promise<void> {
+    this.logger.log(`Applying ${m.name}`);
+    const batch =
+      `BEGIN TRANSACTION;\n${m.sql}\n` +
+      `CREATE schema_migrations CONTENT { migrationId: $mig_id, name: $mig_name };\n` +
+      `COMMIT TRANSACTION;`;
+    let attempts = 0;
+    const maxAttempts = 5;
+    for (;;) {
+      try {
+        await conn.query(batch, { mig_id: m.id, mig_name: m.name });
+        return;
+      } catch (err) {
+        // An aborted batch surfaces as one bare "failed transaction"
+        // wrapper whether the cause was an OCC conflict on NS-level
+        // metadata (0005's DEFINE USER, 0003/0006's functions) or the
+        // ledger's unique index. Settle the ambiguity by re-reading: if
+        // the row is there, an applier that raced us — only possible when
+        // a lease expired under a live holder — already applied identical
+        // DDL, so this is not a failure.
+        if (await this.isRecorded(conn, m.id)) {
+          this.logger.log(`Ledger row for ${m.name} already written by a concurrent applier`);
+          return;
+        }
+        attempts++;
+        const retriable = isReadConflict(enrichTransactionError(err)) || isUniqueViolation(err);
+        if (!retriable || attempts >= maxAttempts) {
+          this.logger.error(
+            `Migration ${m.name} failed after ${attempts} attempt(s): ${(err as Error).message}`,
+          );
+          throw new Error(`Migration ${m.name} failed: ${(err as Error).message}`);
+        }
+        const baseMs = 20 * Math.pow(2, attempts - 1);
+        await this.sleep(baseMs + Math.random() * baseMs);
+      }
+    }
+  }
+
+  /**
+   * Whether the ledger already carries `id`. Reads the whole ledger and
+   * filters in JS rather than `WHERE migrationId = $id`: the 3.2.4
+   * planner has bitten us on indexed-field predicates, and the table
+   * holds one row per migration.
+   */
+  private async isRecorded(conn: Surreal, id: string): Promise<boolean> {
+    try {
+      return (await this.fetchAppliedIds(conn)).includes(id);
+    } catch {
+      return false;
+    }
   }
 
   /** Load + cache migrations from disk. */

--- a/src/db/surreal.service.ts
+++ b/src/db/surreal.service.ts
@@ -10,6 +10,7 @@ import { ConfigService } from '@nestjs/config';
 import { Surreal } from 'surrealdb';
 import { join } from 'node:path';
 import { SchemaMigrator } from './migrator.service';
+import { migrationLeaseName, SurrealMigrationLock } from './migration-lock';
 import { enrichTransactionError } from './surreal-retry';
 import { SESSION_REAUTH_MARGIN_MS, SurrealSessionKeeper } from './session-keeper';
 import { envFlagEnabled } from '../common/env-validation';
@@ -32,6 +33,12 @@ export {
 const SCOPED_PROBE_ACQUIRE_MS = 2000;
 /** Bound on the per-acquire `RETURN 1` liveness probe (see ensureSession). */
 const SESSION_PROBE_TIMEOUT_MS = 3000;
+/**
+ * The platform's own database — global, tenant-agnostic state (see
+ * `withAdminDb`) and the home of the `leader_lease` table the migration
+ * lock arbitrates on.
+ */
+const ADMIN_DATABASE = 'system';
 
 type PoolRole = 'root' | 'scoped';
 
@@ -137,6 +144,16 @@ export class SurrealService implements OnModuleInit, OnApplicationShutdown {
   // A standalone migrator conn breaks the cycle without changing
   // any caller-facing semantics.
   private migratorConn!: Surreal;
+  /**
+   * Second standalone root connection, pinned to the admin database and
+   * used ONLY to arbitrate the migration lease. Separate from
+   * `migratorConn` because that one is `use()`d to the database being
+   * migrated: sharing it would mean switching databases mid-migration
+   * every time the lease is renewed.
+   */
+  private lockConn!: Surreal;
+  private migrationLock!: SurrealMigrationLock;
+  private leaseDbReady = false;
   /** Cached root credentials + URL so a connection can be fully rebuilt
    *  on failure: surrealdb-js (2.0.8) can hold a half-open socket that still
    *  reports connected (gh#618) or invalidate a signin()-established session
@@ -252,6 +269,13 @@ export class SurrealService implements OnModuleInit, OnApplicationShutdown {
     await this.migratorConn.connect(url);
     await this.signin(this.migratorConn, 'root');
     this.all.push(this.migratorConn);
+
+    // Lease connection + the lock that guards every migration run.
+    this.lockConn = new Surreal();
+    await this.lockConn.connect(url);
+    await this.signin(this.lockConn, 'root');
+    this.all.push(this.lockConn);
+    this.migrationLock = new SurrealMigrationLock((fn) => this.withLeaseDb(fn));
 
     // Root pool — admin signin.
     for (let i = 0; i < this.poolSize; i++) {
@@ -432,7 +456,7 @@ export class SurrealService implements OnModuleInit, OnApplicationShutdown {
    * avoids a parallel migrator just for two tables.
    */
   async withAdminDb<T>(fn: (db: Surreal) => Promise<T>): Promise<T> {
-    const database = 'system';
+    const database = ADMIN_DATABASE;
     let conn = await this.acquireRoot();
     try {
       conn = await this.ensureSession(conn, 'root');
@@ -632,6 +656,26 @@ export class SurrealService implements OnModuleInit, OnApplicationShutdown {
   }
 
   /**
+   * Run `fn` on the lease connection, pointed at the admin database.
+   *
+   * Chicken-and-egg: the lease table lives in the admin database, which
+   * is itself migrated, so this path may NOT call ensureSchema — it
+   * provisions namespace + admin database idempotently and leaves the
+   * table DDL to the lock (see SurrealMigrationLock.ensureTable).
+   */
+  private async withLeaseDb<T>(fn: (db: Surreal) => Promise<T>): Promise<T> {
+    this.lockConn = await this.ensureSession(this.lockConn, 'root');
+    if (!this.leaseDbReady) {
+      await this.lockConn.query(`DEFINE NAMESPACE IF NOT EXISTS \`${this.namespace}\``);
+      await this.lockConn.use({ namespace: this.namespace });
+      await this.lockConn.query(`DEFINE DATABASE IF NOT EXISTS \`${ADMIN_DATABASE}\``);
+      this.leaseDbReady = true;
+    }
+    await this.lockConn.use({ namespace: this.namespace, database: ADMIN_DATABASE });
+    return fn(this.lockConn);
+  }
+
+  /**
    * Apply migrations to the target database. ALWAYS runs on a freshly
    * acquired root connection — migration 0005 (DEFINE USER brain_caller)
    * requires OWNER role and would otherwise fail when reached via the
@@ -662,7 +706,15 @@ export class SurrealService implements OnModuleInit, OnApplicationShutdown {
       await this.migratorConn.use({ namespace: this.namespace });
       await this.migratorConn.query(`DEFINE DATABASE IF NOT EXISTS \`${database}\``);
       await this.migratorConn.use({ namespace: this.namespace, database });
-      const result = await this.migrator.migrate(this.migratorConn);
+      // The in-process queue above orders appliers inside THIS pod only.
+      // Across replicas the arbiter is the lease, keyed per target
+      // database so tenants still migrate in parallel; a replica that
+      // loses the race waits for the holder rather than racing it, and
+      // `knownDatabases` is only marked once the manifest really landed.
+      const result = await this.migrator.migrate(this.migratorConn, {
+        lock: this.migrationLock,
+        lockName: migrationLeaseName(this.namespace, database),
+      });
       this.knownDatabases.add(database);
       if (result.applied.length > 0) {
         this.logger.log(

--- a/test/migration-concurrency.e2e-spec.ts
+++ b/test/migration-concurrency.e2e-spec.ts
@@ -1,0 +1,211 @@
+/**
+ * Two replicas booting at once against ONE empty database, on a REAL
+ * SurrealDB (testcontainers, v3.2.4).
+ *
+ * Before the lease, both replicas computed the same pending set and
+ * applied all migration files to the same database in parallel; the only
+ * arbitration was five read-conflict retries inside 320ms and a
+ * tolerated unique violation on the ledger insert. This suite pins the
+ * properties that replaced it:
+ *   - the ledger ends with exactly one row per migration, both callers
+ *     return, and neither errors;
+ *   - a replica that loses the race applies nothing (the holder had
+ *     already finished) rather than half a manifest;
+ *   - a crashed holder is taken over once its lease expires;
+ *   - the whole manifest re-applies cleanly over its own output, so a
+ *     retry after a failed run converges;
+ *   - a file and its ledger row commit in one transaction, and an aborted
+ *     one leaves neither — which is what bounds the crash window to zero,
+ *     and is exactly what a plain batch would NOT give.
+ */
+import { Surreal } from 'surrealdb';
+import { join } from 'node:path';
+import { SchemaMigrator } from '../src/db/migrator.service';
+import { migrationLeaseName, SurrealMigrationLock } from '../src/db/migration-lock';
+
+const MIGRATIONS_DIR = join(__dirname, '..', 'src', 'db', 'migrations');
+/** Own namespace: the shared container also hosts every other e2e spec. */
+const NS = `mig_conc_${Date.now()}`;
+const TARGET_DB = 'co_two_replicas';
+const LEASE_DB = 'system';
+
+interface Replica {
+  conn: Surreal;
+  leaseConn: Surreal;
+  migrator: SchemaMigrator;
+  lock: SurrealMigrationLock;
+}
+
+async function connect(): Promise<Surreal> {
+  const db = new Surreal();
+  await db.connect(process.env.SURREALDB_URL!);
+  await db.signin({
+    username: process.env.SURREALDB_USERNAME ?? 'root',
+    password: process.env.SURREALDB_PASSWORD ?? 'root',
+  });
+  return db;
+}
+
+/** One replica: a migrator conn on the target DB, a lease conn on system. */
+async function makeReplica(database: string): Promise<Replica> {
+  const conn = await connect();
+  await conn.query(`DEFINE NAMESPACE IF NOT EXISTS \`${NS}\``);
+  await conn.use({ namespace: NS });
+  await conn.query(`DEFINE DATABASE IF NOT EXISTS \`${database}\``);
+  await conn.query(`DEFINE DATABASE IF NOT EXISTS \`${LEASE_DB}\``);
+  await conn.use({ namespace: NS, database });
+
+  const leaseConn = await connect();
+  await leaseConn.use({ namespace: NS, database: LEASE_DB });
+
+  return {
+    conn,
+    leaseConn,
+    migrator: new SchemaMigrator(MIGRATIONS_DIR),
+    lock: new SurrealMigrationLock((fn) => fn(leaseConn)),
+  };
+}
+
+async function ledgerIds(conn: Surreal): Promise<string[]> {
+  const [rows] = await conn.query<[Array<{ migrationId: string }>]>(
+    `SELECT migrationId FROM schema_migrations`,
+  );
+  return (rows ?? []).map((r) => r.migrationId);
+}
+
+describe('two replicas migrating one empty database', () => {
+  const replicas: Replica[] = [];
+
+  afterAll(async () => {
+    for (const r of replicas) {
+      await r.conn.close().catch(() => undefined);
+      await r.leaseConn.close().catch(() => undefined);
+    }
+  });
+
+  it('applies the manifest exactly once and both callers return', async () => {
+    const a = await makeReplica(TARGET_DB);
+    const b = await makeReplica(TARGET_DB);
+    replicas.push(a, b);
+    const lockName = migrationLeaseName(NS, TARGET_DB);
+    const manifest = await a.migrator.loadManifest();
+
+    const started = Date.now();
+    const [resA, resB] = await Promise.all([
+      a.migrator.migrate(a.conn, { lock: a.lock, lockName }),
+      b.migrator.migrate(b.conn, { lock: b.lock, lockName }),
+    ]);
+    const elapsedMs = Date.now() - started;
+    // Reported so the lease TTL can be sanity-checked against reality.
+    console.log(
+      `[e2e] cold migration of ${manifest.length} files under contention: ${elapsedMs}ms`,
+    );
+
+    // The winner applied everything; the loser waited, re-read the ledger
+    // and found nothing left to do.
+    const applied = [...resA.applied, ...resB.applied];
+    expect(applied.length).toBe(manifest.length);
+    expect(resA.applied.length === 0 || resB.applied.length === 0).toBe(true);
+
+    // Exactly one ledger row per migration, no duplicates, nothing missing.
+    const ids = await ledgerIds(a.conn);
+    expect(ids.length).toBe(manifest.length);
+    expect([...ids].sort()).toEqual(manifest.map((m) => m.id));
+
+    // The lease is handed back, not left held.
+    const [leases] = await b.leaseConn.query<[Array<{ name: string }>]>(
+      `SELECT name FROM leader_lease`,
+    );
+    expect((leases ?? []).map((l) => l.name)).not.toContain(lockName);
+  }, 180_000);
+
+  it('is a no-op on the next boot', async () => {
+    const [a] = replicas;
+    const lockName = migrationLeaseName(NS, TARGET_DB);
+    const again = await a!.migrator.migrate(a!.conn, { lock: a!.lock, lockName });
+    expect(again.applied).toEqual([]);
+    expect(again.alreadyApplied.length).toBe((await a!.migrator.loadManifest()).length);
+  }, 60_000);
+
+  it('serialises the lease: the second aspirant is refused until release', async () => {
+    const [a, b] = replicas;
+    const name = migrationLeaseName(NS, 'lease_probe');
+    expect(await a!.lock.tryAcquire(name, 30)).toBe(true);
+    expect(await b!.lock.tryAcquire(name, 30)).toBe(false);
+    // The holder renewing is not a second holder.
+    expect(await a!.lock.tryAcquire(name, 30)).toBe(true);
+    // A non-owner cannot release it.
+    await b!.lock.release(name);
+    expect(await b!.lock.tryAcquire(name, 30)).toBe(false);
+    await a!.lock.release(name);
+    expect(await b!.lock.tryAcquire(name, 30)).toBe(true);
+    await b!.lock.release(name);
+  }, 60_000);
+
+  it('hands a crashed holder over once its lease expires', async () => {
+    const [a, b] = replicas;
+    const name = migrationLeaseName(NS, 'expiry_probe');
+    // A "crash" is a holder that never releases; the TTL is the only exit.
+    expect(await a!.lock.tryAcquire(name, 1)).toBe(true);
+    expect(await b!.lock.tryAcquire(name, 30)).toBe(false);
+    await new Promise((r) => setTimeout(r, 1500));
+    expect(await b!.lock.tryAcquire(name, 30)).toBe(true);
+    await b!.lock.release(name);
+  }, 60_000);
+
+  it('re-applies the whole manifest onto its own output without error', async () => {
+    // This is what bounds the crash window. A crash between a file and
+    // its ledger row leaves that file applied but unrecorded, so the next
+    // boot runs it again — over schema it has already created. Every file
+    // must therefore survive being applied twice, which the doctrine gate
+    // checks in form and this checks in fact.
+    const probe = await makeReplica('replay_probe');
+    replicas.push(probe);
+    const lockName = migrationLeaseName(NS, 'replay_probe');
+    const manifest = await probe.migrator.loadManifest();
+    await probe.migrator.migrate(probe.conn, { lock: probe.lock, lockName });
+
+    // Wipe the ledger only: the schema stays, as after a crash that lost
+    // every ledger row it had not written yet.
+    await probe.conn.query(`DELETE schema_migrations`);
+    const replayed = await probe.migrator.migrate(probe.conn, { lock: probe.lock, lockName });
+    expect(replayed.applied.length).toBe(manifest.length);
+    expect((await ledgerIds(probe.conn)).length).toBe(manifest.length);
+  }, 180_000);
+
+  it('rolls DDL back with an aborted transaction, and would not without one', async () => {
+    // Why `applyOne` wraps: 3.2.4 undoes DEFINE statements when the
+    // transaction aborts, so a file and its ledger row commit together or
+    // not at all. The unwrapped alternative — ledger row as the last
+    // statement of a plain batch — is strictly worse: a plain batch keeps
+    // executing after a failed statement, so the row would mark a
+    // half-applied file as done.
+    const wrapped = await makeReplica('crash_window_probe');
+    replicas.push(wrapped);
+    await wrapped.conn.query(`DEFINE TABLE IF NOT EXISTS schema_migrations SCHEMALESS`);
+    await expect(
+      wrapped.conn.query(
+        `BEGIN TRANSACTION;
+         DEFINE TABLE IF NOT EXISTS half_landed SCHEMAFULL;
+         CREATE schema_migrations CONTENT { migrationId: '9999', name: 'aborted.surql' };
+         THROW "killed mid-file";
+         COMMIT TRANSACTION;`,
+      ),
+    ).rejects.toThrow();
+    const [info] = await wrapped.conn.query<[{ tables?: Record<string, string> }]>(`INFO FOR DB`);
+    expect(Object.keys(info?.tables ?? {})).not.toContain('half_landed');
+    expect(await ledgerIds(wrapped.conn)).not.toContain('9999');
+
+    const plain = await makeReplica('plain_batch_probe');
+    replicas.push(plain);
+    await plain.conn.query(`DEFINE TABLE IF NOT EXISTS schema_migrations SCHEMALESS`);
+    await expect(
+      plain.conn.query(
+        `DEFINE TABLE IF NOT EXISTS half_landed SCHEMAFULL;
+         THROW "killed mid-file";
+         CREATE schema_migrations CONTENT { migrationId: '9999', name: 'aborted.surql' };`,
+      ),
+    ).rejects.toThrow();
+    expect(await ledgerIds(plain.conn)).toEqual(['9999']);
+  }, 120_000);
+});

--- a/test/migration-idempotence-doctrine.unit-spec.ts
+++ b/test/migration-idempotence-doctrine.unit-spec.ts
@@ -1,0 +1,116 @@
+/**
+ * GATE: every migration must be idempotent IN FORM.
+ *
+ * The migrator applies a file at most once per database, but "at most
+ * once" is not the same as "exactly once, ever": a replica whose lease
+ * expired mid-run can be taken over and the file re-applied, an aborted
+ * batch is retried in place, and a tenant restored from a snapshot can
+ * meet a manifest it has partly seen. A file that is idempotent in form
+ * survives all three; one that is not corrupts data the second time it
+ * runs.
+ *
+ * Two rules, checked over TOP-LEVEL statements only (statements inside a
+ * DEFINE FUNCTION / DEFINE EVENT body are not executed at migration
+ * time):
+ *   1. every DEFINE carries `IF NOT EXISTS` or `OVERWRITE`;
+ *   2. every data leg (UPDATE / UPSERT / DELETE / CREATE / INSERT, and
+ *      FOR loops that write) is guarded, so a second run is a no-op —
+ *      either the statement has a WHERE, or a FOR loop's source `LET`
+ *      does, or the loop body has an IF.
+ *
+ * Historical violators are allowlisted BY NAME with a reason. Add to the
+ * allowlist only for a file that already shipped; new migrations must
+ * pass.
+ */
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { leadingKeyword, oneLine, splitStatements } from './surql-statements';
+
+const MIGRATIONS_DIR = join(__dirname, '../src/db/migrations');
+
+/**
+ * Files exempt from rule 2, with the reason. These already shipped: the
+ * fix is a follow-up migration, not an edit (migration files are
+ * immutable once released).
+ */
+const UNGUARDED_DATA_LEG_ALLOWLIST: Record<string, string> = {
+  '0007_search_haystack.surql':
+    'unconditional full-table UPDATE knowledge_fact backfilling searchHaystack; ' +
+    'recomputes the same value on a re-run, so it is wasteful rather than wrong',
+};
+
+const WRITE_KEYWORDS = new Set(['UPDATE', 'UPSERT', 'DELETE', 'CREATE', 'INSERT', 'RELATE']);
+const WRITES_SOMEWHERE = new RegExp(`\\b(${[...WRITE_KEYWORDS].join('|')})\\b`, 'i');
+
+function migrationFiles(): string[] {
+  return readdirSync(MIGRATIONS_DIR)
+    .filter((f) => /^\d{4}_.+\.surql$/.test(f))
+    .sort();
+}
+
+describe('GATE: migrations are idempotent in form', () => {
+  const files = migrationFiles();
+
+  it('finds the manifest', () => {
+    expect(files.length).toBeGreaterThan(100);
+  });
+
+  it('every top-level DEFINE carries IF NOT EXISTS or OVERWRITE', () => {
+    const offenders: string[] = [];
+    for (const file of files) {
+      const sql = readFileSync(join(MIGRATIONS_DIR, file), 'utf8');
+      for (const stmt of splitStatements(sql)) {
+        if (leadingKeyword(stmt) !== 'DEFINE') continue;
+        if (!/^DEFINE\s+\w+\s+(IF\s+NOT\s+EXISTS|OVERWRITE)\b/i.test(oneLine(stmt))) {
+          offenders.push(`${file}: ${oneLine(stmt).slice(0, 100)}`);
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it('every top-level data leg is guarded so a second run is a no-op', () => {
+    const offenders: string[] = [];
+    for (const file of files) {
+      const sql = readFileSync(join(MIGRATIONS_DIR, file), 'utf8');
+      const statements = splitStatements(sql);
+      // `FOR $r IN $src { UPDATE ... }` carries its guard in the LET that
+      // built $src, so the loop is judged together with that LET.
+      const letBodies = new Map<string, string>();
+      for (const stmt of statements) {
+        const line = oneLine(stmt);
+        const bound = /^LET\s+\$(\w+)\s*=/i.exec(line);
+        if (bound) letBodies.set(bound[1]!, line);
+        const keyword = leadingKeyword(stmt);
+        const loop = keyword === 'FOR' ? /^FOR\s+\$\w+\s+IN\s+\$(\w+)\b/i.exec(line) : null;
+        const writes =
+          WRITE_KEYWORDS.has(keyword) || (keyword === 'FOR' && WRITES_SOMEWHERE.test(line));
+        if (!writes) continue;
+        const source = loop ? (letBodies.get(loop[1]!) ?? '') : '';
+        // A loop may guard either in the LET that built its source or in
+        // an IF inside the body; a bare write must carry its own WHERE.
+        const guarded =
+          /\bWHERE\b/i.test(`${line} ${source}`) || (keyword === 'FOR' && /\bIF\b/i.test(line));
+        if (guarded) continue;
+        if (UNGUARDED_DATA_LEG_ALLOWLIST[file]) continue;
+        offenders.push(`${file}: ${line.slice(0, 120)}`);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it('the allowlist names only files that really are unguarded', () => {
+    // A stale exemption is as bad as a missing one: it silently blesses
+    // the next unguarded statement someone adds to that file.
+    const stale: string[] = [];
+    for (const file of Object.keys(UNGUARDED_DATA_LEG_ALLOWLIST)) {
+      expect(files).toContain(file);
+      const sql = readFileSync(join(MIGRATIONS_DIR, file), 'utf8');
+      const unguarded = splitStatements(sql).filter(
+        (stmt) => WRITE_KEYWORDS.has(leadingKeyword(stmt)) && !/\bWHERE\b/i.test(oneLine(stmt)),
+      );
+      if (unguarded.length === 0) stale.push(file);
+    }
+    expect(stale).toEqual([]);
+  });
+});

--- a/test/migration-rolling-deploy-doctrine.unit-spec.ts
+++ b/test/migration-rolling-deploy-doctrine.unit-spec.ts
@@ -1,0 +1,120 @@
+/**
+ * GATE: a migration must stay callable by the image it is rolling out
+ * FROM, not only the one it is rolling out TO.
+ *
+ * During a rolling deploy both images serve at once, and the new image's
+ * migrations land while the old one is still taking requests. Two
+ * consequences, one enforceable here and one not:
+ *
+ * ENFORCED — stored-function signatures. `DEFINE FUNCTION OVERWRITE
+ * fn::x(...)` replaces the deployed definition for BOTH images. Measured
+ * against SurrealDB 3.2.4: a call passing more arguments than the
+ * definition takes fails ("Incorrect arguments for function fn::t(). The
+ * function expects 1 to 2 arguments"), while trailing `option<...>`
+ * parameters may be omitted and arrive as NONE. So the safe shape is
+ * append-only: every parameter the previous definition had must survive
+ * at the same position with the same name and type, and anything added
+ * must be trailing and optional. Renaming, retyping, reordering or
+ * dropping a parameter breaks the old image mid-deploy — and, on a
+ * rollback, breaks the older image against the newer schema.
+ *
+ * NOT ENFORCED — a migration that DROPS schema (`REMOVE INDEX`,
+ * `REMOVE FIELD`, `REMOVE TABLE`) must ship one release AFTER the code
+ * that declares or reads it is gone, so the still-running old image
+ * never queries a field the new migration removed. Checking that needs
+ * the PREVIOUS image's source to know what it still reads, which CI does
+ * not have. It stays a review rule, recorded here so it is at least
+ * written down next to the rule that is mechanised.
+ */
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { splitStatements } from './surql-statements';
+
+const MIGRATIONS_DIR = join(__dirname, '../src/db/migrations');
+
+interface FnDefinition {
+  file: string;
+  name: string;
+  params: string[];
+}
+
+/** `DEFINE FUNCTION [IF NOT EXISTS|OVERWRITE] fn::name($a: type, ...)`. */
+const FN_HEAD =
+  /^DEFINE\s+FUNCTION\s+(?:IF\s+NOT\s+EXISTS\s+|OVERWRITE\s+)?fn::([\w:]+)\s*\(([^)]*)\)/is;
+
+function functionDefinitions(): FnDefinition[] {
+  const files = readdirSync(MIGRATIONS_DIR)
+    .filter((f) => /^\d{4}_.+\.surql$/.test(f))
+    .sort();
+  const found: FnDefinition[] = [];
+  for (const file of files) {
+    const sql = readFileSync(join(MIGRATIONS_DIR, file), 'utf8');
+    for (const stmt of splitStatements(sql)) {
+      const head = FN_HEAD.exec(stmt.masked.trim());
+      if (!head) continue;
+      const params = head[2]!
+        .split(',')
+        .map((p) => p.trim().replace(/\s+/g, ' '))
+        .filter((p) => p.length > 0);
+      found.push({ file, name: head[1]!, params });
+    }
+  }
+  return found;
+}
+
+describe('GATE: stored-function signatures are append-only across migrations', () => {
+  const definitions = functionDefinitions();
+
+  it('parses the stored functions out of the manifest', () => {
+    expect(definitions.length).toBeGreaterThan(20);
+    expect(definitions.some((d) => d.name === 'resolve_fact')).toBe(true);
+  });
+
+  it('never renames, retypes, reorders or drops a parameter', () => {
+    const previous = new Map<string, FnDefinition>();
+    const offenders: string[] = [];
+    for (const def of definitions) {
+      const before = previous.get(def.name);
+      previous.set(def.name, def);
+      if (!before) continue;
+      for (let i = 0; i < before.params.length; i++) {
+        const was = before.params[i];
+        const now = def.params[i];
+        if (was === now) continue;
+        offenders.push(
+          `fn::${def.name} argument ${i + 1} changed from '${was}' to '${now ?? '<dropped>'}' ` +
+            `between ${before.file} and ${def.file}`,
+        );
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it('only ever appends optional parameters', () => {
+    const previous = new Map<string, FnDefinition>();
+    const offenders: string[] = [];
+    for (const def of definitions) {
+      const before = previous.get(def.name);
+      previous.set(def.name, def);
+      if (!before) continue;
+      for (const added of def.params.slice(before.params.length)) {
+        // The old image calls with the old arity; a required trailing
+        // parameter makes every one of those calls fail.
+        if (!/:\s*option</i.test(added)) {
+          offenders.push(
+            `fn::${def.name} gained required argument '${added}' in ${def.file} ` +
+              `(previous definition in ${before.file}); make it option<...>`,
+          );
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it('keeps the redefined functions genuinely redefined (the gate has something to guard)', () => {
+    const counts = new Map<string, number>();
+    for (const def of definitions) counts.set(def.name, (counts.get(def.name) ?? 0) + 1);
+    const redefined = [...counts.entries()].filter(([, n]) => n > 1).map(([name]) => name);
+    expect(redefined).toContain('resolve_fact');
+  });
+});

--- a/test/migrator.unit-spec.ts
+++ b/test/migrator.unit-spec.ts
@@ -4,14 +4,18 @@
  * We mock the Surreal connection (just `query`) and verify:
  *   - manifest loads from disk in numeric order
  *   - bootstrap DDL runs first
- *   - applied migrations are recorded in schema_migrations
+ *   - each file lands together with its ledger row in one transaction
  *   - already-applied migrations are skipped
  *   - duplicate migration IDs are detected as a config error
+ *   - the cross-replica lock is held for the whole run, a loser waits
+ *     for the holder and then applies only what is left, and the wait
+ *     has a deadline it fails on rather than serving half a schema
  */
 import { mkdtemp, writeFile, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { SchemaMigrator } from '../src/db/migrator.service';
+import { migrationLeaseName, type MigrationLock } from '../src/db/migration-lock';
 
 interface QueryCall {
   sql: string;
@@ -30,10 +34,12 @@ function makeFakeConn(initiallyApplied: string[] = []) {
       if (sql.includes('SELECT migrationId FROM schema_migrations')) {
         return [applied.map((a) => ({ migrationId: a.migrationId }))] as unknown as T;
       }
-      if (sql.startsWith('CREATE schema_migrations')) {
+      // One apply = one BEGIN/COMMIT batch carrying the file's DDL and
+      // its ledger row, so the row appears exactly when the batch commits.
+      if (sql.includes('CREATE schema_migrations CONTENT')) {
         applied.push({
-          migrationId: params!.id as string,
-          name: params!.name as string,
+          migrationId: params!.mig_id as string,
+          name: params!.mig_name as string,
         });
         return [[applied[applied.length - 1]]] as unknown as T;
       }
@@ -44,6 +50,38 @@ function makeFakeConn(initiallyApplied: string[] = []) {
   // Strip the SELECT call from the user-visible call list once: it's an
   // implementation detail of the migrator and noisy in assertions.
   return { conn, calls, applied };
+}
+
+/** A lock whose holder is scripted by the test. */
+function makeFakeLock(opts: { heldByOther?: number; failAcquires?: number } = {}) {
+  const events: string[] = [];
+  let othersTurnsLeft = opts.heldByOther ?? 0;
+  let failuresLeft = opts.failAcquires ?? 0;
+  let held = false;
+  const lock: MigrationLock & { events: string[]; isHeld: () => boolean } = {
+    events,
+    isHeld: () => held,
+    async tryAcquire(name: string, ttlSeconds: number): Promise<boolean> {
+      if (failuresLeft > 0) {
+        failuresLeft--;
+        events.push(`acquire-error:${name}`);
+        throw new Error('lease store unreachable');
+      }
+      if (othersTurnsLeft > 0) {
+        othersTurnsLeft--;
+        events.push(`busy:${name}`);
+        return false;
+      }
+      events.push(`acquire:${name}:${ttlSeconds}`);
+      held = true;
+      return true;
+    },
+    async release(name: string): Promise<void> {
+      held = false;
+      events.push(`release:${name}`);
+    },
+  };
+  return lock;
 }
 
 async function makeMigrationsDir(files: Record<string, string>): Promise<string> {
@@ -133,29 +171,231 @@ describe('SchemaMigrator', () => {
     expect(result.applied).toEqual([]);
     expect(result.alreadyApplied).toEqual(['0001']);
     expect(calls.some((c) => c.sql.includes('DEFINE TABLE a'))).toBe(false);
-    expect(calls.some((c) => c.sql.startsWith('CREATE schema_migrations'))).toBe(false);
+    expect(calls.some((c) => c.sql.includes('CREATE schema_migrations'))).toBe(false);
+  });
+
+  it('applies each file and its ledger row in one transaction', async () => {
+    // The crash window this closes: DDL that survived with no ledger row,
+    // so the next boot re-ran a file that had already half-landed.
+    dir = await makeMigrationsDir({ '0001_baseline.surql': 'DEFINE TABLE a;' });
+    const migrator = new SchemaMigrator(dir);
+    const { conn, calls } = makeFakeConn();
+    await migrator.migrate(conn as never);
+
+    const batch = calls.find((c) => c.sql.includes('DEFINE TABLE a'));
+    expect(batch).toBeDefined();
+    expect(batch!.sql.startsWith('BEGIN TRANSACTION;')).toBe(true);
+    expect(batch!.sql).toContain('CREATE schema_migrations CONTENT');
+    expect(batch!.sql.trimEnd().endsWith('COMMIT TRANSACTION;')).toBe(true);
+    // Nothing writes the ledger outside that batch.
+    expect(calls.filter((c) => c.sql.includes('CREATE schema_migrations CONTENT'))).toHaveLength(1);
+  });
+
+  it('records nothing when the batch fails', async () => {
+    dir = await makeMigrationsDir({ '0001_baseline.surql': 'DEFINE TABLE a;' });
+    const migrator = new SchemaMigrator(dir, { sleep: async () => undefined });
+    const { conn, applied } = makeFakeConn();
+    const rawQuery = conn.query.bind(conn);
+    conn.query = async <T>(sql: string, params?: Record<string, unknown>): Promise<T> => {
+      if (sql.includes('DEFINE TABLE a')) throw new Error('Parse error: nope');
+      return rawQuery<T>(sql, params);
+    };
+    await expect(migrator.migrate(conn as never)).rejects.toThrow(/0001_baseline\.surql failed/);
+    expect(applied).toEqual([]);
   });
 
   it('tolerates a concurrent applier winning the ledger insert', async () => {
-    // Two processes booting against a SHARED DB (system DB under parallel
-    // e2e, multi-pod boots) both compute the same pending set; the loser's
-    // ledger CREATE hits the UNIQUE index and must be treated as applied.
+    // A lease that expired under a live holder is the one way two
+    // appliers can still overlap. The loser's batch aborts as the bare
+    // "failed transaction" wrapper — indistinguishable from an OCC
+    // conflict — so the migrator settles it by re-reading the ledger and
+    // counts the file as applied: the DDL the racer ran was identical.
     dir = await makeMigrationsDir({
       '0001_baseline.surql': 'DEFINE TABLE a;',
     });
-    const migrator = new SchemaMigrator(dir);
-    const { conn } = makeFakeConn();
+    const migrator = new SchemaMigrator(dir, { sleep: async () => undefined });
+    const { conn, applied } = makeFakeConn();
     const rawQuery = conn.query.bind(conn);
     conn.query = async <T>(sql: string, params?: Record<string, unknown>): Promise<T> => {
-      if (sql.startsWith('CREATE schema_migrations')) {
-        throw new Error(
-          "Database index `schema_migrations_id_idx` already contains '0001', with record `schema_migrations:x`",
-        );
+      if (sql.includes('CREATE schema_migrations CONTENT')) {
+        applied.push({ migrationId: '0001', name: '0001_baseline.surql' });
+        throw new Error('The query was not executed due to a failed transaction');
       }
       return rawQuery<T>(sql, params);
     };
     const result = await migrator.migrate(conn as never);
     expect(result.applied).toEqual(['0001']);
+  });
+
+  it('retries an OCC abort and converges', async () => {
+    // NS-level DDL (0005's DEFINE USER, 0003/0006's functions) aborts
+    // under concurrency; the guards make the second attempt a no-op.
+    dir = await makeMigrationsDir({ '0001_baseline.surql': 'DEFINE TABLE a;' });
+    const migrator = new SchemaMigrator(dir, { sleep: async () => undefined });
+    const { conn, applied } = makeFakeConn();
+    const rawQuery = conn.query.bind(conn);
+    let firstTry = true;
+    conn.query = async <T>(sql: string, params?: Record<string, unknown>): Promise<T> => {
+      if (sql.includes('DEFINE TABLE a') && firstTry) {
+        firstTry = false;
+        throw new Error('Transaction read conflict');
+      }
+      return rawQuery<T>(sql, params);
+    };
+    const result = await migrator.migrate(conn as never);
+    expect(result.applied).toEqual(['0001']);
+    expect(applied.map((a) => a.migrationId)).toEqual(['0001']);
+  });
+
+  describe('cross-replica lock', () => {
+    it('holds the lock for the whole run and releases it after', async () => {
+      dir = await makeMigrationsDir({ '0001_baseline.surql': 'DEFINE TABLE a;' });
+      const migrator = new SchemaMigrator(dir, { lockTtlSeconds: 30 });
+      const { conn } = makeFakeConn();
+      const lock = makeFakeLock();
+      await migrator.migrate(conn as never, { lock, lockName: 'migrate_ns_db_0f0f' });
+
+      expect(lock.events).toEqual(['acquire:migrate_ns_db_0f0f:30', 'release:migrate_ns_db_0f0f']);
+      expect(lock.isHeld()).toBe(false);
+    });
+
+    it('releases the lock when a migration fails', async () => {
+      dir = await makeMigrationsDir({ '0001_baseline.surql': 'DEFINE TABLE a;' });
+      const migrator = new SchemaMigrator(dir, { sleep: async () => undefined });
+      const { conn } = makeFakeConn();
+      const rawQuery = conn.query.bind(conn);
+      conn.query = async <T>(sql: string, params?: Record<string, unknown>): Promise<T> => {
+        if (sql.includes('DEFINE TABLE a')) throw new Error('Parse error: nope');
+        return rawQuery<T>(sql, params);
+      };
+      const lock = makeFakeLock();
+      await expect(migrator.migrate(conn as never, { lock, lockName: 'l' })).rejects.toThrow(
+        /0001_baseline\.surql failed/,
+      );
+      expect(lock.events).toEqual(['acquire:l:30', 'release:l']);
+    });
+
+    it('waits for the holder, then applies only what is genuinely left', async () => {
+      dir = await makeMigrationsDir({
+        '0001_baseline.surql': 'DEFINE TABLE a;',
+        '0002_add_b.surql': 'DEFINE TABLE b;',
+      });
+      const slept: number[] = [];
+      const migrator = new SchemaMigrator(dir, {
+        sleep: async (ms) => {
+          slept.push(ms);
+        },
+      });
+      // The holder finished 0001 while we waited; only 0002 is left.
+      const { conn, calls } = makeFakeConn(['0001']);
+      const lock = makeFakeLock({ heldByOther: 3 });
+      const result = await migrator.migrate(conn as never, { lock, lockName: 'l' });
+
+      expect(lock.events).toEqual(['busy:l', 'busy:l', 'busy:l', 'acquire:l:30', 'release:l']);
+      expect(slept).toEqual([50, 100, 200]); // bounded exponential backoff
+      expect(result.applied).toEqual(['0002']);
+      expect(calls.some((c) => c.sql.includes('DEFINE TABLE a'))).toBe(false);
+      expect(calls.some((c) => c.sql.includes('DEFINE TABLE b'))).toBe(true);
+    });
+
+    it('never reads the ledger before it owns the lock', async () => {
+      dir = await makeMigrationsDir({ '0001_baseline.surql': 'DEFINE TABLE a;' });
+      const migrator = new SchemaMigrator(dir, { sleep: async () => undefined });
+      const { conn, calls } = makeFakeConn();
+      const lock = makeFakeLock({ heldByOther: 2 });
+      lock.tryAcquire = new Proxy(lock.tryAcquire, {
+        apply(target, thisArg, args: [string, number]) {
+          // Anything the migrator queries before it holds the lock would
+          // be a decision taken on a schema another replica is changing.
+          expect(calls).toEqual([]);
+          return Reflect.apply(target, thisArg, args) as Promise<boolean>;
+        },
+      });
+      await migrator.migrate(conn as never, { lock, lockName: 'l' });
+      expect(calls.length).toBeGreaterThan(0);
+    });
+
+    it('fails closed when the holder never lets go', async () => {
+      dir = await makeMigrationsDir({ '0001_baseline.surql': 'DEFINE TABLE a;' });
+      let clock = 0;
+      const migrator = new SchemaMigrator(dir, {
+        lockWaitMs: 500,
+        sleep: async (ms) => {
+          clock += ms;
+        },
+      });
+      const nowSpy = jest.spyOn(Date, 'now').mockImplementation(() => clock);
+      try {
+        const { conn, calls } = makeFakeConn();
+        const lock = makeFakeLock({ heldByOther: Number.MAX_SAFE_INTEGER });
+        await expect(migrator.migrate(conn as never, { lock, lockName: 'l' })).rejects.toThrow(
+          /Timed out after 500ms waiting for migration lock l — another replica is still applying/,
+        );
+        // Fail closed: nothing was applied, so the caller cannot go on to
+        // serve requests against a half-migrated database.
+        expect(calls).toEqual([]);
+      } finally {
+        nowSpy.mockRestore();
+      }
+    });
+
+    it('surfaces the lease-store error when the deadline expires on failures', async () => {
+      dir = await makeMigrationsDir({ '0001_baseline.surql': 'DEFINE TABLE a;' });
+      let clock = 0;
+      const migrator = new SchemaMigrator(dir, {
+        lockWaitMs: 300,
+        sleep: async (ms) => {
+          clock += ms;
+        },
+      });
+      const nowSpy = jest.spyOn(Date, 'now').mockImplementation(() => clock);
+      try {
+        const { conn } = makeFakeConn();
+        const lock = makeFakeLock({ failAcquires: Number.MAX_SAFE_INTEGER });
+        await expect(migrator.migrate(conn as never, { lock, lockName: 'l' })).rejects.toThrow(
+          /Timed out after 300ms waiting for migration lock l: lease store unreachable/,
+        );
+      } finally {
+        nowSpy.mockRestore();
+      }
+    });
+
+    it('retries a transient acquire failure inside the deadline', async () => {
+      dir = await makeMigrationsDir({ '0001_baseline.surql': 'DEFINE TABLE a;' });
+      const migrator = new SchemaMigrator(dir, { sleep: async () => undefined });
+      const { conn } = makeFakeConn();
+      const lock = makeFakeLock({ failAcquires: 2 });
+      const result = await migrator.migrate(conn as never, { lock, lockName: 'l' });
+      expect(lock.events).toEqual([
+        'acquire-error:l',
+        'acquire-error:l',
+        'acquire:l:30',
+        'release:l',
+      ]);
+      expect(result.applied).toEqual(['0001']);
+    });
+
+    it('stops applying when the lease is lost mid-run', async () => {
+      dir = await makeMigrationsDir({
+        '0001_baseline.surql': 'DEFINE TABLE a;',
+        '0002_add_b.surql': 'DEFINE TABLE b;',
+      });
+      // TTL 0 puts the lease permanently at half-life, so the migrator
+      // re-checks ownership before every file; the third check loses it.
+      const migrator = new SchemaMigrator(dir, { lockTtlSeconds: 0 });
+      const { conn, calls } = makeFakeConn();
+      const lock = makeFakeLock();
+      let acquires = 0;
+      const acquire = lock.tryAcquire.bind(lock);
+      lock.tryAcquire = async (name, ttl) => (++acquires > 2 ? false : acquire(name, ttl));
+
+      await expect(migrator.migrate(conn as never, { lock, lockName: 'l' })).rejects.toThrow(
+        /Lost migration lock l before applying 0002_add_b\.surql/,
+      );
+      expect(calls.some((c) => c.sql.includes('DEFINE TABLE a'))).toBe(true);
+      expect(calls.some((c) => c.sql.includes('DEFINE TABLE b'))).toBe(false);
+      expect(lock.events).toContain('release:l');
+    });
   });
 
   it('rejects duplicate migration IDs', async () => {
@@ -181,5 +421,27 @@ describe('SchemaMigrator', () => {
     const a = await migrator.loadManifest();
     const b = await migrator.loadManifest();
     expect(a).toBe(b); // same reference — cached
+  });
+});
+
+describe('migrationLeaseName', () => {
+  it('stays inside the character set a record id can carry', () => {
+    // The name is composed into `leader_lease:<name>`, so a ':' or '/'
+    // would break id parsing and a '-' would parse as minus.
+    for (const db of ['system', 'co_acme', 'co_Weird-Name_1']) {
+      expect(migrationLeaseName('brain', db)).toMatch(/^[a-z0-9_]+$/);
+    }
+  });
+
+  it('is per target database and stable', () => {
+    expect(migrationLeaseName('brain', 'co_a')).toBe(migrationLeaseName('brain', 'co_a'));
+    expect(migrationLeaseName('brain', 'co_a')).not.toBe(migrationLeaseName('brain', 'co_b'));
+    expect(migrationLeaseName('brain', 'system')).not.toBe(migrationLeaseName('other', 'system'));
+  });
+
+  it('keeps targets apart that the character fold would merge', () => {
+    // Folding alone maps both of these to the same slug; the appended
+    // digest is what stops two tenants sharing one migration lease.
+    expect(migrationLeaseName('brain', 'co_a-b')).not.toBe(migrationLeaseName('brain', 'co_a_b'));
   });
 });

--- a/test/surql-statements.ts
+++ b/test/surql-statements.ts
@@ -1,0 +1,92 @@
+/**
+ * Minimal SurrealQL statement splitter for the migration doctrine gates.
+ *
+ * Splitting on `;` alone is wrong: DEFINE FUNCTION / DEFINE EVENT bodies
+ * carry their own semicolons inside `{ ... }`, and string literals can
+ * carry anything. So comments and literals are blanked out first
+ * (keeping offsets stable) and the split then only fires on a `;` at
+ * bracket depth zero. `masked` is the comment/literal-free text to make
+ * assertions against; `raw` is the original slice for error messages.
+ */
+
+export interface SurqlStatement {
+  raw: string;
+  masked: string;
+}
+
+/** Blank out line comments, block comments and quoted literals, length-preserving. */
+export function maskNoise(sql: string): string {
+  let out = '';
+  let i = 0;
+  while (i < sql.length) {
+    const c = sql[i]!;
+    if (c === '-' && sql[i + 1] === '-') {
+      while (i < sql.length && sql[i] !== '\n') {
+        out += ' ';
+        i++;
+      }
+      continue;
+    }
+    if (c === '/' && sql[i + 1] === '*') {
+      while (i < sql.length && !(sql[i] === '*' && sql[i + 1] === '/')) {
+        out += sql[i] === '\n' ? '\n' : ' ';
+        i++;
+      }
+      out += '  ';
+      i += 2;
+      continue;
+    }
+    if (c === "'" || c === '"' || c === '`') {
+      const quote = c;
+      out += ' ';
+      i++;
+      while (i < sql.length && sql[i] !== quote) {
+        if (sql[i] === '\\') {
+          out += ' ';
+          i++;
+        }
+        out += sql[i] === '\n' ? '\n' : ' ';
+        i++;
+      }
+      out += ' ';
+      i++;
+      continue;
+    }
+    out += c;
+    i++;
+  }
+  return out;
+}
+
+/** Top-level statements of one migration file. */
+export function splitStatements(sql: string): SurqlStatement[] {
+  const masked = maskNoise(sql);
+  const found: SurqlStatement[] = [];
+  let depth = 0;
+  let start = 0;
+  const push = (end: number) => {
+    const stmt = { raw: sql.slice(start, end).trim(), masked: masked.slice(start, end).trim() };
+    if (stmt.masked.length > 0) found.push(stmt);
+  };
+  for (let i = 0; i < masked.length; i++) {
+    const c = masked[i];
+    if (c === '{' || c === '(' || c === '[') depth++;
+    else if (c === '}' || c === ')' || c === ']') depth--;
+    else if (c === ';' && depth <= 0) {
+      push(i);
+      start = i + 1;
+    }
+  }
+  push(masked.length);
+  return found;
+}
+
+/** First keyword of a statement, upper-cased. */
+export function leadingKeyword(stmt: SurqlStatement): string {
+  return (stmt.masked.trim().split(/\s+/)[0] ?? '').toUpperCase();
+}
+
+/** Collapse whitespace so a statement fits on one assertion-message line. */
+export function oneLine(stmt: SurqlStatement): string {
+  return stmt.masked.replace(/\s+/g, ' ').trim();
+}


### PR DESCRIPTION
## What

Schema migration is now arbitrated across replicas, and each migration file lands atomically.

- **`src/db/migration-lock.ts` (new)** — `SurrealMigrationLock`, a compare-and-set lock over the **same `leader_lease` table and row shape** as `LeaderLeaseService`, keyed `migrate:<ns>/<db>`. `SurrealService` cannot depend on `LeaderLeaseService` (that service injects `SurrealService`, so the reverse edge is a DI cycle), hence a minimal reimplementation rather than a call; `src/jobs/*` is untouched. The lease name is folded to `[a-z0-9_]` plus a short checksum, because lease names are composed into the record id `leader_lease:<name>`, where a `:` or `/` breaks id parsing and a `-` parses as minus. Writes use `UPSERT … SET` (not `CONTENT`) so fields this module does not know about survive a takeover. Chicken-and-egg: the lease table lives in the admin database, which is itself migrated, so the lock defines the table (idempotent `DEFINE … IF NOT EXISTS`, identical to 0029) before taking the lock for that database.
- **`migrate()` holds the lock for the whole run.** A replica that loses the race waits with bounded backoff (50ms → 2s, deadline 120s) until the holder releases *or* its lease expires — which is how a crashed holder is taken over — then re-reads the ledger and applies only what is genuinely left. Reaching the deadline **throws**; `knownDatabases` stays unset and the caller never serves against a half-migrated schema. The holder renews at half-life and aborts if it ever loses the lease mid-run.
- **Each file + its ledger row go in one `BEGIN TRANSACTION … COMMIT`**, so a crash mid-file leaves everything or nothing. All 142 files tolerate the wrapper on 3.2.4 and an aborted batch rolls the DDL back (both pinned in the e2e). The unwrapped alternative is strictly worse and is pinned too: a plain multi-statement batch **keeps executing after a failed statement**, so a trailing ledger row would mark a half-applied file as done.
- **A second root connection (`lockConn`)** is pinned to the admin database for the lease, because `migratorConn` is `use()`d to the database being migrated.
- **Two doctrine gates.** Idempotence in form: every top-level `DEFINE` carries `IF NOT EXISTS`/`OVERWRITE` and every data leg is guarded so a second run is a no-op. Rolling-deploy safety: a redefined `fn::x` may only ever *append* trailing `option<…>` parameters — measured on 3.2.4, a call with more arguments than the definition takes fails, while trailing optionals may be omitted, so append-only is exactly the shape both images survive.

TTL is 30s, wait deadline 120s; both are constructor-injectable for tests. No new env knobs or flags. No new migration files.

## Why

Audit finding: `src/db/migrator.service.ts:66–123`, driven from `ensureSchema` in `src/db/surreal.service.ts`, had **no DB-level lock** — only a process-local queue and a `knownDatabases` set. N replicas booting at once, or two images overlapping during a rolling deploy, each computed the same pending set and applied every `.surql` file to the same database in parallel. The only arbitration was five read-conflict retries inside 320ms plus a tolerated unique violation on the ledger insert; exhausting them threw out of `ensureSchema`, left `knownDatabases` unset and 500'd the tenant's first requests. Each file was applied through a single un-transacted `conn.query()`, so a crash mid-file left partial DDL with no ledger row — and `0007_search_haystack.surql:36` is an unconditional full-table `UPDATE knowledge_fact` both replicas executed.

**Non-idempotent migrations found:** exactly one — `0007_search_haystack.surql` (unconditional full-table `UPDATE knowledge_fact SET searchHaystack = …`, no `WHERE`), allowlisted by name with its reason (it recomputes the same value, so it is wasteful rather than wrong; migration files are immutable once released). Everything else is clean: 0 `DEFINE` statements without `IF NOT EXISTS`/`OVERWRITE` across ~1100 definitions, and the other top-level data legs (0014, 0033, 0063 ×2, 0095 ×2, and the `FOR`-loop backfills in 0093/0122) all carry a guard. The audit note also named 0117/0128/0138 as data legs — they are not: those files only mention `UPDATE`/`DELETE` in comments or inside stored-function bodies, which do not execute at migration time.

`fn::resolve_fact` has drifted six times (0034→0039→…→0129, 18 params → 27), always by appending trailing `option<…>` — the safe direction. Nothing enforced it; now something does.

## How verified

Empirically, on a SurrealDB 3.2.4 container:
- all files applied wrapped in `BEGIN/COMMIT`, zero failures, and the resulting `INFO FOR DB` + per-table + per-index state is **byte-identical** to applying them unwrapped (diffed); wrapping is also not slower (3946ms vs 4744ms for the same manifest);
- `BEGIN; DEFINE TABLE …; CREATE ledger …; THROW; COMMIT` leaves neither the table nor the row, while the same statements without the wrapper leave the ledger row behind;
- `fn::t($a: string, $b: option<string>)` — `fn::t('x')` returns `['x', null]`, `fn::t('x','y','z')` fails with *"expects 1 to 2 arguments"*;
- CAS lease: A acquires → B refused → A renews → expired lease taken over by B → foreign release is a no-op → owner release frees it.

Commands (rebased onto `9ad2dc0`, dependencies reinstalled):
- `pnpm typecheck` — clean.
- `pnpm lint:ci` — clean (`--max-warnings 0`).
- `pnpm format:check` — *All matched files use Prettier code style!*
- `pnpm jest --config ./test/jest-unit.json --testPathPatterns '(migrator|migration-idempotence|migration-rolling|migration-resolver|flag-budget|surreal)'` — **7 suites / 68 tests passed**.
- Full unit suite (earlier revision): **431 suites / 5271 tests passed**.
- `pnpm jest --config ./test/jest-e2e.json --testPathPatterns 'migration-concurrency'` — **1 suite / 6 tests passed**; logged *"cold migration of 142 files under contention: 1682ms"*. Two `SchemaMigrator`s race one empty database: the ledger ends with exactly one row per migration, the loser applies nothing, both callers return, the lease is handed back; a crashed holder is taken over once its lease expires; and the whole manifest re-applies cleanly over its own output.
- `pnpm jest --config ./test/jest-e2e.json --testPathPatterns '(belief-revision-chain|concurrent-single-active|evidence-grants-api)'` — 3 suites / 25 tests passed. `pnpm jest --config ./test/jest-e2e-real.json --testPathPatterns 'jobs.real-e2e'` — 1 suite / 9 tests passed (confirms `leader_lease` coexistence with `LeaderLeaseService`).

**CodeQL**: the first push tripped `js/insufficient-password-hash` (high) at `src/db/migration-lock.ts:30` — CodeQL taints `database` back to an API-key flow and then objects to hashing it with SHA-1. Fixed at the cause rather than suppressed: a lease name never needed a cryptographic digest, so the collision guard on the folded slug is a 32-bit FNV-1a checksum and `node:crypto`'s hash is gone from the file. CodeQL is green on the following push. `migrationLeaseName` gained unit tests for the record-id character set, per-target stability, and the two inputs the fold alone would merge (`co_a-b` vs `co_a_b`).

**One detour worth recording**: on the pre-#561 base, the transaction wrapper made `belief-revision-chain.e2e` fail 3 of 4 runs with `Transaction conflict: Resource busy` from `BeliefPromotionService.stampScenes`, while the schema it produced was identical either way — i.e. the wrapper only shifted boot timing and exposed a store conflict that was not being retried. #561 added that retry; on top of it the wrapper passes 4/4 and the wrapper is what ships. The earlier `engine-e2e (2)` red on this PR was the same class (`evidence-grants-api` on a root-pool acquire timeout, then this spec), and both pass in isolation here.

Deliberately left out: the global schema-apply queue still serializes every tenant on one pod, so a pod waiting out a *crashed* remote holder (≤30s) stalls its other tenants' first requests behind that wait. Bounding per-tenant waits independently means reworking that queue and belongs in its own change. Also not enforced: the "drop schema one release after the code stops declaring it" rule — CI has no access to the previous image's source — recorded as a comment in the rolling-deploy gate's header instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhrQxeisXJZEt4sg3PGyU6
