### PR TITLE
feat(deploy): run the service as N replicas, and make one run at a time own the deploy transaction

### DIFF
--- a/.github/workflows/deploy-brain.yml
+++ b/.github/workflows/deploy-brain.yml
@@ -37,21 +37,39 @@ on:
   workflow_dispatch:
     inputs:
       action:
-        # `rollback` redeploys the last image that passed BOTH the
-        # readiness gate and the external smoke test, recorded on the box
-        # at .last-good-image. It is the manual twin of the automatic
-        # rollback the deploy job performs when its own verification
-        # fails; see § Rollback in docs/operations.md.
+        # `rollback` redeploys the newest digest in the confirmed-good
+        # history that is NOT the one running, so it steps BACK off a
+        # release that went green and then turned out to be bad. It is the
+        # manual twin of the automatic rollback the deploy job performs
+        # when its own verification fails; see § Rollback in
+        # docs/operations.md.
         description: 'deploy | restart | logs | rollback'
         required: false
         default: 'deploy'
+      image_digest:
+        # Only read by action=rollback, and only accepted when the digest
+        # appears in .good-image-history — an arbitrary digest typed into
+        # a box is not a verified release.
+        description: 'rollback target digest (must be in the confirmed-good history); blank = newest good that is not running'
+        required: false
+        default: ''
 
-# Cancel an in-flight auto-deploy when a new push lands. Manual
-# dispatches keep their own concurrency group so they don't fight
-# auto-deploys.
+# ONE group for every run that can mutate production state on the box,
+# and it QUEUES rather than cancels.
+#
+# It used to be keyed by `github.event_name`, so a push deploy and a
+# manual dispatch ran concurrently over the same state files: run A could
+# pass smoke, run B overwrite `.pending-image`, and A's finalize then
+# promote B as verified (audit F2). Serialising by event name did not help
+# — the two groups were the two racers.
+#
+# `cancel-in-progress: false` is equally load-bearing: the deploy state
+# machine spans three jobs (deploy → smoke → finalize) and cancelling
+# between them leaves a half-applied transaction on the box with nobody
+# left to promote or undo it.
 concurrency:
-  group: deploy-brain-${{ github.event_name }}
-  cancel-in-progress: true
+  group: deploy-brain-production
+  cancel-in-progress: false
 
 env:
   PROJECT_NAME: inite-brain-service
@@ -228,15 +246,13 @@ jobs:
           SEARCH_SEGMENT_LANE_RERANK=1
           SEARCH_FACT_RERANK=1
           # ── Search stack ──
+          # Provisioning follows this flag by default (the schema-ready
+          # hook and the nightly sweep read SEARCH_HNSW_ENABLED unless
+          # HNSW_PROVISION_ENABLED is set explicitly), so the line above
+          # also turns index creation on — no separate pin restating it.
+          # Provisioning only ADDS absent indexes, always CONCURRENTLY,
+          # capped at 5 tenants starting builds per nightly run.
           SEARCH_HNSW_ENABLED=1
-          # …and the provisioning that makes the line above true. Without
-          # it the KNN leg is on for every tenant while index creation is a
-          # human remembering to POST /v1/admin/maintenance/hnsw, and a
-          # tenant nobody remembered is served k arbitrary rows with a null
-          # distance rather than an error (#506). Provisioning only ADDS
-          # absent indexes, always CONCURRENTLY, capped at 5 tenants
-          # starting builds per nightly run.
-          HNSW_PROVISION_ENABLED=1
           SEARCH_COMBINED_VECTOR_GRAPH=1
           SEARCH_HIGHLIGHT_ENABLED=1
           SEARCH_USAGE_RECORDING_ENABLED=1
@@ -350,13 +366,12 @@ jobs:
           PRIVACY_SEGMENT_USER_FENCE=1
           PRIVACY_COMPOSER_USER_SCOPE=1
           # ── Capability probes (active monitoring) ──
-          # ON deliberately, and this is the one line that makes the monitor
-          # real: a probe nobody enables repeats the bug it was written for.
-          # Both incidents it covers (#502 scoped pool anonymous, #503
-          # embedder answering cross-space) reached production while /health
-          # and /ready were green. Cost: one LIMIT 1 read + one short embed
-          # per pod per minute. Kill switch: set to 0 and restart.
-          CAPABILITY_PROBE_ENABLED=1
+          # Not pinned here: the probe is on unless CAPABILITY_PROBE_ENABLED=0,
+          # which is also its kill switch (set it and restart). Cost: one
+          # LIMIT 1 read + one short embed per pod per minute; the incidents
+          # it covers (#502 scoped pool anonymous, #503 embedder answering
+          # cross-space) both reached production while /health and /ready
+          # were green.
           # ── Packs / MCP / QA ──
           MCP_PACK_EXTERNAL_TOOLS_ENABLED=1
           AGENT_QA_TOOLS_V2=1
@@ -452,6 +467,12 @@ jobs:
         env:
           IMAGE_FROM_CI: ${{ needs.verify.outputs.image }}
           ACTION: ${{ github.event.inputs.action }}
+          # Explicit rollback target (optional); validated against the
+          # confirmed-good history below.
+          IMAGE_INPUT: ${{ github.event.inputs.image_digest }}
+          # How many identical containers of this service to run. Repo
+          # variable, empty ⇒ 1. Every check below counts against it.
+          BRAIN_REPLICAS: ${{ vars.BRAIN_REPLICAS }}
           BRAIN_SURREAL_USER: ${{ secrets.BRAIN_SURREAL_USER }}
           BRAIN_SURREAL_PASS: ${{ secrets.BRAIN_SURREAL_PASS }}
           BRAIN_SURREAL_SCOPED_PASS: ${{ secrets.BRAIN_SURREAL_SCOPED_PASS }}
@@ -459,8 +480,101 @@ jobs:
           BRAIN_FORGET_HMAC_KEY: ${{ secrets.BRAIN_FORGET_HMAC_KEY }}
           BRAIN_BILLING_API_KEY: ${{ secrets.BRAIN_BILLING_API_KEY }}
         run: |
-          mkdir -p "/opt/projects/${PROJECT_NAME}"
-          cd "/opt/projects/${PROJECT_NAME}"
+          # The project directory is the deploy's whole state store. It is
+          # read from the environment (defaulting to the real path) so the
+          # truth test can run these exact fragments over a temp dir —
+          # test/deploy-race-truth.unit-spec.ts extracts them from this
+          # file.
+          PROJECT_DIR="${PROJECT_DIR:-/opt/projects/${PROJECT_NAME}}"
+          mkdir -p "${PROJECT_DIR}"
+          cd "${PROJECT_DIR}"
+
+          # Desired replica count. One malformed value must not silently
+          # become "1" and quietly scale production down.
+          BRAIN_REPLICAS="${BRAIN_REPLICAS:-1}"
+          case "${BRAIN_REPLICAS}" in
+            ''|*[!0-9]*) echo "[err] BRAIN_REPLICAS must be a positive integer, got '${BRAIN_REPLICAS}'"; exit 1 ;;
+          esac
+          [ "${BRAIN_REPLICAS}" -ge 1 ] || { echo "[err] BRAIN_REPLICAS must be >= 1"; exit 1; }
+          echo "BRAIN_REPLICAS=${BRAIN_REPLICAS}" >> "$GITHUB_ENV"
+          echo "[deploy] replicas: ${BRAIN_REPLICAS}"
+
+          # Replica-aware helpers, shared by this job's later steps and by
+          # finalize (same host, same directory). Generated rather than
+          # repeated six times: every check has to count or iterate now
+          # that the service is N containers, and six hand-copied loops
+          # drift. Values are baked at generation time.
+          tee deploy-lib.sh > /dev/null << EOF
+          # Generated by .github/workflows/deploy-brain.yml — not edited on the box.
+          SERVICE="${PROJECT_NAME}"
+          SERVICE_PORT="${PORT}"
+          DESIRED_REPLICAS="${BRAIN_REPLICAS}"
+          EOF
+          tee -a deploy-lib.sh > /dev/null << 'EOF'
+
+          # Container ids compose created for the service, running or not.
+          replica_ids() { docker-compose ps -q "$SERVICE" 2>/dev/null || true; }
+
+          # How many of them are actually running. `docker-compose ps` prose
+          # is not parsed: one of N being up passed the old grep for "Up".
+          running_replicas() {
+            local ids n
+            ids="$(replica_ids)"
+            if [ -z "$ids" ]; then echo 0; return 0; fi
+            n="$(docker inspect -f '{{.State.Status}}' $ids 2>/dev/null | grep -c '^running$' || true)"
+            echo "${n:-0}"
+          }
+
+          # Was this container created from exactly this image reference —
+          # digest identity, not a tag that happens to resolve today.
+          replica_runs_image() {
+            local cid="$1" want="$2" cfg img
+            cfg="$(docker inspect -f '{{.Config.Image}}' "$cid" 2>/dev/null || true)"
+            if [ "$cfg" = "$want" ]; then return 0; fi
+            img="$(docker inspect -f '{{.Image}}' "$cid" 2>/dev/null || true)"
+            if [ -z "$img" ]; then return 1; fi
+            docker image inspect -f '{{range .RepoDigests}}{{println .}}{{end}}' "$img" 2>/dev/null |
+              grep -qxF "$want"
+          }
+
+          # Every running replica runs $1, and there is at least one.
+          all_replicas_run_image() {
+            local want="$1" ids seen=0 cid
+            ids="$(replica_ids)"
+            for cid in $ids; do
+              [ "$(docker inspect -f '{{.State.Status}}' "$cid" 2>/dev/null || true)" = "running" ] || continue
+              seen=$((seen + 1))
+              replica_runs_image "$cid" "$want" || { echo "[err] replica $cid does not run $want"; return 1; }
+            done
+            [ "$seen" -ge 1 ]
+          }
+
+          # HTTP probe inside replica index $1 (1-based), path $2.
+          probe_replica() {
+            timeout 15s docker-compose exec -T --index="$1" "$SERVICE" \
+              wget -T 12 -qO- "http://localhost:${SERVICE_PORT}$2" > /dev/null 2>&1
+          }
+
+          # Wait until EVERY replica answers $2 (path) within $1 seconds.
+          # One healthy replica out of N is a failed deploy, not a deploy.
+          await_all_replicas() {
+            local budget="$1" path="$2" deadline pending still i
+            deadline=$((SECONDS + budget))
+            pending="$(seq 1 "$DESIRED_REPLICAS")"
+            while [ "$SECONDS" -lt "$deadline" ]; do
+              still=""
+              for i in $pending; do
+                probe_replica "$i" "$path" || still="$still $i"
+              done
+              pending="$still"
+              if [ -z "$(echo $pending)" ]; then return 0; fi
+              echo "[info] waiting on $path for replica(s):$pending"
+              sleep 5
+            done
+            return 1
+          }
+          EOF
+          . ./deploy-lib.sh
 
           # The image is a DIGEST resolved from the manifest CI published
           # after it smoke-tested that exact artifact — never `:latest`,
@@ -484,17 +598,40 @@ jobs:
 
           IMAGE_REF="${IMAGE_FROM_CI}"
           if [ "${ACTION}" = "rollback" ]; then
-            # The manual escape hatch. .last-good-image is only written
-            # after a deploy passed BOTH the readiness gate and the
-            # external smoke test, so it is a known-good target rather
-            # than merely a previous one.
-            if [ ! -s .last-good-image ]; then
-              echo "[err] no .last-good-image recorded on this host — nothing to roll back to."
+            # The manual escape hatch, and it must step BACK.
+            #
+            # It used to read .last-good-image, which after a green
+            # release holds the release that just went green — so a
+            # rollback prompted by a latent regression re-selected the
+            # image already running and then overwrote .previous-image
+            # with it, destroying the only reference to the version before
+            # (audit F3). The target now comes from the confirmed-good
+            # HISTORY (appended on promote, last five kept), and the
+            # running digest is excluded by construction.
+            if [ ! -s .good-image-history ]; then
+              echo "[err] no confirmed-good history on this host — nothing to roll back to."
               echo "[err] Deploy a known-good commit instead, or pin a digest by hand."
               exit 1
             fi
-            IMAGE_REF="$(cat .last-good-image)"
-            echo "[deploy] ROLLBACK to last known-good image: $IMAGE_REF"
+            if [ -n "${IMAGE_INPUT}" ]; then
+              # An explicit target still has to be a release that passed
+              # both gates on this host.
+              if ! grep -qxF "${IMAGE_INPUT}" .good-image-history; then
+                echo "[err] '${IMAGE_INPUT}' is not in the confirmed-good history:"
+                sed 's/^/[err]   /' .good-image-history
+                exit 1
+              fi
+              IMAGE_REF="${IMAGE_INPUT}"
+            else
+              # Newest confirmed-good digest that is not the running one.
+              IMAGE_REF="$(grep -vxF "${PREVIOUS_IMAGE:-__none__}" .good-image-history | tail -n 1)"
+            fi
+            if [ -z "$IMAGE_REF" ]; then
+              echo "[err] the only confirmed-good image IS the running one (${PREVIOUS_IMAGE:-<nothing>})."
+              echo "[err] There is no earlier verified release on this host to step back to."
+              exit 1
+            fi
+            echo "[deploy] ROLLBACK ${PREVIOUS_IMAGE:-<nothing>} -> ${IMAGE_REF}"
           fi
           if [ -z "$IMAGE_REF" ]; then
             IMAGE_REF="$PREVIOUS_IMAGE"
@@ -511,8 +648,32 @@ jobs:
           # promote/rollback decision is made in a LATER job (after the
           # external smoke test, which runs off-box) and job env does not
           # survive that hop.
-          printf '%s' "$PREVIOUS_IMAGE" > .previous-image
+          #
+          # A manual rollback is the exception: .previous-image is then the
+          # ONLY reference to the release we are stepping off, and if this
+          # rollback is itself bad that reference is the way back. It is
+          # staged here and committed after the readiness gate passes.
+          if [ "${ACTION}" = "rollback" ]; then
+            printf '%s' "$PREVIOUS_IMAGE" > .previous-image.staged
+          else
+            printf '%s' "$PREVIOUS_IMAGE" > .previous-image
+          fi
           printf '%s' "$IMAGE_REF" > .pending-image
+
+          # The deployment transaction: who is mutating this host, what
+          # they are putting on it, and what was there before. finalize
+          # (a different job, after an off-box smoke test) reads this and
+          # refuses to promote or undo anything that is not its own — the
+          # state files alone carried no run identity, so a slow finalize
+          # could promote a newer run's image as verified (audit F2).
+          {
+            echo "run_id=${GITHUB_RUN_ID}"
+            echo "attempt=${GITHUB_RUN_ATTEMPT}"
+            echo "action=${ACTION:-deploy}"
+            echo "image=${IMAGE_REF}"
+            echo "previous=${PREVIOUS_IMAGE}"
+            echo "replicas=${BRAIN_REPLICAS}"
+          } > .deploy-txn
 
           # Brain talks to the SHARED inite-surrealdb container that lives in
           # the temporal stack (inite-temporal/docker-compose). Brain owns
@@ -525,7 +686,12 @@ jobs:
           services:
             ${PROJECT_NAME}:
               image: ${IMAGE_REF}
-              container_name: ${PROJECT_NAME}
+              # No container_name: it pins the service to exactly one
+              # container and makes \`--scale\` / replicas an error. Compose
+              # names the containers <project>-<service>-<n> instead, and
+              # Traefik routes to all of them through the labels below.
+              deploy:
+                replicas: ${BRAIN_REPLICAS:-1}
               restart: unless-stopped
               # PID-1 init (tini): reaps zombie children from the worker
               # pool / native deps and forwards signals so SIGTERM reaches
@@ -573,8 +739,8 @@ jobs:
                 - AUTH_SERVICE_JWKS_URL=https://auth.inite.ai/.well-known/jwks.json
                 - AUTH_SERVICE_AUDIENCE=brain
                 # Required: JwksService refuses to boot in production when JWKS
-                # is enabled without an issuer (else the `iss` claim is not
-                # validated). Must match the `iss` auth-service signs with —
+                # is enabled without an issuer (else the \`iss\` claim is not
+                # validated). Must match the \`iss\` auth-service signs with —
                 # which is the API host (auth-api), NOT the login UI host:
                 # https://auth.inite.ai/.well-known/openid-configuration
                 # reports issuer=https://auth-api.inite.ai. The old value
@@ -759,30 +925,29 @@ jobs:
                 #      compatible with new queries. Audit all vector columns;
                 #      allTables does not yet repair every derived table.
                 #
-                # Drop to `openai` to roll back to text-embedding-3-small.
+                # Drop to \`openai\` to roll back to text-embedding-3-small.
                 - EMBEDDER_PROVIDER=bge-m3
-                # Eval baselines — persisted to a host bind-mount so they
-                # survive container recreate (compose pull + up = new
-                # container; an in-image var/ would evaporate on every
-                # deploy and the diff feature would silently lose history).
-                - BRAIN_BASELINES_DIR=/var/brain/baselines
+                # Eval baselines live in a system-DB table (#553), not on
+                # local disk: a host bind-mount is one replica's disk, so
+                # N replicas would each have kept their own history and
+                # whichever one answered the request would have shown a
+                # different one.
                 # ── Phase J/K job queue (Surreal-native) ─────────────────
                 # Cron handlers (dreams, compaction, calibration_refit,
                 # source_trust_refit) write to job_run as 'pending';
                 # WorkerLoopService — gated by the 'worker_loop'
                 # leader_lease — claims and dispatches.
                 #
-                # Kill switch: set JOBS_QUEUE_MODE=inline + restart to
-                # roll back to the legacy guard.run() inline path
+                # Queue mode (enqueue), the worker loop and the lease
+                # manager are all defaults, so none of them is pinned
+                # here. Kill switch: set JOBS_QUEUE_MODE=inline + restart
+                # to roll back to the legacy guard.run() inline path
                 # without a redeploy. Use when an unexpected backlog
                 # accumulates in pending and the worker loop won't
                 # drain (handler not registered, lease acquire fails).
-                - JOBS_QUEUE_MODE=enqueue
-                - WORKER_LOOP_ENABLED=1
                 - WORKER_LOOP_POLL_MS=1000
                 - WORKER_LOOP_EMPTY_BACKOFF_MS=5000
                 - WORKER_LOOP_LEASE_RENEW_MS=30000
-                - LEASE_MANAGER_ENABLED=1
                 - JOB_RUN_MAX_ATTEMPTS=3
                 - JOB_RUN_BACKOFF_BASE_MS=30000
                 # CPU-bound dispatcher pool. Disabled (size=0) because
@@ -798,12 +963,21 @@ jobs:
               # expressions, so its whole body counts against the 21k
               # max-expression-length limit, and the ~190-line flag block
               # pushed it over (zero-job "workflow file issue" failure).
-              # compose precedence: `environment:` above overrides
+              # compose precedence: \`environment:\` above overrides
               # env_file on key collision.
               env_file:
                 - ./enablement.env
               volumes:
-                - /opt/projects/${PROJECT_NAME}/baselines:/var/brain/baselines
+                # ONNX model cache (TRANSFORMERS_CACHE / HF_HOME /
+                # XDG_CACHE_HOME all point at /app/.cache in the image).
+                # Shared and read-mostly: without it every replica
+                # downloads ~700 MB of BGE-M3 + NER + reranker weights on
+                # first boot, against a 300 s readiness gate. The image
+                # creates /app/.cache owned by node (uid 1000), so a fresh
+                # named volume inherits that ownership and the container's
+                # USER node can write it. Concurrent cold starts may fetch
+                # the same file twice; the bytes are identical.
+                - brain-model-cache:/app/.cache
               labels:
                 # ── Backend routes only — landing handles the rest of brain.inite.ai.
                 # Backend owns /v1/*, /mcp/*, /health, /metrics.
@@ -821,25 +995,36 @@ jobs:
                 # /skills.tar.gz, written there by scripts/build-openapi.ts.
                 - "traefik.enable=true"
                 - "traefik.docker.network=traefik-global"
-                - "traefik.http.routers.${PROJECT_NAME}.rule=Host(\`${DOMAIN}\`) && (PathPrefix(\`/v1\`) || PathPrefix(\`/mcp\`) || PathPrefix(\`/health\`) || PathPrefix(\`/registry\`))"
+                - "traefik.http.routers.${PROJECT_NAME}.rule=Host(\`${DOMAIN}\`) && (PathPrefix(\`/v1\`) || PathPrefix(\`/mcp\`) || PathPrefix(\`/health\`) || PathPrefix(\`/ready\`) || PathPrefix(\`/registry\`))"
                 - "traefik.http.routers.${PROJECT_NAME}.priority=200"
                 - "traefik.http.routers.${PROJECT_NAME}.entrypoints=websecure"
                 - "traefik.http.routers.${PROJECT_NAME}.tls=true"
                 - "traefik.http.routers.${PROJECT_NAME}.tls.certresolver=letsencrypt"
                 - "traefik.http.services.${PROJECT_NAME}.loadbalancer.server.port=${PORT}"
                 - "traefik.http.services.${PROJECT_NAME}.loadbalancer.responseForwarding.flushInterval=-1"
-                # Edge liveness: a wedged process answers 503 at Traefik instead of
-                # timing out client connections. Deliberately /health, NOT /ready:
-                # this is a single replica, and the process degrades on its own
-                # (lexical-only search while the embedder warms, 503 on scoped reads
-                # while writes still work) — pulling it out of rotation on /ready
-                # would turn every partial outage into a total one. /ready is the
-                # deploy gate and the k8s readinessProbe for a multi-replica layout.
-                - "traefik.http.services.${PROJECT_NAME}.loadbalancer.healthcheck.path=/health"
-                - "traefik.http.services.${PROJECT_NAME}.loadbalancer.healthcheck.interval=15s"
-                - "traefik.http.services.${PROJECT_NAME}.loadbalancer.healthcheck.timeout=5s"
+                # Edge rotation, on READINESS. /health answers 200 while the
+                # process reports itself degraded (health.controller.ts), so a
+                # replica with a broken read path or a cold embedder kept its
+                # full share of traffic. /ready is the honest signal: the load
+                # balancer takes an unready replica out of rotation and the
+                # remaining ones absorb it. With one replica this is also the
+                # right answer — an unready pod serving 503 at the edge is what
+                # a 503 means — and the deploy gates never let a release reach
+                # steady state unready in the first place.
+                #
+                # The interval is load-bearing for graceful shutdown: SIGTERM
+                # flips readiness to 503 and waits ~6s before draining, so one
+                # probe (3s interval + 2s timeout) has to land inside that
+                # window for the replica to leave rotation before it stops
+                # accepting work. Raising it past ~5s reintroduces the
+                # connection errors the drain exists to avoid. /health stays
+                # the container's liveness probe and answers 503 during
+                # shutdown too — do not point Docker's healthcheck here.
+                - "traefik.http.services.${PROJECT_NAME}.loadbalancer.healthcheck.path=/ready"
+                - "traefik.http.services.${PROJECT_NAME}.loadbalancer.healthcheck.interval=3s"
+                - "traefik.http.services.${PROJECT_NAME}.loadbalancer.healthcheck.timeout=2s"
                 # http→https redirect for the same backend paths (landing has its own).
-                - "traefik.http.routers.${PROJECT_NAME}-http.rule=Host(\`${DOMAIN}\`) && (PathPrefix(\`/v1\`) || PathPrefix(\`/mcp\`) || PathPrefix(\`/health\`) || PathPrefix(\`/registry\`))"
+                - "traefik.http.routers.${PROJECT_NAME}-http.rule=Host(\`${DOMAIN}\`) && (PathPrefix(\`/v1\`) || PathPrefix(\`/mcp\`) || PathPrefix(\`/health\`) || PathPrefix(\`/ready\`) || PathPrefix(\`/registry\`))"
                 - "traefik.http.routers.${PROJECT_NAME}-http.priority=200"
                 - "traefik.http.routers.${PROJECT_NAME}-http.entrypoints=web"
                 - "traefik.http.routers.${PROJECT_NAME}-http.middlewares=redirect-to-https"
@@ -866,18 +1051,13 @@ jobs:
                 - traefik-global
                 - default
 
+          volumes:
+            brain-model-cache:
+
           networks:
             traefik-global:
               external: true
           EOF
-
-          # Bind-mount target must exist and be writable by the container's
-          # node user (uid 1000 on node:22-slim — the image now runs as
-          # USER node, so this chown matches the runtime user). Without
-          # this docker creates it root-owned and BaselineService's
-          # fs.writeFile fails with EACCES on first save.
-          mkdir -p "/opt/projects/${PROJECT_NAME}/baselines"
-          chown -R 1000:1000 "/opt/projects/${PROJECT_NAME}/baselines" || true
 
           if [ "${ACTION}" = "restart" ]; then
             echo "[deploy] restart only"
@@ -885,63 +1065,100 @@ jobs:
           else
             echo "[deploy] pulling image..."
             docker-compose pull "${PROJECT_NAME}"
-            echo "[deploy] up -d"
-            docker-compose up -d --remove-orphans
+            echo "[deploy] up -d (${BRAIN_REPLICAS} replica(s))"
+            # --scale as well as deploy.replicas: the replicas key is
+            # honoured by compose v2 and ignored by v1, the flag by both.
+            docker-compose up -d --remove-orphans --scale "${PROJECT_NAME}=${BRAIN_REPLICAS}"
           fi
 
-          sleep 25
-
-          if docker-compose ps | grep -q "Up"; then
-            echo "[ok] ${DOMAIN} container is up"
+          # Wait for the FULL desired count, not for "something is up".
+          up=0
+          for i in $(seq 1 12); do
+            up="$(running_replicas)"
+            [ "$up" -ge "${BRAIN_REPLICAS}" ] && break
+            sleep 5
+          done
+          if [ "$up" -ge "${BRAIN_REPLICAS}" ]; then
+            echo "[ok] ${up}/${BRAIN_REPLICAS} replicas of ${DOMAIN} are up"
           else
-            echo "[err] container failed to start"
+            echo "[err] only ${up}/${BRAIN_REPLICAS} replicas started"
+            docker-compose ps
             docker-compose logs --tail=100 "${PROJECT_NAME}"
             exit 1
           fi
 
+          # Identity check: the containers actually running must be THIS
+          # run's image. Anything else means another run has replaced them
+          # underneath us, and every gate below would be measuring
+          # somebody else's release.
+          if ! all_replicas_run_image "${IMAGE_REF}"; then
+            echo "[err] running replicas are not ${IMAGE_REF} — another run replaced them mid-deploy"
+            docker-compose ps
+            exit 1
+          fi
+          echo "[ok] every running replica is ${IMAGE_REF}"
+
       - name: Internal health probe
         if: github.event.inputs.action != 'logs'
         run: |
-          cd /opt/projects/${{ env.PROJECT_NAME }}
+          cd "${PROJECT_DIR:-/opt/projects/${PROJECT_NAME}}"
+          . ./deploy-lib.sh
           # Internal probe via docker exec — bypasses DNS / Traefik /
           # cert provisioning. This is the gate signal: did brain itself
-          # boot and respond. External reachability checked separately
-          # (warning-only) so a missing DNS record or slow Let's Encrypt
-          # cert doesn't fail an otherwise-healthy deploy.
-          for i in $(seq 1 18); do
-            if docker-compose exec -T ${{ env.PROJECT_NAME }} wget -qO- http://localhost:${{ env.PORT }}/health > /dev/null 2>&1; then
-              echo "[ok] container responds on http://localhost:${{ env.PORT }}/health"
-              docker-compose exec -T ${{ env.PROJECT_NAME }} wget -qO- http://localhost:${{ env.PORT }}/health | head -c 500
-              echo ""
-              exit 0
-            fi
-            echo "[info] waiting for brain to come up... ($i/18)"
-            sleep 5
-          done
-          echo "[err] internal health never responded"
-          docker-compose logs --tail=120 ${{ env.PROJECT_NAME }}
+          # boot and respond, on EVERY replica. External reachability is
+          # checked by the smoke job so a missing DNS record or a slow
+          # Let's Encrypt cert doesn't fail an otherwise-healthy deploy.
+          if await_all_replicas 90 /health; then
+            echo "[ok] all ${DESIRED_REPLICAS} replica(s) respond on /health"
+            docker-compose exec -T --index=1 "${PROJECT_NAME}" \
+              wget -qO- "http://localhost:${PORT}/health" | head -c 500 || true
+            echo ""
+            exit 0
+          fi
+          echo "[err] internal health never responded on every replica"
+          docker-compose ps
+          docker-compose logs --tail=120 "${PROJECT_NAME}"
           exit 1
 
       - name: Internal readiness gate
         if: github.event.inputs.action != 'logs'
         run: |
-          cd /opt/projects/${{ env.PROJECT_NAME }}
+          cd "${PROJECT_DIR:-/opt/projects/${PROJECT_NAME}}"
+          . ./deploy-lib.sh
           # /health (gate above) is liveness — green as soon as Nest boots,
           # while the primary embedder is warming. A live process with broken
-          # reads is not a successful deploy. Allow five minutes for cold boot;
-          # bound each probe as well as the retry window.
-          deadline=$((SECONDS + 300))
-          while [ "$SECONDS" -lt "$deadline" ]; do
-            if timeout 15s docker-compose exec -T ${{ env.PROJECT_NAME }} wget -T 12 -qO- http://localhost:${{ env.PORT }}/ready > /dev/null 2>&1; then
-              echo "[ok] container is READY (db + scoped authorization + primary embedder)"
-              exit 0
-            fi
-            echo "[info] waiting for readiness (database, scoped authorization, primary embedder)..."
-            sleep 5
-          done
-          echo "[err] /ready never went green within the readiness window. Deployment is not ready."
+          # reads is not a successful deploy. Every replica has to clear it:
+          # Traefik balances over all of them, so one unready replica is a
+          # fraction of production serving 503s. Five minutes for cold boot
+          # (the model cache volume is what keeps that budget realistic once
+          # replicas share it); each probe is bounded as well as the window.
+          if await_all_replicas 300 /ready; then
+            echo "[ok] all ${DESIRED_REPLICAS} replica(s) READY (db + scoped authorization + primary embedder)"
+            exit 0
+          fi
+          echo "[err] /ready never went green on every replica within the readiness window."
           echo "[err] Inspect scoped DB credentials and primary embedder warmup logs; do not start reindex until /ready is 200."
+          docker-compose ps
           exit 1
+
+      # A manual rollback's `.previous-image` was staged, not written: the
+      # release we stepped off is the way back if the rollback is itself
+      # bad, and overwriting the pointer before this gate passed destroyed
+      # it (audit F3). The gate above passed, so commit it — and drop the
+      # rejected digest from the confirmed-good history so the NEXT
+      # rollback steps further back instead of returning to it.
+      - name: Commit the rollback pointers
+        if: github.event.inputs.action == 'rollback'
+        run: |
+          cd "${PROJECT_DIR:-/opt/projects/${PROJECT_NAME}}"
+          [ -s .previous-image.staged ] || { echo "[rollback] nothing staged"; exit 0; }
+          REJECTED="$(cat .previous-image.staged)"
+          mv .previous-image.staged .previous-image
+          if [ -n "$REJECTED" ] && [ -s .good-image-history ]; then
+            grep -vxF "$REJECTED" .good-image-history > .good-image-history.next || true
+            mv .good-image-history.next .good-image-history
+          fi
+          echo "[rollback] previous-image is now ${REJECTED}; dropped it from the confirmed-good history"
 
       # The external check moved OUT of this job and into `smoke` below.
       # It used to be `curl -fs .../health`, warning-only — which verified
@@ -989,10 +1206,18 @@ jobs:
   # the old build pushed was referenced by nothing, so even a manual
   # rollback meant hand-editing the compose file on the box.
   #
-  # `.last-good-image` is written ONLY here, only after both the readiness
-  # gate and the external smoke passed — so it is a known-good target
-  # rather than merely a previous one. `workflow_dispatch` with
-  # action=rollback redeploys it.
+  # `.last-good-image` and `.good-image-history` are written ONLY here,
+  # only after both the readiness gate and the external smoke passed — so
+  # they hold known-good targets rather than merely previous ones.
+  #
+  # Every step below first checks that the deployment transaction on the
+  # box is still THIS run's. The smoke job runs off-box, so minutes pass
+  # between `deploy` and here, and the state files carried no run
+  # identity: run A's finalize would happily promote the image run B had
+  # just written into `.pending-image`, declaring an unverified release
+  # good (audit F2). A superseded finalize now exits 0 and touches
+  # nothing — the run that owns the transaction is the one that resolves
+  # it.
   # ---------------------------------------------------------------------
   finalize:
     needs: [deploy, smoke]
@@ -1000,17 +1225,67 @@ jobs:
     runs-on: [self-hosted, sfo]
     timeout-minutes: 15
     steps:
-      - name: Promote this image to last-known-good
-        if: needs.deploy.result == 'success' && needs.smoke.result == 'success'
+      - name: Read the deployment transaction
+        id: txn
         run: |
-          set -euo pipefail
-          cd /opt/projects/${{ env.PROJECT_NAME }}
-          if [ ! -s .pending-image ]; then
-            echo "[promote] nothing pending — leaving .last-good-image untouched"
+          set -uo pipefail
+          cd "${PROJECT_DIR:-/opt/projects/${PROJECT_NAME}}" || { echo "ours=0" >> "$GITHUB_OUTPUT"; exit 0; }
+          if [ ! -s .deploy-txn ]; then
+            echo "[txn] no transaction recorded on this host — nothing to resolve"
+            echo "ours=0" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          cp .pending-image .last-good-image
-          echo "[promote] last known-good is now $(cat .last-good-image)"
+          TXN_RUN="$(sed -n 's/^run_id=//p' .deploy-txn)"
+          TXN_IMAGE="$(sed -n 's/^image=//p' .deploy-txn)"
+          TXN_PREVIOUS="$(sed -n 's/^previous=//p' .deploy-txn)"
+          if [ "$TXN_RUN" != "${GITHUB_RUN_ID}" ]; then
+            echo "[txn] superseded by run ${TXN_RUN}, not touching state (this run is ${GITHUB_RUN_ID})"
+            echo "ours=0" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          {
+            echo "ours=1"
+            echo "image=${TXN_IMAGE}"
+            echo "previous=${TXN_PREVIOUS}"
+          } >> "$GITHUB_OUTPUT"
+          echo "[txn] run ${TXN_RUN} owns this host: image=${TXN_IMAGE} previous=${TXN_PREVIOUS:-<nothing>}"
+
+      - name: Promote this image to last-known-good
+        if: needs.deploy.result == 'success' && needs.smoke.result == 'success' && steps.txn.outputs.ours == '1'
+        env:
+          TXN_IMAGE: ${{ steps.txn.outputs.image }}
+        run: |
+          set -euo pipefail
+          cd "${PROJECT_DIR:-/opt/projects/${PROJECT_NAME}}"
+          . ./deploy-lib.sh
+          if [ ! -s .pending-image ]; then
+            echo "[promote] nothing pending — leaving the confirmed-good history untouched"
+            exit 0
+          fi
+          PENDING="$(cat .pending-image)"
+          if [ "$PENDING" != "$TXN_IMAGE" ]; then
+            echo "[promote] .pending-image (${PENDING}) is not this run's image (${TXN_IMAGE}) — superseded, not touching state"
+            exit 0
+          fi
+          # And the thing running has to BE it: smoke passed against the
+          # domain, which is only evidence about this release if this
+          # release is what the replicas are serving.
+          if ! all_replicas_run_image "$TXN_IMAGE"; then
+            echo "[promote] running replicas are not ${TXN_IMAGE} — superseded, not touching state"
+            exit 0
+          fi
+          printf '%s' "$TXN_IMAGE" > .last-good-image
+          # Confirmed-good history, oldest first, last five kept. A digest
+          # already in it is left where it is, so the order stays "when it
+          # was first confirmed" and a rollback cannot ping-pong.
+          touch .good-image-history
+          if ! grep -qxF "$TXN_IMAGE" .good-image-history; then
+            echo "$TXN_IMAGE" >> .good-image-history
+            tail -n 5 .good-image-history > .good-image-history.next
+            mv .good-image-history.next .good-image-history
+          fi
+          echo "[promote] last known-good is now ${TXN_IMAGE}; history:"
+          sed 's/^/[promote]   /' .good-image-history
 
       # Deliberately NOT `!= 'success'`. When `verify` fails — a red CI, no
       # manifest — `deploy` is *skipped*, which is also not 'success', and
@@ -1019,10 +1294,23 @@ jobs:
       # deploy that actually ran and went wrong, or a smoke test that
       # actually failed, is a reason to move the running image.
       - name: Roll back to the previous image
-        if: needs.deploy.result == 'failure' || needs.deploy.result == 'cancelled' || needs.smoke.result == 'failure'
+        if: (needs.deploy.result == 'failure' || needs.deploy.result == 'cancelled' || needs.smoke.result == 'failure') && steps.txn.outputs.ours == '1'
+        env:
+          TXN_IMAGE: ${{ steps.txn.outputs.image }}
         run: |
           set -euo pipefail
-          cd /opt/projects/${{ env.PROJECT_NAME }}
+          cd "${PROJECT_DIR:-/opt/projects/${PROJECT_NAME}}"
+          . ./deploy-lib.sh
+
+          CURRENT="$(awk '/^[[:space:]]+image:/ {print $2; exit}' docker-compose.yml || true)"
+          # Undo THIS run's deploy, or nothing. If the pinned image is no
+          # longer the one this run put there, a later run has already
+          # moved production and restarting into our idea of "previous"
+          # would roll that newer release back behind its back.
+          if [ -n "$TXN_IMAGE" ] && [ "$CURRENT" != "$TXN_IMAGE" ]; then
+            echo "[rollback] pinned image (${CURRENT}) is not this run's (${TXN_IMAGE}) — superseded, not touching state"
+            exit 0
+          fi
 
           # Prefer the last image that passed BOTH gates over merely "the
           # one that was pinned before this run" — if the previous deploy
@@ -1037,12 +1325,11 @@ jobs:
           if [ -z "$TARGET" ]; then
             echo "[rollback] no known-good or previous image recorded on this host."
             echo "[rollback] The broken deploy is still running and MUST be handled by hand:"
-            echo "[rollback]   pin a digest in /opt/projects/${{ env.PROJECT_NAME }}/docker-compose.yml"
+            echo "[rollback]   pin a digest in ${PROJECT_DIR:-/opt/projects/${PROJECT_NAME}}/docker-compose.yml"
             echo "[rollback]   then: docker-compose up -d"
             exit 1
           fi
 
-          CURRENT="$(awk '/^[[:space:]]+image:/ {print $2; exit}' docker-compose.yml || true)"
           if [ "$TARGET" = "$CURRENT" ]; then
             echo "[rollback] already running $TARGET — the failure is not the image."
             echo "[rollback] Not restarting into the same thing. Investigate the deploy logs."
@@ -1051,21 +1338,18 @@ jobs:
 
           echo "[rollback] $CURRENT -> $TARGET"
           sed -i "s|^\([[:space:]]*image:\).*|\1 ${TARGET}|" docker-compose.yml
-          docker-compose pull ${{ env.PROJECT_NAME }}
-          docker-compose up -d --remove-orphans
+          docker-compose pull "${PROJECT_NAME}"
+          docker-compose up -d --remove-orphans --scale "${PROJECT_NAME}=${DESIRED_REPLICAS}"
 
           # A rollback that is not itself verified is just a second
-          # unverified deploy.
-          deadline=$((SECONDS + 300))
-          while [ "$SECONDS" -lt "$deadline" ]; do
-            if timeout 15s docker-compose exec -T ${{ env.PROJECT_NAME }} wget -T 12 -qO- http://localhost:${{ env.PORT }}/ready > /dev/null 2>&1; then
-              echo "[rollback] $TARGET is READY. Production is back on the last known-good image."
-              echo "[rollback] The commit that failed is still on main — fix forward or revert it."
-              exit 1
-            fi
-            echo "[rollback] waiting for readiness on the rolled-back image..."
-            sleep 5
-          done
+          # unverified deploy — and one ready replica out of N is not a
+          # verified rollback either.
+          if await_all_replicas 300 /ready; then
+            echo "[rollback] $TARGET is READY on all ${DESIRED_REPLICAS} replica(s). Production is back on the last known-good image."
+            echo "[rollback] The commit that failed is still on main — fix forward or revert it."
+            exit 1
+          fi
           echo "[rollback] FAILED — the rolled-back image did not become ready either."
-          docker-compose logs --tail=120 ${{ env.PROJECT_NAME }}
+          docker-compose ps
+          docker-compose logs --tail=120 "${PROJECT_NAME}"
           exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ var/
 
 # Repo-indexer run state (per-checkout, never source) — scripts/index-repo.ts
 .brain-indexer-state.json
+
+# Local compose overrides (see docker-compose.override.yml.example) — a
+# laptop-specific port mapping is never source.
+docker-compose.override.yml

--- a/README.md
+++ b/README.md
@@ -228,10 +228,12 @@ curl --fail-with-body "$BRAIN_URL/health"
 ```
 
 For the full container setup, use `docker compose --env-file .env up -d --build`
-instead of `pnpm start:dev`. Its host port defaults to **3030**, so set
-`BRAIN_URL=http://localhost:3030` for the requests below. The Compose defaults
-are for local development; production credentials and topology are covered in
-[deployment](docs/DEPLOY.md).
+instead of `pnpm start:dev`. The app service publishes no host port — that is
+what lets `--scale brain=N` run several replicas — so copy
+`docker-compose.override.yml.example` to `docker-compose.override.yml` first;
+it maps host **3030**, and `BRAIN_URL=http://localhost:3030` then works for the
+requests below. The Compose defaults are for local development; production
+credentials and topology are covered in [deployment](docs/DEPLOY.md).
 
 ### Write and retrieve a fact
 

--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -1,0 +1,18 @@
+# Local-dev overrides. Copy to docker-compose.override.yml (gitignored;
+# compose picks it up automatically) — it is NOT applied as .example.
+#
+#   cp docker-compose.override.yml.example docker-compose.override.yml
+#   docker compose up -d
+#
+# Why the base file publishes no app port: a fixed host port allows
+# exactly one container, so `docker compose up -d --scale brain=3` fails
+# on the second one. Production runs N identical replicas behind Traefik
+# and reaches them over the network, so the port mapping lives here
+# instead — where it belongs, since it is a laptop convenience.
+#
+# Note this override and `--scale brain=N` are mutually exclusive for the
+# same reason: with a mapping in place, only one replica can bind 3030.
+services:
+  brain:
+    ports:
+      - "${BRAIN_HOST_PORT:-3030}:3000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,10 +34,6 @@ services:
       # password on first tenant request (migration 0005 + ensureScopedUser).
       - SURREALDB_SCOPED_USER=brain_caller
       - SURREALDB_SCOPED_PASS=${SURREALDB_SCOPED_PASS:-local-scoped-secret}
-      # Container runs as non-root (uid 1000); the default ./var path is
-      # root-owned → BaselineService writes EACCES. Point at the node-owned
-      # cache dir created in the Dockerfile.
-      - BRAIN_BASELINES_DIR=/app/.cache/baselines
       - OPENAI_API_KEY=${OPENAI_API_KEY}
       - BRAIN_API_KEYS=${BRAIN_API_KEYS:-[]}
       # The image runs NODE_ENV=production, where validateEnv REQUIRES a
@@ -52,8 +48,23 @@ services:
       # single-process deployment. See docs/operations.md
       # "Splitting API and worker roles".
       # - PROCESS_ROLE=api
-    ports:
-      - "${BRAIN_HOST_PORT:-3030}:3000"
+    # No published host port: a fixed host port allows exactly one
+    # container, so `docker compose up -d --scale brain=N` fails on the
+    # second one — and N replicas is the shape production runs. Traefik
+    # (prod) and other compose services reach the app over the network on
+    # 3000. For local dev, copy docker-compose.override.yml.example to
+    # docker-compose.override.yml to map a host port back.
+    expose:
+      - "3000"
+    volumes:
+      # Shared ONNX model cache (TRANSFORMERS_CACHE / HF_HOME /
+      # XDG_CACHE_HOME point here in the image). Read-mostly: the first
+      # container to warm up downloads BGE-M3 / NER / reranker weights and
+      # every replica — and every later `up` — reads them instead of
+      # fetching ~700MB again. The image creates /app/.cache owned by node
+      # (uid 1000), so a fresh named volume inherits that ownership and
+      # the non-root container can write it.
+      - brain-model-cache:/app/.cache
     # PID-1 init (tini): reaps zombie children — the app spawns
     # worker_threads / native processes, and without an init the Node
     # PID-1 doesn't reap them. Also forwards signals correctly.
@@ -96,11 +107,12 @@ services:
       - SURREALDB_NAMESPACE=brain
       - SURREALDB_SCOPED_USER=brain_caller
       - SURREALDB_SCOPED_PASS=${SURREALDB_SCOPED_PASS:-local-scoped-secret}
-      - BRAIN_BASELINES_DIR=/app/.cache/baselines
       - OPENAI_API_KEY=${OPENAI_API_KEY}
       - BRAIN_API_KEYS=${BRAIN_API_KEYS:-[]}
       - FORGET_HMAC_KEY=${FORGET_HMAC_KEY:-local-dev-forget-hmac-key-change-in-prod}
     # No `ports:` — internal healthcheck only; nothing routes here.
+    volumes:
+      - brain-model-cache:/app/.cache
     init: true
     stop_grace_period: 30s
     mem_limit: 2g
@@ -116,3 +128,4 @@ services:
 
 volumes:
   surrealdb-data:
+  brain-model-cache:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -915,9 +915,11 @@ Consequences worth knowing:
   running 45 minutes later" — not being able to confirm green is not
   permission to ship.
 - **The commit and the running image are the same thing.**
-  `docker inspect inite-brain-service --format '{{index .RepoDigests 0}}'`
-  on the box gives you a digest you can match against the CI run that
-  produced it.
+  `docker inspect $(docker-compose ps -q inite-brain-service) --format '{{.Config.Image}}'`
+  on the box gives you the digest of every replica, to match against the
+  CI run that produced it. The containers are no longer named
+  `inite-brain-service` (a fixed name allows only one), so reach one by
+  index instead: `docker-compose exec --index=2 inite-brain-service sh`.
 
 ### Verification after a deploy
 
@@ -934,20 +936,90 @@ The landing has its own surface (`/en`, `/skills.tar.gz`, `/install.sh`,
 routes that path to the engine, so asserting it made the landing's release
 gate on a different service's health.
 
+Both internal gates now run **per replica** (`docker-compose exec
+--index=N`) and pass only when *every* replica answers. One healthy
+container out of three is a fraction of production serving 503s, not a
+successful deploy.
+
+### What the deploy assumes about replicas
+
+**`BRAIN_REPLICAS`** is a repository *variable* (Settings → Actions →
+Variables), read by `deploy-brain.yml`; unset means **1**. It is written
+into the generated compose file as `deploy.replicas` and passed to
+`docker-compose up -d --scale`, so both the v1 and v2 compose CLIs land on
+the same count, and it is the number every post-deploy check counts
+against (`running_replicas` in the generated `deploy-lib.sh`). A
+non-integer value fails the deploy rather than silently scaling to 1.
+Changing it takes effect on the next deploy; `action: restart` restarts the
+containers that already exist, so the count check will fail the run if you
+raise the variable and only restart.
+
+**The load balancer contract is `/ready`, not `/health`.** Traefik polls
+`/ready` every 3s (2s timeout) per replica and takes an unready one out of
+rotation; `/health` stays the *liveness* probe that Docker restarts on.
+The interval is not cosmetic: SIGTERM flips readiness to 503 and waits ~6s
+before draining, so one probe has to land inside that window for the
+replica to leave rotation before it stops accepting work — raising the
+interval past ~5s puts connection errors back into a rolling deploy.
+This matters because `/health` returns 200 while the process reports
+itself `degraded`, so a replica with a broken scoped pool or a cold
+embedder used to keep its full share of traffic. Both Traefik routers
+carry `PathPrefix(/ready)`, so readiness is reachable through the domain —
+without that the healthcheck would 404 and every replica would look dead.
+The corollary: if *all* replicas are unready the edge returns 503, which
+is what a readiness failure means; the deploy gates exist so a release
+never reaches that state unnoticed.
+
+**The model cache is one shared volume** (`brain-model-cache` at
+`/app/.cache`, where the image points `TRANSFORMERS_CACHE`, `HF_HOME` and
+`XDG_CACHE_HOME`). Without it every replica downloads its own ~700MB of
+BGE-M3 + NER + reranker weights on first boot, against a 300s readiness
+gate — the second and third replicas would simply never make it. The image
+creates the directory owned by `node` (uid 1000), so a fresh named volume
+inherits that ownership and the non-root container can write it. Wiping it
+is safe (the next warmup re-downloads) but costs that download.
+
+**Every replica names itself.** `PROCESS_IDENTITY`
+(`src/common/process-identity.ts`) — `<hostname>#<pid>#<uuid>`, where the
+hostname is the container id — is a default label on all Prometheus
+series, a field on every JSON request line, and `service.instance.id` on
+OTel spans, so a metric spike, the log lines behind it and its traces can
+be tied to one process. Alloy discovers brain containers over the Docker
+socket and labels each *target* with its container name
+(`<project>-<service>-<n>`, so replica 2 is
+`inite-brain-service-inite-brain-service-2`), which is the label to filter
+on in Grafana (the app's own value arrives alongside it as
+`exported_instance`, and is what you see when you curl one replica's
+`/metrics` directly). Gauges that only the lease holder writes (changefeed
+lag, corpus census) export *nothing* on the other replicas rather than a
+boot zero — so alert rules aggregate them with `max()`, not `avg()`.
+
 ### Rollback
 
-Three files live in `/opt/projects/inite-brain-service/`:
+State files live in `/opt/projects/inite-brain-service/`:
 
-| File               | Meaning                                                                             |
-| ------------------ | ----------------------------------------------------------------------------------- |
-| `.pending-image`   | the digest this run is deploying                                                    |
-| `.previous-image`  | whatever was pinned before this run started                                         |
-| `.last-good-image` | the last digest that passed **both** the readiness gate and the external smoke test |
+| File                  | Meaning                                                                                   |
+| --------------------- | ----------------------------------------------------------------------------------------- |
+| `.deploy-txn`         | run id, attempt, action, image and previous image of the run that currently owns this host |
+| `.pending-image`      | the digest this run is deploying                                                          |
+| `.previous-image`     | whatever was pinned before this run started                                               |
+| `.last-good-image`    | the last digest that passed **both** the readiness gate and the external smoke test       |
+| `.good-image-history` | the last five such digests, oldest first — what a manual rollback picks from               |
 
-`.last-good-image` is written only by the `finalize` job, only when the
-smoke test passed. It is a known-good target rather than merely a previous
-one — which matters, because rolling back to a previous deploy that was
-itself broken achieves nothing.
+`.last-good-image` and `.good-image-history` are written only by the
+`finalize` job, only when the smoke test passed. They are known-good
+targets rather than merely previous ones — which matters, because rolling
+back to a previous deploy that was itself broken achieves nothing.
+
+**Runs queue, and each one only resolves its own transaction.** Every run
+of the workflow shares one concurrency group and never cancels an
+in-flight one, so a push deploy and a manual dispatch cannot interleave
+over these files. On top of that, `finalize` reads `.deploy-txn` and
+refuses to promote or roll back unless the run id is its own *and* the
+containers are running the image it deployed; otherwise it exits
+successfully with `superseded by run <id>, not touching state`. Seeing
+that line means another run owns production — read its logs, not this
+one's.
 
 **Automatic.** If the deploy job or the smoke job fails, `finalize`
 rewrites the compose image to `.last-good-image` (falling back to
@@ -958,16 +1030,31 @@ broken and needs a fix-forward or a revert.
 
 **By hand.** Actions → _Deploy brain.inite.ai_ → Run workflow →
 `action: rollback`. This skips verification entirely (it must work while
-CI is red — that is what it is for) and redeploys `.last-good-image`.
+CI is red — that is what it is for) and steps **back**: the target is the
+newest digest in `.good-image-history` that is not the one running, or the
+`image_digest` input if you name one, which must itself appear in that
+history.
+It deliberately does not read `.last-good-image` — after a green release
+that file holds the release you are trying to leave, so a rollback for a
+latent regression used to redeploy the same image and then overwrite
+`.previous-image` with it, destroying the only pointer to the version
+before. The `.previous-image` pointer is now written only *after* the
+rolled-back release answers `/ready`, and the rejected digest is dropped
+from the history so a second rollback goes further back instead of
+returning to it.
 
-**When there is nothing to roll back to** — a first deploy, or a host
-whose state files were wiped — the rollback step says so and exits 1
-rather than pretending. Recover by pinning a digest by hand:
+**When there is nothing to roll back to** — a first deploy, a host whose
+state files were wiped, or a history holding only the running image — the
+step says so and exits 1 rather than pretending. Recover by pinning a
+digest by hand:
 
 ```bash
 cd /opt/projects/inite-brain-service
 sed -i 's|^\( *image:\).*|\1 <user>/inite-brain-service@sha256:…|' docker-compose.yml
-docker-compose pull inite-brain-service && docker-compose up -d
+docker-compose pull inite-brain-service
+# --scale matches deploy.replicas in the file; pass it explicitly because
+# compose v1 ignores that key.
+docker-compose up -d --scale "inite-brain-service=$(awk '/replicas:/ {print $2}' docker-compose.yml)"
 ```
 
 A `rollback` cannot cross a database migration. Migrations run forward on

--- a/monitoring/alloy/config.alloy
+++ b/monitoring/alloy/config.alloy
@@ -7,14 +7,68 @@
 //   4. OTLP in from brain (HTTP :4318)      → Tempo (gRPC)
 
 // ── 1. Metrics: brain app ────────────────────────────────────────────
-// brain joins traefik-global, so its service name resolves from here.
-// /health and /metrics hits are already excluded from brain's request
-// logs, so a 15s scrape adds no log noise.
+// One target per RUNNING brain container, discovered from the Docker
+// socket this collector already mounts (read-only, for the log pipeline
+// below).
+//
+// It used to be the single static name "inite-brain-service:3000". With
+// N replicas that name round-robins over them, so one scrape landed on
+// replica 1 and the next on replica 3 while every sample carried the same
+// identity: per-process series (event-loop lag, RSS, is-leader) collapsed
+// into one flapping line, and a dead replica was invisible because the
+// other two answered for it.
+//
+// The `job = "brain"` label is preserved verbatim so every existing rule
+// and dashboard panel keeps matching; `instance` becomes the container
+// name compose assigns each replica (`<project>-<service>-<n>`).
+// Aggregating rules keep their aggregation (sum / min / max) — see
+// grafana/provisioning/alerting.
+// /health, /ready and /metrics are excluded from brain's request logs, so
+// a 15s scrape adds no log noise.
+discovery.docker "brain" {
+	host = "unix:///var/run/docker.sock"
+
+	filter {
+		name   = "label"
+		values = ["com.docker.compose.service=inite-brain-service"]
+	}
+}
+
+discovery.relabel "brain" {
+	targets = discovery.docker.brain.targets
+
+	// Docker discovery yields one target per (network, exposed port), so
+	// keep exactly the endpoint that can answer: brain's own port on the
+	// network this collector shares with it. Without both keeps the same
+	// replica is scraped twice under two addresses.
+	rule {
+		source_labels = ["__meta_docker_network_name"]
+		regex         = "traefik-global"
+		action        = "keep"
+	}
+
+	rule {
+		source_labels = ["__meta_docker_port_private"]
+		regex         = "3000"
+		action        = "keep"
+	}
+
+	// Compose numbers replicas in the container name; strip the leading
+	// slash the Docker API adds.
+	rule {
+		source_labels = ["__meta_docker_container_name"]
+		regex         = "/?(.*)"
+		target_label  = "instance"
+	}
+
+	rule {
+		target_label = "job"
+		replacement  = "brain"
+	}
+}
+
 prometheus.scrape "brain" {
-	targets = [{
-		__address__ = "inite-brain-service:3000",
-		job         = "brain",
-	}]
+	targets         = discovery.relabel.brain.output
 	metrics_path    = "/metrics"
 	scrape_interval = "15s"
 	forward_to      = [prometheus.remote_write.vm.receiver]

--- a/monitoring/grafana/dashboards/brain-overview.json
+++ b/monitoring/grafana/dashboards/brain-overview.json
@@ -1204,7 +1204,7 @@
             "type": "prometheus",
             "uid": "vm"
           },
-          "expr": "brain_changefeed_lag_records",
+          "expr": "max(brain_changefeed_lag_records)",
           "legendFormat": "lag"
         }
       ],

--- a/monitoring/grafana/provisioning/alerting/rules.yaml
+++ b/monitoring/grafana/provisioning/alerting/rules.yaml
@@ -43,6 +43,42 @@ groups:
               conditions:
                 - evaluator: { type: lt, params: [1] }
 
+      # BrainScrapeDown fires when a target that IS discovered stops
+      # answering. It cannot see a replica that disappears from discovery
+      # altogether: the query still returns the survivors' series, all of
+      # them 1. This rule watches the COUNT instead — how many brain
+      # replicas are exporting now against the most this host has run in
+      # the last six hours — so "one of three quietly went away" is an
+      # alert rather than a slightly quieter dashboard. `for: 15m` rides
+      # out a rolling recreate, which briefly runs fewer containers.
+      - uid: brain-replica-missing
+        title: BrainReplicaMissing
+        condition: C
+        for: 15m
+        noDataState: OK # nothing exporting at all is BrainScrapeDown's job
+        execErrState: Alerting
+        labels:
+          severity: warning
+        annotations:
+          summary: fewer brain replicas are exporting metrics than this host was running (a replica stopped or vanished from discovery)
+        data:
+          - refId: A
+            relativeTimeRange: { from: 21600, to: 0 }
+            datasourceUid: vm
+            model:
+              refId: A
+              expr: count(up{job="brain"} == 1) / clamp_min(max_over_time(count(up{job="brain"} == 1)[6h:1m]), 1)
+              instant: true
+          - refId: C
+            relativeTimeRange: { from: 0, to: 0 }
+            datasourceUid: __expr__
+            model:
+              refId: C
+              type: threshold
+              expression: A
+              conditions:
+                - evaluator: { type: lt, params: [1] }
+
       - uid: brain-policy-resolution-errors
         title: PolicyResolutionErrors
         condition: C
@@ -127,6 +163,11 @@ groups:
               conditions:
                 - evaluator: { type: gt, params: [0.2] }
 
+      # max(), not sum() and not a bare series: the consumer runs only on
+      # the replica holding the changefeed_consumer lease, so exactly one
+      # instance reports a measurement and the others report nothing at
+      # all (MetricsService drops the boot zero for lease-only gauges, so
+      # a non-leader cannot contribute an invented 0 here).
       - uid: brain-changefeed-lag
         title: ChangefeedLagSustained
         condition: C

--- a/scripts/ci/smoke.mjs
+++ b/scripts/ci/smoke.mjs
@@ -25,6 +25,16 @@ const SURFACES = {
   brain: [
     { path: '/health', method: 'GET', expect: [200], why: 'engine is live behind Traefik' },
     {
+      path: '/ready',
+      method: 'GET',
+      expect: [200],
+      // This is also the load balancer's own contract: Traefik health-checks
+      // /ready and takes an unready replica out of rotation, so if the
+      // router rule for it is missing the check 404s, every replica is
+      // marked down, and the domain serves nothing. A 404 here IS that bug.
+      why: 'readiness is routed through the domain — the load balancer probes it',
+    },
+    {
       path: '/v1/search',
       method: 'POST',
       expect: [401],

--- a/src/admin/health-components.service.ts
+++ b/src/admin/health-components.service.ts
@@ -7,6 +7,7 @@ import { CapabilityProbeService, type LastProbeReport } from '../metrics/capabil
 import { isConclusive } from '../metrics/capability-probe';
 import { IntentClassifierService } from './intent-classifier.service';
 import { ChangefeedConsumerService } from '../audit/changefeed-consumer.service';
+import { LeaderLeaseService } from '../jobs/leader-lease.service';
 import type {
   HealthComponent,
   HealthComponentsResponse,
@@ -35,6 +36,7 @@ export class HealthComponentsService {
     private readonly embedder: EmbedderService,
     private readonly intent: IntentClassifierService,
     private readonly changefeed: ChangefeedConsumerService,
+    private readonly leases: LeaderLeaseService,
   ) {}
 
   async build(): Promise<HealthComponentsResponse> {
@@ -47,7 +49,7 @@ export class HealthComponentsService {
       this.evidenceStoreRow(readiness, last.evidence_store),
       this.intentRow(),
       this.openAiKeyRow(),
-      this.changefeedRow(),
+      await this.changefeedRow(),
       this.calibrationRow(),
     ];
     return {
@@ -209,21 +211,40 @@ export class HealthComponentsService {
     };
   }
 
-  private changefeedRow(): HealthComponent {
+  /**
+   * The consumer only ticks on the pod holding the `changefeed_consumer`
+   * lease, so this pod's counters describe the cluster only when this pod
+   * is that one. On every other replica they are the initial values, and
+   * the row used to render them as "ok · 0 pending" — a green claim about
+   * work being done somewhere else. A non-leader says so instead, and
+   * names the holder so an operator knows where to look.
+   */
+  private async changefeedRow(): Promise<HealthComponent> {
     const cf = this.changefeed.stats();
+    const name = 'changefeed consumer';
+    if (!cf.enabled) {
+      return { name, status: 'disabled', message: 'AUDIT_CHANGEFEED_ENABLED=0' };
+    }
+    const holder = await this.changefeedLeaseHolder();
+    if (holder !== undefined && holder !== this.leases.identity()) {
+      return {
+        name,
+        status: 'disabled',
+        message: `not leader — ${holder} holds the changefeed_consumer lease; its pending count is the cluster's`,
+      };
+    }
     return {
-      name: 'changefeed consumer',
-      status: !cf.enabled
-        ? 'disabled'
-        : cf.lastError
-          ? 'degraded'
-          : cf.lastPendingRemaining > 100
-            ? 'degraded'
-            : 'ok',
-      message: cf.enabled
-        ? `${cf.lastPendingRemaining} pending · ${cf.tickCount} ticks`
-        : 'AUDIT_CHANGEFEED_ENABLED=0',
+      name,
+      status: cf.lastError ? 'degraded' : cf.lastPendingRemaining > 100 ? 'degraded' : 'ok',
+      message: `${cf.lastPendingRemaining} pending · ${cf.tickCount} ticks`,
     };
+  }
+
+  /** leaderId of a live `changefeed_consumer` lease, if one is held. */
+  private async changefeedLeaseHolder(): Promise<string | undefined> {
+    const row = (await this.leases.list()).find((l) => l.name === 'changefeed_consumer');
+    if (!row) return undefined;
+    return Date.parse(row.leaseUntil) > Date.now() ? row.leaderId : undefined;
   }
 
   private calibrationRow(): HealthComponent {

--- a/src/common/env-validation.ts
+++ b/src/common/env-validation.ts
@@ -75,11 +75,15 @@ export function validateEnv(env: NodeJS.ProcessEnv = process.env): void {
   // ── Process role (api / worker split) ─────────────────────────────
   validateProcessRole(env, errors);
 
-  // ── Pool size ─────────────────────────────────────────────────────
-  const pool = env.SURREALDB_POOL_SIZE;
-  if (pool && (!/^\d+$/.test(pool) || parseInt(pool, 10) < 1)) {
-    errors.push('SURREALDB_POOL_SIZE must be a positive integer');
-  }
+  // ── Pool sizes ────────────────────────────────────────────────────
+  // Both pools take the same guard — the same one every other integer
+  // knob here gets. The scoped pool's failure is the quieter of the two:
+  // a typo parses to NaN, the build loop runs zero times while
+  // scopedPoolEnabled() stays true, and every read then waits for a
+  // connection that will never exist — the replica sits permanently
+  // not-ready with nothing naming the cause.
+  positiveInt(env, 'SURREALDB_POOL_SIZE', errors);
+  positiveInt(env, 'SURREALDB_SCOPED_POOL_SIZE', errors);
 
   // ── OpenAI resilience knobs ───────────────────────────────────────
   positiveInt(env, 'OPENAI_TIMEOUT_MS', errors);

--- a/src/common/process-identity.ts
+++ b/src/common/process-identity.ts
@@ -1,0 +1,17 @@
+import { randomUUID } from 'node:crypto';
+import { hostname } from 'node:os';
+
+/**
+ * The name this process answers to everywhere it has to be told apart from
+ * its siblings: the `instance` label on Prometheus series, the `instance`
+ * field on JSON request lines, `service.instance.id` on OTel spans, and
+ * the holder id on a leader lease.
+ *
+ * One constant so those cannot disagree — correlating a metric spike with
+ * the log lines and traces from the same replica only works if all of them
+ * name it the same way. Shape: `<hostname>#<pid>#<uuid>`. The hostname is
+ * the container id under Docker, the pid separates roles inside one
+ * container, and the uuid makes a RESTART a distinct identity — a lease
+ * holder that died and came back is not the process that took the lease.
+ */
+export const PROCESS_IDENTITY = `${hostname()}#${process.pid}#${randomUUID()}`;

--- a/src/common/request-logger.ts
+++ b/src/common/request-logger.ts
@@ -1,6 +1,7 @@
 import { Logger } from '@nestjs/common';
 import type { Request, Response, NextFunction } from 'express';
 import { getCorrelationId } from './request-context';
+import { PROCESS_IDENTITY } from './process-identity';
 
 const log = new Logger('Request');
 
@@ -14,11 +15,13 @@ const log = new Logger('Request');
  *     friendly for log shippers (Loki, CloudWatch, Datadog).
  *   - otherwise → human-readable single-line text, friendly for `tail -f`.
  *
- * /health and /metrics are filtered out — both get hit on a tight cadence
- * by infrastructure (load balancer, prom-scraper) and would drown out
- * useful traffic.
+ * /health, /ready and /metrics are filtered out — all three get hit on a
+ * tight cadence by infrastructure (Traefik's load-balancer healthcheck
+ * polls /ready every 3s per replica, the prom-scraper /metrics every 15s)
+ * and would drown out useful traffic. Readiness flips are visible on
+ * `brain_capability_probe_*` and in the boot log, not here.
  */
-const SKIP_PATHS = new Set(['/health', '/metrics']);
+const SKIP_PATHS = new Set(['/health', '/ready', '/metrics']);
 
 function useJson(): boolean {
   if (process.env.LOG_FORMAT === 'json') return true;
@@ -53,6 +56,10 @@ export function requestLogger() {
             ts: new Date().toISOString(),
             level: 'info',
             kind: 'request',
+            // Which replica served it. Loki keeps one stream per
+            // container, but a line read on its own (or after a
+            // `| json` across replicas) is otherwise anonymous.
+            instance: PROCESS_IDENTITY,
             requestId,
             method: req.method,
             path: url,

--- a/src/common/tracing.ts
+++ b/src/common/tracing.ts
@@ -23,9 +23,10 @@ import { trace, SpanStatusCode, type Span } from '@opentelemetry/api';
 import { NodeSDK } from '@opentelemetry/sdk-node';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
 import { resourceFromAttributes } from '@opentelemetry/resources';
-import { ATTR_SERVICE_NAME } from '@opentelemetry/semantic-conventions';
+import { ATTR_SERVICE_NAME, ATTR_SERVICE_INSTANCE_ID } from '@opentelemetry/semantic-conventions';
 import { getNodeAutoInstrumentations } from '@opentelemetry/auto-instrumentations-node';
 import { traceSpan as debugTraceSpan } from './debug-trace';
+import { PROCESS_IDENTITY } from './process-identity';
 
 const TRACER_NAME = 'inite-brain-service';
 
@@ -52,6 +53,10 @@ export function initTracing(): void {
   sdk = new NodeSDK({
     resource: resourceFromAttributes({
       [ATTR_SERVICE_NAME]: serviceName,
+      // Which replica emitted the span. Every trace in Tempo is
+      // otherwise attributed to one anonymous "inite-brain-service", so a
+      // latency tail confined to one replica is invisible.
+      [ATTR_SERVICE_INSTANCE_ID]: PROCESS_IDENTITY,
     }),
     traceExporter: new OTLPTraceExporter(),
     // Auto-instrumentations cover http/https (so OpenAI + JWKS calls),

--- a/src/db/surreal.service.ts
+++ b/src/db/surreal.service.ts
@@ -236,6 +236,9 @@ export class SurrealService implements OnModuleInit, OnApplicationShutdown {
     if (!Number.isFinite(this.poolSize) || this.poolSize < 1) {
       throw new Error('SURREALDB_POOL_SIZE must be a positive integer');
     }
+    if (!Number.isFinite(this.scopedPoolSize) || this.scopedPoolSize < 1) {
+      throw new Error('SURREALDB_SCOPED_POOL_SIZE must be a positive integer');
+    }
     if (!Number.isFinite(this.acquireTimeoutMs) || this.acquireTimeoutMs < 100) {
       throw new Error('SURREALDB_ACQUIRE_TIMEOUT_MS must be >= 100ms');
     }

--- a/src/metrics/metrics.service.ts
+++ b/src/metrics/metrics.service.ts
@@ -8,6 +8,7 @@ import {
   type LabelValues,
 } from 'prom-client';
 import { isConclusive, type CapabilityName, type ProbeOutcome } from './capability-probe';
+import { PROCESS_IDENTITY } from '../common/process-identity';
 
 /** knowledge_fact.status enum (schema ASSERT) — every value gets a series. */
 export const FACT_STATUSES = [
@@ -965,6 +966,28 @@ export class MetricsService implements OnModuleInit {
   onModuleInit() {
     // Node defaults: GC, event-loop lag, memory, CPU. Cheap and useful.
     collectDefaultMetrics({ register: this.registry, prefix: 'brain_' });
+
+    // Which replica produced these numbers. Without it N replicas'
+    // series are indistinguishable in a scrape read straight off
+    // /metrics, and every per-process gauge (event-loop lag, RSS,
+    // is-leader) reads as one flapping identity.
+    this.registry.setDefaultLabels({ instance: PROCESS_IDENTITY });
+
+    // Cluster-wide gauges, written only by whichever replica holds the
+    // relevant lease. prom-client publishes a label-less gauge as 0 from
+    // construction, so every non-leader replica exported a confident
+    // "0 pending" / "0 nonconforming" it had never measured, and an
+    // aggregate over replicas read the invented zeros as fact. Dropping
+    // the boot series means a non-leader exports nothing for them until
+    // it actually becomes the leader and measures something.
+    //
+    // brain_worker_is_leader is deliberately NOT in this list: 0 there is
+    // a real per-replica measurement ("I am not the leader"), and
+    // sum() over replicas is how the NoWorkerLeader alert counts leaders.
+    this.changefeedLag.remove();
+    this.vectorCorpusTenantsNonconforming.remove();
+    this.memoryOrphanEntities.remove();
+    this.policySetsActive.remove();
   }
 
   countIngestFact(outcome: string): void {

--- a/test/contracts-admin-health-components.unit-spec.ts
+++ b/test/contracts-admin-health-components.unit-spec.ts
@@ -12,6 +12,7 @@ import type { HealthService } from '../src/common/health.service';
 import type { CapabilityProbeService } from '../src/metrics/capability-probe.service';
 import type { IntentClassifierService } from '../src/admin/intent-classifier.service';
 import type { ChangefeedConsumerService } from '../src/audit/changefeed-consumer.service';
+import type { LeaderLeaseService } from '../src/jobs/leader-lease.service';
 
 function makeController(): AdminInfraController {
   const surreal = {
@@ -58,8 +59,19 @@ function makeController(): AdminInfraController {
       perBatchLimit: 100,
     }),
   } as unknown as ChangefeedConsumerService;
+  const leases = {
+    identity: () => 'pod-a#1',
+    list: async () => [],
+  } as unknown as LeaderLeaseService;
   const adminInfra = new AdminInfraService(surreal, undefined as never);
-  const healthComponents = new HealthComponentsService(health, probe, embedder, intent, changefeed);
+  const healthComponents = new HealthComponentsService(
+    health,
+    probe,
+    embedder,
+    intent,
+    changefeed,
+    leases,
+  );
   return makeAdminInfraController({ adminInfra, healthComponents });
 }
 

--- a/test/deploy-race-truth.unit-spec.ts
+++ b/test/deploy-race-truth.unit-spec.ts
@@ -1,0 +1,316 @@
+import { execFileSync } from 'node:child_process';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+/**
+ * Truth test for the two deploy-state races the 2026-09-09 runtime audit
+ * reproduced (F2, F3). It does not assert on the workflow's prose: it
+ * EXTRACTS the real shell fragments out of deploy-brain.yml and runs them
+ * over a temp directory with stub `docker` / `docker-compose` binaries, so
+ * what is verified is the code the self-hosted runner executes.
+ *
+ * F2 — a finalize that arrived after another run had redeployed used to
+ *      `cp .pending-image .last-good-image`, declaring an image nothing
+ *      had verified to be the last known-good.
+ * F3 — a manual rollback read `.last-good-image`, which after a green
+ *      release IS the running release, and then overwrote `.previous-image`
+ *      with it — destroying the only pointer to the version before.
+ */
+
+const ROOT = join(__dirname, '..');
+const WORKFLOW = readFileSync(join(ROOT, '.github', 'workflows', 'deploy-brain.yml'), 'utf8');
+
+/**
+ * A step's `run:` script, dedented exactly as the YAML block scalar hands
+ * it to the runner (the body is uniformly indented ten spaces).
+ */
+function stepScript(name: string): string {
+  const start = WORKFLOW.indexOf(`      - name: ${name}\n`);
+  expect(start).toBeGreaterThan(-1);
+  const rest = WORKFLOW.slice(start + 1);
+  const end = rest.search(/\n {6}(?:- name:|#)/);
+  const block = end < 0 ? rest : rest.slice(0, end);
+  const runIdx = block.indexOf('run: |\n');
+  expect(runIdx).toBeGreaterThan(-1);
+  return block.slice(runIdx + 'run: |\n'.length).replace(/^ {10}/gm, '');
+}
+
+const DEPLOY = stepScript('Deploy to server');
+
+/** The part of the deploy step between two literal markers. */
+function fragment(from: string, to: string): string {
+  const start = DEPLOY.indexOf(from);
+  const end = DEPLOY.indexOf(to);
+  expect(start).toBeGreaterThan(-1);
+  expect(end).toBeGreaterThan(start);
+  return DEPLOY.slice(start, end);
+}
+
+/** Image selection + state writes: the F3 fragment. */
+const SELECT_IMAGE = () => fragment('PREVIOUS_IMAGE=""', '# Brain talks');
+/** The generator for the replica helpers the later steps and finalize source. */
+const WRITE_LIB = () => fragment('tee deploy-lib.sh', '. ./deploy-lib.sh');
+
+/**
+ * A box: a project dir with the REAL generated `deploy-lib.sh` and stub
+ * `docker` / `docker-compose` on PATH. The stubs answer only what these
+ * fragments ask — which containers exist, whether they run, and what image
+ * they were created from.
+ */
+interface Box {
+  dir: string;
+  env: NodeJS.ProcessEnv;
+}
+
+function writeDockerStub(dir: string, imageFile: string): void {
+  const bin = join(dir, 'bin');
+  // `docker inspect -f '{{.State.Status}}' <ids…>` prints one line per
+  // container id it was given; every other format answers with the image
+  // the containers were created from.
+  writeFileSync(
+    join(bin, 'docker'),
+    '#!/bin/sh\ncase "$*" in\n' +
+      '  *State.Status*)\n' +
+      '    for a in "$@"; do\n' +
+      '      case "$a" in -*|*\'{{\'*|inspect|image) ;; *) echo running ;; esac\n' +
+      '    done ;;\n' +
+      `  *) cat '${imageFile}' ;;\n` +
+      'esac\nexit 0\n',
+  );
+  chmodSync(join(bin, 'docker'), 0o755);
+}
+
+function makeBox(state: { replicaIds?: string[]; runningImage?: string }): Box {
+  const dir = mkdtempSync(join(tmpdir(), 'brain-deploy-race-'));
+  const bin = join(dir, 'bin');
+  mkdirSync(bin);
+  const ids = state.replicaIds ?? ['cid1'];
+  const imageFile = join(dir, 'running-image');
+  writeFileSync(imageFile, state.runningImage ?? '');
+  writeFileSync(
+    join(bin, 'docker-compose'),
+    '#!/bin/sh\ncase "$1 $2" in\n' +
+      `  "ps -q") printf '%s\\n' ${ids.map((i) => `'${i}'`).join(' ')} ;;\n` +
+      '  *) : ;;\nesac\nexit 0\n',
+  );
+  chmodSync(join(bin, 'docker-compose'), 0o755);
+  writeDockerStub(dir, imageFile);
+
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    PATH: `${bin}:${process.env.PATH ?? ''}`,
+    PROJECT_DIR: dir,
+    PROJECT_NAME: 'inite-brain-service',
+    PORT: '3000',
+    BRAIN_REPLICAS: String(ids.length),
+    GITHUB_ENV: join(dir, 'github-env'),
+    GITHUB_OUTPUT: join(dir, 'github-output'),
+  };
+  // The helpers the finalize steps source are the ones the deploy step
+  // generates — extracted and run, not re-typed here.
+  execFileSync('bash', ['-c', WRITE_LIB()], { cwd: dir, env, encoding: 'utf8' });
+  return { dir, env };
+}
+
+function runFragment(
+  frag: string,
+  box: Box,
+  env: Record<string, string>,
+): {
+  code: number;
+  out: string;
+} {
+  try {
+    const out = execFileSync('bash', ['-c', frag], {
+      cwd: box.dir,
+      env: { ...box.env, ...env },
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return { code: 0, out };
+  } catch (err) {
+    const e = err as { status?: number; stdout?: string; stderr?: string };
+    return { code: e.status ?? -1, out: (e.stdout ?? '') + (e.stderr ?? '') };
+  }
+}
+
+const A = 'acme/brain@sha256:' + 'a'.repeat(64);
+const B = 'acme/brain@sha256:' + 'b'.repeat(64);
+const C = 'acme/brain@sha256:' + 'c'.repeat(64);
+
+describe('the generated replica helpers', () => {
+  it('count RUNNING containers instead of grepping compose prose', () => {
+    const box = makeBox({ replicaIds: ['cid1', 'cid2', 'cid3'] });
+    const lib = readFileSync(join(box.dir, 'deploy-lib.sh'), 'utf8');
+    expect(lib).toContain('DESIRED_REPLICAS="3"');
+    const out = execFileSync('bash', ['-c', '. ./deploy-lib.sh && running_replicas'], {
+      cwd: box.dir,
+      env: box.env,
+      encoding: 'utf8',
+    });
+    expect(out.trim()).toBe('3');
+  });
+});
+
+describe('F2: a superseded finalize promotes nothing', () => {
+  const promote = () => stepScript('Promote this image to last-known-good');
+
+  it('refuses to promote an image another run left pending', () => {
+    // Run A deployed A and passed smoke. Before A finalized, manual run B
+    // deployed B and overwrote .pending-image. A's finalize must not
+    // declare B — which nothing has verified — the last known-good.
+    const box = makeBox({ runningImage: B });
+    writeFileSync(join(box.dir, '.pending-image'), B);
+    writeFileSync(join(box.dir, '.last-good-image'), 'image-G');
+    const r = runFragment(promote(), box, { TXN_IMAGE: A });
+    expect(r.code).toBe(0);
+    expect(r.out).toMatch(/superseded/);
+    expect(readFileSync(join(box.dir, '.last-good-image'), 'utf8')).toBe('image-G');
+    expect(existsSync(join(box.dir, '.good-image-history'))).toBe(false);
+  });
+
+  it('refuses to promote when the replicas are running a different image', () => {
+    // .pending-image is still ours, but another run has already replaced
+    // the containers, so the smoke test passed against something else.
+    const box = makeBox({ runningImage: C });
+    writeFileSync(join(box.dir, '.pending-image'), A);
+    const r = runFragment(promote(), box, { TXN_IMAGE: A });
+    expect(r.code).toBe(0);
+    expect(r.out).toMatch(/superseded/);
+    expect(existsSync(join(box.dir, '.last-good-image'))).toBe(false);
+  });
+
+  it('promotes its own image and appends it to the history exactly once', () => {
+    const box = makeBox({ runningImage: A, replicaIds: ['cid1', 'cid2', 'cid3'] });
+    writeFileSync(join(box.dir, '.pending-image'), A);
+    expect(runFragment(promote(), box, { TXN_IMAGE: A }).code).toBe(0);
+    expect(runFragment(promote(), box, { TXN_IMAGE: A }).code).toBe(0);
+    expect(readFileSync(join(box.dir, '.last-good-image'), 'utf8')).toBe(A);
+    expect(readFileSync(join(box.dir, '.good-image-history'), 'utf8').trim().split('\n')).toEqual([
+      A,
+    ]);
+  });
+
+  it('keeps only the last five confirmed-good digests', () => {
+    const box = makeBox({ runningImage: '' });
+    const digests = Array.from(
+      { length: 7 },
+      (_, i) => `acme/brain@sha256:${String(i).repeat(64)}`,
+    );
+    for (const d of digests) {
+      writeFileSync(join(box.dir, '.pending-image'), d);
+      writeFileSync(join(box.dir, 'running-image'), d);
+      expect(runFragment(promote(), box, { TXN_IMAGE: d }).code).toBe(0);
+    }
+    const history = readFileSync(join(box.dir, '.good-image-history'), 'utf8').trim().split('\n');
+    expect(history).toEqual(digests.slice(-5));
+  });
+});
+
+describe('F2: a superseded rollback restarts nothing', () => {
+  const rollback = () => stepScript('Roll back to the previous image');
+
+  it('exits successfully without touching a newer run’s release', () => {
+    const box = makeBox({ runningImage: C });
+    writeFileSync(join(box.dir, 'docker-compose.yml'), `services:\n  brain:\n    image: ${C}\n`);
+    writeFileSync(join(box.dir, '.last-good-image'), A);
+    const r = runFragment(rollback(), box, { TXN_IMAGE: B });
+    expect(r.code).toBe(0);
+    expect(r.out).toMatch(/superseded/);
+    // The compose file still pins what the newer run deployed.
+    expect(readFileSync(join(box.dir, 'docker-compose.yml'), 'utf8')).toContain(C);
+  });
+});
+
+describe('F3: a manual rollback steps back', () => {
+  function boxRunning(image: string): Box {
+    const b = makeBox({ runningImage: image });
+    writeFileSync(join(b.dir, 'docker-compose.yml'), `services:\n  brain:\n    image: ${image}\n`);
+    return b;
+  }
+
+  it('never re-selects the running release, even when it is the newest good one', () => {
+    // The reproduced scenario: B went green (so it is both the newest
+    // confirmed-good digest and what is running), then a latent
+    // regression prompts a rollback.
+    const b = boxRunning(B);
+    writeFileSync(join(b.dir, '.good-image-history'), `${A}\n${B}\n`);
+    writeFileSync(join(b.dir, '.previous-image'), A);
+    const r = runFragment(SELECT_IMAGE(), b, {
+      ACTION: 'rollback',
+      IMAGE_FROM_CI: '',
+      IMAGE_INPUT: '',
+    });
+    expect(r.code).toBe(0);
+    expect(readFileSync(join(b.dir, '.pending-image'), 'utf8')).toBe(A);
+    // And the only pointer to the version before is untouched until the
+    // rollback has answered /ready.
+    expect(readFileSync(join(b.dir, '.previous-image'), 'utf8')).toBe(A);
+    expect(readFileSync(join(b.dir, '.previous-image.staged'), 'utf8')).toBe(B);
+  });
+
+  it('refuses a digest that never passed both gates', () => {
+    const b = boxRunning(B);
+    writeFileSync(join(b.dir, '.good-image-history'), `${A}\n${B}\n`);
+    const r = runFragment(SELECT_IMAGE(), b, {
+      ACTION: 'rollback',
+      IMAGE_FROM_CI: '',
+      IMAGE_INPUT: C,
+    });
+    expect(r.code).toBe(1);
+    expect(r.out).toMatch(/not in the confirmed-good history/);
+  });
+
+  it('accepts an explicit digest that did', () => {
+    const b = boxRunning(B);
+    writeFileSync(join(b.dir, '.good-image-history'), `${C}\n${A}\n${B}\n`);
+    const r = runFragment(SELECT_IMAGE(), b, {
+      ACTION: 'rollback',
+      IMAGE_FROM_CI: '',
+      IMAGE_INPUT: C,
+    });
+    expect(r.code).toBe(0);
+    expect(readFileSync(join(b.dir, '.pending-image'), 'utf8')).toBe(C);
+  });
+
+  it('refuses when the only confirmed-good digest is the running one', () => {
+    const b = boxRunning(B);
+    writeFileSync(join(b.dir, '.good-image-history'), `${B}\n`);
+    const r = runFragment(SELECT_IMAGE(), b, {
+      ACTION: 'rollback',
+      IMAGE_FROM_CI: '',
+      IMAGE_INPUT: '',
+    });
+    expect(r.code).toBe(1);
+    expect(r.out).toMatch(/no earlier verified release/);
+  });
+
+  it('records the transaction so a later finalize can tell whose it is', () => {
+    const b = boxRunning(A);
+    const r = runFragment(SELECT_IMAGE(), b, {
+      ACTION: '',
+      IMAGE_FROM_CI: B,
+      IMAGE_INPUT: '',
+      GITHUB_RUN_ID: '4242',
+      GITHUB_RUN_ATTEMPT: '1',
+      BRAIN_REPLICAS: '3',
+    });
+    expect(r.code).toBe(0);
+    const txn = readFileSync(join(b.dir, '.deploy-txn'), 'utf8');
+    expect(txn).toContain('run_id=4242');
+    expect(txn).toContain(`image=${B}`);
+    expect(txn).toContain(`previous=${A}`);
+    expect(txn).toContain('replicas=3');
+    // A normal deploy DOES move .previous-image immediately: the automatic
+    // rollback needs it even when the readiness gate fails.
+    expect(readFileSync(join(b.dir, '.previous-image'), 'utf8')).toBe(A);
+  });
+});

--- a/test/deploy-replicas-truth.unit-spec.ts
+++ b/test/deploy-replicas-truth.unit-spec.ts
@@ -1,0 +1,152 @@
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Truth test for "the service is N identical replicas".
+ *
+ * Every property here is one a single-replica assumption silently
+ * reintroduces: a `container_name` makes `--scale` an error, a published
+ * host port makes the second container fail to bind, a `/health`
+ * load-balancer probe keeps a degraded replica in rotation (it answers 200
+ * while reporting itself degraded), a check that asks "is something up"
+ * passes with one container out of three, and a per-replica model download
+ * cannot finish inside the readiness gate.
+ *
+ * It also pins the five env pins that were deleted for restating a
+ * default: a deploy file that restates defaults invites the next reader to
+ * treat the value as deliberate.
+ */
+
+const ROOT = join(__dirname, '..');
+const DEPLOY = readFileSync(join(ROOT, '.github', 'workflows', 'deploy-brain.yml'), 'utf8');
+const COMPOSE = readFileSync(join(ROOT, 'docker-compose.yml'), 'utf8');
+
+/** The compose file the deploy generates on the box, as workflow source. */
+const HEREDOC = (() => {
+  const start = DEPLOY.indexOf('tee docker-compose.yml > /dev/null << EOF');
+  const end = DEPLOY.indexOf('\n          EOF\n', start);
+  expect(start).toBeGreaterThan(-1);
+  expect(end).toBeGreaterThan(start);
+  return DEPLOY.slice(start, end);
+})();
+
+describe('the generated compose can run N replicas', () => {
+  it('does not name the container', () => {
+    // container_name pins the service to exactly one container: compose
+    // refuses `--scale` and `deploy.replicas` outright.
+    expect(HEREDOC).not.toMatch(/^\s*container_name:/m);
+  });
+
+  it('declares the replica count and also passes it to --scale', () => {
+    // deploy.replicas is honoured by compose v2 and ignored by v1; the
+    // flag is honoured by both. The box runs `docker-compose`, so both.
+    expect(HEREDOC).toMatch(/deploy:\s*\n\s*replicas: \$\{BRAIN_REPLICAS:-1\}/);
+    expect(DEPLOY).toMatch(
+      /up -d --remove-orphans --scale "\$\{PROJECT_NAME\}=\$\{BRAIN_REPLICAS\}"/,
+    );
+  });
+
+  it('publishes no host port — Traefik reaches it over the network', () => {
+    expect(HEREDOC).toMatch(/expose:/);
+    expect(HEREDOC).not.toMatch(/^\s+ports:/m);
+  });
+
+  it('shares one model cache so replica 2 does not re-download 700MB', () => {
+    expect(HEREDOC).toMatch(/brain-model-cache:\/app\/\.cache/);
+    // And the named volume is declared, or compose refuses the file.
+    expect(HEREDOC).toMatch(/volumes:\s*\n\s*brain-model-cache:/);
+  });
+
+  it('refuses a malformed replica count instead of quietly scaling to 1', () => {
+    expect(DEPLOY).toMatch(/BRAIN_REPLICAS must be a positive integer/);
+  });
+});
+
+describe('the edge routes on readiness', () => {
+  it('points the load-balancer healthcheck at /ready', () => {
+    expect(HEREDOC).toMatch(/loadbalancer\.healthcheck\.path=\/ready/);
+    expect(HEREDOC).not.toMatch(/loadbalancer\.healthcheck\.path=\/health/);
+    // A slow probe is a slow rotation; keep it seconds, not a quarter minute.
+    expect(HEREDOC).toMatch(/loadbalancer\.healthcheck\.interval=3s/);
+    expect(HEREDOC).toMatch(/loadbalancer\.healthcheck\.timeout=2s/);
+  });
+
+  it('routes /ready through the domain on BOTH routers', () => {
+    // Without the router rule the healthcheck 404s and Traefik takes
+    // every replica out of rotation — the failure mode is total.
+    const rules = [...HEREDOC.matchAll(/routers\.\$\{PROJECT_NAME\}(-http)?\.rule=([^\n]+)/g)];
+    expect(rules).toHaveLength(2);
+    for (const rule of rules) {
+      expect(rule[2]).toContain('PathPrefix(\\`/ready\\`)');
+    }
+  });
+
+  it('keeps the container healthcheck on liveness', () => {
+    // Docker restarts on this one: recycling a container because its
+    // embedder is still warming is a restart loop, not a repair.
+    expect(HEREDOC).toMatch(/healthcheck:\s*\n\s*test:.*\/health/);
+  });
+});
+
+describe('post-deploy checks count replicas instead of assuming one', () => {
+  it('waits for the full desired count, not for "something is up"', () => {
+    expect(DEPLOY).not.toMatch(/docker-compose ps \| grep -q "Up"/);
+    expect(DEPLOY).toMatch(/running_replicas/);
+    expect(DEPLOY).toMatch(/\[ "\$up" -ge "\$\{BRAIN_REPLICAS\}" \]/);
+  });
+
+  it('probes health, readiness and the rolled-back image on every replica', () => {
+    expect(DEPLOY).toMatch(/await_all_replicas 90 \/health/);
+    expect(DEPLOY).toMatch(/await_all_replicas 300 \/ready/);
+    // The rollback verification is the third caller; it is the one that
+    // used to accept a single ready container as a verified rollback.
+    expect([...DEPLOY.matchAll(/await_all_replicas/g)].length).toBeGreaterThanOrEqual(4);
+    expect(DEPLOY).toMatch(/--index="\$1"/);
+  });
+
+  it('asserts the running replicas are this run’s image', () => {
+    expect(DEPLOY).toMatch(/all_replicas_run_image "\$\{IMAGE_REF\}"/);
+  });
+});
+
+describe('the deploy env restates no defaults', () => {
+  // Each was cross-checked against the reader in src/: provisioning
+  // follows SEARCH_HNSW_ENABLED (hnsw-provision.service.ts), the probe and
+  // the worker loop read envFlagNotDisabled (on unless =0), the lease
+  // manager defaults to '1', and JOBS_QUEUE_MODE defaults to 'enqueue'.
+  for (const pin of [
+    'HNSW_PROVISION_ENABLED=1',
+    'CAPABILITY_PROBE_ENABLED=1',
+    'WORKER_LOOP_ENABLED=1',
+    'LEASE_MANAGER_ENABLED=1',
+    'JOBS_QUEUE_MODE=enqueue',
+  ]) {
+    it(`does not pin ${pin}`, () => {
+      expect(DEPLOY).not.toContain(`\n          ${pin}\n`);
+      expect(DEPLOY).not.toContain(`- ${pin}\n`);
+    });
+  }
+});
+
+describe('the repo compose is scalable too', () => {
+  it('does not publish a fixed host port for the app', () => {
+    const brain = COMPOSE.slice(
+      COMPOSE.indexOf('\n  brain:'),
+      COMPOSE.indexOf('\n  brain-worker:'),
+    );
+    expect(brain).toMatch(/expose:/);
+    expect(brain).not.toMatch(/^\s+ports:/m);
+  });
+
+  it('documents the local-dev port mapping instead of deleting it', () => {
+    expect(existsSync(join(ROOT, 'docker-compose.override.yml.example'))).toBe(true);
+    const example = readFileSync(join(ROOT, 'docker-compose.override.yml.example'), 'utf8');
+    expect(example).toMatch(/ports:/);
+    expect(example).toMatch(/BRAIN_HOST_PORT/);
+  });
+
+  it('mounts the shared model cache', () => {
+    expect(COMPOSE).toMatch(/brain-model-cache:\/app\/\.cache/);
+    expect(COMPOSE).toMatch(/^volumes:\n(?:.*\n)*?  brain-model-cache:/m);
+  });
+});

--- a/test/deploy-smoke-truth.unit-spec.ts
+++ b/test/deploy-smoke-truth.unit-spec.ts
@@ -52,6 +52,11 @@ describe('each surface smoke-tests only what it owns', () => {
   it('the engine asserts more than liveness', () => {
     const paths = surfacePaths('brain');
     expect(paths).toContain('/health');
+    // /ready is the load balancer's contract: if its router rule is
+    // missing the healthcheck 404s, Traefik marks every replica down and
+    // the domain serves nothing. Asserting it through the domain is the
+    // only place that bug is visible before real traffic finds it.
+    expect(paths).toContain('/ready');
     // The point of the change: a route whose 401 proves the API is
     // mounted and fail-closed. /health alone proves only that Nest bound
     // a port.
@@ -108,6 +113,79 @@ describe('a failed deploy has a way back', () => {
   it('a rollback is reachable by hand without editing the box', () => {
     expect(BRAIN).toMatch(/deploy \| restart \| logs \| rollback/);
     expect(BRAIN).toMatch(/inputs\.action == 'rollback'/);
+  });
+});
+
+describe('only one run at a time may resolve the deploy transaction', () => {
+  it('every production-mutating run shares one concurrency group', () => {
+    // Keying the group by github.event_name gave a push deploy and a
+    // manual dispatch a group each — i.e. the two racers ran in parallel
+    // over the same state files (audit F2).
+    const block = /\nconcurrency:\n((?:  .*\n)+)/.exec(BRAIN);
+    expect(block).not.toBeNull();
+    const body = block?.[1] ?? '';
+    expect(body).toMatch(/group: deploy-brain-production/);
+    expect(body).not.toMatch(/github\.event_name/);
+  });
+
+  it('queues instead of cancelling a run mid-transaction', () => {
+    // The state machine spans deploy → smoke → finalize. A cancel between
+    // them leaves a half-applied transaction with nobody to resolve it.
+    expect(BRAIN).toMatch(/cancel-in-progress: false/);
+  });
+
+  it('records a transaction with the run id at deploy time', () => {
+    expect(BRAIN).toMatch(/\.deploy-txn/);
+    expect(BRAIN).toMatch(/run_id=\$\{GITHUB_RUN_ID\}/);
+  });
+
+  it('promote and rollback both refuse a transaction that is not theirs', () => {
+    const guard = /- name: Read the deployment transaction[\s\S]*?- name: Promote/.exec(BRAIN);
+    expect(guard?.[0]).toMatch(/superseded by run/);
+    for (const step of [
+      'Promote this image to last-known-good',
+      'Roll back to the previous image',
+    ]) {
+      const start = BRAIN.indexOf(`- name: ${step}`);
+      expect(start).toBeGreaterThan(-1);
+      // The `if:` on the step, i.e. everything up to its `run:`.
+      const condition = BRAIN.slice(start, BRAIN.indexOf('run: |', start));
+      expect(condition).toMatch(/steps\.txn\.outputs\.ours == '1'/);
+    }
+  });
+
+  it('promote also checks that what is RUNNING is this run’s image', () => {
+    const start = BRAIN.indexOf('- name: Promote this image to last-known-good');
+    const promote = BRAIN.slice(start, BRAIN.indexOf('- name: Roll back', start));
+    expect(promote).toMatch(/all_replicas_run_image "\$TXN_IMAGE"/);
+    // Smoke passing against the domain is only evidence about this
+    // release if this release is what the replicas serve.
+    expect(promote).toMatch(/superseded, not touching state/);
+  });
+});
+
+describe('a manual rollback steps back rather than sideways', () => {
+  it('never targets the digest that is already running', () => {
+    // .last-good-image after a green release IS the running release, so
+    // reading it re-selected the very thing being rolled back (audit F3).
+    const start = BRAIN.indexOf('if [ "${ACTION}" = "rollback" ]; then');
+    expect(start).toBeGreaterThan(-1);
+    const select = BRAIN.slice(start, BRAIN.indexOf('printf', start));
+    expect(select).toMatch(/\.good-image-history/);
+    expect(select).toMatch(/grep -vxF "\$\{PREVIOUS_IMAGE:-__none__\}"/);
+    expect(select).not.toMatch(/cat \.last-good-image/);
+  });
+
+  it('keeps the way back until the rollback has proven itself', () => {
+    expect(BRAIN).toMatch(/\.previous-image\.staged/);
+    const commit = BRAIN.indexOf('- name: Commit the rollback pointers');
+    expect(commit).toBeGreaterThan(-1);
+    // Ordering is the property: the pointer moves only after the gate.
+    expect(BRAIN.indexOf('- name: Internal readiness gate')).toBeLessThan(commit);
+  });
+
+  it('bounds the confirmed-good history', () => {
+    expect(BRAIN).toMatch(/tail -n 5 \.good-image-history/);
   });
 });
 

--- a/test/env-validation.unit-spec.ts
+++ b/test/env-validation.unit-spec.ts
@@ -52,6 +52,33 @@ describe('validateEnv — scoped pool fence', () => {
   });
 });
 
+describe('validateEnv — pool sizes', () => {
+  // A typo in the SCOPED size used to parse to NaN: the build loop ran
+  // zero times while scopedPoolEnabled() stayed true, so every scoped read
+  // waited for a connection that would never exist and the replica sat
+  // permanently not-ready with nothing naming the cause. The root pool has
+  // always been guarded; both are now.
+  for (const key of ['SURREALDB_POOL_SIZE', 'SURREALDB_SCOPED_POOL_SIZE']) {
+    it(`rejects a non-numeric ${key}`, () => {
+      const env = baseProdEnv();
+      env[key] = '8x';
+      expect(() => validateEnv(env)).toThrow(new RegExp(key));
+    });
+
+    it(`rejects a zero ${key}`, () => {
+      const env = baseProdEnv();
+      env[key] = '0';
+      expect(() => validateEnv(env)).toThrow(new RegExp(key));
+    });
+
+    it(`accepts a positive ${key}`, () => {
+      const env = baseProdEnv();
+      env[key] = '4';
+      expect(() => validateEnv(env)).not.toThrow();
+    });
+  }
+});
+
 describe('validateEnv — THROTTLE_DISABLED is test-only', () => {
   it('hard-errors when THROTTLE_DISABLED=1 in production', () => {
     const env = baseProdEnv();

--- a/test/fovea-adaptive-abstain.e2e-spec.ts
+++ b/test/fovea-adaptive-abstain.e2e-spec.ts
@@ -49,7 +49,9 @@ describe('Fovea Optics §4.2 adaptive abstention e2e (safety fallback)', () => {
   async function abstainPathCount(path: string): Promise<number> {
     const metrics = f.app.get(MetricsService);
     const { body } = await metrics.serialize();
-    const m = body.match(new RegExp(`brain_abstain_path_total\\{path="${path}"\\} (\\d+)`));
+    const m = body.match(
+      new RegExp(`brain_abstain_path_total\\{[^}]*path="${path}"[^}]*\\} (\\d+)`),
+    );
     return m ? parseInt(m[1]!, 10) : 0;
   }
 

--- a/test/fovea-adaptive-l3.e2e-spec.ts
+++ b/test/fovea-adaptive-l3.e2e-spec.ts
@@ -51,7 +51,9 @@ describe('Fovea Optics-2 adaptive L3 escalation e2e', () => {
   async function triggerPathCount(app: AppFixture, path: string): Promise<number> {
     const metrics = app.app.get(MetricsService);
     const { body } = await metrics.serialize();
-    const m = body.match(new RegExp(`brain_l3_adaptive_trigger_total\\{path="${path}"\\} (\\d+)`));
+    const m = body.match(
+      new RegExp(`brain_l3_adaptive_trigger_total\\{[^}]*path="${path}"[^}]*\\} (\\d+)`),
+    );
     return m ? parseInt(m[1]!, 10) : 0;
   }
 

--- a/test/fovea-answer-integrity.e2e-spec.ts
+++ b/test/fovea-answer-integrity.e2e-spec.ts
@@ -54,7 +54,7 @@ describe('Fovea verifier answer-integrity arm e2e', () => {
   async function counter(name: string): Promise<number> {
     const metrics = f.app.get(MetricsService);
     const { body } = await metrics.serialize();
-    const m = body.match(new RegExp(`^${name} (\\d+)`, 'm'));
+    const m = body.match(new RegExp(`^${name}(?:\\{[^}]*\\})? (\\d+)`, 'm'));
     return m ? parseInt(m[1]!, 10) : 0;
   }
 

--- a/test/fovea-cascade.e2e-spec.ts
+++ b/test/fovea-cascade.e2e-spec.ts
@@ -121,7 +121,7 @@ describe('fovea cascade shakedown — full stack composed', () => {
   async function metricValue(name: string, outcome: string): Promise<number> {
     const metrics = f.app.get(MetricsService);
     const { body } = await metrics.serialize();
-    const m = body.match(new RegExp(`${name}\\{outcome="${outcome}"\\} (\\d+)`));
+    const m = body.match(new RegExp(`${name}\\{[^}]*outcome="${outcome}"[^}]*\\} (\\d+)`));
     return m ? parseInt(m[1]!, 10) : 0;
   }
   const l3Count = (o: string) => metricValue('brain_l3_escalation_total', o);

--- a/test/fovea-evidence-capability.e2e-spec.ts
+++ b/test/fovea-evidence-capability.e2e-spec.ts
@@ -36,7 +36,10 @@ describe('Fovea evidence-capability gate e2e', () => {
   async function capabilityCounter(outcome: 'checked' | 'downgraded'): Promise<number> {
     const { body } = await f.app.get(MetricsService).serialize();
     const m = body.match(
-      new RegExp(`^brain_evidence_capability_total\\{outcome="${outcome}"\\} (\\d+)`, 'm'),
+      new RegExp(
+        `^brain_evidence_capability_total\\{[^}]*outcome="${outcome}"[^}]*\\} (\\d+)`,
+        'm',
+      ),
     );
     return m ? parseInt(m[1]!, 10) : 0;
   }

--- a/test/fovea-lens-suppress.e2e-spec.ts
+++ b/test/fovea-lens-suppress.e2e-spec.ts
@@ -86,7 +86,7 @@ describe('Fovea Optics §4.3 lens-suppression governor e2e', () => {
     const metrics = app.app.get(MetricsService);
     const { body } = await metrics.serialize();
     const m = body.match(
-      new RegExp(`brain_lens_suppression_total\\{outcome="${outcome}"\\} (\\d+)`),
+      new RegExp(`brain_lens_suppression_total\\{[^}]*outcome="${outcome}"[^}]*\\} (\\d+)`),
     );
     return m ? parseInt(m[1]!, 10) : 0;
   }

--- a/test/health-components.unit-spec.ts
+++ b/test/health-components.unit-spec.ts
@@ -42,10 +42,20 @@ type DetailOverrides = Partial<ReadinessReport['detail']>;
 
 const at = (secondsAgo: number) => new Date(Date.now() - secondsAgo * 1000).toISOString();
 
+interface ChangefeedFixture {
+  enabled?: boolean;
+  pending?: number;
+  /** leaderId on a live changefeed_consumer lease, if any pod holds one. */
+  leaseHolder?: string;
+  /** Our own leaderId — the lease matches it when this pod is the leader. */
+  identity?: string;
+}
+
 function grid(
   readiness: Partial<Omit<ReadinessReport, 'detail'>> & { detail?: DetailOverrides } = {},
   last: LastReports = {},
   intent: IntentFixture = {},
+  changefeed: ChangefeedFixture = {},
 ) {
   const report: ReadinessReport = {
     ...READY,
@@ -68,16 +78,31 @@ function grid(
     } as never,
     {
       stats: () => ({
-        enabled: false,
+        enabled: changefeed.enabled ?? false,
         inFlight: false,
         lastTickAt: null,
-        lastPendingRemaining: 0,
+        lastPendingRemaining: changefeed.pending ?? 0,
         totalConsumed: 0,
         tickCount: 0,
         lastError: null,
         sources: [],
         perBatchLimit: 100,
       }),
+    } as never,
+    {
+      identity: () => changefeed.identity ?? 'pod-a#1',
+      list: async () =>
+        changefeed.leaseHolder === undefined
+          ? []
+          : [
+              {
+                name: 'changefeed_consumer',
+                leaderId: changefeed.leaseHolder,
+                leaseUntil: new Date(Date.now() + 60_000).toISOString(),
+                heartbeatAt: new Date().toISOString(),
+                acquiredAt: new Date().toISOString(),
+              },
+            ],
     } as never,
   );
   return svc.build();
@@ -289,6 +314,41 @@ describe('health grid — wire contract and provenance', () => {
       'changefeed consumer',
       'calibration',
     ]);
+  });
+
+  it('says NOT LEADER instead of "ok, 0 pending" on a replica that does not consume', async () => {
+    // The consumer ticks only under the changefeed_consumer lease, so on
+    // every other replica the counters are the initial values. Rendering
+    // them green was a claim about work happening on a different pod.
+    const r = await row(
+      'changefeed consumer',
+      {},
+      {},
+      {},
+      { enabled: true, leaseHolder: 'pod-b#7', identity: 'pod-a#1' },
+    );
+    expect(r.status).toBe('disabled');
+    expect(r.message).toContain('not leader');
+    expect(r.message).toContain('pod-b#7');
+    expect(r.message).not.toContain('0 pending');
+  });
+
+  it('reports its own counters on the replica that holds the lease', async () => {
+    const r = await row(
+      'changefeed consumer',
+      {},
+      {},
+      {},
+      { enabled: true, pending: 5, leaseHolder: 'pod-a#1', identity: 'pod-a#1' },
+    );
+    expect(r.status).toBe('ok');
+    expect(r.message).toContain('5 pending');
+  });
+
+  it('still says disabled when the consumer is switched off entirely', async () => {
+    const r = await row('changefeed consumer', {}, {}, {}, { enabled: false });
+    expect(r.status).toBe('disabled');
+    expect(r.message).toContain('AUDIT_CHANGEFEED_ENABLED=0');
   });
 
   it('takes the database row from the readiness report, latency included — no second ping', async () => {

--- a/test/l3-escalation.e2e-spec.ts
+++ b/test/l3-escalation.e2e-spec.ts
@@ -56,21 +56,25 @@ describe('G2 L3 escalation e2e', () => {
   async function l3Count(app: AppFixture, outcome: string): Promise<number> {
     const metrics = app.app.get(MetricsService);
     const { body } = await metrics.serialize();
-    const m = body.match(new RegExp(`brain_l3_escalation_total\\{outcome="${outcome}"\\} (\\d+)`));
+    const m = body.match(
+      new RegExp(`brain_l3_escalation_total\\{[^}]*outcome="${outcome}"[^}]*\\} (\\d+)`),
+    );
     return m ? parseInt(m[1]!, 10) : 0;
   }
 
   async function counter(app: AppFixture, name: string): Promise<number> {
     const metrics = app.app.get(MetricsService);
     const { body } = await metrics.serialize();
-    const m = body.match(new RegExp(`^${name} (\\d+)`, 'm'));
+    const m = body.match(new RegExp(`^${name}(?:\\{[^}]*\\})? (\\d+)`, 'm'));
     return m ? parseInt(m[1]!, 10) : 0;
   }
 
   async function anchorSourceCount(app: AppFixture, source: string): Promise<number> {
     const metrics = app.app.get(MetricsService);
     const { body } = await metrics.serialize();
-    const m = body.match(new RegExp(`brain_l3_anchor_source_total\\{source="${source}"\\} (\\d+)`));
+    const m = body.match(
+      new RegExp(`brain_l3_anchor_source_total\\{[^}]*source="${source}"[^}]*\\} (\\d+)`),
+    );
     return m ? parseInt(m[1]!, 10) : 0;
   }
 
@@ -78,7 +82,7 @@ describe('G2 L3 escalation e2e', () => {
     const metrics = app.app.get(MetricsService);
     const { body } = await metrics.serialize();
     const m = body.match(
-      new RegExp(`brain_l3_episode_citation_total\\{outcome="${outcome}"\\} (\\d+)`),
+      new RegExp(`brain_l3_episode_citation_total\\{[^}]*outcome="${outcome}"[^}]*\\} (\\d+)`),
     );
     return m ? parseInt(m[1]!, 10) : 0;
   }

--- a/test/metrics.unit-spec.ts
+++ b/test/metrics.unit-spec.ts
@@ -13,12 +13,26 @@ describe('MetricsService', () => {
     metrics.onModuleInit();
   });
 
+  /**
+   * The payload with the per-replica `instance` default label stripped, so
+   * the assertions below read each metric's OWN labels. That the label is
+   * there at all is asserted separately.
+   */
+  async function payload(): Promise<string> {
+    const { body } = await metrics.serialize();
+    // Counters/gauges append it, histograms prepend it.
+    return body
+      .replace(/,instance="[^"]*"/g, '')
+      .replace(/\{instance="[^"]*",/g, '{')
+      .replace(/\{instance="[^"]*"\}/g, '');
+  }
+
   it('counts ingest outcomes by label', async () => {
     metrics.countIngestFact('INSERTED');
     metrics.countIngestFact('INSERTED');
     metrics.countIngestFact('SUPERSEDED');
 
-    const { body } = await metrics.serialize();
+    const body = await payload();
     expect(body).toMatch(/brain_ingest_facts_total\{outcome="INSERTED"\} 2/);
     expect(body).toMatch(/brain_ingest_facts_total\{outcome="SUPERSEDED"\} 1/);
   });
@@ -28,7 +42,7 @@ describe('MetricsService', () => {
     metrics.observeSearchDuration(0.2);
     metrics.observeSearchDuration(1.5);
 
-    const { body } = await metrics.serialize();
+    const body = await payload();
     // 3 observations recorded
     expect(body).toMatch(/brain_search_duration_seconds_count 3/);
     // Sum should be ≈ 1.75
@@ -44,14 +58,14 @@ describe('MetricsService', () => {
     metrics.countCompacted(42);
     metrics.countCompacted(0); // should be a no-op
 
-    const { body } = await metrics.serialize();
+    const body = await payload();
     expect(body).toMatch(/brain_retract_total 1/);
     expect(body).toMatch(/brain_forget_total 2/);
     expect(body).toMatch(/brain_compaction_facts_total 42/);
   });
 
   it('exposes node default metrics with brain_ prefix', async () => {
-    const { body } = await metrics.serialize();
+    const body = await payload();
     expect(body).toMatch(/brain_process_/); // process_cpu_user_seconds_total etc.
     expect(body).toMatch(/brain_nodejs_/); // nodejs_eventloop_lag_seconds etc.
   });
@@ -82,7 +96,7 @@ describe('MetricsService', () => {
       durationSeconds: 5.2,
     });
 
-    const { body } = await metrics.serialize();
+    const body = await payload();
     expect(body).toMatch(/brain_openai_calls_total\{kind="embed",outcome="ok"\} 1/);
     expect(body).toMatch(/brain_openai_calls_total\{kind="chat",outcome="ok"\} 1/);
     expect(body).toMatch(/brain_openai_calls_total\{kind="chat",outcome="error"\} 1/);
@@ -101,7 +115,7 @@ describe('MetricsService', () => {
       durationSeconds: 0.1,
       promptTokens: 0,
     });
-    const { body } = await metrics.serialize();
+    const body = await payload();
     expect(body).not.toMatch(/brain_openai_tokens_total\{[^}]*kind="embed"/);
   });
 
@@ -110,7 +124,7 @@ describe('MetricsService', () => {
     metrics.countIngestMention('skipped');
     metrics.countIngestMention('extracted');
 
-    const { body } = await metrics.serialize();
+    const body = await payload();
     expect(body).toMatch(/brain_ingest_mentions_total\{result="extracted"\} 2/);
     expect(body).toMatch(/brain_ingest_mentions_total\{result="skipped"\} 1/);
   });
@@ -123,7 +137,7 @@ describe('MetricsService', () => {
     metrics.countL3Escalation('skipped_no_anchor');
     metrics.countL3Escalation('over_budget_degraded');
 
-    const { body } = await metrics.serialize();
+    const body = await payload();
     expect(body).toMatch(/brain_l3_escalation_total\{outcome="fired"\} 2/);
     expect(body).toMatch(/brain_l3_escalation_total\{outcome="flipped"\} 1/);
     expect(body).toMatch(/brain_l3_escalation_total\{outcome="no_flip"\} 1/);
@@ -139,11 +153,50 @@ describe('MetricsService', () => {
     metrics.countIngestWrite('candidate');
     metrics.countIngestWrite('mcp');
 
-    const { body } = await metrics.serialize();
+    const body = await payload();
     expect(body).toMatch(/brain_ingest_writes_total\{path="mention"\} 2/);
     expect(body).toMatch(/brain_ingest_writes_total\{path="fact"\} 1/);
     expect(body).toMatch(/brain_ingest_writes_total\{path="document"\} 1/);
     expect(body).toMatch(/brain_ingest_writes_total\{path="candidate"\} 1/);
     expect(body).toMatch(/brain_ingest_writes_total\{path="mcp"\} 1/);
+  });
+
+  describe('per-replica identity', () => {
+    it('labels every series with the replica that produced it', async () => {
+      // N replicas otherwise serialise indistinguishable payloads, and a
+      // scrape read straight off /metrics cannot say whose numbers it has.
+      metrics.countIngestFact('INSERTED');
+      const { body } = await metrics.serialize();
+      expect(body).toMatch(/brain_ingest_facts_total\{outcome="INSERTED",instance="[^"]+"\} 1/);
+    });
+
+    it('publishes no boot zero for gauges only the lease holder writes', async () => {
+      // prom-client publishes a label-less gauge as 0 from construction,
+      // so every non-leader replica exported a confident "0 pending" it had
+      // never measured — and max()/avg() over replicas read it as fact.
+      const { body } = await metrics.serialize();
+      for (const name of [
+        'brain_changefeed_lag_records',
+        'brain_vector_corpus_tenants_nonconforming',
+        'brain_memory_orphan_entities',
+        'brain_policy_sets_active',
+      ]) {
+        expect(body).not.toMatch(new RegExp(`^${name}\\{`, 'm'));
+      }
+    });
+
+    it('publishes the gauge again once this replica measures something', async () => {
+      metrics.setChangefeedLag(7);
+      const body = await payload();
+      expect(body).toMatch(/brain_changefeed_lag_records 7/);
+    });
+
+    it('still reports worker_is_leader on a non-leader — 0 is a measurement there', async () => {
+      // Deliberate exception: sum() across replicas is how the
+      // NoWorkerLeader alert counts leaders, so "I am not it" must be said
+      // out loud rather than left absent.
+      const body = await payload();
+      expect(body).toMatch(/brain_worker_is_leader 0/);
+    });
   });
 });

--- a/test/monitoring-replicas-truth.unit-spec.ts
+++ b/test/monitoring-replicas-truth.unit-spec.ts
@@ -1,0 +1,73 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * Truth test for "the collector can see each replica".
+ *
+ * A single static scrape target (`inite-brain-service:3000`) is not a
+ * broken config — it resolves, it answers, and it silently round-robins
+ * over the replicas while labelling every sample with one identity. So the
+ * failure is invisible: per-process series collapse into one flapping
+ * line, and a dead replica is covered for by its siblings. These gates pin
+ * the discovery, the label that distinguishes replicas, and the two alert
+ * rules that only make sense once there is more than one.
+ */
+
+const ROOT = join(__dirname, '..');
+const ALLOY = readFileSync(join(ROOT, 'monitoring', 'alloy', 'config.alloy'), 'utf8');
+const RULES = readFileSync(
+  join(ROOT, 'monitoring', 'grafana', 'provisioning', 'alerting', 'rules.yaml'),
+  'utf8',
+);
+const MON_COMPOSE = readFileSync(join(ROOT, 'monitoring', 'docker-compose.yml'), 'utf8');
+
+describe('alloy scrapes every brain replica', () => {
+  it('discovers containers instead of pinning one service name', () => {
+    expect(ALLOY).toMatch(/discovery\.docker "brain"/);
+    expect(ALLOY).not.toMatch(/__address__\s*=\s*"inite-brain-service:3000"/);
+  });
+
+  it('filters by the compose service label, not a name substring', () => {
+    expect(ALLOY).toMatch(/com\.docker\.compose\.service=inite-brain-service/);
+  });
+
+  it('labels each target with its container so replicas are distinguishable', () => {
+    expect(ALLOY).toMatch(/__meta_docker_container_name/);
+    expect(ALLOY).toMatch(/target_label\s*=\s*"instance"/);
+  });
+
+  it('keeps the job name every existing rule and panel matches on', () => {
+    expect(ALLOY).toMatch(/replacement\s*=\s*"brain"/);
+    expect(RULES).toMatch(/up\{job="brain"\}/);
+  });
+
+  it('scrapes exactly one endpoint per container', () => {
+    // Docker discovery yields one target per (network, port); without both
+    // keeps the same replica is scraped twice under two addresses.
+    expect(ALLOY).toMatch(/regex\s*=\s*"traefik-global"\n\s*action\s*=\s*"keep"/);
+    expect(ALLOY).toMatch(/__meta_docker_port_private/);
+  });
+
+  it('has the docker socket mounted read-only for that discovery', () => {
+    expect(MON_COMPOSE).toMatch(/\/var\/run\/docker\.sock:\/var\/run\/docker\.sock:ro/);
+  });
+});
+
+describe('alert rules survive more than one replica', () => {
+  it('notices a replica that stops exporting', () => {
+    // BrainScrapeDown cannot: with one of three gone the query still
+    // returns two series, both 1.
+    expect(RULES).toMatch(/uid: brain-replica-missing/);
+    expect(RULES).toMatch(/count\(up\{job="brain"\} == 1\)/);
+    expect(RULES).toMatch(/max_over_time\(count\(up\{job="brain"\} == 1\)\[6h:1m\]\)/);
+  });
+
+  it('aggregates the lease-holder gauge instead of reading one replica', () => {
+    expect(RULES).toMatch(/expr: max\(brain_changefeed_lag_records\)/);
+  });
+
+  it('still SUMS the leader gauge — that is how it counts leaders', () => {
+    // Deliberately not max(): sum=0 means no leader, sum>1 a split brain.
+    expect(RULES).toMatch(/expr: sum\(brain_worker_is_leader\) or vector\(0\)/);
+  });
+});

--- a/test/process-identity.unit-spec.ts
+++ b/test/process-identity.unit-spec.ts
@@ -1,0 +1,64 @@
+import { hostname } from 'node:os';
+import type { Request, Response } from 'express';
+import { PROCESS_IDENTITY } from '../src/common/process-identity';
+import { requestLogger } from '../src/common/request-logger';
+
+/**
+ * One identity across metrics, logs and traces. Correlating a metric spike
+ * with the log lines and the traces from the SAME replica only works if
+ * all three name it the same way — so this pins that the log line carries
+ * the identifier and that the value is the one the other two use.
+ */
+describe('per-replica identity', () => {
+  it('starts from the OS hostname, which Docker sets to the container id', () => {
+    expect(PROCESS_IDENTITY.startsWith(`${hostname()}#${process.pid}#`)).toBe(true);
+  });
+});
+
+describe('the JSON request line', () => {
+  function logOne(path: string): string[] {
+    const written: string[] = [];
+    const spy = jest.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+      written.push(String(chunk));
+      return true;
+    });
+    const saved = process.env.LOG_FORMAT;
+    process.env.LOG_FORMAT = 'json';
+    try {
+      const finish: Array<() => void> = [];
+      const req = { path, method: 'POST', originalUrl: path } as unknown as Request;
+      const res = {
+        statusCode: 200,
+        once: (event: string, cb: () => void) => {
+          if (event === 'finish') finish.push(cb);
+        },
+        removeListener: () => undefined,
+      } as unknown as Response;
+      requestLogger()(req, res, () => undefined);
+      for (const cb of finish) cb();
+      return written;
+    } finally {
+      spy.mockRestore();
+      if (saved === undefined) delete process.env.LOG_FORMAT;
+      else process.env.LOG_FORMAT = saved;
+    }
+  }
+
+  it('says which replica served the request', () => {
+    const [line] = logOne('/v1/search');
+    expect(line).toBeDefined();
+    expect(JSON.parse(line!)).toMatchObject({
+      kind: 'request',
+      instance: PROCESS_IDENTITY,
+      path: '/v1/search',
+    });
+  });
+
+  it('does not log the load balancer’s readiness poll', () => {
+    // Traefik polls /ready every 3s per replica; logging it would drown
+    // real traffic in the same way /health and /metrics already did.
+    expect(logOne('/ready')).toEqual([]);
+    expect(logOne('/health')).toEqual([]);
+    expect(logOne('/metrics')).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What

Makes the service deployable and observable as N identical replicas on the existing single-host Compose + Traefik setup, and closes the two deploy-pipeline races from the round-2 runtime audit (`docs/audits/round2-runtime-2026-09-09.md`, F2 and F3).

**Deploy transaction (F2, P1)**

- One concurrency group (`deploy-brain-production`) for every production-mutating run, `cancel-in-progress: false`. The group used to be keyed by `github.event_name`, which gave a push deploy and a manual dispatch a group each — i.e. the two racers ran in parallel over the same state files — and a cancel between `deploy → smoke → finalize` left a half-applied transaction with nobody to resolve it.
- The deploy writes `.deploy-txn` (run id, attempt, action, image, previous image, replicas) and then asserts every *running* replica was created from this run's digest.
- `finalize` reads that file first and refuses to promote or roll back unless the run id is its own **and** the running digest is the expected one; otherwise it exits **0** with `superseded by run X, not touching state`.

**Manual rollback (F3, P2)**

- Confirmed-good **history** (`.good-image-history`, appended on promote, last five kept). A manual rollback targets the newest entry that is not the running digest, or an explicit `image_digest` input that must appear in the history.
- `.previous-image` is staged and only committed once the rollback has answered `/ready`, so the single pointer to the release being left is not destroyed by the rollback itself. The rejected digest is then dropped from the history, so a second rollback steps further back instead of ping-ponging.

**Replicas**

- No `container_name` (it forbids `--scale`); `deploy.replicas: ${BRAIN_REPLICAS:-1}` **and** `--scale ${PROJECT_NAME}=$BRAIN_REPLICAS` so compose v1 (which ignores `deploy:`) and v2 land on the same count. A malformed `BRAIN_REPLICAS` fails the deploy instead of silently scaling to 1.
- Every post-deploy check is replica-aware: running containers counted against the desired count (the old check passed with one of N up), `/health` and `/ready` probed per `--index`, rollback verification likewise. The helpers are generated once into `deploy-lib.sh` and sourced by the later steps and by `finalize` (same host, same directory) rather than copied into six loops.
- Traefik's load-balancer healthcheck moves to `/ready` (3s interval, 2s timeout). `/health` returns 200 even when the service reports itself degraded (`src/common/health.controller.ts:27-39`), so a broken replica kept its full share of traffic. `PathPrefix(/ready)` is added to **both** router rules — without it the healthcheck 404s and every replica leaves rotation — and the smoke test now asserts `/ready` through the domain, which is the only place that particular bug is visible before real traffic finds it.
- Shared, read-mostly `brain-model-cache` volume at `/app/.cache` (where the Dockerfile points `TRANSFORMERS_CACHE`/`HF_HOME`/`XDG_CACHE_HOME`). The image creates that directory owned by `node`, so a fresh named volume inherits uid 1000 and the non-root container can write it. Without the volume each replica downloads ~700MB against a 300s readiness gate.
- The repo's own `docker-compose.yml` publishes no host port for the app (a fixed port allows exactly one container); `docker-compose.override.yml.example` restores it for local dev and is referenced from the README. SurrealDB keeps its published `8000` deliberately — it is a singleton, `--scale` never touches it, and the README quick-start runs the app on the host against it.
- Deleted five env pins that restated defaults, each cross-checked in `src/`: `HNSW_PROVISION_ENABLED` (provisioning follows `SEARCH_HNSW_ENABLED`, which is pinned on), `CAPABILITY_PROBE_ENABLED`, `WORKER_LOOP_ENABLED`, `LEASE_MANAGER_ENABLED` (all on unless `=0`), `JOBS_QUEUE_MODE` (defaults to `enqueue`). The kill-switch information those comments carried is kept.
- `SURREALDB_SCOPED_POOL_SIZE` is validated like `SURREALDB_POOL_SIZE` (`env-validation.ts` + the matching runtime throw in `surreal.service.ts`): a typo parsed to NaN, built zero scoped connections while `scopedPoolEnabled()` stayed true, and left every replica permanently not-ready with nothing naming the cause. Both now go through the file's own `positiveInt()` helper — the same guard every other integer knob there gets — which is also what keeps `env-validation.ts` under the eslint `max-lines: 800` ceiling after #555 (net −2 lines instead of +5; see the note below).

**Observability**

- Alloy discovers brain containers over the Docker socket it already mounts and scrapes one target per replica, keeping `job="brain"` so existing rules and panels match. The static `inite-brain-service:3000` round-robined over the replicas under one identity, so per-process series collapsed into one flapping line and a dead replica was covered for by its siblings.
- `PROCESS_IDENTITY` labels every Prometheus series (`instance`), every JSON request line, and the OTel resource (`service.instance.id`).
- Gauges only the lease holder writes (`brain_changefeed_lag_records`, `brain_vector_corpus_tenants_nonconforming`, `brain_memory_orphan_entities`, `brain_policy_sets_active`) no longer publish prom-client's boot zero — a non-leader was exporting a confident "0 pending" it had never measured. `brain_worker_is_leader` deliberately keeps its 0: `sum()` over replicas is how `NoWorkerLeader` counts leaders. New `BrainReplicaMissing` rule fires when fewer replicas export than this host was running (`BrainScrapeDown` cannot see that — the survivors still answer). No thresholds changed.
- The admin cockpit renders the changefeed row as `disabled — not leader (<holder> holds the changefeed_consumer lease)` on a replica that does not hold it, instead of "ok · 0 pending". Read through `LeaderLeaseService`; `src/jobs/*` untouched.
- `/ready` joins `/health` and `/metrics` in the request-log skip list — Traefik polls it every 3s per replica.
- `docs/operations.md`: a paragraph each for `BRAIN_REPLICAS`, the `/ready` load-balancer contract, the model-cache volume and the per-replica `instance` label, plus the rewritten rollback section (state-file table, transaction ownership, step-back semantics). The general "Running more than one replica" section is left to its own PR.

## Why

Audit F2 (P1): finalize could promote a foreign image or roll back a newer run. Audit F3 (P2): a manual rollback after a green release re-selected that same release and destroyed the only pointer to the one before. Everything else here is what stopped `--scale` from being an option at all — a fixed container name and host port, checks that pass when one of N containers is up, a load balancer probing an endpoint that is green while the process is degraded, a 700MB-per-replica model download inside a 300s gate, and a metrics/logging/tracing plane that could not tell two replicas apart.

## How verified

- `pnpm typecheck` — clean.
- `pnpm lint:ci` — clean (`--max-warnings 0`).
- `pnpm format:check` — clean.
- Rebased onto `origin/main` twice while in flight — after #552/#553/#555/#557, then after #548/#558/#561 (only conflict: the rollback state-file table in `docs/operations.md`, resolved keeping both sides' rows in main's alignment). `pnpm install --frozen-lockfile` re-run for #555's new `@aws-sdk/client-s3`. All gates below are from AFTER the rebase.
- `env-validation.ts` needed a restructure to stay inside `max-lines: 800` once #555's S3 family landed: the two pool-size checks became `positiveInt()` calls. One behaviour follows from that — an EMPTY `SURREALDB_POOL_SIZE=` is now a boot error rather than silently falling back to the default. That was already a crash one layer down (`parseInt('')` → NaN → the runtime guard in `surreal.service.ts` throws), so it is the same outcome with a better message, and it matches every other integer knob in the file.
- Unit, touched areas: `pnpm jest --config ./test/jest-unit.json --testPathPatterns 'deploy-|monitoring-replicas|process-identity|metrics.unit|env-validation|health-components|flag-budget|truth|doctrine'` → **21 suites, 272 tests passed**. Plus the other metric-asserting suites and the new evidence-storage ones (`multilingual-lang-attribution`, `memory-quality`, `mri-*`, `capability-probe`, `session-keeper`, `jobs-otel`, `evidence*`): **23 suites, 361 tests passed** (the `instance` default label appends to every series, so `metrics.unit-spec` strips it in one helper and asserts its presence separately).
- E2E: `pnpm jest --config ./test/jest-e2e.json --testPathPatterns 'admin-health-components'` → **1 suite, 3 tests passed** against a real SurrealDB (confirms the new `LeaderLeaseService` dependency resolves in the DI graph).
- **New behavioural test** `test/deploy-race-truth.unit-spec.ts` (11 tests) *extracts the real shell fragments from the YAML* — the promote step, the rollback step, the image-selection block and the `deploy-lib.sh` generator — and runs them under `bash` in a temp directory with stub `docker` / `docker-compose` binaries on `PATH`. It asserts: a superseded promote leaves `.last-good-image` and the history untouched, a promote whose replicas run a different image does the same, a promote appends its digest exactly once and truncates to five, a superseded rollback leaves the newer run's compose pin alone, and the rollback selection never re-picks the running digest, refuses an unlisted digest, accepts a listed one, and stages rather than overwrites `.previous-image`.
- **The same fragments still reproduce the audit's races on `origin/main`**, which is what makes the test non-vacuous: running main's promote + selection blocks over the audit's scenario gives `.last-good-image = image-B` (A's finalize promoting unverified B) and `selected image-B | .previous-image = image-B` (rollback re-selecting the running release and destroying the pointer to A). Both assertions invert on this branch.
- Workflow YAML parses: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/deploy-brain.yml'))"` → OK. Also checked that no `run:` script contains `${{ }}` any more except the 96-char `Logs` step, so the 21000-character max-expression-length limit no longer applies to the deploy or finalize scripts.
- **Seven e2e metric helpers needed the same treatment as the unit one.** The `instance` default label appends to every series, and the fovea / L3 e2e specs read counters with `\\{outcome="x"\\}` and `^name ` regexes, so all four `engine-e2e` shards went red on the first push (14 failures, every one of them in those 7 files — `build-test` failed only as their gate). The helpers now tolerate a label list. Re-run locally: `l3-escalation|fovea-answer-integrity|fovea-evidence-capability` → 3 suites / 20 tests passed; `fovea-cascade|fovea-lens-suppress|fovea-adaptive-abstain|fovea-adaptive-l3` → 4 suites / 17 tests passed. CI is green on all 21 checks (the two `skipping` ones are the opt-in real-LLM jobs).
- **The generated compose is valid.** A script loads the workflow with PyYAML, slices the `tee docker-compose.yml … EOF` heredoc out of the `Deploy to server` step, runs that exact fragment under `bash` with dummy env (`IMAGE_REF`, secrets, `BRAIN_REPLICAS`), and runs `docker compose -f <rendered file> config` over the result: clean at `BRAIN_REPLICAS=3`, `2` and unset (`replicas: 3 / 2 / 1`), with `expose`, no `container_name`, `healthcheck.path=/ready`, `/ready` in both router rules and the `brain-model-cache` volume present in the rendered output. `docker compose -f docker-compose.yml config` is clean for the repo file too. (Rendering it also surfaced four pre-existing backticked words in heredoc comments that the unquoted heredoc was command-substituting away; escaped.)
- `monitoring/alloy/config.alloy`: `docker run --rm grafana/alloy:v1.9.2 validate` → exit 0 (and `fmt` is a no-op diff). Confirmed the validator is real by corrupting one attribute name and watching it fail. `rules.yaml` and the dashboard JSON parse.

## Deviations and dependencies worth reviewing

- **#553 has landed** (baselines live in `admin_baseline`, migration 0140), so removing `BRAIN_BASELINES_DIR` and the `/opt/projects/inite-brain-service/baselines` bind-mount here is no longer a forward dependency — the code no longer reads the directory.
- **Depends on #554** for `src/common/process-identity.ts`: this branch adds the file with the agreed `PROCESS_IDENTITY` (`<hostname>#<pid>#<uuid>`) export and imports it in metrics, request logging and tracing. Keep #554's version of the file at merge; the three call sites need no change.
- The digest-identity assertion lives in the **deploy** job (on the box) and in `finalize`, not in `smoke`: `smoke` runs on a GitHub-hosted runner with no access to the Docker daemon, and no HTTP surface exposes the running digest. `smoke` does now assert `/ready` through Traefik.
- Replica counting uses `docker-compose ps -q` + `docker inspect` rather than `docker compose ps --format json`: every compose invocation on the box is the `docker-compose` (v1-named) CLI, and `--format json` is v2-only, while `ps -q`/`inspect` work on both. Same reason `--scale` is passed alongside `deploy.replicas`.
- The admin cockpit's "not leader" state reuses the existing `disabled` status with a distinct message rather than adding an enum value; a new status would change the wire contract, its duplicate in `brain-landing/lib/contracts/` and the panel's tone/icon maps. Say the word and I will add a real `not_leader` status.
- `brain_worker_is_leader` is deliberately excluded from the boot-zero removal and keeps `sum()` in its rule.
- Not done: nothing in `src/jobs/*`, `src/main.ts` or `src/db/migrator*` was touched (`surreal.service.ts` only on the two guard lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhrQxeisXJZEt4sg3PGyU6
