### PR TITLE
fix(db): keep schema provisioning off the connection pool and off the lease

### DIFF
--- a/src/db/migrator.service.ts
+++ b/src/db/migrator.service.ts
@@ -76,10 +76,12 @@ const LOCK_TTL_SECONDS = 30;
 
 /**
  * How long a replica that lost the race waits for the holder before it
- * gives up. Comfortably longer than the TTL, so a crashed holder is
- * always taken over rather than waited out forever.
+ * gives up. Longer than the TTL, so a crashed holder is always taken over
+ * rather than waited out forever, and short enough that a stuck lease
+ * cannot hold a caller's pooled connection for minutes. The wait ends
+ * early — and never throws — as soon as the ledger says the work is done.
  */
-const LOCK_WAIT_MS = 120_000;
+const LOCK_WAIT_MS = 60_000;
 
 const SCHEMA_MIGRATIONS_DDL = `
 DEFINE TABLE IF NOT EXISTS schema_migrations SCHEMAFULL;
@@ -110,11 +112,24 @@ export class SchemaMigrator {
   /**
    * Apply all pending migrations against `conn`, holding `opts.lock` for
    * the whole run so replicas booting together apply the manifest once.
+   *
+   * The ledger is read BEFORE the lease is touched. A database whose
+   * manifest is already complete needs no arbitration — that is every
+   * request after the first one for that tenant, and every boot of a
+   * tenant some other replica already migrated — and it must not pay a
+   * cross-replica round trip, let alone wait behind a lease a dead holder
+   * left, while the caller sits on a pooled connection.
    */
   async migrate(conn: Surreal, opts: MigrateOptions = {}): Promise<MigrationResult> {
     const { lock, lockName } = opts;
+    const upToDate = await this.readLedger(conn);
+    if (upToDate.pending.length === 0) return upToDate.result;
     if (!lock || !lockName) return this.applyPending(conn);
-    await this.acquireOrWait(lock, lockName);
+
+    if (!(await this.acquireOrWait(lock, lockName, conn))) {
+      // The holder finished what we were waiting for: nothing left to do.
+      return (await this.readLedger(conn)).result;
+    }
     try {
       return await this.applyPending(conn, lock, lockName);
     } finally {
@@ -123,15 +138,19 @@ export class SchemaMigrator {
   }
 
   /**
-   * Take the lock or wait for whoever holds it. Losing the race is not a
-   * reason to proceed: we wait until the holder releases — or until its
-   * lease expires, which is how a crashed holder is taken over — and only
-   * then read the ledger, so the retry applies exactly what is left.
-   * Transient acquire failures are absorbed inside the same deadline;
-   * reaching the deadline throws, because the alternative is serving
-   * requests against a half-migrated schema.
+   * Take the lock, or wait for whoever holds it.
+   *
+   * Losing the race is not a reason to apply anything: we wait until the
+   * holder releases — or until its lease expires, which is how a crashed
+   * holder is taken over. Returns false when the wait ended because the
+   * work itself is gone (the holder committed the last pending file), so
+   * the caller can proceed without ever owning the lease. Transient
+   * acquire failures are absorbed inside the same deadline, and the
+   * deadline only throws if there is still schema missing — a lease store
+   * we cannot reach must never turn a request against an already-migrated
+   * database into a 500.
    */
-  private async acquireOrWait(lock: MigrationLock, name: string): Promise<void> {
+  private async acquireOrWait(lock: MigrationLock, name: string, conn: Surreal): Promise<boolean> {
     const deadline = Date.now() + this.lockWaitMs;
     let delayMs = 50;
     let lastErr: unknown;
@@ -140,13 +159,19 @@ export class SchemaMigrator {
       try {
         if (await lock.tryAcquire(name, this.lockTtlSeconds)) {
           if (waited) this.logger.log(`Took migration lock ${name} after waiting for the holder`);
-          return;
+          return true;
         }
         lastErr = undefined;
       } catch (err) {
         lastErr = err;
       }
       waited = true;
+      // Whoever holds it may have finished while we backed off, and an
+      // unreachable lease store is only fatal if schema is still missing.
+      if ((await this.readLedger(conn)).pending.length === 0) {
+        this.logger.log(`Migration lock ${name} not needed — the manifest is already complete`);
+        return false;
+      }
       const left = deadline - Date.now();
       if (left <= 0) {
         const why = lastErr
@@ -161,23 +186,44 @@ export class SchemaMigrator {
     }
   }
 
+  /**
+   * Bootstrap the ledger table and read it. Racing replicas abort each
+   * other on the guarded DDL, so the read conflict is retried rather than
+   * surfaced — this runs before any lease is held, by construction.
+   */
+  private async readLedger(
+    conn: Surreal,
+  ): Promise<{ pending: Migration[]; result: MigrationResult }> {
+    const manifest = await this.loadManifest();
+    let attempts = 0;
+    for (;;) {
+      try {
+        await conn.query(SCHEMA_MIGRATIONS_DDL);
+        break;
+      } catch (err) {
+        if (!isReadConflict(enrichTransactionError(err)) || ++attempts >= 5) throw err;
+        await this.sleep(20 * Math.pow(2, attempts - 1));
+      }
+    }
+    const applied = new Set(await this.fetchAppliedIds(conn));
+    const pending = manifest.filter((m) => !applied.has(m.id));
+    return {
+      pending,
+      result: {
+        applied: [],
+        alreadyApplied: pending.length === 0 ? manifest.map((m) => m.id) : [...applied],
+      },
+    };
+  }
+
   private async applyPending(
     conn: Surreal,
     lock?: MigrationLock,
     lockName?: string,
   ): Promise<MigrationResult> {
-    await conn.query(SCHEMA_MIGRATIONS_DDL);
-
-    const manifest = await this.loadManifest();
-    const applied = new Set(await this.fetchAppliedIds(conn));
-
-    const pending = manifest.filter((m) => !applied.has(m.id));
-    if (pending.length === 0) {
-      return {
-        applied: [],
-        alreadyApplied: manifest.map((m) => m.id),
-      };
-    }
+    const { pending, result } = await this.readLedger(conn);
+    if (pending.length === 0) return result;
+    const applied = result.alreadyApplied;
 
     let renewAt = Date.now() + (this.lockTtlSeconds * 1000) / 2;
     for (const m of pending) {
@@ -195,7 +241,7 @@ export class SchemaMigrator {
 
     return {
       applied: pending.map((m) => m.id),
-      alreadyApplied: [...applied],
+      alreadyApplied: applied,
     };
   }
 

--- a/src/db/surreal.service.ts
+++ b/src/db/surreal.service.ts
@@ -432,13 +432,19 @@ export class SurrealService implements OnModuleInit, OnApplicationShutdown {
       throw new Error(`Invalid companyId: ${companyId}`);
     }
     const database = `co_${companyId}`;
+    // Schema FIRST, then the pool. Provisioning runs on the dedicated
+    // migrator and lease connections and can wait — on this pod's schema
+    // queue, and on another replica finishing the same database — so
+    // holding a pool slot across it starves every other request here for
+    // as long as the wait lasts, which is how one cold tenant used to
+    // exhaust the pool for the whole process.
+    await this.ensureSchema(database);
     let conn = await this.acquireRoot();
     try {
       // ensureSession may hand back a rebuilt connection — always use the
       // returned reference.
       conn = await this.ensureSession(conn, 'root');
       await conn.use({ namespace: this.namespace, database });
-      await this.ensureSchema(conn, database);
       return await fn(conn);
     } finally {
       this.releaseRoot(conn);
@@ -460,11 +466,11 @@ export class SurrealService implements OnModuleInit, OnApplicationShutdown {
    */
   async withAdminDb<T>(fn: (db: Surreal) => Promise<T>): Promise<T> {
     const database = ADMIN_DATABASE;
+    await this.ensureSchema(database); // before the pool — see withCompany
     let conn = await this.acquireRoot();
     try {
       conn = await this.ensureSession(conn, 'root');
       await conn.use({ namespace: this.namespace, database });
-      await this.ensureSchema(conn, database);
       return await fn(conn);
     } finally {
       this.releaseRoot(conn);
@@ -517,14 +523,13 @@ export class SurrealService implements OnModuleInit, OnApplicationShutdown {
       throw new Error(`Invalid companyId: ${companyId}`);
     }
     const database = `co_${companyId}`;
+    // Before the scoped pool, for the reason spelled out in withCompany:
+    // schema apply never runs on the caller's connection anyway, and a
+    // pool slot held across it blocks every other scoped read.
+    await this.ensureSchema(database);
     const conn = await this.acquireScoped();
     try {
       await conn.use({ namespace: this.namespace, database });
-      // Migrations are idempotent and already serialised through
-      // schemaQueue; running on a scoped connection works because
-      // EDITOR role can DEFINE in v2 against an existing database
-      // it has access to (NS-level USER + DB exists).
-      await this.ensureSchema(conn, database);
       // Bind scopes + policy-deny for this request. The variables live
       // until the next LET on this connection — releasing back to the
       // pool doesn't reset them, but the next withScopedCompany call
@@ -679,14 +684,14 @@ export class SurrealService implements OnModuleInit, OnApplicationShutdown {
   }
 
   /**
-   * Apply migrations to the target database. ALWAYS runs on a freshly
-   * acquired root connection — migration 0005 (DEFINE USER brain_caller)
+   * Apply migrations to the target database. ALWAYS runs on the dedicated
+   * migrator connection — migration 0005 (DEFINE USER brain_caller)
    * requires OWNER role and would otherwise fail when reached via the
-   * scoped pool. Other migrations don't strictly need root, but
-   * centralising here means schema apply behaves identically regardless
-   * of which pool the request entered through.
+   * scoped pool, and a pool connection held across a schema apply starves
+   * every concurrent request. Callers therefore await this BEFORE they
+   * acquire a connection of their own; it takes none from either pool.
    */
-  private async ensureSchema(_conn: Surreal, database: string): Promise<void> {
+  private async ensureSchema(database: string): Promise<void> {
     if (this.knownDatabases.has(database)) return;
     const next = this.schemaQueue.then(async () => {
       if (this.knownDatabases.has(database)) return;

--- a/test/migrator.unit-spec.ts
+++ b/test/migrator.unit-spec.ts
@@ -298,21 +298,76 @@ describe('SchemaMigrator', () => {
       expect(calls.some((c) => c.sql.includes('DEFINE TABLE b'))).toBe(true);
     });
 
-    it('never reads the ledger before it owns the lock', async () => {
+    it('never touches the lease when the manifest is already complete', async () => {
+      // The steady state: every request after the first one for a tenant,
+      // and every boot of a tenant another replica already migrated. A
+      // lease round trip here would sit on the caller's request for no
+      // reason, and a lease a dead holder left would block it outright.
       dir = await makeMigrationsDir({ '0001_baseline.surql': 'DEFINE TABLE a;' });
-      const migrator = new SchemaMigrator(dir, { sleep: async () => undefined });
+      const migrator = new SchemaMigrator(dir);
+      const { conn } = makeFakeConn(['0001']);
+      const lock = makeFakeLock();
+      const result = await migrator.migrate(conn as never, { lock, lockName: 'l' });
+
+      expect(result.applied).toEqual([]);
+      expect(lock.events).toEqual([]);
+    });
+
+    it('reads the ledger before it reaches for the lease', async () => {
+      dir = await makeMigrationsDir({ '0001_baseline.surql': 'DEFINE TABLE a;' });
+      const migrator = new SchemaMigrator(dir);
       const { conn, calls } = makeFakeConn();
-      const lock = makeFakeLock({ heldByOther: 2 });
+      const lock = makeFakeLock();
       lock.tryAcquire = new Proxy(lock.tryAcquire, {
         apply(target, thisArg, args: [string, number]) {
-          // Anything the migrator queries before it holds the lock would
-          // be a decision taken on a schema another replica is changing.
-          expect(calls).toEqual([]);
+          // Read first, arbitrate second — but nothing may be APPLIED
+          // before the lease is held.
+          expect(calls.some((c) => c.sql.includes('SELECT migrationId'))).toBe(true);
+          expect(calls.some((c) => c.sql.includes('DEFINE TABLE a'))).toBe(false);
           return Reflect.apply(target, thisArg, args) as Promise<boolean>;
         },
       });
-      await migrator.migrate(conn as never, { lock, lockName: 'l' });
-      expect(calls.length).toBeGreaterThan(0);
+      const result = await migrator.migrate(conn as never, { lock, lockName: 'l' });
+      expect(result.applied).toEqual(['0001']);
+    });
+
+    it('stops waiting as soon as the holder has finished the work', async () => {
+      dir = await makeMigrationsDir({ '0001_baseline.surql': 'DEFINE TABLE a;' });
+      const migrator = new SchemaMigrator(dir, { sleep: async () => undefined });
+      const { conn, calls, applied } = makeFakeConn();
+      const lock = makeFakeLock({ heldByOther: Number.MAX_SAFE_INTEGER });
+      const busy = lock.tryAcquire.bind(lock);
+      lock.tryAcquire = async (name, ttl) => {
+        const refused = await busy(name, ttl);
+        // The holder commits the last pending file while we back off.
+        applied.push({ migrationId: '0001', name: '0001_baseline.surql' });
+        return refused;
+      };
+
+      const result = await migrator.migrate(conn as never, { lock, lockName: 'l' });
+      expect(result.applied).toEqual([]);
+      expect(calls.some((c) => c.sql.includes('DEFINE TABLE a'))).toBe(false);
+      // One refusal, then the ledger settled it — no second attempt, and
+      // nothing to release because nothing was ever held.
+      expect(lock.events).toEqual(['busy:l']);
+    });
+
+    it('does not fail a request when the lease store is unreachable but the schema is there', async () => {
+      // A lease store we cannot reach must never turn a request against an
+      // already-migrated database into a 500.
+      dir = await makeMigrationsDir({ '0001_baseline.surql': 'DEFINE TABLE a;' });
+      const migrator = new SchemaMigrator(dir, { sleep: async () => undefined });
+      const { conn, applied } = makeFakeConn();
+      const lock = makeFakeLock({ failAcquires: Number.MAX_SAFE_INTEGER });
+      const failing = lock.tryAcquire.bind(lock);
+      lock.tryAcquire = async (name, ttl) => {
+        applied.push({ migrationId: '0001', name: '0001_baseline.surql' });
+        return failing(name, ttl);
+      };
+
+      await expect(migrator.migrate(conn as never, { lock, lockName: 'l' })).resolves.toMatchObject(
+        { applied: [] },
+      );
     });
 
     it('fails closed when the holder never lets go', async () => {
@@ -333,7 +388,7 @@ describe('SchemaMigrator', () => {
         );
         // Fail closed: nothing was applied, so the caller cannot go on to
         // serve requests against a half-migrated database.
-        expect(calls).toEqual([]);
+        expect(calls.some((c) => c.sql.includes('DEFINE TABLE a'))).toBe(false);
       } finally {
         nowSpy.mockRestore();
       }

--- a/test/schema-provision-pool.e2e-spec.ts
+++ b/test/schema-provision-pool.e2e-spec.ts
@@ -1,0 +1,90 @@
+/**
+ * Provisioning a cold tenant must not consume the connection pool.
+ *
+ * `withCompany` / `withScopedCompany` / `withAdminDb` used to acquire a
+ * pooled connection and only then wait for `ensureSchema` — which runs on
+ * the dedicated migrator connection, queues behind every other tenant on
+ * this pod, and (since the cross-replica lease) can also wait for another
+ * replica. So N concurrent first-requests parked N pool slots on work
+ * that never touches them, and everything else on the process queued
+ * behind an acquire timeout it had no way to influence. That is what took
+ * out unrelated suites — `tool-observation`, `db-restart-recovery` — with
+ * "Surreal root pool acquire timed out (pool=8, waiters=4)".
+ *
+ * The pool is deliberately tiny here and the acquire timeout short, so
+ * the property is tested rather than the machine's speed: more cold
+ * tenants at once than the pool has connections, all of them served.
+ */
+import { createApp, type AppFixture } from './app-fixture';
+import { SurrealService } from '../src/db/surreal.service';
+
+const POOL_SIZE = 2;
+const ACQUIRE_TIMEOUT_MS = 2000;
+const COLD_TENANTS = 6;
+
+describe('cold-tenant provisioning does not hold pool connections', () => {
+  let f: AppFixture;
+  const saved: Record<string, string | undefined> = {};
+
+  beforeAll(async () => {
+    for (const k of [
+      'SURREALDB_POOL_SIZE',
+      'SURREALDB_SCOPED_POOL_SIZE',
+      'SURREALDB_ACQUIRE_TIMEOUT_MS',
+    ]) {
+      saved[k] = process.env[k];
+    }
+    process.env.SURREALDB_POOL_SIZE = String(POOL_SIZE);
+    process.env.SURREALDB_SCOPED_POOL_SIZE = String(POOL_SIZE);
+    process.env.SURREALDB_ACQUIRE_TIMEOUT_MS = String(ACQUIRE_TIMEOUT_MS);
+    f = await createApp({ companyId: 'co_provision_pool_e2e' });
+  });
+
+  afterAll(async () => {
+    if (f) await f.close();
+    for (const [k, v] of Object.entries(saved)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  });
+
+  it('serves more concurrent cold tenants than the pool has connections', async () => {
+    const surreal = f.app.get(SurrealService);
+    const stamp = Date.now();
+    const results = await Promise.allSettled(
+      Array.from({ length: COLD_TENANTS }, (_, i) =>
+        surreal.withCompany(`prov${stamp}x${i}`, async (db) => {
+          await db.query('RETURN 1');
+          return i;
+        }),
+      ),
+    );
+    const failures = results
+      .filter((r): r is PromiseRejectedResult => r.status === 'rejected')
+      .map((r) => String((r.reason as Error)?.message ?? r.reason));
+    expect(failures).toEqual([]);
+    expect(results).toHaveLength(COLD_TENANTS);
+  }, 300_000);
+
+  it('serves a warm tenant while cold ones are still provisioning', async () => {
+    // The warm read needs nothing but a free connection. If provisioning
+    // parks the pool, this is the request that 500s in production.
+    const surreal = f.app.get(SurrealService);
+    const stamp = Date.now();
+    const cold = Promise.allSettled(
+      Array.from({ length: COLD_TENANTS }, (_, i) =>
+        surreal.withCompany(`warmside${stamp}x${i}`, async (db) => {
+          await db.query('RETURN 1');
+        }),
+      ),
+    );
+    await new Promise((r) => setTimeout(r, 150));
+    const warm = await surreal.withCompany(f.companyId, async (db) => {
+      const [rows] = await db.query<[Array<{ n: number }>]>('RETURN { n: 1 }');
+      return rows;
+    });
+    expect(warm).toBeDefined();
+    const settled = await cold;
+    expect(settled.filter((r) => r.status === 'rejected')).toEqual([]);
+  }, 300_000);
+});


### PR DESCRIPTION
## What

Fixes the #556 regression that turned main red. Two changes, one of them the actual cause.

**1. Schema provisioning no longer holds a pooled connection.** `withCompany`, `withScopedCompany` and `withAdminDb` acquired a connection and *then* awaited `ensureSchema`. `ensureSchema` runs on the dedicated migrator connection, serialises behind every other tenant on this pod, and — since #556 — can additionally wait for another replica. So N concurrent cold tenants parked N pool slots on work that never touches them, and everything else on the process queued behind an acquire timeout it had no way to influence. `ensureSchema` never used the caller's connection (the parameter was already `_conn`), so awaiting it before the pool acquire is a move, not a behaviour change. It also retires the deadlock the standalone migrator connection was introduced to dodge.

**2. The lease is off the hot path.** The migrator now reads the ledger *before* it reaches for the lease, so a database whose manifest is complete — every request after the first for that tenant, every boot of a tenant another replica already migrated — pays no lease round trip at all. A replica that is waiting re-reads the ledger each time round, so it stops the moment the holder commits the last pending file, and an unreachable lease store can no longer turn a request against an already-migrated database into a 500. The wait deadline drops 120s → 60s (still twice the lease TTL, so a crashed holder is still always taken over).

## Why

Failing CI run 34529247068 on `a1f3345`: `tool-observation` died on `Surreal root pool acquire timed out after 10000ms (pool=8, waiters=4)`, and `db-restart-recovery`'s scoped read 500'd from the same timeout (`at Timeout._onTimeout (src/db/surreal.service.ts:652)`). Nothing links the suites that have been failing since #556 except that each boots an app and provisions a tenant — which is exactly the path #556 made slower in the tail while it sat on a pool slot.

The lock itself was not the whole story: holding a pool connection across provisioning is older than #556. #556 lengthened the tail enough (lease bootstrap DDL + CAS acquire + release per database, plus back-off waits when two app instances in one process contend for the `system` lease) to push it over the 10s acquire timeout in a four-way sharded run.

## How verified

**The regression test reproduces the CI error exactly.** `test/schema-provision-pool.e2e-spec.ts` boots an app with `SURREALDB_POOL_SIZE=2` and a 2s acquire timeout, then asks for 6 cold tenants at once. Without the hoist (verified by reverting it locally):

```
"Surreal root pool acquire timed out after 2000ms (pool=2, waiters=3). ..."
"Surreal root pool acquire timed out after 2000ms (pool=2, waiters=2). ..."
"Surreal root pool acquire timed out after 2000ms (pool=2, waiters=1). ..."
Test Suites: 1 failed
```

With it: 2 tests passed. The second test pins the consequence that mattered in production — a *warm* tenant's read is served while cold tenants are still provisioning.

**Cold-tenant first request, 20 fresh tenants, same machine, same container image** (the number the coordinator asked for):

| build | mean | p50 | p90 | max | warm mean |
|---|---|---|---|---|---|
| pre-#556 (`95a2861`) | 1768ms | 1532ms | 3377ms | 4388ms | 1.9ms |
| #556 as merged (`a1f3345`) | 1308ms | 1079ms | 2928ms | 4694ms | 2.1ms |
| this branch | **1066ms** | **1047ms** | **1178ms** | **1760ms** | **1.4ms** |

So a cold tenant is not slower than before #556 — it is faster, and the tail that was doing the damage (p90 2928 → 1178) is gone. The measurement harness was a throwaway spec; it is not committed.

Commands:
- `pnpm typecheck` — clean. `pnpm lint:ci` — clean. `pnpm format:check` — clean.
- Full unit suite: **448 suites / 5456 tests passed**.
- `pnpm jest --config ./test/jest-e2e.json --testPathPatterns '(db-restart-recovery|tool-observation|migration-concurrency|schema-provision-pool)'` — **4 suites / 14 tests passed**, i.e. both CI failures plus the migration concurrency suite plus the new regression.
- Unit coverage for the new lock contract: never touches the lease when the manifest is complete; reads the ledger before reaching for it; stops waiting the moment the holder finishes; does not fail a request when the lease store is unreachable but the schema is there. **25 tests in `migrator.unit-spec`.**
- e2e shards 3 and 4 (the two that failed in CI) run separately; result in the PR thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhrQxeisXJZEt4sg3PGyU6
