### PR TITLE
fix(ci): let an overtaken deploy stand down instead of failing

### DIFF
--- a/scripts/ci/await-ci.mjs
+++ b/scripts/ci/await-ci.mjs
@@ -35,6 +35,10 @@ const POLL_SECONDS = Number(process.env.AWAIT_POLL_SECONDS ?? '20');
 // branch that was never pushed to main. Holding a runner for the full
 // 45 minutes to tell someone that is just rude.
 const NOT_FOUND_GRACE_MIN = Number(process.env.AWAIT_NOT_FOUND_GRACE_MINUTES ?? '10');
+// The branch a deploy ships from. Used only to tell "this commit was
+// overtaken" from "this commit's CI was cancelled while it was still the
+// one being deployed".
+const BRANCH = process.env.AWAIT_BRANCH ?? 'main';
 
 function fail(message) {
   console.error(`[await-ci] ${message}`);
@@ -45,7 +49,10 @@ if (!REPO) fail('GITHUB_REPOSITORY is not set');
 if (!TOKEN) fail('GITHUB_TOKEN is not set');
 if (!SHA) fail('AWAIT_SHA is not set');
 
-const api = `https://api.github.com/repos/${REPO}/actions/workflows/${WORKFLOW}/runs?head_sha=${SHA}&per_page=20`;
+// Overridable only so the truth test can serve both endpoints locally;
+// production never sets it.
+const API_BASE = process.env.AWAIT_API_BASE ?? 'https://api.github.com';
+const api = `${API_BASE}/repos/${REPO}/actions/workflows/${WORKFLOW}/runs?head_sha=${SHA}&per_page=20`;
 
 async function latestRun() {
   const res = await fetch(api, {
@@ -70,6 +77,29 @@ async function latestRun() {
 }
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * True when SHA is no longer the tip of the deploy branch — i.e. a newer
+ * commit has landed and owns the deploy. Any API trouble answers false, so
+ * an unreadable branch tip can never turn a cancelled CI into permission
+ * to stand down.
+ */
+async function superseded() {
+  try {
+    const res = await fetch(`${API_BASE}/repos/${REPO}/commits/${BRANCH}`, {
+      headers: {
+        authorization: `Bearer ${TOKEN}`,
+        accept: 'application/vnd.github+json',
+        'x-github-api-version': '2022-11-28',
+      },
+    });
+    if (!res.ok) return false;
+    const tip = (await res.json())?.sha;
+    return typeof tip === 'string' && tip !== SHA;
+  } catch {
+    return false;
+  }
+}
 
 async function main() {
   const deadline = Date.now() + TIMEOUT_MIN * 60_000;
@@ -97,9 +127,20 @@ async function main() {
         console.log(`[await-ci] CI passed for ${SHA} (run ${run.id})`);
         process.exit(0);
       }
-      fail(
-        `CI concluded "${run.conclusion}" for ${SHA}. Not deploying. See ${run.html_url}`,
-      );
+      if (run.conclusion === 'cancelled' && (await superseded())) {
+        // GitHub keeps at most one PENDING run per concurrency group, so a
+        // second merge landing while this commit's CI is still queued
+        // cancels it. That is not a red commit and not an operator's
+        // cancellation — the newer commit carries this one's code and its
+        // own deploy will ship it. Refusing here is correct but noisy; a
+        // deploy that has been overtaken should stand down quietly.
+        console.log(
+          `[await-ci] CI for ${SHA} was cancelled and the commit is no longer the tip of ` +
+            `${BRANCH}. Superseded by a newer commit, which deploys itself. Standing down.`,
+        );
+        process.exit(0);
+      }
+      fail(`CI concluded "${run.conclusion}" for ${SHA}. Not deploying. See ${run.html_url}`);
     }
 
     if (!run) {

--- a/test/await-ci-superseded.unit-spec.ts
+++ b/test/await-ci-superseded.unit-spec.ts
@@ -1,0 +1,116 @@
+import { spawn } from 'node:child_process';
+import { createServer, type Server } from 'node:http';
+import { join } from 'node:path';
+import type { AddressInfo } from 'node:net';
+
+/**
+ * The deploy refuses to ship a commit whose CI is not green, and that
+ * refusal must stay absolute. There is exactly one exception, and this
+ * pins its shape.
+ *
+ * GitHub keeps at most ONE pending run per concurrency group, so when two
+ * merges land within a few minutes the first commit's CI is cancelled
+ * while still queued. Its deploy then reported a hard failure although the
+ * code was neither red nor unshipped: the newer commit contains it and
+ * deploys itself. Standing down quietly is right ONLY when the commit is
+ * no longer the tip of the branch — a cancelled CI on the tip is still a
+ * refusal, and so is an unreadable tip.
+ */
+
+const SCRIPT = join(__dirname, '..', 'scripts', 'ci', 'await-ci.mjs');
+const SHA = 'a'.repeat(40);
+const NEWER = 'b'.repeat(40);
+
+type Case = { conclusion: string; tip: string | null; tipStatus?: number };
+
+/** Serve the two endpoints the script reads, then run it. Returns its exit code. */
+async function runAwait(c: Case): Promise<{ code: number; out: string }> {
+  const server: Server = createServer((req, res) => {
+    if (req.url?.includes('/actions/workflows/')) {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(
+        JSON.stringify({
+          workflow_runs: [
+            {
+              id: 1,
+              event: 'push',
+              status: 'completed',
+              conclusion: c.conclusion,
+              created_at: '2026-09-10T20:00:00Z',
+              html_url: 'https://example.invalid/run/1',
+            },
+          ],
+        }),
+      );
+      return;
+    }
+    if (req.url?.includes('/commits/')) {
+      if (c.tipStatus && c.tipStatus !== 200) {
+        res.writeHead(c.tipStatus).end('{}');
+        return;
+      }
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ sha: c.tip }));
+      return;
+    }
+    res.writeHead(404).end('{}');
+  });
+
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const { port } = server.address() as AddressInfo;
+  try {
+    // spawn, never spawnSync: the script fetches from the server running in
+    // THIS process, and a synchronous child would block the event loop that
+    // has to answer it.
+    const child = spawn(process.execPath, [SCRIPT], {
+      env: {
+        ...process.env,
+        GITHUB_REPOSITORY: 'acme/brain',
+        GITHUB_TOKEN: 'test-token',
+        AWAIT_SHA: SHA,
+        AWAIT_API_BASE: `http://127.0.0.1:${port}`,
+        AWAIT_TIMEOUT_MINUTES: '1',
+        AWAIT_POLL_SECONDS: '1',
+        GITHUB_OUTPUT: '',
+      },
+    });
+    let out = '';
+    child.stdout.on('data', (b: Buffer) => (out += b.toString()));
+    child.stderr.on('data', (b: Buffer) => (out += b.toString()));
+    const code = await new Promise<number>((resolve) => {
+      child.on('close', (c) => resolve(c ?? -1));
+    });
+    return { code, out };
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+}
+
+describe('await-ci: a superseded commit stands down, everything else refuses', () => {
+  it('passes a green CI', async () => {
+    const { code } = await runAwait({ conclusion: 'success', tip: SHA });
+    expect(code).toBe(0);
+  });
+
+  it('stands down when CI was cancelled and a newer commit owns the branch', async () => {
+    const { code, out } = await runAwait({ conclusion: 'cancelled', tip: NEWER });
+    expect(code).toBe(0);
+    expect(out).toContain('Superseded');
+  });
+
+  it('still refuses when CI was cancelled on the tip commit', async () => {
+    const { code, out } = await runAwait({ conclusion: 'cancelled', tip: SHA });
+    expect(code).toBe(1);
+    expect(out).toContain('Not deploying');
+  });
+
+  it('still refuses when the branch tip cannot be read', async () => {
+    const { code } = await runAwait({ conclusion: 'cancelled', tip: null, tipStatus: 500 });
+    expect(code).toBe(1);
+  });
+
+  it('never stands down for a red CI, tip or not', async () => {
+    expect((await runAwait({ conclusion: 'failure', tip: NEWER })).code).toBe(1);
+    expect((await runAwait({ conclusion: 'failure', tip: SHA })).code).toBe(1);
+  });
+});


### PR DESCRIPTION
**What**: `await-ci.mjs` now exits 0 with an explicit "superseded" line when the commit's CI was **cancelled** *and* the commit is no longer the tip of the deploy branch. Every other outcome refuses exactly as before, including a cancelled CI on the tip commit and an unreadable branch tip.

**Why**: GitHub keeps at most one *pending* run per concurrency group, so when two merges land within a few minutes the earlier commit's CI is cancelled while still queued. Its deploy then failed the pipeline although nothing was wrong: the code was neither red nor unshipped, because the newer commit contains it and deploys itself. Three such failures were logged tonight (runs 34528750664, 34528940448 among them), which trains operators to ignore a red deploy — the one signal that must stay meaningful.

**How verified**: new `test/await-ci-superseded.unit-spec.ts` runs the real script against a local stub of the two GitHub endpoints: green passes; cancelled with a newer tip stands down; cancelled on the tip still refuses; an unreadable tip still refuses; a red CI never stands down, tip or not. 5 tests pass, and `deploy-artifact-truth` stays green. `pnpm typecheck`, `pnpm lint:ci`, `pnpm format:check` clean.

Note: the script gained one env seam, `AWAIT_API_BASE`, used only by that test; production never sets it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhrQxeisXJZEt4sg3PGyU6
