### PR TITLE
fix(live,vectors): repair the LIVE channel after an outage, and stop the width repair re-embedding whole tenants

### DIFF
--- a/src/admin/hnsw-maintenance.service.ts
+++ b/src/admin/hnsw-maintenance.service.ts
@@ -274,8 +274,9 @@ export class HnswMaintenanceService {
       builds = await this.waitForBuilds(companyId, builds, waitMs);
     }
     // The legs remember an index they saw missing or building; a build or
-    // drop makes that memory stale on every pod that shares this process.
-    if (action !== 'status') resetKnnIndexMemo();
+    // drop makes that memory stale on every pod that shares this process. An
+    // `ensure` that found every index present changed nothing and keeps it.
+    if (action === 'create' || action === 'drop' || created.length > 0) resetKnnIndexMemo();
     const mismatched = builds
       .filter((b) => b.dimension !== undefined && b.dimension !== dimension)
       .map((b) => b.index);

--- a/src/admin/vector-corpus.service.ts
+++ b/src/admin/vector-corpus.service.ts
@@ -266,7 +266,14 @@ export class VectorCorpusService implements OnModuleInit {
       },
     });
     try {
-      const sweep = await this.reindex.run({ tenant: companyId, allTables: true });
+      // Only the rows the census just counted as non-conforming: the sweep
+      // without this narrowing re-embeds every row of every swept table, so
+      // one stray vector cost a full-tenant re-embed.
+      const sweep = await this.reindex.run({
+        tenant: companyId,
+        allTables: true,
+        widthMismatchOnly: { dim: before.dimension },
+      });
       const swept = {
         factsScanned: sweep.factsScanned,
         factsUpdated: sweep.factsUpdated,

--- a/src/ai/embedder/bge-m3-embedder.provider.ts
+++ b/src/ai/embedder/bge-m3-embedder.provider.ts
@@ -13,6 +13,16 @@ export interface FeatureExtractionPipeline {
   ): Promise<{ data: Float32Array | number[] }>;
 }
 
+/** The slice of `worker_threads.Worker` the provider drives; a test seam
+ *  can hand in a fake with the same members. */
+export interface InferenceWorker {
+  on(event: 'message', listener: (value: unknown) => void): unknown;
+  on(event: 'error', listener: (err: Error) => void): unknown;
+  on(event: 'exit', listener: (code: number) => void): unknown;
+  postMessage(value: unknown): void;
+  terminate(): Promise<unknown>;
+}
+
 export interface BgeM3EmbedderConfig {
   /** The DECLARED space (EMBEDDING_SPACES['bge-m3']) — model id and width
    *  arrive together and are not separately configurable. Truncating the
@@ -32,6 +42,12 @@ export interface BgeM3EmbedderConfig {
    * model on disk. Production leaves it unset.
    */
   loadPipeline?: () => Promise<FeatureExtractionPipeline>;
+  /**
+   * Test seam for the worker path: replaces `new Worker(path)` so the
+   * thread lifecycle (late exit of a terminated worker, error events) can
+   * be driven without a model. Production leaves it unset.
+   */
+  createWorker?: (workerPath: string) => InferenceWorker;
 }
 
 /**
@@ -67,12 +83,13 @@ export class BgeM3EmbedderProvider implements EmbedderProvider {
   private readonly limiter: Semaphore;
   private readonly useWorker: boolean;
   private readonly loadPipeline: () => Promise<FeatureExtractionPipeline>;
+  private readonly createWorker: (workerPath: string) => InferenceWorker;
 
   // In-thread fallback
   private pipeline: FeatureExtractionPipeline | null = null;
 
   // Worker runtime
-  private worker: Worker | null = null;
+  private worker: InferenceWorker | null = null;
   private workerReady = false;
   private nextReqId = 1;
   private readonly pending = new Map<
@@ -89,6 +106,7 @@ export class BgeM3EmbedderProvider implements EmbedderProvider {
     // construct the provider directly and rely on the in-thread path
     // via setPipelineForTesting().
     this.useWorker = cfg.useWorker === true;
+    this.createWorker = cfg.createWorker ?? ((workerPath) => new Worker(workerPath));
     this.loadPipeline =
       cfg.loadPipeline ??
       (async () => {
@@ -156,15 +174,25 @@ export class BgeM3EmbedderProvider implements EmbedderProvider {
       // A previous attempt may have left a half-initialised worker behind
       // (an RPC that timed out already reclaimed its own). Never stack two.
       await this.terminate();
-      const workerPath = this.resolveWorkerPath();
-      this.worker = new Worker(workerPath);
-      this.worker.on('message', (m: unknown) => this.handleReply(m));
-      this.worker.on('error', (err) => {
+      const w = this.createWorker(this.resolveWorkerPath());
+      this.worker = w;
+      // Every handler is scoped to ITS worker. A terminated thread keeps
+      // emitting ('exit' lands after terminate() resolved, and after a
+      // timed-out RPC has already re-armed a warmup on a fresh worker); an
+      // unscoped handler would then reject the new worker's pending RPCs
+      // and mark the provider not-ready for a thread it no longer owns.
+      w.on('message', (m) => {
+        if (this.worker !== w) return;
+        this.handleReply(m);
+      });
+      w.on('error', (err) => {
+        if (this.worker !== w) return;
         this.logger.warn(`BGE-M3 worker error: ${err.message}`);
         this.failAllPending(err);
         this.workerReady = false;
       });
-      this.worker.on('exit', (code) => {
+      w.on('exit', (code) => {
+        if (this.worker !== w) return;
         if (code !== 0) {
           this.logger.warn(`BGE-M3 worker exited with code ${code}`);
         }

--- a/src/ai/embedder/reindex-embeddings.service.ts
+++ b/src/ai/embedder/reindex-embeddings.service.ts
@@ -40,6 +40,13 @@ export interface ReindexOptions {
   allTables?: boolean;
   /** Retry selector: sweep exactly these tables (REINDEX_SWEPT_COLUMNS). */
   tables?: string[];
+  /**
+   * Repair selector: rewrite ONLY rows whose vector is present and not `dim`
+   * wide. The corpus census (VectorCorpusService) passes its primary
+   * dimension here so one stray row costs one embed, not a full-tenant
+   * re-embed.
+   */
+  widthMismatchOnly?: { dim: number };
 }
 
 /**
@@ -89,6 +96,9 @@ export class ReindexEmbeddingsService {
           remaining: maxFacts - factsScanned,
           allTables,
           ...(opts.tables !== undefined ? { tables: opts.tables } : {}),
+          ...(opts.widthMismatchOnly !== undefined
+            ? { widthMismatchOnly: opts.widthMismatchOnly }
+            : {}),
         });
         parts.push({ key: companyId, outcome: tenantResult.outcome });
         factsScanned += tenantResult.factsScanned;

--- a/src/ai/embedder/reindex-engine.service.ts
+++ b/src/ai/embedder/reindex-engine.service.ts
@@ -173,6 +173,38 @@ function sweepPlan(opts: { allTables?: boolean; tables?: string[] }): SweepPlan 
   return { facts: true, extra: all ? ADDITIONAL_TABLE_SPECS : [], breakdown: all };
 }
 
+/**
+ * Per-tenant sweep options. `widthMismatchOnly` narrows every swept table's
+ * SELECT to rows whose vector is present and not `dim` wide — exactly the
+ * rows the corpus census counts as non-conforming — so a repair re-embeds the
+ * stray rows instead of the tenant's whole corpus.
+ */
+export interface ReindexTenantOptions {
+  dryRun: boolean;
+  remaining: number;
+  allTables?: boolean;
+  tables?: string[];
+  widthMismatchOnly?: { dim: number };
+}
+
+/** The narrowing condition for one vector column (no leading WHERE), or ''. */
+function widthNarrowing(field: string, only: { dim: number } | undefined): string {
+  // `array::len(NONE)` is a hard error on 3.2.4, so the presence check comes
+  // first and AND short-circuits it.
+  return only ? `${field} != NONE AND array::len(${field}) != $dim` : '';
+}
+
+/**
+ * How far the offset moves after one page. Under the width narrowing a
+ * repaired row leaves the result set, so the next page begins where the rows
+ * that were NOT rewritten still stand; without it every row keeps its place
+ * and the page advances by its full length. A row that failed to rewrite is
+ * stepped over either way.
+ */
+function pageStride(narrowed: boolean, scanned: number, updated: number): number {
+  return narrowed ? scanned - updated : scanned;
+}
+
 function tableFailure(table: string, f: TableFailures): BatchFailure | null {
   if (f.failedPages === 0 && f.failedRows === 0) return null;
   return {
@@ -240,10 +272,7 @@ export class ReindexEngineService {
     return this.embedder.activeSpaceId();
   }
 
-  async reindexTenant(
-    companyId: string,
-    opts: { dryRun: boolean; remaining: number; allTables?: boolean; tables?: string[] },
-  ): Promise<ReindexTenantResult> {
+  async reindexTenant(companyId: string, opts: ReindexTenantOptions): Promise<ReindexTenantResult> {
     return this.surreal.withCompany(companyId, async (db) => {
       const ctx: ReindexCtx = { db, companyId, spaceId: this.spaceStampId() };
       const plan = sweepPlan(opts);
@@ -307,26 +336,30 @@ export class ReindexEngineService {
    */
   private async reindexKnowledgeFacts(
     ctx: ReindexCtx,
-    opts: { dryRun: boolean; remaining: number },
+    opts: ReindexTenantOptions,
   ): Promise<{ factsScanned: number; factsUpdated: number } & TableFailures> {
     let offset = 0;
     let factsScanned = 0;
     let factsUpdated = 0;
     const failures: TableFailures = { failedPages: 0, failedRows: 0 };
     const batch = Math.min(this.batchSize, opts.remaining);
+    const narrowing = widthNarrowing('embedding', opts.widthMismatchOnly);
+    const params = narrowing ? { dim: opts.widthMismatchOnly!.dim } : {};
     // Paginate until either the tenant is empty or we hit the cap.
     while (factsScanned < opts.remaining) {
       const [rows] = await ctx.db.query<[FactRowForReindex[]]>(
         `SELECT id, predicate, object
             FROM knowledge_fact
+            ${narrowing ? `WHERE ${narrowing}` : ''}
             ORDER BY id
             LIMIT $batch START $offset`,
-        { batch, offset },
+        { batch, offset, ...params },
       );
       const page = (rows as FactRowForReindex[]) ?? [];
       if (page.length === 0) break;
 
       factsScanned += page.length;
+      let pageUpdated = 0;
       if (!opts.dryRun) {
         // Batch the whole page through one embedMany — the previous
         // per-row embed() loop paid one HTTP round-trip per fact.
@@ -335,13 +368,14 @@ export class ReindexEngineService {
         if (embeddings) {
           const entries = page.map((row, i) => ({ id: row.id, vector: embeddings[i] }));
           const written = await this.writePage(ctx, 'embedding', entries);
+          pageUpdated = written.updated;
           factsUpdated += written.updated;
           failures.failedRows += written.failed;
         } else {
           failures.failedPages += 1;
         }
       }
-      offset += page.length;
+      offset += pageStride(narrowing !== '', page.length, pageUpdated);
       if (page.length < batch) break;
     }
     return { factsScanned, factsUpdated, ...failures };
@@ -359,32 +393,36 @@ export class ReindexEngineService {
   private async reindexGenericTable(
     ctx: ReindexCtx,
     spec: ReindexTableSpec,
-    opts: { dryRun: boolean; remaining: number },
+    opts: ReindexTenantOptions,
   ): Promise<TableReindexCount & TableFailures> {
     let offset = 0;
     let scanned = 0;
     let updated = 0;
     const failures: TableFailures = { failedPages: 0, failedRows: 0 };
     const batch = Math.min(this.batchSize, opts.remaining);
+    const narrowing = widthNarrowing(spec.vectorField, opts.widthMismatchOnly);
+    const params = narrowing ? { dim: opts.widthMismatchOnly!.dim } : {};
     while (scanned < opts.remaining) {
       const [rows] = await ctx.db.query<[Array<Record<string, unknown>>]>(
         `SELECT ${spec.select}
             FROM ${spec.table}
-            WHERE ${spec.vectorField} != NONE
+            WHERE ${narrowing || `${spec.vectorField} != NONE`}
             ORDER BY id
             LIMIT $batch START $offset`,
-        { batch, offset },
+        { batch, offset, ...params },
       );
       const page = (rows as Array<Record<string, unknown>>) ?? [];
       if (page.length === 0) break;
       scanned += page.length;
+      let pageUpdated = 0;
       if (!opts.dryRun) {
         const written = await this.reindexGenericPage(ctx, spec, page);
+        pageUpdated = written.updated;
         updated += written.updated;
         failures.failedPages += written.failedPages;
         failures.failedRows += written.failedRows;
       }
-      offset += page.length;
+      offset += pageStride(narrowing !== '', page.length, pageUpdated);
       if (page.length < batch) break;
     }
     return { table: spec.table, scanned, updated, ...failures };

--- a/src/db/migrations/0143_retire_alt_embedding_element.surql
+++ b/src/db/migrations/0143_retire_alt_embedding_element.surql
@@ -1,0 +1,18 @@
+-- 0143: finish retiring knowledge_fact.altEmbedding.
+--
+-- 0139 issued `REMOVE FIELD altEmbedding`, which on SurrealDB 3.2.4 removes
+-- only the column's own definition: the `altEmbedding.*` element definition
+-- the server generated for the `array<float>` type stays behind, and while it
+-- does a SCHEMAFULL write of `altEmbedding = [...]` is still accepted and
+-- stored (measured on v3.2.4). A retired column has to reject writes, not
+-- merely drop out of INFO FOR TABLE, so the element definition goes too
+-- (test/segment-hnsw.e2e-spec.ts asserts the rejection).
+--
+-- The UNSET pass comes FIRST and is not optional: once no definition covers
+-- the field, a row that still HOLDS a value cannot be written at all — every
+-- UPDATE of it fails with "Found field 'altEmbedding', but no such field
+-- exists" (measured). The column's writer was reverted long before 0139, so
+-- this is a no-op on every current deployment and a repair on any tenant that
+-- ingested while SEARCH_HYPE_ENABLED was on.
+UPDATE knowledge_fact UNSET altEmbedding WHERE altEmbedding != NONE;
+REMOVE FIELD IF EXISTS altEmbedding.* ON knowledge_fact;

--- a/src/dreams/dedup.service.ts
+++ b/src/dreams/dedup.service.ts
@@ -6,6 +6,7 @@ import { withSpan } from '../common/tracing';
 import { envFlagEnabled } from '../common/env-validation';
 import { derivedVersionFence } from '../episodes/read-pin.service';
 import { knnIndexKnownUnusable, knnOperatorDropped, noteKnnOperatorDropped } from '../db/knn-index';
+import { sameWidthGate } from '../db/vector-width';
 
 /** The index the entity-dedup seed KNN rides — for the diagnostic. */
 const DEDUP_HNSW = { table: 'knowledge_fact', index: 'fact_embedding_hnsw' } as const;
@@ -272,7 +273,7 @@ export class DreamsDedupService {
       `LET $q = (SELECT VALUE embedding FROM ONLY type::record($fid));
        SELECT entityId, vector::similarity::cosine(embedding, $q) AS sim
          FROM knowledge_fact
-        WHERE array::len(embedding) = array::len($q)
+        WHERE ${sameWidthGate('embedding')}
           AND ${filters}
         ORDER BY sim DESC
         LIMIT 5;`,

--- a/src/live/live-subscription.manager.ts
+++ b/src/live/live-subscription.manager.ts
@@ -1,6 +1,6 @@
 import { Injectable, Logger, OnApplicationShutdown } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { Surreal, Table } from 'surrealdb';
+import { LiveSubscriptionError, Surreal, Table } from 'surrealdb';
 import type { LiveSubscription } from 'surrealdb';
 import { envFlagEnabled } from '../common/env-validation';
 import { queryRows, withTimeout } from '../db/surreal.service';
@@ -8,9 +8,14 @@ import { SurrealSessionKeeper } from '../db/session-keeper';
 import { changefeedRow } from '../db/changefeed-row';
 import { makeRowPolicyFilter, type PredicatePolicyLookup } from '../policy/row-filter';
 
-/** One `SHOW CHANGES` batch row: a versionstamp plus its changefeed items. */
+/**
+ * One `SHOW CHANGES` batch row: a versionstamp plus its changefeed items.
+ * On SurrealDB 3.x the versionstamp is a u64 (~1.17e17, past
+ * Number.MAX_SAFE_INTEGER) and the SDK hands it over as a bigint; a unit
+ * stub may still emit a plain number. Both go through BigInt().
+ */
 interface ChangefeedShowRow {
-  versionstamp?: number | string;
+  versionstamp?: number | bigint | string;
   changes?: unknown[];
 }
 
@@ -65,21 +70,37 @@ interface Subscriber {
 interface TenantChannel {
   conn: Surreal;
   sub: LiveSubscription;
+  /** Detaches the LIVE handler and the connection-event listeners. */
   unsubscribe: () => void;
   subscribers: Map<string, Subscriber>;
-  /** Changefeed cursor — everything at or below this has been accounted for. */
-  versionstamp: number;
+  /**
+   * Changefeed cursor — everything at or below this has been accounted for.
+   * bigint end to end: folded through Number() two same-millisecond commits
+   * (16 apart at this magnitude) round to one value, and `vs <= cursor` then
+   * skips or re-delivers them.
+   */
+  versionstamp: bigint;
   /** Fact ids the LIVE path already delivered, so replay doesn't double-send. */
   delivered: Set<string>;
   timer: NodeJS.Timeout | null;
   /** A catch-up tick is running; the interval must not stack another. */
   catchingUp: boolean;
+  /**
+   * The driver failed to restart the LIVE query after a reconnect
+   * (LiveSubscriptionError on the connection) while `sub.isAlive` still says
+   * true — measured on 3.2.4 after an outage longer than its reconnect
+   * budget. The next tick rebuilds.
+   */
+  liveBroken: boolean;
 }
 
 const TABLE = 'knowledge_fact';
-/** Bounds on the two statements a catch-up tick issues on a standing socket. */
+/** Bounds on the statements a catch-up tick issues on a standing socket. */
+const CONNECT_TIMEOUT_MS = 5_000;
 const SIGNIN_TIMEOUT_MS = 3_000;
+const PROBE_TIMEOUT_MS = 3_000;
 const CATCHUP_QUERY_TIMEOUT_MS = 10_000;
+const CLOSE_TIMEOUT_MS = 1_000;
 
 type LiveCredentials =
   | { username: string; password: string }
@@ -108,6 +129,17 @@ type LiveCredentials =
  * `SHOW CHANGES FOR TABLE knowledge_fact SINCE <versionstamp>` and emits
  * anything LIVE did not deliver, deduped by fact id. The changefeed — not the
  * socket — is the source of truth about what happened.
+ *
+ * WHY THE TICK ALSO CHECKS THE CONNECTION. The pools survive a database
+ * restart because every acquire runs `ensureSession` (a bounded `RETURN 1`
+ * probe, then a rebuild). A subscription connection is handed out to nobody,
+ * so the tick is where the same discipline lives: a half-open socket
+ * (surrealdb-js gh#618 — status stays "connected"), a driver whose reconnect
+ * attempts ran out, or a session the driver brought back anonymous all fail
+ * the probe, and the channel is rebuilt on a fresh connection — new signin,
+ * new LIVE query — while the cursor it kept replays whatever the outage hid.
+ * Without that, every tick fails the same way forever and the subscribers
+ * starve silently.
  *
  * WHY THE FENCE IS NOT OPTIONAL. LIVE rows arrive raw: they never pass the
  * per-row `makeRowPolicyFilter` every read surface applies, and the DB-level
@@ -209,11 +241,7 @@ export class LiveSubscriptionManager implements OnApplicationShutdown {
     const existing = this.channels.get(companyId);
     if (existing) return existing;
 
-    const conn = new Surreal();
-    await conn.connect(this.url);
-    await this.signin(conn);
-    await conn.use({ namespace: this.namespace, database: dbNameFor(companyId) });
-
+    const conn = await this.openConnection(companyId);
     // Anchor the changefeed cursor BEFORE the LIVE query starts. Anything
     // already committed is the subscriber's problem to read normally; from
     // here on, every change reaches them via LIVE or via replay.
@@ -228,22 +256,65 @@ export class LiveSubscriptionManager implements OnApplicationShutdown {
       delivered: new Set(),
       timer: null,
       catchingUp: false,
+      liveBroken: false,
     };
-    channel.unsubscribe = sub.subscribe((msg) => {
+    channel.unsubscribe = this.attach(companyId, channel);
+    channel.timer = setInterval(() => this.tick(companyId), this.catchUpMs);
+    // Never hold the process open for a subscription.
+    channel.timer.unref?.();
+    this.channels.set(companyId, channel);
+    return channel;
+  }
+
+  /** A fresh, signed-in connection switched to the tenant's database. */
+  private async openConnection(companyId: string): Promise<Surreal> {
+    const conn = new Surreal();
+    try {
+      // Bounded: a published port can accept TCP before the server takes
+      // websockets (docker-proxy), where an unbounded connect() hangs.
+      await withTimeout(conn.connect(this.url), CONNECT_TIMEOUT_MS, 'live connect');
+      await this.signin(conn);
+      await conn.use({ namespace: this.namespace, database: dbNameFor(companyId) });
+      return conn;
+    } catch (e) {
+      await withTimeout(conn.close(), CLOSE_TIMEOUT_MS, 'live close').catch(() => undefined);
+      throw e;
+    }
+  }
+
+  /**
+   * Wire the channel's current connection: LIVE messages fan out, and the
+   * driver's own reconnect (or its giving up) runs a tick at once instead of
+   * up to an interval later — the tick decides what state the session and
+   * the standing LIVE query came back in.
+   */
+  private attach(companyId: string, channel: TenantChannel): () => void {
+    const { conn, sub } = channel;
+    const offLive = sub.subscribe((msg) => {
       const event = toFactEvent(msg, 'live');
       if (!event) return;
       channel.delivered.add(event.factId);
       this.fanOut(channel, event);
     });
-    channel.timer = setInterval(() => {
-      void this.catchUp(companyId).catch((e) =>
-        this.logger.warn(`live catch-up failed: ${(e as Error).message}`),
-      );
-    }, this.catchUpMs);
-    // Never hold the process open for a subscription.
-    channel.timer.unref?.();
-    this.channels.set(companyId, channel);
-    return channel;
+    const offConnected = conn.subscribe('connected', () => this.tick(companyId));
+    const offDisconnected = conn.subscribe('disconnected', () => this.tick(companyId));
+    const offError = conn.subscribe('error', (err) => {
+      if (!(err instanceof LiveSubscriptionError)) return;
+      channel.liveBroken = true;
+      this.tick(companyId);
+    });
+    return () => {
+      offLive();
+      offConnected();
+      offDisconnected();
+      offError();
+    };
+  }
+
+  private tick(companyId: string): void {
+    void this.catchUp(companyId).catch((e) =>
+      this.logger.warn(`live catch-up failed for ${companyId}: ${(e as Error).message}`),
+    );
   }
 
   /**
@@ -262,12 +333,7 @@ export class LiveSubscriptionManager implements OnApplicationShutdown {
     if (channel.catchingUp) return 0;
     channel.catchingUp = true;
     try {
-      // The catch-up tick is the only thing that touches this connection on
-      // a schedule, so it is where the session gets renewed. The changefeed
-      // makes the renewal safe regardless of what the driver-side invalidate
-      // does to the standing LIVE query: anything LIVE misses in the gap is
-      // replayed from here (test/scoped-session-expiry.e2e-spec.ts).
-      await this.signin(channel.conn);
+      await this.ensureLive(companyId, channel);
       const changes = await withTimeout(
         queryRows<ChangefeedShowRow>(
           channel.conn,
@@ -282,11 +348,76 @@ export class LiveSubscriptionManager implements OnApplicationShutdown {
     }
   }
 
+  /**
+   * The connection and the standing LIVE query must both be usable before
+   * the tick reads the changefeed. Same discipline as SurrealService's
+   * `ensureSession`: a session outside the re-auth margin gets a bounded
+   * `RETURN 1` probe, one inside it (or one the driver already dropped) is
+   * re-signed; if either fails, or the driver reports the LIVE query dead,
+   * the channel is rebuilt on a fresh connection and the kept cursor
+   * replays the gap (test/live-db-restart.e2e-spec.ts).
+   */
+  private async ensureLive(companyId: string, channel: TenantChannel): Promise<void> {
+    const { conn, sub } = channel;
+    try {
+      if (conn.isConnected && conn.accessToken && !this.sessions.needsSignin(conn)) {
+        await withTimeout(conn.query('RETURN 1'), PROBE_TIMEOUT_MS, 'live probe');
+      } else {
+        await this.signin(conn);
+      }
+      if (channel.liveBroken) throw new Error('LIVE query failed to restart');
+      if (sub.isAlive) return;
+      throw new Error('LIVE query is no longer alive');
+    } catch (e) {
+      this.logger.warn(
+        `live channel check failed for ${companyId} ` +
+          `(${(e as Error).message?.slice(0, 120)}) — rebuilding`,
+      );
+    }
+    await this.rebuild(companyId, channel);
+  }
+
+  /**
+   * Replace the channel's connection and LIVE query, keeping its subscribers
+   * and its cursor. The replacement is built FIRST; if it cannot be, the old
+   * one stays in place and the tick fails loudly for the interval to retry.
+   */
+  private async rebuild(companyId: string, channel: TenantChannel): Promise<void> {
+    const conn = await this.openConnection(companyId);
+    let sub: LiveSubscription;
+    try {
+      sub = await conn.live<Record<string, unknown>>(new Table(TABLE));
+    } catch (e) {
+      await withTimeout(conn.close(), CLOSE_TIMEOUT_MS, 'live close').catch(() => undefined);
+      throw e;
+    }
+    if (this.channels.get(companyId) !== channel) {
+      // The last subscriber left while the replacement was being built and
+      // closeChannel already tore the old sockets down; this one must not
+      // outlive it.
+      await withTimeout(conn.close(), CLOSE_TIMEOUT_MS, 'live close').catch(() => undefined);
+      throw new Error('channel closed during rebuild');
+    }
+    const old = { conn: channel.conn, unsubscribe: channel.unsubscribe };
+    channel.conn = conn;
+    channel.sub = sub;
+    channel.liveBroken = false;
+    channel.unsubscribe = this.attach(companyId, channel);
+    this.sessions.forget(old.conn);
+    old.unsubscribe();
+    // Closing the socket drops its server-side LIVE query with it; a KILL on
+    // a connection that may be half-open would only hang.
+    await withTimeout(old.conn.close(), CLOSE_TIMEOUT_MS, 'live close').catch(() => undefined);
+    this.logger.log(
+      `live channel for ${companyId} rebuilt; replaying the changefeed from ${channel.versionstamp}`,
+    );
+  }
+
   private replay(channel: TenantChannel, changes: ChangefeedShowRow[]): number {
     let emitted = 0;
     let highest = channel.versionstamp;
     for (const change of changes) {
-      const vs = Number(change.versionstamp ?? 0);
+      const vs = BigInt(change.versionstamp ?? 0);
       if (vs <= channel.versionstamp) continue;
       if (vs > highest) highest = vs;
       for (const item of change.changes ?? []) {
@@ -347,13 +478,8 @@ export class LiveSubscriptionManager implements OnApplicationShutdown {
     }
   }
 
-  /**
-   * Sign the subscription connection in, but only when its access token is
-   * close enough to expiry that the driver would otherwise invalidate the
-   * session. A no-op on the overwhelming majority of catch-up ticks.
-   */
+  /** Sign the connection in and record the access token's expiry. */
   private async signin(conn: Surreal): Promise<void> {
-    if (!this.sessions.needsSignin(conn)) return;
     const tokens = await withTimeout(conn.signin(this.creds), SIGNIN_TIMEOUT_MS, 'live signin');
     this.sessions.record(conn, tokens?.access);
   }
@@ -389,15 +515,18 @@ export function dbNameFor(companyId: string): string {
  * Unreadable → 0, which is safe-but-noisy (replays history) rather than
  * silently skipping forward past real changes.
  */
-async function currentVersionstamp(conn: Surreal): Promise<number> {
+async function currentVersionstamp(conn: Surreal): Promise<bigint> {
   try {
     const changes = await queryRows<ChangefeedShowRow>(
       conn,
       `SHOW CHANGES FOR TABLE ${TABLE} SINCE 0 LIMIT 100000`,
     );
-    return changes.reduce((max, c) => Math.max(max, Number(c.versionstamp ?? 0)), 0);
+    return changes.reduce((max, c) => {
+      const vs = BigInt(c.versionstamp ?? 0);
+      return vs > max ? vs : max;
+    }, 0n);
   } catch {
-    return 0;
+    return 0n;
   }
 }
 

--- a/test/bge-m3-worker-scope.unit-spec.ts
+++ b/test/bge-m3-worker-scope.unit-spec.ts
@@ -1,0 +1,112 @@
+/**
+ * BgeM3EmbedderProvider worker handlers are scoped to THEIR worker.
+ *
+ * A timed-out RPC terminates the worker (worker = null, synchronously) and
+ * the owner re-arms a warmup that builds a fresh one — while the old thread
+ * is still exiting. Its late 'exit' / 'error' must not reject the new
+ * worker's pending warmup or mark the provider not-ready for a thread it
+ * no longer owns.
+ */
+import { EventEmitter } from 'node:events';
+import {
+  BgeM3EmbedderProvider,
+  type InferenceWorker,
+} from '../src/ai/embedder/bge-m3-embedder.provider';
+import { declaredSpace } from '../src/ai/embedder/embedding-space';
+
+interface Rpc {
+  id: number;
+  kind: string;
+}
+
+/** A worker thread stand-in: `terminate()` resolves at once (the real thread
+ *  exits later, which the test emits by hand). */
+class FakeWorker extends EventEmitter implements InferenceWorker {
+  constructor(private readonly onRpc: (w: FakeWorker, rpc: Rpc) => void) {
+    super();
+  }
+  postMessage(value: unknown): void {
+    this.onRpc(this, value as Rpc);
+  }
+  async terminate(): Promise<number> {
+    return 0;
+  }
+}
+
+function provider(onRpc: (w: FakeWorker, rpc: Rpc) => void) {
+  const workers: FakeWorker[] = [];
+  const p = new BgeM3EmbedderProvider({
+    space: declaredSpace('bge-m3'),
+    concurrency: 1,
+    useWorker: true,
+    createWorker: () => {
+      const w = new FakeWorker(onRpc);
+      workers.push(w);
+      return w;
+    },
+  });
+  return { p, workers };
+}
+
+const ready = (w: FakeWorker, rpc: Rpc) =>
+  w.emit('message', { id: rpc.id, ok: true, result: { ready: true } });
+
+describe('BgeM3EmbedderProvider — worker handler scoping', () => {
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+
+  it('a terminated worker exiting late does not fail the replacement warmup', async () => {
+    const { p, workers } = provider((w, rpc) => {
+      // Worker 1 never answers; worker 2 answers only after the old thread
+      // finally exits — the interleaving a timed-out warmup produces.
+      if (w !== workers[0]) {
+        workers[0]!.emit('exit', 1);
+        ready(w, rpc);
+      }
+    });
+    const first = p.warmup();
+    first.catch(() => undefined);
+    await jest.advanceTimersByTimeAsync(120_000);
+    await expect(first).rejects.toThrow(/timed out/);
+    expect(p.isReady()).toBe(false);
+
+    await expect(p.warmup()).resolves.toBeUndefined();
+    expect(p.isReady()).toBe(true);
+    expect(workers).toHaveLength(2);
+    await p.terminate();
+  });
+
+  it("a replaced worker's late error is ignored as well", async () => {
+    const { p, workers } = provider((w, rpc) => {
+      if (w !== workers[0]) {
+        workers[0]!.emit('error', new Error('old thread crashed while unloading'));
+        ready(w, rpc);
+      }
+    });
+    const first = p.warmup();
+    first.catch(() => undefined);
+    await jest.advanceTimersByTimeAsync(120_000);
+    await expect(first).rejects.toThrow(/timed out/);
+
+    await expect(p.warmup()).resolves.toBeUndefined();
+    expect(p.isReady()).toBe(true);
+    await p.terminate();
+  });
+
+  it("the CURRENT worker's exit still fails its pending RPCs and flips not-ready", async () => {
+    const { p, workers } = provider((w, rpc) => {
+      if (rpc.kind === 'warmup') ready(w, rpc);
+      // embed: never answered — the exit must reject it.
+    });
+    await expect(p.warmup()).resolves.toBeUndefined();
+    const embed = p.embed('cats');
+    embed.catch(() => undefined);
+    // The RPC is registered behind the concurrency semaphore's await, so
+    // let the microtasks run before the thread dies under it.
+    await jest.advanceTimersByTimeAsync(0);
+    workers[0]!.emit('exit', 1);
+    await expect(embed).rejects.toThrow(/worker exited/);
+    expect(p.isReady()).toBe(false);
+    await p.terminate();
+  });
+});

--- a/test/embedding-space-truth.unit-spec.ts
+++ b/test/embedding-space-truth.unit-spec.ts
@@ -9,7 +9,7 @@ import {
   declaredSpace,
   providerIdOf,
 } from '../src/ai/embedder/embedding-space';
-import { widthGateClause } from '../src/db/vector-width';
+import { sameWidthGate, widthGateClause } from '../src/db/vector-width';
 
 /**
  * Embedding-space truth gate.
@@ -102,6 +102,26 @@ describe('embedding-space truth — every cosine scan carries the width gate', (
   // src/db/vector-width.ts); this is what keeps the next scan site honest.
   const COSINE = /vector::similarity::cosine\(\s*([A-Za-z_.]+)\s*,\s*\$([A-Za-z_]+)\s*\)/g;
 
+  /** `${sameWidthGate('col'…)}` emits the whole gate — NONE check first. */
+  const helperGate = (field: string) => new RegExp(String.raw`\$\{\s*sameWidthGate\(\s*'${field}'`);
+  /** `col != NONE`, not the tail of `gistCol != NONE`. */
+  const noneCheck = (field: string) => new RegExp(String.raw`(?<![\w.])${field}\s*!=\s*NONE`);
+  const lenCall = (field: string) => new RegExp(String.raw`(?<![\w.])array::len\(\s*${field}\s*\)`);
+
+  /** What is wrong with this literal's gate for `field`, or null when nothing is. */
+  function gateOffence(lit: string, field: string, param: string): string | null {
+    if (helperGate(field).test(lit)) return null;
+    if (!lit.includes(widthGateClause(field, param))) return 'without gate';
+    // `array::len(NONE)` is a hard error on 3.2.4, so the width comparison
+    // must never be the first thing the row meets: the NONE check has to
+    // stand before it in the same WHERE, not merely somewhere in it.
+    const none = noneCheck(field).exec(lit);
+    const len = lenCall(field).exec(lit);
+    if (!none) return 'width gate with no `!= NONE` check';
+    if (len && none.index > len.index) return '`!= NONE` check after array::len';
+    return null;
+  }
+
   it('in application code: each statement with a cosine has the gate for that column', () => {
     const offenders: string[] = [];
     for (const f of TS_FILES) {
@@ -110,13 +130,20 @@ describe('embedding-space truth — every cosine scan carries the width gate', (
       for (const lit of text.match(/`[^`]*`/gs) ?? []) {
         for (const m of lit.matchAll(COSINE)) {
           const [, field, param] = m as unknown as [string, string, string];
-          if (!lit.includes(widthGateClause(field, param))) {
-            offenders.push(`${f.slice(ROOT.length + 1)}: cosine(${field}, $${param}) without gate`);
+          const offence = gateOffence(lit, field, param);
+          if (offence) {
+            offenders.push(`${f.slice(ROOT.length + 1)}: cosine(${field}, $${param}) ${offence}`);
           }
         }
       }
     }
     expect(offenders).toEqual([]);
+  });
+
+  it('the shared helper puts the NONE check before the width comparison', () => {
+    const gate = sameWidthGate('embedding');
+    expect(gate.indexOf('embedding != NONE')).toBeLessThan(gate.indexOf('array::len(embedding)'));
+    expect(gate).toContain(widthGateClause('embedding'));
   });
 
   it('in the store: the latest fn::resolve_fact revision gates its dedup cosine', () => {

--- a/test/hnsw-ensure-memo.unit-spec.ts
+++ b/test/hnsw-ensure-memo.unit-spec.ts
@@ -1,0 +1,69 @@
+/**
+ * The KNN legs memoise "this tenant's index is missing/building" so an
+ * un-indexed tenant is not diagnosed on every query. A build or a drop makes
+ * that memory stale; an `ensure` that found every index present changed
+ * nothing and must leave it alone — the provisioner sweeps every tenant on a
+ * schedule, and clearing the memo on each no-op re-opened the per-query
+ * diagnostics for all of them.
+ */
+jest.mock('../src/db/knn-index', () => ({
+  ...jest.requireActual('../src/db/knn-index'),
+  resetKnnIndexMemo: jest.fn(),
+}));
+
+import { resetKnnIndexMemo } from '../src/db/knn-index';
+import { HnswMaintenanceService } from '../src/admin/hnsw-maintenance.service';
+
+const ALL_INDEXES = ['fact_embedding_hnsw', 'segment_embedding_hnsw'];
+
+function fakeDb(state: 'ready' | 'absent') {
+  const query = jest.fn(async (sql: string) => {
+    if (sql.startsWith('INFO FOR TABLE')) {
+      return [
+        {
+          indexes: Object.fromEntries(
+            (state === 'absent' ? [] : ALL_INDEXES).map((n) => [n, `DEFINE INDEX ${n} …`]),
+          ),
+        },
+      ];
+    }
+    if (sql.startsWith('INFO FOR INDEX')) {
+      return [{ building: { initial: 1, pending: 0, status: 'ready' } }];
+    }
+    return [null];
+  });
+  return { query };
+}
+
+function service(db: ReturnType<typeof fakeDb>) {
+  const surreal = {
+    withCompany: async <T>(_c: string, fn: (d: unknown) => Promise<T>): Promise<T> => fn(db),
+  };
+  const embedder = { primaryDimensions: () => 1024, primarySpaceId: () => 'bge:bge-m3:1024:l2' };
+  return new HnswMaintenanceService(surreal as never, embedder as never);
+}
+
+describe('hnsw maintenance — when the KNN index memo is reset', () => {
+  beforeEach(() => jest.mocked(resetKnnIndexMemo).mockClear());
+
+  it('ensure with every index present is a no-op and keeps the memo', async () => {
+    const res = await service(fakeDb('ready')).apply('co1', 'ensure');
+    expect(res.created).toEqual([]);
+    expect(resetKnnIndexMemo).not.toHaveBeenCalled();
+  });
+
+  it('ensure that had to create an index resets it', async () => {
+    const res = await service(fakeDb('absent')).apply('co1', 'ensure');
+    expect(res.created).toEqual(ALL_INDEXES);
+    expect(resetKnnIndexMemo).toHaveBeenCalledTimes(1);
+  });
+
+  it('create and drop reset it; status never does', async () => {
+    await service(fakeDb('ready')).apply('co1', 'create', { waitMs: 0 });
+    expect(resetKnnIndexMemo).toHaveBeenCalledTimes(1);
+    await service(fakeDb('ready')).apply('co1', 'drop');
+    expect(resetKnnIndexMemo).toHaveBeenCalledTimes(2);
+    await service(fakeDb('ready')).apply('co1', 'status');
+    expect(resetKnnIndexMemo).toHaveBeenCalledTimes(2);
+  });
+});

--- a/test/live-db-restart.e2e-spec.ts
+++ b/test/live-db-restart.e2e-spec.ts
@@ -1,0 +1,182 @@
+/**
+ * A LIVE subscription outlives a database outage — against a REAL SurrealDB
+ * (testcontainers, v3.2.4, started by test/global-setup.ts on a FIXED host
+ * port so the database comes back on the same URL, as a compose service does).
+ *
+ * THE CONTRACT. The subscription connection is handed out to nobody, so it
+ * never passes through `ensureSession` the way every pooled connection does on
+ * acquire. Its own repair point is the catch-up tick: probe the connection,
+ * re-sign the session, re-issue the LIVE query, replay the changefeed from the
+ * cursor it kept. A subscriber must therefore see a fact written after the
+ * outage WITHOUT a process restart, and the standing LIVE query must be
+ * working again afterwards — not a changefeed-only half-life at tick latency.
+ *
+ * What this spec is and is not. Measured on 3.2.4 with surrealdb-js 2.0.8:
+ * the driver's own reconnect does eventually restore the session and restart
+ * its managed subscriptions, so the naive tick recovers too — about 10 s
+ * later (the in-flight catch-up burns its whole timeout first), and only
+ * because of the driver. This spec is the end-to-end guard on the contract;
+ * the per-state proof (a session that comes back anonymous while the keeper
+ * still holds a valid expiry, a LIVE query the driver could not restart, a
+ * rebuild that cannot connect) is in test/live-subscription.unit-spec.ts,
+ * where each of those fails without the fix.
+ *
+ * With a preconfigured SURREALDB_URL there is no container to restart, so the
+ * suite skips rather than pretending.
+ */
+import { execFileSync } from 'node:child_process';
+import { ConfigService } from '@nestjs/config';
+import { Surreal } from 'surrealdb';
+import { SurrealService } from '../src/db/surreal.service';
+import { LiveSubscriptionManager } from '../src/live/live-subscription.manager';
+
+const CONTAINER_ID = process.env.SURREALDB_CONTAINER_ID;
+const describeIfContainer = CONTAINER_ID ? describe : describe.skip;
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+/** Outage length: past the driver's reconnect budget (5 attempts, backing off). */
+const OUTAGE_MS = 45_000;
+
+/** Poll until the database answers a fresh connection again. */
+async function waitForDatabase(url: string, timeoutMs: number): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let lastError = 'no attempt';
+  while (Date.now() < deadline) {
+    const probe = new Surreal();
+    try {
+      // The published port answers TCP the moment the container is up
+      // (docker-proxy), before the server accepts websockets — an unbounded
+      // connect() hangs there, so every attempt is bounded.
+      const attempt = probe.connect(url).then(() => probe.version());
+      attempt.catch(() => undefined);
+      await Promise.race([
+        attempt,
+        new Promise((_, reject) => setTimeout(() => reject(new Error('probe timeout')), 3_000)),
+      ]);
+      await probe.close().catch(() => undefined);
+      return;
+    } catch (e) {
+      lastError = (e as Error).message;
+      await probe.close().catch(() => undefined);
+      await sleep(250);
+    }
+  }
+  throw new Error(`database did not come back within ${timeoutMs} ms: ${lastError}`);
+}
+
+describeIfContainer('LIVE subscription recovery across a database restart', () => {
+  const tenant = `liverst${Date.now().toString(36)}`;
+  const saved: Record<string, string | undefined> = {};
+  let svc: SurrealService;
+  let mgr: LiveSubscriptionManager;
+  let entityId: unknown;
+
+  const setEnv = (key: string, value: string) => {
+    saved[key] = process.env[key];
+    process.env[key] = value;
+  };
+
+  beforeAll(async () => {
+    setEnv('LIVE_SUBSCRIPTIONS_ENABLED', '1');
+    // The tick is the recovery point, so let it run on a short interval
+    // instead of making the test wait out the 10 s production default.
+    setEnv('LIVE_CATCHUP_INTERVAL_MS', '1000');
+    svc = new SurrealService(new ConfigService());
+    await svc.onModuleInit();
+    // First touch creates and migrates the tenant database (knowledge_fact
+    // carries the CHANGEFEED the catch-up leg reads).
+    entityId = await svc.withCompany(tenant, async (db) => {
+      const [ents] = await db.query<[Array<{ id: unknown }>]>(
+        `CREATE knowledge_entity SET type = 'other', canonicalName = 'restart probe'`,
+      );
+      return (ents as Array<{ id: unknown }>)[0]!.id;
+    });
+    mgr = new LiveSubscriptionManager(new ConfigService());
+  }, 120_000);
+
+  afterAll(async () => {
+    if (mgr) await mgr.onApplicationShutdown();
+    if (svc) await svc.onApplicationShutdown();
+    for (const [k, v] of Object.entries(saved)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  });
+
+  const createFact = (object: string) =>
+    svc.withCompany(tenant, (db) =>
+      db.query(
+        `CREATE knowledge_fact SET entityId = $e, predicate = 'restart_probe', object = $o,
+           confidence = 0.9, validFrom = time::now(),
+           source = { vertical: 'rent', eventId: 'restart.probe' }`,
+        { e: entityId, o: object },
+      ),
+    );
+
+  /** Wait for a condition the subscription is supposed to reach on its own. */
+  async function waitUntil(what: string, ok: () => boolean, timeoutMs: number): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      if (ok()) return;
+      await sleep(250);
+    }
+    throw new Error(`${what} did not happen within ${timeoutMs} ms`);
+  }
+
+  it('delivers a fact written after the database restarted, with no process restart', async () => {
+    const events: Array<{ object: string; via: string }> = [];
+    const received: string[] = [];
+    const handle = await mgr.subscribe(tenant, {
+      callerScopes: ['brain:read'],
+      sink: (e) => {
+        if (e.kind !== 'fact') return;
+        events.push({ object: e.object, via: e.via });
+        received.push(e.object);
+      },
+    });
+    try {
+      // Baseline: the channel works before the outage.
+      await createFact('before-restart');
+      await waitUntil('before-restart delivery', () => received.includes('before-restart'), 20_000);
+
+      // The database goes away and comes back on the same URL. rocksdb lives
+      // inside the container, so schema and rows survive; every websocket
+      // (the subscription's included) does not.
+      const t0 = Date.now();
+      const stage = (m: string) => console.log(`[live-restart-e2e +${Date.now() - t0}ms] ${m}`);
+      // Down for longer than the driver's own reconnect budget (5 attempts),
+      // which is what a real upgrade or a partition looks like: by the time
+      // the database is back, nothing is going to restore the socket, the
+      // session or the LIVE query for us.
+      execFileSync('docker', ['stop', CONTAINER_ID!], { stdio: 'ignore' });
+      stage('container stopped');
+      await sleep(OUTAGE_MS);
+      execFileSync('docker', ['start', CONTAINER_ID!], { stdio: 'ignore' });
+      stage('container started again');
+      await waitForDatabase(process.env.SURREALDB_URL!, 60_000);
+      stage('database answers a fresh connection');
+
+      // The write path recovers on its own (pool ensureSession), so this is
+      // purely about the subscription seeing what was written.
+      await createFact('after-restart');
+      stage('fact written after the restart');
+      await waitUntil('after-restart delivery', () => received.includes('after-restart'), 90_000);
+      stage('subscriber received the post-restart fact');
+
+      // And the channel is whole again, not limping on the changefeed alone:
+      // the next write arrives over the STANDING LIVE QUERY. Without the
+      // rebuild the socket's subscription stays dead for the life of the
+      // process and every event is a replay, at tick latency.
+      await createFact('after-recovery');
+      await waitUntil(
+        'after-recovery delivery over LIVE',
+        () => events.some((e) => e.object === 'after-recovery' && e.via === 'live'),
+        30_000,
+      );
+      stage('post-recovery fact arrived over the rebuilt LIVE query');
+      await expect(mgr.catchUp(tenant)).resolves.toBeGreaterThanOrEqual(0);
+    } finally {
+      await handle.close();
+    }
+  }, 300_000);
+});

--- a/test/live-subscription.unit-spec.ts
+++ b/test/live-subscription.unit-spec.ts
@@ -34,13 +34,18 @@ describe('LiveSubscriptionManager', () => {
    */
   function installChannel(
     mgr: LiveSubscriptionManager,
-    opts: { changes?: any[]; versionstamp?: number } = {},
+    opts: { changes?: any[]; versionstamp?: bigint } = {},
   ) {
     const received: Array<{ sub: string; event: LiveEvent }> = [];
     const signins: number[] = [];
+    const queries: string[] = [];
     const channel = {
       conn: {
-        query: async () => [opts.changes ?? []],
+        query: async (sql: string) => {
+          queries.push(sql);
+          // `RETURN 1` is the tick's liveness probe, not a changefeed read.
+          return sql.startsWith('RETURN') ? [1] : [opts.changes ?? []];
+        },
         // A subscription connection outlives its access token, so the
         // catch-up tick renews it. Hand back a token that is nowhere near
         // expiring, so a second tick must NOT re-sign.
@@ -48,13 +53,20 @@ describe('LiveSubscriptionManager', () => {
           signins.push(Date.now());
           return { access: farFutureJwt() };
         },
+        // A standing, authenticated socket the tick can probe instead of
+        // rebuilding (the real Surreal getters).
+        isConnected: true,
+        accessToken: farFutureJwt(),
+        subscribe: () => () => {},
+        close: async () => {},
       },
-      sub: { kill: async () => {} },
+      sub: { kill: async () => {}, isAlive: true },
       unsubscribe: () => {},
       subscribers: new Map(),
-      versionstamp: opts.versionstamp ?? 10,
+      versionstamp: opts.versionstamp ?? 10n,
       delivered: new Set<string>(),
       timer: null,
+      liveBroken: false,
     };
     (mgr as any).channels.set('co_x', channel);
     const addSubscriber = (id: string, scopes: string[], lookup?: any) => {
@@ -66,7 +78,7 @@ describe('LiveSubscriptionManager', () => {
         queued: 0,
       });
     };
-    return { channel, received, addSubscriber, signins };
+    return { channel, received, addSubscriber, signins, queries };
   }
 
   /** A syntactically real access token that expires in a year. */
@@ -75,7 +87,7 @@ describe('LiveSubscriptionManager', () => {
     return `${b64({ alg: 'HS512' })}.${b64({ exp: Math.floor(Date.now() / 1000) + 31_536_000 })}.s`;
   }
 
-  const change = (versionstamp: number, id: string, predicate: string) => ({
+  const change = (versionstamp: number | bigint, id: string, predicate: string) => ({
     versionstamp,
     changes: [{ update: { id, predicate, object: 'v', entityId: 'knowledge_entity:e1' } }],
   });
@@ -140,7 +152,7 @@ describe('LiveSubscriptionManager', () => {
     it('replays changes the socket never delivered', async () => {
       const mgr = makeManager();
       const { received, addSubscriber } = installChannel(mgr, {
-        versionstamp: 10,
+        versionstamp: 10n,
         changes: [
           change(11, 'knowledge_fact:a', 'lives_in'),
           change(12, 'knowledge_fact:b', 'reads'),
@@ -158,7 +170,7 @@ describe('LiveSubscriptionManager', () => {
     it('does NOT re-deliver what the live socket already pushed', async () => {
       const mgr = makeManager();
       const { channel, received, addSubscriber } = installChannel(mgr, {
-        versionstamp: 10,
+        versionstamp: 10n,
         changes: [
           change(11, 'knowledge_fact:a', 'lives_in'),
           change(12, 'knowledge_fact:b', 'reads'),
@@ -175,18 +187,18 @@ describe('LiveSubscriptionManager', () => {
     it('advances the cursor so the next tick does not repeat the batch', async () => {
       const mgr = makeManager();
       const { channel, addSubscriber } = installChannel(mgr, {
-        versionstamp: 10,
+        versionstamp: 10n,
         changes: [change(11, 'knowledge_fact:a', 'p'), change(17, 'knowledge_fact:b', 'p')],
       });
       addSubscriber('s1', ['brain:read']);
       await mgr.catchUp('co_x');
-      expect(channel.versionstamp).toBe(17);
+      expect(channel.versionstamp).toBe(17n);
     });
 
     it('ignores changes at or below the cursor (SINCE is inclusive)', async () => {
       const mgr = makeManager();
       const { received, addSubscriber } = installChannel(mgr, {
-        versionstamp: 10,
+        versionstamp: 10n,
         changes: [change(10, 'knowledge_fact:old', 'p'), change(11, 'knowledge_fact:new', 'p')],
       });
       addSubscriber('s1', ['brain:read']);
@@ -196,6 +208,35 @@ describe('LiveSubscriptionManager', () => {
 
     it('is a no-op for a tenant with no channel', async () => {
       await expect(makeManager().catchUp('co_missing')).resolves.toBe(0);
+    });
+
+    /**
+     * A 3.x versionstamp is a u64 around 1.17e17, where a double's ULP is 16:
+     * folded through Number(), a cursor and a later commit inside the same
+     * millisecond round to the SAME value, and `vs <= cursor` then drops the
+     * commit (or, the other way round, re-delivers one). The cursor and every
+     * comparison are bigint end to end.
+     */
+    it('keeps u64 versionstamps exact past 2^53', async () => {
+      const cursor = 117_000_000_000_000_001n;
+      const next = 117_000_000_000_000_005n;
+      expect(Number(next)).toBe(Number(cursor)); // both round to …000
+      const mgr = makeManager();
+      const { channel, received, addSubscriber } = installChannel(mgr, {
+        versionstamp: cursor,
+        changes: [change(next, 'knowledge_fact:u64', 'p')],
+      });
+      addSubscriber('s1', ['brain:read']);
+      expect(await mgr.catchUp('co_x')).toBe(1);
+      expect(received.map((r) => (r.event as any).factId)).toEqual(['knowledge_fact:u64']);
+      expect(channel.versionstamp).toBe(next);
+    });
+
+    it('reads the changefeed SINCE the exact cursor, not a rounded one', async () => {
+      const mgr = makeManager();
+      const { queries } = installChannel(mgr, { versionstamp: 117_000_000_000_000_001n });
+      await mgr.catchUp('co_x');
+      expect(queries.join('\n')).toContain('SINCE 117000000000000001');
     });
   });
 
@@ -209,7 +250,7 @@ describe('LiveSubscriptionManager', () => {
     it('withholds a scoped predicate from a subscriber without the scope', async () => {
       const mgr = makeManager();
       const { received, addSubscriber } = installChannel(mgr, {
-        versionstamp: 10,
+        versionstamp: 10n,
         changes: [change(11, 'knowledge_fact:pii', 'dob')],
       });
       addSubscriber('reader', ['brain:read'], lookup);
@@ -220,7 +261,7 @@ describe('LiveSubscriptionManager', () => {
     it('delivers the same event to a subscriber that HAS the scope', async () => {
       const mgr = makeManager();
       const { received, addSubscriber } = installChannel(mgr, {
-        versionstamp: 10,
+        versionstamp: 10n,
         changes: [change(11, 'knowledge_fact:pii', 'dob')],
       });
       addSubscriber('privileged', ['brain:read', 'brain:read_pii'], lookup);
@@ -231,7 +272,7 @@ describe('LiveSubscriptionManager', () => {
     it('fences per subscriber — one stream being allowed does not leak into another', async () => {
       const mgr = makeManager();
       const { received, addSubscriber } = installChannel(mgr, {
-        versionstamp: 10,
+        versionstamp: 10n,
         changes: [change(11, 'knowledge_fact:pii', 'dob')],
       });
       addSubscriber('privileged', ['brain:read', 'brain:read_pii'], lookup);
@@ -252,14 +293,14 @@ describe('LiveSubscriptionManager', () => {
      */
     it('signs the channel connection in on the first catch-up tick', async () => {
       const mgr = makeManager();
-      const { signins } = installChannel(mgr, { versionstamp: 10, changes: [] });
+      const { signins } = installChannel(mgr, { versionstamp: 10n, changes: [] });
       await mgr.catchUp('co_x');
       expect(signins).toHaveLength(1);
     });
 
     it('does not re-sign while the token still has life left', async () => {
       const mgr = makeManager();
-      const { signins } = installChannel(mgr, { versionstamp: 10, changes: [] });
+      const { signins } = installChannel(mgr, { versionstamp: 10n, changes: [] });
       await mgr.catchUp('co_x');
       await mgr.catchUp('co_x');
       await mgr.catchUp('co_x');
@@ -270,11 +311,95 @@ describe('LiveSubscriptionManager', () => {
     });
   });
 
+  /**
+   * The database goes away and comes back (a restart, an upgrade, a network
+   * partition longer than the driver's reconnect budget). The SDK brings the
+   * socket back with an ANONYMOUS session and the standing LIVE query gone,
+   * while the session keeper still holds a valid expiry — so a tick that
+   * only re-signs "when the token is near expiry" fails the same way
+   * forever and the subscribers starve in silence. The tick therefore probes
+   * the connection the way every pool acquire does (`RETURN 1`), and rebuilds
+   * the channel — fresh connection, fresh signin, fresh LIVE — replaying the
+   * gap from the cursor it kept.
+   */
+  describe('recovery after the database restarts', () => {
+    /** A replacement connection the rebuild can adopt, with its own LIVE. */
+    function replacement(changes: any[] = []) {
+      const sub = { kill: async () => {}, isAlive: true, subscribe: () => () => {} };
+      const conn = {
+        query: async (sql: string) => (sql.startsWith('RETURN') ? [1] : [changes]),
+        signin: async () => ({ access: farFutureJwt() }),
+        isConnected: true,
+        accessToken: farFutureJwt(),
+        subscribe: () => () => {},
+        close: async () => {},
+        live: async () => sub,
+      };
+      return { conn, sub };
+    }
+
+    it('rebuilds the channel when the session came back anonymous, and replays the gap', async () => {
+      const mgr = makeManager();
+      const missed = change(12, 'knowledge_fact:during_outage', 'p');
+      const { channel, received, addSubscriber } = installChannel(mgr, { versionstamp: 10n });
+      // The keeper holds a valid expiry, so nothing would re-sign on its own.
+      (mgr as any).sessions.record(channel.conn, farFutureJwt());
+      channel.conn.query = async () => {
+        throw new Error('IAM error: Not enough permissions: Anonymous access not allowed');
+      };
+      const fresh = replacement([missed]);
+      const open = jest.spyOn(mgr as any, 'openConnection').mockResolvedValue(fresh.conn as never);
+      addSubscriber('s1', ['brain:read']);
+
+      expect(await mgr.catchUp('co_x')).toBe(1);
+      expect(open).toHaveBeenCalledWith('co_x');
+      // The channel now rides the replacement, LIVE query included.
+      expect(channel.conn).toBe(fresh.conn);
+      expect(channel.sub).toBe(fresh.sub);
+      // …and the change committed while the socket was dead was delivered.
+      expect(received.map((r) => (r.event as any).factId)).toEqual([
+        'knowledge_fact:during_outage',
+      ]);
+      expect(channel.versionstamp).toBe(12n);
+    });
+
+    it('rebuilds when the standing LIVE query is gone even though the socket answers', async () => {
+      const mgr = makeManager();
+      const { channel, addSubscriber } = installChannel(mgr, { versionstamp: 10n });
+      (mgr as any).sessions.record(channel.conn, farFutureJwt());
+      channel.sub.isAlive = false; // the driver could not restart it
+      const fresh = replacement([change(11, 'knowledge_fact:after', 'p')]);
+      jest.spyOn(mgr as any, 'openConnection').mockResolvedValue(fresh.conn as never);
+      addSubscriber('s1', ['brain:read']);
+
+      expect(await mgr.catchUp('co_x')).toBe(1);
+      expect(channel.sub).toBe(fresh.sub);
+    });
+
+    it('a rebuild that cannot connect leaves the channel in place for the next tick', async () => {
+      const mgr = makeManager();
+      const { channel, addSubscriber } = installChannel(mgr, { versionstamp: 10n });
+      (mgr as any).sessions.record(channel.conn, farFutureJwt());
+      channel.sub.isAlive = false;
+      jest
+        .spyOn(mgr as any, 'openConnection')
+        .mockRejectedValue(new Error('connect timed out') as never);
+      addSubscriber('s1', ['brain:read']);
+
+      await expect(mgr.catchUp('co_x')).rejects.toThrow(/connect timed out/);
+      // Nothing was thrown away: the cursor and the subscribers survive, so
+      // the interval's next tick tries again.
+      expect((mgr as any).channels.get('co_x')).toBe(channel);
+      expect(channel.versionstamp).toBe(10n);
+      expect(channel.subscribers.size).toBe(1);
+    });
+  });
+
   describe('backpressure and lifecycle', () => {
     it('signals resync instead of growing an unbounded queue', async () => {
       const mgr = makeManager({ LIVE_MAX_QUEUE_PER_SUBSCRIBER: '0' });
       const { received, addSubscriber } = installChannel(mgr, {
-        versionstamp: 10,
+        versionstamp: 10n,
         changes: [change(11, 'knowledge_fact:a', 'p')],
       });
       addSubscriber('slow', ['brain:read']);
@@ -285,7 +410,7 @@ describe('LiveSubscriptionManager', () => {
     it('drops a subscriber whose sink throws, without killing the stream', async () => {
       const mgr = makeManager();
       const { channel, received, addSubscriber } = installChannel(mgr, {
-        versionstamp: 10,
+        versionstamp: 10n,
         changes: [change(11, 'knowledge_fact:a', 'p')],
       });
       channel.subscribers.set('broken', {

--- a/test/segment-hnsw.e2e-spec.ts
+++ b/test/segment-hnsw.e2e-spec.ts
@@ -68,6 +68,32 @@ describe('segment HNSW index: retired indexes gone, segment leg rides the one th
     });
     expect(fields.embedding).toBeDefined();
     expect(fields.altEmbedding).toBeUndefined();
+    // 0140: `REMOVE FIELD altEmbedding` leaves the server-generated
+    // `altEmbedding.*` element definition behind, and while it stands a
+    // SCHEMAFULL write of the retired column is still accepted AND STORED
+    // (measured on 3.2.4). A retired column has to reject writes.
+    expect(fields['altEmbedding.*']).toBeUndefined();
+    const write = await surreal.withCompany(f.companyId, async (db) => {
+      const [ents] = await db.query<[Array<{ id: unknown }>]>(
+        `CREATE knowledge_entity SET type = 'other', canonicalName = 'alt probe'`,
+      );
+      const e = (ents as Array<{ id: unknown }>)[0]!.id;
+      const row = `entityId = $e, predicate = 'alt_probe', object = 'o', confidence = 0.9,
+         validFrom = time::now(), source = { vertical: 'rent', eventId: 'alt.probe' }`;
+      // Baseline: the identical row WITHOUT the retired column is accepted,
+      // so the rejection below is about altEmbedding and nothing else.
+      await db.query(`CREATE knowledge_fact SET ${row}`, { e });
+      try {
+        await db.query(`CREATE knowledge_fact SET ${row}, altEmbedding = [1.0]`, { e });
+        const [stored] = await db.query<[Array<{ id: unknown }>]>(
+          `SELECT id FROM knowledge_fact WHERE altEmbedding != NONE`,
+        );
+        return { rejected: false, stored: ((stored as unknown[]) ?? []).length };
+      } catch (err) {
+        return { rejected: true, message: (err as Error).message };
+      }
+    });
+    expect(write).toMatchObject({ rejected: true, message: expect.stringMatching(/altEmbedding/) });
 
     const create = await f.http.post('/v1/admin/maintenance/hnsw').set(auth()).send({});
     expect(create.status).toBe(201);

--- a/test/vector-corpus-width.e2e-spec.ts
+++ b/test/vector-corpus-width.e2e-spec.ts
@@ -11,6 +11,7 @@
  */
 import { AppFixture, createApp } from './app-fixture';
 import { SurrealService } from '../src/db/surreal.service';
+import { EmbedderService } from '../src/ai/embedder.service';
 
 describe('vector corpus width: gate, census, repair (real SurrealDB)', () => {
   let f: AppFixture;
@@ -102,5 +103,62 @@ describe('vector corpus width: gate, census, repair (real SurrealDB)', () => {
       return new Set((rows as Array<{ w: number }>).map((r) => Number(r.w)));
     });
     expect([...widths]).toEqual([1536]);
+  });
+
+  /**
+   * The repair pays for the rows the census counted, not for the tenant. The
+   * sweep it drives used to `SELECT id, predicate, object FROM knowledge_fact`
+   * with no width filter, so ONE stray vector re-embedded (and rewrote) every
+   * row of every swept table — the cost of a full migration for a one-row
+   * defect, plus a write storm on rows that were already correct.
+   */
+  it('re-embeds only the non-conforming rows, not the whole tenant', async () => {
+    for (const object of ['the intercom buzzes at night', 'bins collected on friday']) {
+      expect([200, 201]).toContain((await ingest(object, 'width_narrow_subject')).status);
+    }
+    const poisoned = 'the stairwell light flickers';
+    expect([200, 201]).toContain((await ingest(poisoned, 'width_narrow_subject')).status);
+
+    const surreal = f.app.get(SurrealService);
+    await surreal.withCompany(f.companyId, async (db) => {
+      await db.query(
+        `UPDATE knowledge_fact SET embedding = $v
+          WHERE predicate = 'complained_about' AND object = $object`,
+        { v: vec(FOREIGN), object: poisoned },
+      );
+    });
+
+    const conforming = await surreal.withCompany(f.companyId, async (db) => {
+      const [rows] = await db.query<[Array<{ c: number }>]>(
+        `SELECT count() AS c FROM knowledge_fact
+          WHERE embedding != NONE AND array::len(embedding) = 1536 GROUP ALL`,
+      );
+      return Number((rows as Array<{ c: number }>)[0]?.c ?? 0);
+    });
+    expect(conforming).toBeGreaterThan(1);
+
+    // Count what the repair actually asks the embedder for.
+    const embedder = f.app.get(EmbedderService);
+    const embedded: string[] = [];
+    const many = jest
+      .spyOn(embedder, 'embedManyForWrite')
+      .mockImplementation(async (texts: string[]) => {
+        embedded.push(...texts);
+        return Promise.all(texts.map((t) => embedder.embed(t)));
+      });
+    const one = jest.spyOn(embedder, 'embedForWrite');
+    try {
+      const repair = await f.http.post('/v1/admin/embedding-space/repair').set(auth()).send({});
+      expect(repair.status).toBe(201);
+      expect(repair.body.outcome).toBe('repaired');
+      expect(repair.body.after.nonConforming).toBe(0);
+    } finally {
+      many.mockRestore();
+      one.mockRestore();
+    }
+    // Exactly the poisoned row: `<predicate>: <object>` is the sweep's
+    // projection for knowledge_fact.
+    expect(embedded).toEqual([`complained_about: ${poisoned}`]);
+    expect(one).not.toHaveBeenCalled();
   });
 });

--- a/test/vector-corpus.unit-spec.ts
+++ b/test/vector-corpus.unit-spec.ts
@@ -126,7 +126,13 @@ describe('VectorCorpusService', () => {
     const r = await svc.reconcileTenant('co_x', 'startup');
     expect(r.outcome).toBe('repaired');
     expect(reindex.run).toHaveBeenCalledTimes(1);
-    expect(reindex.run).toHaveBeenCalledWith({ tenant: 'co_x', allTables: true });
+    // The sweep is narrowed to the rows the census just counted: without
+    // `widthMismatchOnly` one stray vector costs a full-tenant re-embed.
+    expect(reindex.run).toHaveBeenCalledWith({
+      tenant: 'co_x',
+      allTables: true,
+      widthMismatchOnly: { dim: 1024 },
+    });
     expect(jobs.start).toHaveBeenCalledWith(
       expect.objectContaining({
         jobType: 'reindex_embeddings',
@@ -191,7 +197,11 @@ describe('VectorCorpusService', () => {
       await jest.advanceTimersByTimeAsync(60_000);
       await jest.advanceTimersByTimeAsync(0);
       expect(reindex.run).toHaveBeenCalledTimes(1);
-      expect(reindex.run).toHaveBeenCalledWith({ tenant: 'co_x', allTables: true });
+      expect(reindex.run).toHaveBeenCalledWith({
+        tenant: 'co_x',
+        allTables: true,
+        widthMismatchOnly: { dim: 1024 },
+      });
     } finally {
       jest.useRealTimers();
     }


### PR DESCRIPTION
## What

Seven findings from the second-pass review of this week's infra and vector PRs, each verified against a real SurrealDB 3.2.4 before it was fixed.

**LIVE subscriptions**
- `src/live/live-subscription.manager.ts`: the catch-up tick is now the channel's repair point, mirroring `SurrealService.ensureSession` — a bounded `RETURN 1` probe on a session outside the re-auth margin, a `signin()` on one inside it (or one the driver dropped), and, when either fails or the driver reports the standing LIVE query dead, a full rebuild on a fresh connection (new signin, new `conn.live(...)`) with the kept cursor replaying the gap. The connection's `connected` / `disconnected` / `error` events run a tick at once instead of waiting up to an interval; a `LiveSubscriptionError` marks the LIVE query broken so the next tick rebuilds. A rebuild that cannot connect leaves the old channel in place for the interval to retry.
- The changefeed cursor is **bigint end to end** (`SHOW CHANGES` versionstamp, comparisons, anchor). A 3.x versionstamp is a u64 around 1.17e17, where a double's ULP is 16 — measured on the testcontainer: `117248438146629632`.

**Vector plane**
- New migration **0143** removes the `altEmbedding.*` element definition that 0139's `REMOVE FIELD altEmbedding` left behind, preceded by an `UNSET` pass.
- `src/ai/embedder/reindex-engine.service.ts` gains `widthMismatchOnly: { dim }`, narrowing every swept table to rows whose vector is present and not `dim` wide (page offsets account for repaired rows leaving the result set); the census-triggered repair in `src/admin/vector-corpus.service.ts` passes it.
- `src/dreams/dedup.service.ts` brute leg now uses `sameWidthGate('embedding')`, and the truth gate requires the `!= NONE` check to precede `array::len` for every cosine scan in `src/`.
- `src/ai/embedder/bge-m3-embedder.provider.ts`: each worker's `message` / `error` / `exit` handler is scoped to its own Worker (`if (this.worker !== w) return`), behind a `createWorker` test seam.
- `src/admin/hnsw-maintenance.service.ts`: the KNN index memo resets only on `create`, `drop`, or an `ensure` that actually created something.

## Why

Named findings from the review (P2 #1, P3 #2–#7):

1. **P2 — a LIVE channel never re-authorizes after the database restarts.** The subscription connection is handed out to nobody, so it never passes through `ensureSession`; the tick's `signin()` was skipped whenever the session keeper held a valid expiry, and nothing re-issued the LIVE query. **Correction to the finding's severity:** on 3.2.4 with surrealdb-js 2.0.8 the driver's own reconnect does eventually restore the session *and* restart its managed subscriptions, so the naive tick recovers too — measured at ~10 s after the write (the in-flight catch-up burns its full 10 s timeout first) versus ~1 s (one tick) with the fix, and only by grace of the driver. It is a real defect with a real repair, not a permanent outage. The per-state proof lives in the unit spec; the e2e is the end-to-end guard.
2. **P3 — `Number()` on u64 versionstamps.** `Number(117000000000000001n) === Number(117000000000000005n)`, so `vs <= cursor` skipped a real commit.
3. **P3 — 0139 did not actually retire `altEmbedding`.** Measured on a v3.2.4 container: after `REMOVE FIELD IF EXISTS altEmbedding ON knowledge_fact`, `INFO FOR TABLE` still lists `altEmbedding.* … TYPE float`, and a SCHEMAFULL `CREATE … SET altEmbedding = [1.0, 2.0]` is accepted **and stored**. `REMOVE FIELD IF EXISTS altEmbedding.* ON <table>` parses and fixes it, after which the write fails with `Found field 'altEmbedding', but no such field exists`. Also measured: with no definition covering the field, a row that still *holds* a value can no longer be written at all (every `UPDATE` of it fails), so the migration `UNSET`s leftovers first — a no-op on every current deployment (0139: the writer was reverted, the column is empty), a repair on any tenant that ingested while `SEARCH_HYPE_ENABLED` was on.
4. **P3 — unscoped bge-m3 worker handlers.** An RPC timeout calls `void this.terminate()` (nulling the worker synchronously) and a re-armed warmup builds a new Worker while the old thread is still exiting; the old thread's `exit`/`error` then rejected the new warmup's pending RPCs and cleared the ready flag.
5. **P3 — the dedup brute leg gated width before checking for NONE.** `array::len(NONE)` is a hard error on 3.2.4; the statement survived only on planner luck.
6. **P3 — the census-triggered repair re-embedded every row.** Measured in the e2e: one poisoned row triggered **178** embed calls across the tenant (facts, entities, the whole predicate registry); it is now exactly 1.
7. **P3 — the KNN memo was cleared on every `ensure`,** including the provisioner's no-op sweep over every tenant, re-opening per-query diagnostics for all of them.

## How verified

Every item fails without its fix (checked by reverting the fix and re-running):

| # | Test | Without the fix |
|---|------|-----------------|
| 1 | `test/live-subscription.unit-spec.ts` (3 new cases: anonymous session with a valid keeper entry, dead LIVE subscription, rebuild that cannot connect) + `test/live-db-restart.e2e-spec.ts` | 3 unit cases fail (the tick throws and nothing is rebuilt) |
| 2 | `test/live-subscription.unit-spec.ts` — `keeps u64 versionstamps exact past 2^53` | fails: the commit is skipped (`emitted` 0) |
| 3 | `test/segment-hnsw.e2e-spec.ts` — the retired-column write | fails: the write is accepted and stored |
| 4 | `test/bge-m3-worker-scope.unit-spec.ts` | 2 of 3 fail |
| 5 | `test/embedding-space-truth.unit-spec.ts` — gate ordering | fails: `dedup.service.ts: cosine(embedding, $q) width gate with no \`!= NONE\` check` |
| 6 | `test/vector-corpus-width.e2e-spec.ts` — stub-embedder call count | fails: 178 texts embedded instead of 1 |
| 7 | `test/hnsw-ensure-memo.unit-spec.ts` | fails: the no-op `ensure` clears the memo |

Migration syntax and the two 3.2.4 behaviours in finding #3 were established on a throwaway `surrealdb/surrealdb:v3.2.4` container over the HTTP `/sql` endpoint before any code was written; the container was removed afterwards.

Gates (all on the rebased branch):

```
pnpm typecheck                                    # clean
pnpm lint:ci                                      # clean (eslint --max-warnings 0)
pnpm format:check                                 # All matched files use Prettier code style!

pnpm jest --config ./test/jest-unit.json --testPathPatterns \
  'live-subscription|bge-m3|embedder|dedup|hnsw|embedding-space|vector|reindex|flag-budget|engine-layering|truth|doctrine|migration'
  # Test Suites: 33 passed, 33 total   Tests: 288 passed, 288 total

pnpm jest --config ./test/jest-e2e.json --testPathPatterns 'segment-hnsw|vector-corpus-width|live-db-restart'
  # Test Suites: 3 passed, 3 total     Tests: 5 passed, 5 total

pnpm jest --config ./test/jest-e2e.json --testPathPatterns \
  'embedding-space.e2e|hnsw.e2e|scan-hnsw|scoped-session-expiry|dreams-corroborate|retracted-by-dreams|db-restart-recovery'
  # Test Suites: 8 passed / 2 passed (two runs)   Tests: 35 passed / 2 passed
```

No new flags or env knobs: `widthMismatchOnly` is a call-site option, `createWorker` a test seam. `src/jobs/*`, `src/main.ts`, `src/db/migrator*`, `src/answer-cache/*`, `src/auth/*` and `.github/workflows/*` are untouched. Migration re-checked against `origin/main` (now at #557) and against every open PR that adds one: 0140/0141 are on main and #554 claims 0142 — hence **0143**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhrQxeisXJZEt4sg3PGyU6
