### PR TITLE
fix(review): seven integrity defects — belief CAS watermark, conditional promotion, active-pack consent, answer_cache erasure, dedupe hop

### DIFF
--- a/src/admin/belief-promotion.service.ts
+++ b/src/admin/belief-promotion.service.ts
@@ -980,8 +980,26 @@ export class BeliefPromotionService {
    * the watermark and leaves the beginning alone; a differing candidate
    * is measured against the watermark, so evidence older than what the
    * belief already saw can never revise it, whatever order it arrived in.
+   *
+   * A lost compare-and-set is CONTENTION, not a verdict: the head moved
+   * between the read and the transaction (another run revised it, or
+   * corroborated it into a later watermark), so the decision was taken
+   * against a state that no longer exists. Decide again against a fresh
+   * read, once — a second loss is counted and the group skipped.
    */
-  private async upsertBelief({
+  private async upsertBelief(args: {
+    db: BeliefDb;
+    belief: FoldedBelief;
+    promoterVersion: string;
+    edgesOn: boolean;
+    result: BeliefPromotionResult;
+  }): Promise<void> {
+    if ((await this.upsertBeliefOnce(args)) !== 'contended') return;
+    if ((await this.upsertBeliefOnce(args)) === 'contended') args.result.skippedContended += 1;
+  }
+
+  /** One attempt of the verdict above: 'contended' = nothing written. */
+  private async upsertBeliefOnce({
     db,
     belief,
     promoterVersion: runPromoterVersion,
@@ -993,7 +1011,7 @@ export class BeliefPromotionService {
     promoterVersion: string;
     edgesOn: boolean;
     result: BeliefPromotionResult;
-  }): Promise<void> {
+  }): Promise<'done' | 'contended'> {
     // Per-belief stamp: identical to the run stamp unless this belief
     // came wholly out of ONE pack world (promoterVersionFor).
     const promoterVersion = promoterVersionFor(belief, runPromoterVersion);
@@ -1035,10 +1053,7 @@ export class BeliefPromotionService {
         statement: await this.composeStatement(belief),
         logger: this.logger,
       });
-      if (!committed) {
-        result.skippedContended += 1;
-        return;
-      }
+      if (!committed) return 'contended';
       await this.stampScenes(db, belief.sceneIds, beliefRecordString(belief, 1));
       if (edgesOn) {
         result.supportEdges += await this.writeEdges(db, promoterVersion, [
@@ -1049,7 +1064,7 @@ export class BeliefPromotionService {
         ]);
       }
       result.beliefsCreated += 1;
-      return;
+      return 'done';
     }
 
     const headId = String(head.id);
@@ -1059,6 +1074,9 @@ export class BeliefPromotionService {
     // row is stamped on its next corroboration.
     const storedWatermark = epochMs(head.latestEvidenceAt);
     const headWatermark = Number.isFinite(storedWatermark) ? storedWatermark : headValidFrom;
+    // What the supersede predicate compares against: the stored value as
+    // read, or nothing at all on a legacy row (`latestEvidenceAt IS NONE`).
+    const watermark = Number.isFinite(storedWatermark) ? new Date(storedWatermark) : undefined;
 
     if (head.value === belief.value) {
       await corroborateBelief({
@@ -1083,7 +1101,7 @@ export class BeliefPromotionService {
           },
         ]);
       }
-      return;
+      return 'done';
     }
 
     // STALE GUARD against the WATERMARK, not the beginning: a differing
@@ -1100,7 +1118,7 @@ export class BeliefPromotionService {
           `the active revision ${head.revision} ('${head.value}') watermark ` +
           `${new Date(headWatermark).toISOString()} — group skipped`,
       );
-      return;
+      return 'done';
     }
     // The new state began at the first contribution of its run that is
     // past the head's watermark: a run that started before the head's
@@ -1114,7 +1132,7 @@ export class BeliefPromotionService {
           `'${belief.value}' would begin at ${revisionValidFrom.toISOString()}, not after the ` +
           `active revision ${head.revision} ('${head.value}') began — group skipped`,
       );
-      return;
+      return 'done';
     }
 
     // REVISION — supersede chain in code, never in-place: revision N+1
@@ -1134,13 +1152,10 @@ export class BeliefPromotionService {
       revision,
       promoterVersion,
       statement: await this.composeStatement(revised),
-      displaced: { id: headId, revision: head.revision, until: revisionValidFrom },
+      displaced: { id: headId, revision: head.revision, until: revisionValidFrom, watermark },
       logger: this.logger,
     });
-    if (!committed) {
-      result.skippedContended += 1;
-      return;
-    }
+    if (!committed) return 'contended';
     await this.stampScenes(db, belief.sceneIds, newId);
     // The 0106 baselineRef contract, NAMESPACED: the belief revision the
     // delta was applied against lands in `baselineRef.supersededFrom`
@@ -1170,6 +1185,7 @@ export class BeliefPromotionService {
       ]);
     }
     result.beliefsRevised += 1;
+    return 'done';
   }
 
   /** consolidatedInto ∪= [belief] on the consumed scenes (idempotent). */

--- a/src/admin/belief-revision.ts
+++ b/src/admin/belief-revision.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto';
 import type { Logger } from '@nestjs/common';
 import { RecordId, StringRecordId, type Surreal } from 'surrealdb';
-import { runTransaction } from '../db/surreal.service';
+import { isReadConflict, isUniqueViolation, runTransaction } from '../db/surreal.service';
 import type { BeliefDb, BeliefPromotionResult, FoldedBelief } from './belief-promotion.service';
 
 /**
@@ -162,6 +162,24 @@ export async function corroborateBelief({
   if (realigned) result.beliefsRealigned += 1;
 }
 
+/** The revision transaction's own aborts, verbatim. */
+const REVISION_ABORTS = [
+  'belief revision slot already holds another value',
+  'belief head moved',
+] as const;
+
+/**
+ * Contract: exactly these failures mean "another writer won this
+ * revision" — a datastore read conflict, a unique violation, or one of
+ * the transaction's own aborts. Everything else is a fault in the write
+ * path and must reach the caller as an error.
+ */
+function isRevisionLost(e: unknown): boolean {
+  if (isReadConflict(e) || isUniqueViolation(e)) return true;
+  if (!(e instanceof Error)) return false;
+  return REVISION_ABORTS.some((abort) => e.message.includes(abort));
+}
+
 /**
  * The ONE write that changes what a belief says, as a compare-and-set
  * transaction (BEGIN … COMMIT, runTransaction):
@@ -171,18 +189,24 @@ export async function corroborateBelief({
  *      would have let this run believe it wrote its value);
  *   2. INSERT IGNORE the revision (a replay of the SAME value no-ops);
  *   3. on a revise, the displaced head is stamped superseded ONLY IF it
- *      is still the active head at the revision this run read
- *      (`WHERE status = 'active' AND revision = $headRevision`); zero
+ *      is still the active head at the revision AND the watermark this
+ *      run read (`WHERE status = 'active' AND revision = $headRevision
+ *      AND (latestEvidenceAt IS NONE OR latestEvidenceAt = $wm)`); zero
  *      rows stamped means the head moved under us — abort, which also
  *      rolls the INSERT back (verified on 3.2.4: THROW inside the
- *      transaction cancels every prior statement).
+ *      transaction cancels every prior statement). The watermark belongs
+ *      in the predicate because a corroboration changes neither status
+ *      nor revision: without it a revise decided against a January
+ *      watermark still committed over a head another run had already
+ *      confirmed into March.
  * The statement text is composed by the caller BEFORE this call (the
  * optional LLM call must not sit inside a database transaction).
  *
- * Returns false when the transaction was lost — nothing written, the
- * next run recomputes the key from its evidence. Any other failure is
- * reported the same way: the caller's contract is "did my revision
- * land", and it did not.
+ * Returns false when the revision was LOST to a concurrent writer —
+ * nothing written, the caller re-reads and decides again. Every other
+ * failure (a schema rejection, a dead connection) is a broken write path
+ * and is rethrown: a write that cannot work must not read as harmless
+ * contention forever.
  */
 export async function commitRevision({
   db,
@@ -198,7 +222,16 @@ export async function commitRevision({
   revision: number;
   promoterVersion: string;
   statement: { text: string; source: 'template' | 'llm' };
-  displaced?: { id: string; revision: number; until: Date } | undefined;
+  displaced?:
+    | {
+        id: string;
+        revision: number;
+        until: Date;
+        /** The head's stored `latestEvidenceAt` as the caller read it;
+         *  omitted for a legacy row that carried none. */
+        watermark?: Date | undefined;
+      }
+    | undefined;
   logger: Logger;
 }): Promise<boolean> {
   const newId = new RecordId('semantic_belief', beliefIdTail(belief, revision));
@@ -234,11 +267,13 @@ export async function commitRevision({
       if (displaced) {
         tx.bind('headId', new StringRecordId(displaced.id))
           .bind('headRevision', displaced.revision)
-          .bind('until', displaced.until);
+          .bind('until', displaced.until)
+          .bind('wm', displaced.watermark ?? null);
         tx.add(
           `LET $stamped = (UPDATE $headId SET status = 'superseded', supersededBy = $newId, ` +
             `validUntil = $until, updatedAt = time::now() ` +
-            `WHERE status = 'active' AND revision = $headRevision RETURN AFTER)`,
+            `WHERE status = 'active' AND revision = $headRevision ` +
+            `AND (latestEvidenceAt IS NONE OR latestEvidenceAt = $wm) RETURN AFTER)`,
         );
         tx.add(`IF array::len($stamped) = 0 { THROW 'belief head moved' }`);
       }
@@ -246,6 +281,7 @@ export async function commitRevision({
     });
     return true;
   } catch (e) {
+    if (!isRevisionLost(e)) throw e;
     logger.warn(
       `belief promotion contended: (${belief.subject}, ${belief.field}) revision ${revision} ` +
         `for user ${belief.userId} lost to a concurrent writer — nothing written, the next ` +

--- a/src/compaction/promotion-runner.service.ts
+++ b/src/compaction/promotion-runner.service.ts
@@ -384,14 +384,28 @@ export class PromotionRunnerService {
     // their content, or a summary next to five still-active originals.
     // Record-id params — 3.x does not coerce string↔record (see
     // compaction-runner).
+    //
+    // Atomic is not enough: the members were selected BEFORE the awaited
+    // summary + embedding window, so the close carries the full member
+    // predicate and its row count is checked against what was
+    // summarised. A member retracted or already compacted inside the
+    // window (a second pass over the same group) makes the counts differ
+    // and THROWS — the group is skipped, not promoted over content that
+    // moved. Nothing is written, the CREATE included.
     const ids = members.map((m) => new StringRecordId(String(m.id)));
     const createdRows = await runTransaction<Array<{ id: unknown }> | undefined>(db, (tx) => {
-      tx.add(`LET $created = (CREATE knowledge_fact CONTENT $doc RETURN AFTER)`).bind('doc', doc);
+      tx.bind('doc', doc).bind('ids', ids).bind('expected', ids.length);
       tx.add(
-        `UPDATE knowledge_fact
+        `LET $closed = (UPDATE knowledge_fact
            SET status = 'compacted', embedding = NONE
-           WHERE id INSIDE $ids`,
-      ).bind('ids', ids);
+           WHERE id INSIDE $ids AND status = 'active' AND retractedAt IS NONE
+           RETURN AFTER)`,
+      );
+      tx.add(
+        `IF array::len($closed) != $expected ` +
+          `{ THROW 'promotion members moved under the summary' }`,
+      );
+      tx.add(`LET $created = (CREATE knowledge_fact CONTENT $doc RETURN AFTER)`);
       tx.add(`RETURN $created`);
     });
     const summary = createdRows?.[0];

--- a/src/documents/document-store.service.ts
+++ b/src/documents/document-store.service.ts
@@ -21,7 +21,12 @@ import { idTailOf, redactPii } from '../ingest/ingest-utils';
 import { MetricsService } from '../metrics/metrics.service';
 import { scopeForUser } from '../auth/scope-tags';
 import { chunkDocument, DocumentChunk } from './chunker';
-import { mergeDocumentMeta, reservedKeysIn, type DocumentWriteOrigin } from './document-meta';
+import {
+  mergeDocumentMeta,
+  reservedKeysIn,
+  type DocumentWriteOrigin,
+  type InternalDocumentMeta,
+} from './document-meta';
 import { markFactsProvenancePurged, purgeDocumentChunks } from './document-purge.util';
 import { IngestDocumentDto } from './dto/ingest-document.dto';
 
@@ -211,9 +216,59 @@ export class DocumentStoreService {
           `document dedupe hit contentHash=${contentHash.slice(0, 12)}… doc=${existing.id}`,
         );
         this.metrics?.countDocument('deduplicated');
-        return { doc: existing, chunks, deduplicated: true };
+        const doc = await this.adoptInternalMeta(db, existing, origin.internal);
+        return { doc, chunks, deduplicated: true };
       }
     });
+  }
+
+  /**
+   * A dedupe hit returns the row that already exists, so the brain-owned
+   * provenance THIS request carried has nowhere to land. The 0111
+   * tool-observation hop is merged onto the stored header when that
+   * header has none: the bytes are byte-identical and in the same user
+   * scope (fenced above), the ref was verified for this tenant, and the
+   * commit writer reads the hop off the header — so without the merge a
+   * re-post's verified observation is dropped from every fact committed
+   * afterwards, with only a generic dedupe line in the log.
+   *
+   * Never overwritten: a header that already carries a hop keeps it (one
+   * true observation must not displace another), and the origin
+   * identifiers (conversationId / messageId / eventId) name the turn the
+   * header was first stored for. Those keys are reported at warn with the
+   * document id instead of being written or swallowed.
+   */
+  private async adoptInternalMeta(
+    db: Surreal,
+    existing: StoredDocument,
+    internal: InternalDocumentMeta | undefined,
+  ): Promise<StoredDocument> {
+    if (internal === undefined) return existing;
+    const stored: Record<string, unknown> = existing.meta ?? {};
+    const adoptHop =
+      typeof internal.toolObservationRef === 'string' &&
+      typeof stored['toolObservationRef'] !== 'string';
+    const patch: Record<string, string> = {};
+    const dropped: string[] = [];
+    for (const [key, value] of Object.entries(internal)) {
+      if (typeof value !== 'string') continue;
+      const isHop = key === 'toolObservationRef' || key === 'toolObservationNote';
+      if (isHop && adoptHop) patch[key] = value;
+      else if (stored[key] !== value) dropped.push(key);
+    }
+    if (dropped.length > 0) {
+      this.logger.warn(
+        `document dedupe hit doc=${existing.id} dropped internal meta: ${dropped.join(', ')}`,
+      );
+    }
+    if (Object.keys(patch).length === 0) return existing;
+    const meta = { ...stored, ...patch };
+    await db.query(`UPDATE type::record('source_document', $id) SET meta = $meta`, {
+      id: idTailOf(existing.id),
+      meta,
+    });
+    this.logger.log(`document dedupe hit doc=${existing.id} adopted the tool-observation hop`);
+    return { ...existing, meta };
   }
 
   async getById(companyId: string, docId: string): Promise<StoredDocument | null> {

--- a/src/entities/entity-forget.service.ts
+++ b/src/entities/entity-forget.service.ts
@@ -250,6 +250,7 @@ export class EntityForgetService {
           .bind('forgottenBy', actorKeyHash ?? 'unknown')
           .bind('forgottenAt', forgottenAt)
           .bind('feedbackIds', feedbackIds)
+          .bind('factIdStrings', factIds)
           .bind('artifactIds', artifactIds)
           .bind('purgeDocs', docPlan.exclusiveDocRefs)
           .bind('purgedSourceChunks', purgedSourceChunks);
@@ -263,6 +264,9 @@ export class EntityForgetService {
         // pre-collect comment above).
         tx.add(`DELETE fact_usage WHERE factId.entityId = $ent`);
         tx.add(`DELETE $feedbackIds`);
+        // answer_cache (0091/0136): the cached ANSWER TEXT is a copy of
+        // what the erased rows said — see addAnswerCachePurgeLeg.
+        this.addAnswerCachePurgeLeg(tx);
         // Scenes (0106): a scene whose membership quotes an erased episode
         // goes whole, with ALL its member rows (mixed-subject scenes lose
         // the scene, other subjects keep their own facts) — members before
@@ -726,6 +730,22 @@ export class EntityForgetService {
       // A partial batch means the subject's raw rows are drained.
       if (((batch as unknown[]) ?? []).length < 5000) break;
     }
+  }
+
+  /**
+   * answer_cache (0091/0136) in-tx leg. A cached entry keeps the ANSWER
+   * TEXT beside the record-id STRINGS it was grounded in, so an entry
+   * citing this entity or one of its facts holds a copy of what is being
+   * erased — check-on-read only stops it from SERVING. Uncounted in
+   * txRecordCount, like fact_usage: regenerable bookkeeping. Two-step
+   * LET→DELETE, the repo idiom for every delete-by-predicate.
+   */
+  private addAnswerCachePurgeLeg(tx: TxBuilder): void {
+    tx.add(
+      `LET $ansIds = (SELECT VALUE id FROM answer_cache
+         WHERE entityIds CONTAINS $needle OR citedFactIds CONTAINSANY $factIdStrings)`,
+    );
+    tx.add(`DELETE $ansIds`);
   }
 
   /**

--- a/src/entities/user-forget.service.ts
+++ b/src/entities/user-forget.service.ts
@@ -332,6 +332,20 @@ export class UserForgetService {
         evidenceGrantsDeleted,
       } = await this.eraseEvidenceRows(db, companyId, userId);
 
+      // answer_cache (0091/0136): a cached entry keeps the ANSWER TEXT
+      // beside the record-id strings it was grounded in. Check-on-read
+      // stops it serving, but erasure is about the bytes, so the rows go:
+      // this user's own entries plus any tenant-global entry quoting one
+      // of the user's facts or personal entities. LET-select-ids → DELETE
+      // (the 3.2.4 compound-index planner contract).
+      await db.query(
+        `LET $ansIds = (SELECT VALUE id FROM answer_cache
+           WHERE userId = $u OR citedFactIds CONTAINSANY $facts
+              OR entityIds CONTAINSANY $ents);
+         DELETE $ansIds;`,
+        { u: userId, facts: factIds, ents: entityIds },
+      );
+
       // Purge the materialised audit mirror (same contract as entity
       // forget): recordId is the full `table:id` string. The changefeed
       // consumer's PII redaction covers any still-unconsumed lag.

--- a/src/evidence/processor-broker.service.ts
+++ b/src/evidence/processor-broker.service.ts
@@ -271,11 +271,14 @@ export class EvidenceProcessorBrokerService {
         `SELECT * FROM type::record('evidence_asset', $tail) LIMIT 1`,
         { tail: idTailOf(req.assetId) },
       );
-      // Direct row read — no admin-module import, no DI cycle.
+      // Direct row read — no admin-module import, no DI cycle. ACTIVE
+      // installs only: uninstall keeps the row (status = 'removed') with
+      // its manifest and accepted-modality checksum, and a removed pack
+      // authorises no processing of raw bytes — it reads as not installed.
       const packRow = await queryFirst<PackRow>(
         db,
         `SELECT manifest, acceptedModalities, acceptedModalitiesChecksum
-           FROM domain_pack WHERE packId = $p LIMIT 1`,
+           FROM domain_pack WHERE packId = $p AND status = 'active' LIMIT 1`,
         { p: req.packId },
       );
       return { asset: assetRow, pack: packRow };

--- a/src/synthesize/fragment-lane.service.ts
+++ b/src/synthesize/fragment-lane.service.ts
@@ -113,7 +113,11 @@ export class FragmentLaneService {
       // Fence 4 (0112): tenant-level consent — absent/stale ⇒ EMPTY.
       const consented = await this.surreal.withCompany(opts.companyId, async (db) => {
         const [rows] = await db.query<[ModalityConsentRow[]]>(
-          `SELECT manifest, acceptedModalities, acceptedModalitiesChecksum FROM domain_pack`,
+          // ACTIVE installs only: uninstall keeps the row (status =
+          // 'removed') with its manifest and accepted-modality checksum,
+          // so a removed pack must not go on consenting to derived text.
+          `SELECT manifest, acceptedModalities, acceptedModalitiesChecksum FROM domain_pack
+            WHERE status = 'active'`,
         );
         return hasCurrentModalityConsent(rows ?? []);
       });
@@ -253,7 +257,9 @@ export class FragmentLaneService {
     const { piiGate, userFence } = this.rowFences(opts.callerScopes, opts.userId);
     const rows = await this.surreal.withCompany(opts.companyId, async (db) => {
       const [consentRows] = await db.query<[ModalityConsentRow[]]>(
-        `SELECT manifest, acceptedModalities, acceptedModalitiesChecksum FROM domain_pack`,
+        // ACTIVE installs only — same fence as fragmentLines above.
+        `SELECT manifest, acceptedModalities, acceptedModalitiesChecksum FROM domain_pack
+          WHERE status = 'active'`,
       );
       if (!hasCurrentModalityConsent(consentRows ?? [])) return [];
       const [reprRows] = await db.query<[Array<{ id?: unknown; content?: unknown }>]>(

--- a/test/belief-promotion.unit-spec.ts
+++ b/test/belief-promotion.unit-spec.ts
@@ -509,6 +509,10 @@ describe('orphan absorb (SCENES_BELIEF_FIELD_FOLD — run()-level, fake db)', ()
     conversationIds: string[];
   }
 
+  /** A stored datetime (Date or ISO string) as epoch ms. */
+  const epoch = (v: unknown): number =>
+    v instanceof Date ? v.getTime() : new Date(String(v)).getTime();
+
   /**
    * Minimal stateful SurrealDB double for the promotion pass: routes the
    * service's exact SQL shapes onto an in-memory semantic_belief store
@@ -520,7 +524,7 @@ describe('orphan absorb (SCENES_BELIEF_FIELD_FOLD — run()-level, fake db)', ()
     sceneHeads: PromotableSceneHead[] = [];
     sql: string[] = [];
     /** Runs right before a commitRevision transaction — a concurrent writer's move. */
-    beforeTransaction?: () => void;
+    beforeTransaction?: (() => void) | undefined;
 
     async query(sqlText: string, params: Record<string, unknown> = {}): Promise<unknown> {
       this.sql.push(sqlText);
@@ -570,7 +574,18 @@ describe('orphan absorb (SCENES_BELIEF_FIELD_FOLD — run()-level, fake db)', ()
         }
         if (p.headId !== undefined) {
           const head = this.rows.find((r) => r.id === String(p.headId));
-          if (head === undefined || head.status !== 'active' || head.revision !== p.headRevision) {
+          // The guarded stamp models the FULL predicate: status, revision
+          // AND the watermark the run read (a corroboration moves only the
+          // watermark, so without it the CAS misses a moved head).
+          const boundWm = p.wm === null || p.wm === undefined ? undefined : epoch(p.wm);
+          const rowWm =
+            head?.latestEvidenceAt === undefined ? undefined : epoch(head.latestEvidenceAt);
+          if (
+            head === undefined ||
+            head.status !== 'active' ||
+            head.revision !== p.headRevision ||
+            (rowWm !== undefined && rowWm !== boundWm)
+          ) {
             throw new Error('The query was not executed due to a failed transaction');
           }
           head.status = 'superseded';
@@ -991,20 +1006,72 @@ describe('orphan absorb (SCENES_BELIEF_FIELD_FOLD — run()-level, fake db)', ()
       expect(db.sql.some((s) => s.includes('userIds CONTAINSANY $users'))).toBe(true);
     });
 
-    it('a revision is one compare-and-set transaction; a head that moved under the run is not revised twice', async () => {
+    it('a head that moved under the run is not revised twice: the verdict is taken again against the head that now exists', async () => {
       const db = new FakeBeliefDb();
       db.rows = [headA({ latestEvidenceAt: at('01-01') })];
       db.sceneHeads = [evidence('t2', '02-01', 'B', 'A')];
-      // Another writer supersedes the head between this run's read and
-      // its transaction — the guarded stamp matches zero rows and the
-      // whole write (INSERT included) is abandoned.
+      // Another writer's revise lands between this run's head read and
+      // its transaction: the guarded stamp matches zero rows, the write
+      // (INSERT included) is abandoned whole, and the retry judges the
+      // candidate against the head that actually exists now — which
+      // already says B, so this run only corroborates it.
       db.beforeTransaction = () => {
+        db.beforeTransaction = undefined;
         db.rows[0]!.status = 'superseded';
+        db.rows.push(
+          belief({
+            id: 'semantic_belief:rival2',
+            subject: 'alice',
+            field: 'city',
+            value: 'B',
+            priorValue: 'A',
+            revision: 2,
+            validFrom: at('02-01'),
+            latestEvidenceAt: at('02-01'),
+            sourceSceneIds: [],
+            conversationIds: [],
+          }),
+        );
+      };
+      const res = await makeRunService(db).run('co_test');
+      expect(res).toMatchObject({ beliefsRevised: 0, beliefsCreated: 0, skippedContended: 0 });
+      expect(db.rows.filter((r) => r.status === 'active')).toHaveLength(1);
+      expect(db.active('city', 'alice')).toMatchObject({ value: 'B', revision: 2 });
+      expect(db.sql.filter((s) => s.startsWith('BEGIN TRANSACTION'))).toHaveLength(1);
+    });
+
+    it('a head that keeps moving is counted as contended after one retry, never written', async () => {
+      const db = new FakeBeliefDb();
+      db.rows = [headA({ latestEvidenceAt: at('01-01') })];
+      db.sceneHeads = [evidence('t2', '02-01', 'B', 'A')];
+      // The head's revision moves after every read — both attempts lose.
+      db.beforeTransaction = () => {
+        db.rows[0]!.revision += 1;
       };
       const res = await makeRunService(db).run('co_test');
       expect(res).toMatchObject({ skippedContended: 1, beliefsRevised: 0, beliefsCreated: 0 });
       expect(db.rows).toHaveLength(1);
-      expect(db.sql.filter((s) => s.startsWith('BEGIN TRANSACTION'))).toHaveLength(1);
+      expect(db.sql.filter((s) => s.startsWith('BEGIN TRANSACTION'))).toHaveLength(2);
+    });
+
+    it('a corroboration between the read and the transaction stops the revise: the watermark is in the predicate', async () => {
+      // The window is the awaited statement composition. Another run
+      // confirms A into March while this run still believes the watermark
+      // is January — its revise to B (February validity) must not land,
+      // or A would be superseded with a validUntil BEFORE its own latest
+      // evidence.
+      const db = new FakeBeliefDb();
+      db.rows = [headA({ latestEvidenceAt: at('01-01') })];
+      db.sceneHeads = [evidence('t2', '02-01', 'B', 'A')];
+      db.beforeTransaction = () => {
+        db.beforeTransaction = undefined;
+        db.rows[0]!.latestEvidenceAt = new Date(at('03-01'));
+      };
+      const res = await makeRunService(db).run('co_test');
+      expect(res).toMatchObject({ beliefsRevised: 0, beliefsCreated: 0, skippedStale: 1 });
+      expect(db.rows).toHaveLength(1);
+      expect(db.rows[0]).toMatchObject({ value: 'A', status: 'active', revision: 1 });
+      expect(db.rows[0]!.validUntil).toBeUndefined();
     });
 
     it('the revise transaction carries the new row AND the guarded supersede stamp together', async () => {
@@ -1015,7 +1082,10 @@ describe('orphan absorb (SCENES_BELIEF_FIELD_FOLD — run()-level, fake db)', ()
       expect(res).toMatchObject({ beliefsRevised: 1, skippedContended: 0 });
       const tx = db.sql.find((s) => s.startsWith('BEGIN TRANSACTION'))!;
       expect(tx).toContain('INSERT IGNORE INTO semantic_belief $rows');
-      expect(tx).toContain("WHERE status = 'active' AND revision = $headRevision RETURN AFTER");
+      expect(tx).toContain(
+        "WHERE status = 'active' AND revision = $headRevision " +
+          'AND (latestEvidenceAt IS NONE OR latestEvidenceAt = $wm) RETURN AFTER',
+      );
       expect(tx).toContain("THROW 'belief head moved'");
       expect(tx).toContain('COMMIT TRANSACTION');
       const [rev1, rev2] = [...db.rows].sort((a, b) => a.revision - b.revision);

--- a/test/belief-revision-chain.e2e-spec.ts
+++ b/test/belief-revision-chain.e2e-spec.ts
@@ -226,6 +226,53 @@ describe('belief revision chain: two clocks + compare-and-set (e2e)', () => {
     expect(iso(head!.validFrom)).toBe(MAR); // no interlude after March — kept
   });
 
+  it('a corroboration between the head read and the commit stops the revise', async () => {
+    // The window is the awaited statement composition between the head
+    // SELECT and the transaction. Another run confirms A into March in
+    // there — an in-place update that changes neither status nor revision
+    // — so a supersede guarded on those two alone still committed: A ended
+    // up superseded with a February validUntil although its own latest
+    // evidence was March.
+    const user = 'wm_race_user';
+    await seedScene({ tail: 'wmr_a1', user, conv: 'wmr:c1', at: JAN, value: 'A' });
+    expect(await promoteConv('wmr:c1')).toMatchObject({ beliefsCreated: 1 });
+    await seedScene({ tail: 'wmr_b2', user, conv: 'wmr:c2', at: FEB, value: 'B' });
+
+    const svc = f.app.get(BeliefPromotionService) as unknown as {
+      composeStatement: (b: FoldedBelief) => Promise<{ text: string; source: 'template' | 'llm' }>;
+    };
+    const compose = svc.composeStatement.bind(svc);
+    let corroborated = false;
+    svc.composeStatement = async (b: FoldedBelief) => {
+      if (!corroborated) {
+        corroborated = true;
+        await db(async (d) => {
+          await d.query(
+            `UPDATE type::record('semantic_belief', $tail)
+               SET latestEvidenceAt = <datetime>$mar, corroborationCount = corroborationCount + 1`,
+            { tail: beliefIdTail({ userId: user, subject: 'alice', field: 'city' }, 1), mar: MAR },
+          );
+        });
+      }
+      return compose(b);
+    };
+    let res: Awaited<ReturnType<typeof promoteConv>>;
+    try {
+      res = await promoteConv('wmr:c2');
+    } finally {
+      svc.composeStatement = compose;
+    }
+    expect(corroborated).toBe(true);
+    // Nothing written: the retry judged B against the watermark it found.
+    expect(res).toMatchObject({ beliefsRevised: 0, beliefsCreated: 0, skippedStale: 1 });
+    const chain = await chainOf(user);
+    expect(chain).toHaveLength(1);
+    expect(chain[0]).toMatchObject({ value: 'A', revision: 1, status: 'active' });
+    expect(chain[0]!.validUntil).toBeFalsy();
+    expect(chain[0]!.supersededBy).toBeFalsy();
+    expect(iso(chain[0]!.latestEvidenceAt)).toBe(MAR);
+  });
+
   it('two concurrent runs revising one key leave exactly one active head', async () => {
     const user = 'race_user';
     await seedScene({ tail: 'rc_a', user, conv: 'rc:c0', at: JAN, value: 'A' });
@@ -269,7 +316,13 @@ describe('belief revision chain: two clocks + compare-and-set (e2e)', () => {
     // The compare-and-set, driven directly: two writers, two values, one
     // revision slot — on two separate pool connections.
     const logger = new Logger('belief-revision-chain.e2e');
-    const displaced = { id: String(head!.id), revision: 1, until: new Date(FEB) };
+    const displaced = {
+      id: String(head!.id),
+      revision: 1,
+      until: new Date(FEB),
+      // The watermark the head carries — the supersede predicate checks it.
+      watermark: new Date(JAN),
+    };
     const commit = (value: string) =>
       db((d) =>
         commitRevision({

--- a/test/belief-revision-commit.unit-spec.ts
+++ b/test/belief-revision-commit.unit-spec.ts
@@ -1,0 +1,141 @@
+/**
+ * The belief revision compare-and-set, error classification (audit
+ * 2026-09-09).
+ *
+ * `commitRevision` returning false means ONE thing to its caller: another
+ * writer won this revision, nothing was written, decide again. Every
+ * failure used to be reported that way — a schema rejection or a lost
+ * connection was warned as contention and counted as `skippedContended`,
+ * so a write path that could never work read as harmless contention
+ * forever. Only a read conflict, a unique violation and the
+ * transaction's own two aborts are contention now; anything else is
+ * rethrown.
+ */
+import type { Logger } from '@nestjs/common';
+import { commitRevision } from '../src/admin/belief-revision';
+import type { BeliefDb, FoldedBelief } from '../src/admin/belief-promotion.service';
+
+const belief = (): FoldedBelief => ({
+  userId: 'u1',
+  subject: 'alice',
+  field: 'city',
+  value: 'Porto',
+  priorValue: 'Lisbon',
+  displacedValue: 'Lisbon',
+  displacedAt: new Date('2026-01-01T00:00:00.000Z'),
+  validFrom: new Date('2026-02-01T00:00:00.000Z'),
+  evidenceAt: new Date('2026-02-01T00:00:00.000Z'),
+  runEvidenceAt: [new Date('2026-02-01T00:00:00.000Z')],
+  sceneIds: [],
+  allSceneIds: [],
+  conversationIds: [],
+  confidence: 0.8,
+  worlds: [],
+});
+
+const logger = { warn: jest.fn(), debug: jest.fn(), log: jest.fn() } as unknown as Logger;
+
+/** A db whose transaction fails exactly the way the driver reports it. */
+const failing = (make: () => Error): BeliefDb => ({
+  query: <T>(): Promise<T> => Promise.reject(make()),
+});
+
+const commit = (db: BeliefDb): Promise<boolean> =>
+  commitRevision({
+    db,
+    belief: belief(),
+    revision: 2,
+    promoterVersion: 'belief-promotion-v1',
+    statement: { text: 'alice — city: Porto (was: Lisbon)', source: 'template' },
+    displaced: {
+      id: 'semantic_belief:head',
+      revision: 1,
+      until: new Date('2026-02-01T00:00:00.000Z'),
+      watermark: new Date('2026-01-01T00:00:00.000Z'),
+    },
+    logger,
+  });
+
+/** The wrapper shape runTransaction enriches, with a per-statement cause. */
+const wrapped = (cause: string): Error => {
+  const err = new Error('The query was not executed due to a failed transaction');
+  (err as Error & { cause?: unknown }).cause = new Error(cause);
+  return err;
+};
+
+beforeEach(() => jest.clearAllMocks());
+
+describe('commitRevision reports contention, and only contention, as false', () => {
+  it('a datastore read conflict is contention', async () => {
+    await expect(
+      commit(
+        failing(
+          () =>
+            new Error(
+              'Failed to commit transaction due to a read or write conflict. ' +
+                'This transaction can be retried',
+            ),
+        ),
+      ),
+    ).resolves.toBe(false);
+  });
+
+  it('a unique violation is contention', async () => {
+    await expect(
+      commit(failing(() => new Error('Database record `semantic_belief:x` already exists'))),
+    ).resolves.toBe(false);
+  });
+
+  it("the transaction's own aborts are contention", async () => {
+    await expect(
+      commit(failing(() => wrapped('An error occurred: belief head moved'))),
+    ).resolves.toBe(false);
+    await expect(
+      commit(
+        failing(() =>
+          wrapped('An error occurred: belief revision slot already holds another value'),
+        ),
+      ),
+    ).resolves.toBe(false);
+  });
+
+  it('a schema rejection is rethrown, not warned as contention', async () => {
+    await expect(
+      commit(
+        failing(() =>
+          wrapped(
+            "Found 'later' for field `latestEvidenceAt`, with record " +
+              '`semantic_belief:x`, but expected a datetime',
+          ),
+        ),
+      ),
+    ).rejects.toThrow('expected a datetime');
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('a lost connection is rethrown, not warned as contention', async () => {
+    await expect(
+      commit(failing(() => new Error('There was a problem with the datastore: connection closed'))),
+    ).rejects.toThrow('connection closed');
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+});
+
+describe('the supersede predicate carries the watermark the caller read', () => {
+  it('binds $wm and guards latestEvidenceAt in the same UPDATE', async () => {
+    const seen: Array<{ sql: string; vars: Record<string, unknown> | undefined }> = [];
+    const db: BeliefDb = {
+      query: <T>(sql: string, vars?: Record<string, unknown>): Promise<T> => {
+        seen.push({ sql, vars });
+        return Promise.resolve([null, null, null, null, null, true, null] as unknown as T);
+      },
+    };
+    await expect(commit(db)).resolves.toBe(true);
+    const tx = seen[0]!;
+    expect(tx.sql).toContain(
+      "WHERE status = 'active' AND revision = $headRevision " +
+        'AND (latestEvidenceAt IS NONE OR latestEvidenceAt = $wm)',
+    );
+    expect(tx.vars?.wm).toEqual(new Date('2026-01-01T00:00:00.000Z'));
+  });
+});

--- a/test/compaction.unit-spec.ts
+++ b/test/compaction.unit-spec.ts
@@ -472,7 +472,7 @@ describe('PromotionRunnerService — summary episode stamping', () => {
           // BEGIN, LET (create), UPDATE (compact), RETURN, COMMIT — the
           // 3.x slot shape runTransaction reads the RETURN from.
           created.push(params!.doc as Record<string, unknown>);
-          return [null, null, [], [{ id: 'knowledge_fact:summary1' }], null] as unknown as R;
+          return [null, [], null, [], [{ id: 'knowledge_fact:summary1' }], null] as unknown as R;
         }
         return [[]] as unknown as R;
       },
@@ -582,9 +582,11 @@ describe('summary runners — derived_from edge mirror (PROVENANCE_SUPPORT_EDGES
           return [candidates] as unknown as R;
         }
         if (sql.startsWith('BEGIN TRANSACTION')) {
-          // Promotion: create + compact in one batch (BEGIN, LET, UPDATE, RETURN, COMMIT).
+          // Promotion: guarded close + create in one batch
+          // (BEGIN, LET $closed, IF, LET $created, RETURN, COMMIT).
           return [
             null,
+            [],
             null,
             [],
             [{ ...(params!.doc as object), id: 'knowledge_fact:sum1' }],

--- a/test/document-dedupe-hop.unit-spec.ts
+++ b/test/document-dedupe-hop.unit-spec.ts
@@ -1,0 +1,128 @@
+/**
+ * A dedupe hit must not swallow the provenance the request carried
+ * (audit 2026-09-09).
+ *
+ * Re-posting byte-identical text returns the EXISTING header row, so a
+ * freshly verified `toolObservationRef` had nowhere to land: the commit
+ * writer reads the 0111 hop off the header, so every fact committed
+ * afterwards lacked it and the log said only "dedupe hit". The hop is
+ * merged onto a header that has none; a header that already carries one
+ * keeps it, and the origin identifiers (which name the header's first
+ * turn) are reported at warn with the document id — never written, never
+ * dropped in silence.
+ */
+import { Logger } from '@nestjs/common';
+import { DocumentStoreService } from '../src/documents/document-store.service';
+import type { SurrealService } from '../src/db/surreal.service';
+import type { IngestDocumentDto } from '../src/documents/dto/ingest-document.dto';
+import type { InternalDocumentMeta } from '../src/documents/document-meta';
+
+const TEXT = 'Fetched report: Acme is platinum tier.';
+
+const dto = (): IngestDocumentDto =>
+  ({
+    kind: 'markdown',
+    text: TEXT,
+    occurredAt: '2026-09-01T10:00:00.000Z',
+    contextRef: { vertical: 'crm' },
+  }) as IngestDocumentDto;
+
+interface Issued {
+  sql: string;
+  params: Record<string, unknown> | undefined;
+}
+
+/** A store whose CREATE always collides, so every call is a dedupe hit. */
+function fixture(storedMeta?: Record<string, unknown>) {
+  const issued: Issued[] = [];
+  const existing: Record<string, unknown> = {
+    id: 'source_document:d1',
+    kind: 'markdown',
+    contentHash: 'a'.repeat(64),
+    charLen: TEXT.length,
+    chunkCount: 1,
+    hasContent: true,
+    vertical: 'crm',
+    occurredAt: '2026-09-01T10:00:00.000Z',
+    status: 'received',
+    ...(storedMeta ? { meta: storedMeta } : {}),
+  };
+  const db = {
+    query: async (sql: string, params?: Record<string, unknown>) => {
+      issued.push({ sql, params });
+      if (sql.includes('CREATE type::table($t)')) {
+        throw new Error(
+          'Database index `source_document_hash_idx` already contains a record with id',
+        );
+      }
+      if (sql.includes('FROM source_document WHERE contentHash')) return [[existing]];
+      return [[]];
+    },
+  };
+  const surreal = {
+    withCompany: async <T>(_c: string, fn: (d: typeof db) => Promise<T>) => fn(db),
+  } as unknown as SurrealService;
+  return { store: new DocumentStoreService(surreal), issued, existing };
+}
+
+const post = (store: DocumentStoreService, internal: InternalDocumentMeta | undefined) =>
+  store.createOrGet('co_x', dto(), { channel: 'ingest_sync', internal });
+
+const metaUpdate = (issued: Issued[]) =>
+  issued.find((q) => q.sql.includes("UPDATE type::record('source_document', $id) SET meta"));
+
+describe('a dedupe hit and the 0111 tool-observation hop', () => {
+  let warn: jest.SpyInstance;
+  beforeEach(() => {
+    warn = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+    jest.spyOn(Logger.prototype, 'log').mockImplementation(() => undefined);
+  });
+  afterEach(() => jest.restoreAllMocks());
+
+  it('merges the verified hop onto a header that carries none', async () => {
+    const f = fixture();
+    const res = await post(f.store, {
+      toolObservationRef: 'tool_observation:abc',
+      toolObservationNote: 'web_fetch @ 2026-09-01T09:59:00.000Z',
+    });
+    expect(res.deduplicated).toBe(true);
+    const update = metaUpdate(f.issued);
+    expect(update).toBeDefined();
+    expect(update!.params?.meta).toEqual({
+      toolObservationRef: 'tool_observation:abc',
+      toolObservationNote: 'web_fetch @ 2026-09-01T09:59:00.000Z',
+    });
+    // The caller gets the header it will commit facts against.
+    expect(res.doc.meta).toMatchObject({ toolObservationRef: 'tool_observation:abc' });
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('keeps the hop a header already carries, and says which keys were dropped', async () => {
+    const f = fixture({ toolObservationRef: 'tool_observation:first' });
+    const res = await post(f.store, {
+      toolObservationRef: 'tool_observation:second',
+      toolObservationNote: 'web_fetch @ 2026-09-01T09:59:00.000Z',
+    });
+    expect(metaUpdate(f.issued)).toBeUndefined();
+    expect(res.doc.meta).toEqual({ toolObservationRef: 'tool_observation:first' });
+    expect(warn).toHaveBeenCalledTimes(1);
+    const line = String(warn.mock.calls[0]![0]);
+    expect(line).toContain('source_document:d1');
+    expect(line).toContain('toolObservationRef');
+  });
+
+  it('origin identifiers are reported, never rewritten onto the stored header', async () => {
+    const f = fixture({ conversationId: 'conv:first' });
+    await post(f.store, { conversationId: 'conv:second' });
+    expect(metaUpdate(f.issued)).toBeUndefined();
+    expect(String(warn.mock.calls[0]![0])).toContain('conversationId');
+  });
+
+  it('a request carrying no internal bag writes nothing and warns nothing', async () => {
+    const f = fixture({ toolObservationRef: 'tool_observation:first' });
+    const res = await post(f.store, undefined);
+    expect(metaUpdate(f.issued)).toBeUndefined();
+    expect(warn).not.toHaveBeenCalled();
+    expect(res.doc.id).toBe('source_document:d1');
+  });
+});

--- a/test/entities-forget.e2e-spec.ts
+++ b/test/entities-forget.e2e-spec.ts
@@ -179,6 +179,27 @@ describe('POST /v1/entities/:id/forget — GDPR cascade', () => {
             object: $rid, detail: { note: 'secret-pii-value' } }`,
         { rid: entityId },
       );
+      // answer_cache (0091/0136): the cached ANSWER TEXT quotes the rows
+      // being erased. Two shapes — one keyed on the entity, one on a
+      // cited fact of it.
+      for (const [hash, ents, cited] of [
+        ['hash-entity', [entityId], []],
+        ['hash-fact', [], [String(subjFactId)]],
+      ] as Array<[string, string[], string[]]>) {
+        await db.query(
+          `CREATE answer_cache CONTENT {
+              companyId: $cid, queryHash: $h, queryText: 'who is the subject',
+              answer: 'secret-pii-value', citedFactIds: $cited, entityIds: $ents,
+              profileHash: 'p1', modelId: 'm1', promptVersion: 1, expiresAt: $exp }`,
+          {
+            cid: f.companyId,
+            h: hash,
+            cited,
+            ents,
+            exp: new Date(Date.now() + 3600_000),
+          },
+        );
+      }
       await db.query(
         `CREATE debug_trace CONTENT {
             requestId: 'rq1', method: 'POST', path: '/v1/ingest/fact',
@@ -268,6 +289,9 @@ describe('POST /v1/entities/:id/forget — GDPR cascade', () => {
       expect(
         await countWhere(`SELECT id FROM debug_trace WHERE companyId = $cid`, { cid: f.companyId }),
       ).toBe(0);
+      // The cached answers quoting the erased entity / its facts are gone
+      // — check-on-read only stopped them serving, it kept the bytes.
+      expect(await countWhere(`SELECT id FROM answer_cache`, {})).toBe(0);
 
       // Fact-keyed side tables (fact_usage + retrieval_feedback) must be
       // gone BY THEIR CAPTURED IDS: a 3.2.4 DELETE planner no-op leaves

--- a/test/fragment-lane.unit-spec.ts
+++ b/test/fragment-lane.unit-spec.ts
@@ -69,12 +69,21 @@ function surrealOf(opts: {
   bm25Rows?: ReprRowFixture[];
   denseRows?: ReprRowFixture[];
   failRetrieval?: boolean;
+  /** Install status of the pack row the double holds (0040 default). */
+  packStatus?: string;
 }) {
   const calls: Array<{ sql: string; params: Record<string, unknown> | undefined }> = [];
   const db = {
     query: async (sql: string, params?: Record<string, unknown>) => {
       calls.push({ sql, params });
-      if (sql.includes('FROM domain_pack')) return [opts.consentRows ?? [CONSENT_ROW]];
+      // The consent read is filtered server-side: a row whose status is
+      // not 'active' is simply not returned to an active-only SELECT.
+      if (sql.includes('FROM domain_pack')) {
+        const rows = opts.consentRows ?? [CONSENT_ROW];
+        const activeOnly = sql.includes("status = 'active'");
+        const status = opts.packStatus ?? 'active';
+        return [activeOnly && status !== 'active' ? [] : rows];
+      }
       if (opts.failRetrieval) throw new Error('boom');
       if (sql.includes('vector::similarity')) return [opts.denseRows ?? []];
       if (sql.includes('@1@')) return [opts.bm25Rows ?? []];
@@ -112,6 +121,26 @@ describe('FragmentLaneService — consent gate (0112)', () => {
     expect(out.byId.size).toBe(0);
     expect(calls).toHaveLength(1);
     expect(calls[0]!.sql).toContain('FROM domain_pack');
+  });
+
+  it('an UNINSTALLED pack consents to nothing: no fragment lines, no fuller texts', async () => {
+    // Uninstall keeps the row (status='removed') with its manifest and
+    // accepted-modality checksum, so an unfiltered consent read went on
+    // serving OCR and transcript text under a removed pack's consent.
+    const { surreal, calls } = surrealOf({ packStatus: 'removed', bm25Rows: [row({})] });
+    const lane = new FragmentLaneService(surreal, embedderOk);
+    const out = await lane.fragmentLines(baseOpts);
+    expect(out.lines).toEqual([]);
+    expect(calls).toHaveLength(1);
+    const fuller = await lane.fullerTexts({
+      companyId: baseOpts.companyId,
+      reprIds: ['derived_representation:r1'],
+      maxChars: 600,
+      callerScopes: [],
+    });
+    expect(fuller.size).toBe(0);
+    // Neither read reached derived_representation.
+    expect(calls.filter((c) => c.sql.includes('FROM derived_representation'))).toHaveLength(0);
   });
 
   it('consent STALE (checksum drift) ⇒ EMPTY', async () => {

--- a/test/processor-broker.unit-spec.ts
+++ b/test/processor-broker.unit-spec.ts
@@ -68,7 +68,13 @@ function fixture(opts: { adapters: ProcessorAdapter[]; packRow?: Record<string, 
     query: jest.fn((sql: string, vars?: Record<string, unknown>) => {
       queries.push({ sql, vars });
       if (sql.includes("type::record('evidence_asset'")) return Promise.resolve([[assetRow]]);
-      if (sql.includes('FROM domain_pack')) return Promise.resolve([[packRow]]);
+      // The pack read is filtered server-side: a row whose status is not
+      // 'active' is not returned to an active-only SELECT.
+      if (sql.includes('FROM domain_pack')) {
+        const status = (packRow as { status?: string }).status ?? 'active';
+        const activeOnly = sql.includes("status = 'active'");
+        return Promise.resolve([activeOnly && status !== 'active' ? [] : [packRow]]);
+      }
       if (sql.includes('INSERT IGNORE INTO processing_run')) {
         return Promise.resolve([[{ id: (vars?.row as { id: unknown }).id }]]);
       }
@@ -151,6 +157,26 @@ describe('EvidenceProcessorBrokerService', () => {
         producedByRun: res.runs[0]!.runId,
       }),
     );
+  });
+
+  it('an UNINSTALLED pack authorises no dispatch — it reads as not installed', async () => {
+    // Uninstall keeps the row (status='removed') with its manifest and
+    // accepted-modality checksum, and packId is caller-supplied on
+    // upload — an unfiltered read let a removed pack keep authorising
+    // processor dispatch over raw bytes.
+    const f = fixture({
+      adapters: [stubAdapter()],
+      packRow: {
+        manifest: PACK,
+        acceptedModalities: true,
+        acceptedModalitiesChecksum: CHECKSUM,
+        status: 'removed',
+      },
+    });
+    await expect(
+      f.broker.dispatchForPack('co_x', { packId: 'proc_pack', assetId: 'evidence_asset:a1' }),
+    ).rejects.toThrow(/pack proc_pack is not installed/);
+    expect(f.queries.some((q) => q.sql.includes('INSERT IGNORE INTO processing_run'))).toBe(false);
   });
 
   it('no installed adapter ⇒ denied entry and NO run row', async () => {

--- a/test/promotion-gate.unit-spec.ts
+++ b/test/promotion-gate.unit-spec.ts
@@ -89,7 +89,7 @@ function makePromotionStack(
         // BEGIN, LET (create), UPDATE (compact), RETURN, COMMIT — the
         // 3.x slot shape runTransaction reads the RETURN from.
         created.push(params!.doc as Record<string, unknown>);
-        return [null, null, [], [{ id: 'knowledge_fact:summary1' }], null] as unknown as R;
+        return [null, [], null, [], [{ id: 'knowledge_fact:summary1' }], null] as unknown as R;
       }
       return [[]] as unknown as R;
     },

--- a/test/promotion-validity.unit-spec.ts
+++ b/test/promotion-validity.unit-spec.ts
@@ -100,7 +100,7 @@ describe('PromotionRunnerService — the replace is one transaction', () => {
         }
         if (sql.startsWith('BEGIN TRANSACTION')) {
           txParams = params;
-          return [null, null, [], [{ id: 'knowledge_fact:summary1' }], null] as unknown as R;
+          return [null, [], null, [], [{ id: 'knowledge_fact:summary1' }], null] as unknown as R;
         }
         return [[]] as unknown as R;
       },
@@ -134,6 +134,13 @@ describe('PromotionRunnerService — the replace is one transaction', () => {
     const batch = batches[0]!;
     expect(batch).toContain('CREATE knowledge_fact CONTENT $doc');
     expect(batch).toContain("SET status = 'compacted', embedding = NONE");
+    // Atomic is not enough: the members were selected before the awaited
+    // summary window, so the close carries the FULL member predicate and
+    // its row count is checked against what was summarised — a member
+    // retracted (or already compacted by a second pass) aborts the whole
+    // transaction instead of being folded away under a new summary.
+    expect(batch).toContain("WHERE id INSIDE $ids AND status = 'active' AND retractedAt IS NONE");
+    expect(batch).toContain("THROW 'promotion members moved under the summary'");
     expect(batch.trim().endsWith('COMMIT TRANSACTION;')).toBe(true);
     // The compaction never travels on its own — that was the window where
     // the originals were hidden with nothing standing in for them.
@@ -144,6 +151,7 @@ describe('PromotionRunnerService — the replace is one transaction', () => {
       'knowledge_fact:s0',
       'knowledge_fact:s1',
     ]);
+    expect(params.expected).toBe(2);
     const doc = params.doc as Record<string, unknown>;
     expect(doc.predicate).toBe('summary_said');
     expect(doc.status).toBe('active');
@@ -211,7 +219,7 @@ describe('PromotionRunnerService — the replace is one transaction', () => {
             ] as unknown as R;
           }
           if (sql.startsWith('BEGIN TRANSACTION'))
-            return [null, null, [], [], null] as unknown as R;
+            return [null, [], null, [], [], null] as unknown as R;
           return [[]] as unknown as R;
         },
       });

--- a/test/promotion.e2e-spec.ts
+++ b/test/promotion.e2e-spec.ts
@@ -9,6 +9,7 @@ import { AppFixture, createApp } from './app-fixture';
 import { StringRecordId } from 'surrealdb';
 import { SurrealService } from '../src/db/surreal.service';
 import { PromotionRunnerService } from '../src/compaction/promotion-runner.service';
+import type { SummaryGenerator } from '../src/compaction/summary-generator';
 
 describe('episodic→semantic promotion (real SurrealDB)', () => {
   let f: AppFixture;
@@ -120,5 +121,69 @@ describe('episodic→semantic promotion (real SurrealDB)', () => {
     // Idempotent: the promoted tail is compacted now, nothing new to fold.
     const again = await svc.promoteCompany(f.companyId);
     expect(again.groupsPromoted).toBe(0);
+  });
+
+  it('a member retracted inside the summarise window skips the group instead of promoting it', async () => {
+    // The members are selected BEFORE the awaited summary + embedding
+    // window. The close used to be unconditional (`WHERE id INSIDE $ids`,
+    // no row-count check), so a member retracted in that window was
+    // flipped to 'compacted' with its content already inside the summary
+    // — and a second pass could add a second active summary over the
+    // same derivedFrom. The full predicate plus the count check makes the
+    // whole transaction abort.
+    const aged: string[] = [];
+    for (let i = 1; i <= 5; i++) {
+      aged.push(await ingest('complained_about', `race remark number ${i}`));
+    }
+    await backdate(aged, 365);
+    const victim = aged[0]!;
+
+    const svc = f.app.get(PromotionRunnerService);
+    const seam = svc as unknown as { summaryGenerator: SummaryGenerator };
+    const real = seam.summaryGenerator;
+    const surreal = f.app.get(SurrealService);
+    let retracted = false;
+    seam.summaryGenerator = {
+      generate: async (group) => {
+        if (!retracted) {
+          retracted = true;
+          await surreal.withCompany(f.companyId, async (db) => {
+            await db.query(
+              `UPDATE type::record('knowledge_fact', $tail)
+                 SET status = 'retracted', retractedAt = time::now()`,
+              { tail: victim.split(':')[1] },
+            );
+          });
+        }
+        return real.generate(group);
+      },
+    };
+    let stats;
+    try {
+      stats = await svc.promoteCompany(f.companyId);
+    } finally {
+      seam.summaryGenerator = real;
+    }
+    expect(retracted).toBe(true);
+    expect(stats.groupsPromoted).toBe(0);
+    expect(stats.factsPromoted).toBe(0);
+
+    await surreal.withCompany(f.companyId, async (db) => {
+      const [summaries] = await db.query<[Array<{ id: unknown }>]>(
+        `SELECT id FROM knowledge_fact WHERE predicate = 'summary_complained_about'`,
+      );
+      expect(summaries as Array<{ id: unknown }>).toHaveLength(0);
+      const [rows] = await db.query<[Array<{ id: unknown; status: string }>]>(
+        `SELECT id, status FROM knowledge_fact WHERE id INSIDE $ids`,
+        { ids: aged.map((id) => new StringRecordId(id)) },
+      );
+      const byId = new Map(
+        (rows as Array<{ id: unknown; status: string }>).map((r) => [String(r.id), r.status]),
+      );
+      // The retracted member stays retracted; the survivors stay active —
+      // nothing was closed under a summary that never landed.
+      expect(byId.get(victim)).toBe('retracted');
+      for (const id of aged.slice(1)) expect(byId.get(id)).toBe('active');
+    });
   });
 });

--- a/test/user-forget-edge-audit.e2e-spec.ts
+++ b/test/user-forget-edge-audit.e2e-spec.ts
@@ -71,6 +71,24 @@ describe('user-forget purges edge audit_event rows', () => {
            reason='secret-pii' RETURN id`,
         { f: factId },
       );
+      // answer_cache (0091/0136): the entry keeps the ANSWER TEXT beside
+      // the ids it was grounded in. Two shapes — the user's own entry and
+      // a tenant-global one (userId NONE, never NULL) quoting the user's
+      // fact.
+      const cacheBody = `companyId: $cid, queryText: 'what does user_x say',
+             answer: 'secret-pii', entityIds: [],
+             profileHash: 'p1', modelId: 'm1', promptVersion: 1, expiresAt: $exp`;
+      const exp = new Date(Date.now() + 3600_000);
+      await db.query(
+        `CREATE answer_cache CONTENT { ${cacheBody}, queryHash: 'hash-user',
+           citedFactIds: [], userId: $user }`,
+        { cid: f.companyId, exp, user: 'user_x' },
+      );
+      await db.query(
+        `CREATE answer_cache CONTENT { ${cacheBody}, queryHash: 'hash-global',
+           citedFactIds: [$cited] }`,
+        { cid: f.companyId, exp, cited: String(factId) },
+      );
       return {
         edgeId: eid,
         feedbackId: String((feedback as Array<{ id: unknown }>)[0]!.id),
@@ -95,6 +113,17 @@ describe('user-forget purges edge audit_event rows', () => {
 
     // The edge's audit mirror is gone with it.
     expect(await countAudit()).toBe(0);
+
+    // GDPR: the cached answer BYTES go too. Check-on-read stops a stale
+    // entry serving, but the quoted answer text survived until TTL.
+    const cachedRows = await surreal.withCompany(f.companyId, async (db) => {
+      const [rows] = await db.query<[Array<{ id: unknown; userId?: string }>]>(
+        `SELECT id, userId FROM answer_cache`,
+      );
+      return (rows as Array<{ id: unknown; userId?: string }>) ?? [];
+    });
+    expect(cachedRows.filter((r) => r.userId === 'user_x')).toHaveLength(0);
+    expect(cachedRows).toHaveLength(0);
 
     // The edge row and the fact-keyed feedback row must be gone BY THEIR
     // CAPTURED IDS — the reported counts and the traversal-based reads


### PR DESCRIPTION
## What

Seven defects from the second-pass review of this week's merged domain PRs, each fixed in place with a failing-first test.

**1 · P2 — the belief compare-and-set now checks the watermark it exists to enforce.**
`commitRevision` guarded the supersede on `status='active' AND revision=$headRevision`, and a concurrent `corroborateBelief` touches neither field. A revise whose stale-guard read predated that corroboration still committed: head A, corroborated into March by one run, was superseded with a February `validUntil` by a second run that had read a January watermark. The predicate now pins the observed watermark (`latestEvidenceAt IS NONE OR latestEvidenceAt = $wm`; `NONE` keeps legacy pre-0137 rows revisable), and zero rows stamped is treated as contention: `upsertBelief` re-reads and decides again once, then counts `skippedContended` and skips.

**2 · P3 — `commitRevision` no longer classifies every failure as contention.** False is returned for a read conflict, a unique violation and the transaction's own two aborts; anything else (schema rejection, dead connection) is rethrown, so a broken write path can no longer read as harmless contention forever.

**3 · P2 — the promotion transaction is conditional, not just atomic.** The member close ran `UPDATE … WHERE id INSIDE $ids` with no lifecycle predicate and no row-count check, over members selected before the awaited summary + embedding window. It now closes with the full predicate (`status='active' AND retractedAt IS NONE`), captures the closed rows, and THROWs when the count differs from the summarised member count — which also stops a second pass from creating a second active summary over the same `derivedFrom`.

**4 · P2 — a removed pack no longer consents in the fragment lane.** Both 0112 consent reads (retrieval and zoom `fullerTexts`) filter `status = 'active'`; uninstall keeps the row with its manifest and checksum, so synthesize was serving OCR and transcript text under a removed pack's consent.

**5 · P2 — a removed pack no longer authorises processor dispatch over raw bytes.** The broker's pack read filters `status = 'active'`, so a non-active pack reads as not installed (`packId` is caller-supplied on upload).

**6 · P3 — GDPR forget erases `answer_cache`.** Neither cascade mentioned the table: check-on-read stopped a stale entry serving, but the quoted answer text survived until TTL. User forget removes the user's own entries plus any tenant-global entry citing the user's facts or personal entities; entity forget removes, inside the atomic erase, every entry citing the entity or its facts. Both use the `LET $ids = SELECT id …` → `DELETE $ids` idiom.

**7 · P3 — a dedupe hit keeps the verified tool-observation reference.** Re-posting byte-identical text returns the existing header, and the commit writer reads the 0111 hop off that row, so a re-post's verified `toolObservationRef` was dropped from every fact committed afterwards. **Decision: merge**, and only onto a header that carries no hop. The commit-writer contract allows it — the text is byte-identical, the scope fence guarantees the same user scope, the ref was verified for this tenant in this request, and facts already committed keep their own `source.evidence[]`, so nothing is rewritten retroactively. A header that already carries a hop keeps it (one true observation must not displace another) and the origin identifiers (`conversationId` / `messageId` / `eventId`) name the turn the header was first stored for; both cases are logged at warn with the document id instead of vanishing.

## Why

Second-pass review of the merged domain PRs, 2026-09-09 (items 1–7 above). No new flags or env knobs; no migration.

## How verified

Each fix was reverted in isolation to confirm its test fails first:

| item | proof |
| --- | --- |
| 1 | `belief-revision-chain.e2e` new case, predicate reverted → `beliefsRevised: 1` (the audit's repro, real DB) |
| 1–2 | `belief-promotion.unit` 4 failures, `belief-revision-commit.unit` 3 failures |
| 3 | `promotion.e2e` new case, guard reverted → group promoted (`Expected: 0, Received: 1`) |
| 4 | `fragment-lane.unit` 1 failure with the filter removed |
| 5 | `processor-broker.unit` 1 failure with the filter removed |
| 6 | `entities-forget.e2e` (`Expected: 0, Received: 2`) and `user-forget-edge-audit.e2e` (the user's row survives) with the legs removed |
| 7 | `document-dedupe-hop.unit` 3 failures with the merge removed |

Gates, on the rebased branch (`origin/main` = `89875c9`):

```
pnpm typecheck                                   → clean
pnpm lint:ci                                     → clean (0 warnings)
pnpm format:check                                → all files match
pnpm jest --config ./test/jest-unit.json         → 438 suites / 5308 tests passed
e2e (real SurrealDB, --runInBand):
  belief-revision-chain | promotion.e2e | belief-promotion
  | entities-forget | user-forget-edge-audit       → 5 suites / 27 tests passed
  fragment-lane.e2e | evidence-processing
  | documents-pipeline | document-async-internal-meta → 4 suites / 24 tests passed
```

Note on item 2: a genuine fault now aborts the promotion pass instead of being counted as contention (there is no per-belief failure counter on `BeliefPromotionResult`, and inventing one was out of scope). The transaction-error enrichment in `surreal-retry.ts` still turns a bare `failed transaction` wrapper with no cause into a read-conflict-shaped message, so such a rejection is still read as contention — unchanged behaviour, noted rather than widened here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhrQxeisXJZEt4sg3PGyU6
