### PR TITLE
fix(beliefs): retry the scene consolidation stamp when the store reports a conflict

### DIFF
--- a/src/admin/belief-promotion.service.ts
+++ b/src/admin/belief-promotion.service.ts
@@ -3,6 +3,7 @@ import { ConfigService } from '@nestjs/config';
 import type OpenAI from 'openai';
 import { StringRecordId } from 'surrealdb';
 import { SurrealService } from '../db/surreal.service';
+import { retryOnUniqueViolation } from '../db/surreal-retry';
 import { chatCallParams, createOpenAiClient } from '../ai/openai-client';
 import {
   sceneBeliefFieldFoldEnabled,
@@ -1188,19 +1189,29 @@ export class BeliefPromotionService {
     return 'done';
   }
 
-  /** consolidatedInto ∪= [belief] on the consumed scenes (idempotent). */
+  /**
+   * consolidatedInto ∪= [belief] on the consumed scenes (idempotent).
+   *
+   * Two promotion runs over one conversation stamp the same scene rows, so
+   * this write races and the datastore answers "Resource busy" / read
+   * conflict. The union is idempotent, so a retry is always safe: without
+   * one the whole promotion pass throws after the belief has already been
+   * committed.
+   */
   private async stampScenes(db: BeliefDb, sceneIds: string[], beliefId: string): Promise<void> {
     if (sceneIds.length === 0) return;
     // Primary-key addressed (WHERE id INSIDE explicit list) — immune by
     // construction to the 3.2.4 secondary-index planner bug class.
-    await db.query(
-      `UPDATE memory_episode
+    await retryOnUniqueViolation(() =>
+      db.query(
+        `UPDATE memory_episode
           SET consolidatedInto = array::union(consolidatedInto ?? [], [$belief])
         WHERE id INSIDE $sceneIds`,
-      {
-        belief: new StringRecordId(beliefId),
-        sceneIds: sceneIds.map((s) => new StringRecordId(s)),
-      },
+        {
+          belief: new StringRecordId(beliefId),
+          sceneIds: sceneIds.map((s) => new StringRecordId(s)),
+        },
+      ),
     );
   }
 


### PR DESCRIPTION
**What**: retry the scene-stamping write in belief promotion (`stampScenes`) on a transient store conflict, using the existing `retryOnUniqueViolation` helper.

**Why**: two promotion runs over one conversation stamp the same `memory_episode` rows, so the write races and 3.2.4 answers `Transaction conflict: Resource busy. This transaction can be retried`. Nothing retried it, so the exception escaped `upsertBeliefOnce` and aborted the whole promotion pass *after* the belief had already been committed. It surfaced as a red `belief-revision-chain` e2e ("two concurrent runs revising one key leave exactly one active head") on CI run 34525147250, job 103032806520 — the concurrency test added by #557, which exercises exactly this race. The union is idempotent, so re-running the statement is always safe.

**How verified**: `belief-revision-chain` e2e against a real SurrealDB 3.2.4 container — 11/11 pass (the concurrent-revise case included). `pnpm typecheck` clean, `pnpm eslint` on the file clean, `prettier --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhrQxeisXJZEt4sg3PGyU6
