### PR TITLE
feat(ingest): make the first write two lines, and fix an ingest docs page that describes a different API

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,9 +244,35 @@ it maps host **3030**, and `BRAIN_URL=http://localhost:3030` then works for the
 requests below. The Compose defaults are for local development; production
 credentials and topology are covered in [deployment](docs/DEPLOY.md).
 
-### Write and retrieve a fact
+### Remember something, then ask about it
 
-The same requests work with either `BRAIN_URL` above:
+Text in, facts out. Brain captures the turn, extracts entities and claims,
+and runs each one through bitemporal conflict resolution:
+
+```bash
+curl --fail-with-body -X POST "$BRAIN_URL/v1/ingest/mention" \
+  -H "Authorization: Bearer $BRAIN_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "text": "Maria moved to Berlin in June and prefers morning appointments.",
+    "userId": "user_42"
+  }'
+
+curl --fail-with-body -X POST "$BRAIN_URL/v1/search" \
+  -H "Authorization: Bearer $BRAIN_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{ "query": "where does Maria live", "userId": "user_42", "limit": 5 }'
+```
+
+Use your application's stable user ID on **both** writes and reads. Omit
+`userId` on both only for tenant-global memory.
+
+### Record a fact you already know
+
+When the claim is already structured — a CRM field changed, an event
+fired — skip the extractor and state it. The response says what the
+resolver *decided* (`INSERTED`, `SUPERSEDED`, `COMPETING`…), not just
+that the write happened:
 
 ```bash
 curl --fail-with-body -X POST "$BRAIN_URL/v1/ingest/fact" \
@@ -260,17 +286,11 @@ curl --fail-with-body -X POST "$BRAIN_URL/v1/ingest/fact" \
     "userId": "user_42",
     "source": { "vertical": "rent", "messageId": "msg_1" }
   }'
-
-curl --fail-with-body -X POST "$BRAIN_URL/v1/search" \
-  -H "Authorization: Bearer $BRAIN_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{ "query": "maintenance issues", "userId": "user_42", "limit": 5 }'
 ```
 
-Use your application's stable user ID on **both** writes and reads. Omit
-`userId` on both only for tenant-global memory. The local key above has no
-administrative scope; pack installation and forgetting require an appropriately
-scoped operator key. More: [getting started](docs/getting-started.md).
+The local key above has no administrative scope; pack installation and
+forgetting require an appropriately scoped operator key. More:
+[getting started](docs/getting-started.md).
 
 ## Connect an agent
 

--- a/brain-landing/__tests__/quickstart-examples.test.ts
+++ b/brain-landing/__tests__/quickstart-examples.test.ts
@@ -1,6 +1,20 @@
 import { describe, it, expect } from 'vitest'
 import { MCP_CONFIG, QUICKSTART_EXAMPLES } from '../lib/quickstart'
 
+const example = (id: string) => QUICKSTART_EXAMPLES.find((item) => item.id === id)!
+const curlBodies = (code: string) =>
+  [...code.matchAll(/-d '(.*?)'/gs)].map((match) => JSON.parse(match[1]))
+
+/** Run a TypeScript example against a fake fetch and report the calls. */
+async function runExample(
+  id: string,
+  fetch: (url: string, init: RequestInit) => Promise<unknown>,
+  env: Record<string, string>,
+) {
+  const run = new Function('fetch', 'process', `return (async () => { ${example(id).code} })()`)
+  await run(fetch, { env })
+}
+
 describe('copyable quickstart examples', () => {
   it('configures the first-party stdio bridge with the required environment', () => {
     const server = JSON.parse(MCP_CONFIG).mcpServers.brain
@@ -9,34 +23,47 @@ describe('copyable quickstart examples', () => {
     expect(Object.keys(server.env).sort()).toEqual(['BRAIN_API_KEY', 'BRAIN_COMPANY_ID'])
   })
 
-  it('writes and searches the same personal scope with required fact fields', async () => {
+  it('leads with the smallest write that works — text and a user, nothing else', () => {
+    // The first thing a reader copies decides whether they get to a
+    // result. Five domain concepts before the first success is the
+    // category's worst onboarding, and we had it.
+    const [write] = curlBodies(example('curl').code)
+    expect(Object.keys(write).sort()).toEqual(['text', 'userId'])
+    expect(example('curl').code).toContain('/v1/ingest/mention')
+  })
+
+  it('writes and searches the same personal scope', async () => {
     const calls: { url: string; body: Record<string, unknown> }[] = []
     const fetch = async (url: string, init: RequestInit) => {
       calls.push({ url, body: JSON.parse(String(init.body)) })
       expect(init.headers).toMatchObject({ Authorization: 'Bearer brain_example' })
       return { ok: true, json: async () => ({ hits: [] }) }
     }
-    const code = QUICKSTART_EXAMPLES.find((item) => item.id === 'sdk')!.code
-    const run = new Function('fetch', 'process', `return (async () => { ${code} })()`)
-    await run(fetch, { env: { BRAIN_KEY: 'brain_example' } })
+    await runExample('sdk', fetch, { BRAIN_KEY: 'brain_example' })
     expect(calls).toHaveLength(2)
-    expect(calls[0].url).toContain('/v1/ingest/fact')
-    for (const field of ['entityRef', 'predicate', 'object', 'validFrom', 'source']) {
-      expect(calls[0].body).toHaveProperty(field)
-    }
-    expect(Number.isNaN(Date.parse(String(calls[0].body.validFrom)))).toBe(false)
+    expect(calls[0].url).toContain('/v1/ingest/mention')
+    expect(calls[1].url).toContain('/v1/search')
     expect(calls[1].body.userId).toBe(calls[0].body.userId)
-    const curl = QUICKSTART_EXAMPLES.find((item) => item.id === 'curl')!.code
-    const bodies = [...curl.matchAll(/-d '(.*?)'/gs)].map((match) => JSON.parse(match[1]))
-    expect(bodies).toEqual(calls.map((call) => call.body))
+    // The REST tab and the TypeScript tab must stay the same two calls.
+    expect(curlBodies(example('curl').code)).toEqual(calls.map((call) => call.body))
+  })
+
+  it('keeps the typed path complete, as the precision route', () => {
+    const [write, read] = curlBodies(example('typed').code)
+    for (const field of ['entityRef', 'predicate', 'object', 'validFrom', 'source']) {
+      expect(write).toHaveProperty(field)
+    }
+    expect(Number.isNaN(Date.parse(String(write.validFrom)))).toBe(false)
+    expect(read.userId).toBe(write.userId)
   })
 
   it('stops when the write fails instead of implying the memory was stored', async () => {
     let requests = 0
-    const fetch = async () => { requests++; return { ok: false, status: 401 } }
-    const code = QUICKSTART_EXAMPLES.find((item) => item.id === 'sdk')!.code
-    const run = new Function('fetch', 'process', `return (async () => { ${code} })()`)
-    await expect(run(fetch, { env: {} })).rejects.toThrow('Ingest failed: 401')
+    const fetch = async () => {
+      requests++
+      return { ok: false, status: 401 }
+    }
+    await expect(runExample('sdk', fetch, {})).rejects.toThrow('Ingest failed: 401')
     expect(requests).toBe(1)
   })
 })

--- a/brain-landing/content/docs/en/api/ingest.mdx
+++ b/brain-landing/content/docs/en/api/ingest.mdx
@@ -4,9 +4,69 @@ Three ingest paths. All route through the conflict resolver before landing.
 
 | Endpoint | Input | When to use |
 | --- | --- | --- |
+| `POST /v1/ingest/mention` | raw text (`text` is the only required field) | The simplest write. Chat turns, inbox messages, transcripts, reviews — anything where you have prose rather than a claim. |
 | `POST /v1/ingest/fact` | one structured `{entityRef, predicate, object, validFrom, …}` | You already know the predicate / object pair. Structured event streams, CRM exports, programmatic writes. |
-| `POST /v1/ingest/mention` | raw text + `sourceVertical` | NLU-extract entities + facts from natural language. Inbox messages, transcripts, reviews. |
 | `POST /v1/ingest/link` | typed edge `{from, to, kind}` | Cross-vertical merges (`identity_of`), graph relationships (`paid_for`, `mentioned_in`). |
+
+## POST /v1/ingest/mention
+
+The smallest write brain accepts:
+
+```bash
+curl -X POST "$BRAIN_URL/v1/ingest/mention" \
+  -H "Authorization: Bearer $BRAIN_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "text": "Maria moved to Berlin in June and prefers morning appointments.",
+    "userId": "user_42"
+  }'
+```
+
+The full shape:
+
+```ts
+{
+  text: string                  // required, ≤16 000 chars
+  userId?: string               // per-user memory scope (0055)
+  contextRef?: {                // default: { vertical: 'chat' }
+    vertical: string
+    conversationId?: string
+    messageId?: string
+    eventId?: string
+    recorder?: string           // default: the extraction model id
+  }
+  knownEntities?: Array<{       // anchors coreference to participants
+    vertical: string
+    id: string
+    role?: 'speaker' | 'addressee'
+    name?: string
+  }>
+  emittedAt?: string            // ISO-8601 event time, default: now
+  timezone?: string             // IANA zone, anchors relative dates
+}
+```
+
+`contextRef` and `emittedAt` are optional because an agent capturing a conversation has text and a user and nothing else it can honestly fill in. A caller replaying history — the case where event time actually matters — always knows the timestamp and passes it.
+
+The response names what was written:
+
+```ts
+{
+  skipped: boolean                  // true = the extractor found nothing
+  reason?: string                   // which check stopped it
+  extractedEntityIds: string[]
+  extractedFactIds: string[]
+  extractedEdgeIds?: string[]
+}
+```
+
+`skipped: true` is a normal outcome, not an error — a greeting has no facts in it.
+
+Extraction is deliberately noisy: every extracted fact goes through the same bitemporal resolver as `/v1/ingest/fact`, so duplicates corroborate and contradictions surface as competing facts instead of being filtered out up front. The raw text is kept as the episode behind those facts, so each one traces back to the turn it came from.
+
+The extractor model comes from the `OPENAI_CHAT_MODEL` env var (default `gpt-4o-mini`, operator-configurable). Cost is tracked per call; the operator playbook covers per-tenant budget alerts.
+
+For anything long enough to need chunking, use [`POST /v1/ingest/document`](/en/docs/platform/document-pipeline) instead.
 
 ## POST /v1/ingest/fact
 
@@ -23,40 +83,26 @@ Three ingest paths. All route through the conflict resolver before landing.
 }
 ```
 
-Response carries `factId` and the resolver outcome:
+Response carries `factId` and the resolver outcome — what it *decided*, never just "ok":
 
 ```ts
 {
-  factId: string
-  outcome: 'INSERTED' | 'SUPERSEDED' | 'COMPETING' | 'REJECTED'
-  margin?: number
-  contradicting?: string[]   // factIds of the rivals
+  factId: string | null              // null when the claim was REJECTED
+  outcome:
+    | 'INSERTED'
+    | 'INSERTED_HISTORICAL'          // backdated: filed behind a newer row
+    | 'CORROBORATED'                 // same claim, different source
+    | 'SUPERSEDED'
+    | 'COMPETING'
+    | 'REJECTED'
+  supersededFactIds?: string[]
+  competingFactIds?: string[]
+  supersededByFactId?: string        // INSERTED_HISTORICAL only
+  corroboratedFactId?: string        // CORROBORATED only
+  reason?: string
+  conflictExplanation?: object       // only with `explain: true`
 }
 ```
-
-## POST /v1/ingest/mention
-
-```ts
-{
-  text: string
-  sourceVertical: string
-  source: { messageId?: string, ... }
-  entityHints?: Array<{ vertical: string, id: string }>  // anchor extraction
-  asOf?: string  // when the mention happened (default: now)
-}
-```
-
-Returns a batch result — every entity the NLU found, every fact emitted, per-fact resolver outcome:
-
-```ts
-{
-  entities: Array<{ entityId: string, externalRefs: [...] }>
-  facts: Array<{ factId: string, outcome: ... }>
-  cost: { promptTokens: number, completionTokens: number }
-}
-```
-
-The extractor model comes from the `OPENAI_CHAT_MODEL` env var (default `gpt-4o-mini`, operator-configurable). Cost is tracked per call; the operator playbook covers per-tenant budget alerts.
 
 ## POST /v1/ingest/link
 
@@ -72,9 +118,16 @@ The extractor model comes from the `OPENAI_CHAT_MODEL` env var (default `gpt-4o-
 
 `kind=identity_of` is the cross-vertical merge primitive — when the rent vertical and the inbox vertical both have an `alice@example.com`, they're the same person. Issuing the link triggers re-attribution: existing facts get merged onto the canonical entity.
 
-## Idempotency
+## Repeating a write
 
-All three accept an `Idempotency-Key` header. Same key + same body within 24h returns the original outcome, doesn't re-run the resolver. Different body with the same key returns 409.
+There is no `Idempotency-Key` header. The resolver is what makes a repeat
+safe: the same claim arriving twice from the same source is
+`CORROBORATED` against the standing fact rather than duplicated, and the
+same claim from a *different* source raises the incumbent's corroboration
+count. A retry after a timeout is therefore the right thing to do.
+
+Predicates are open vocabulary — an unregistered predicate is a coinage,
+not an error, and resolves in its own slot.
 
 ## Errors
 
@@ -82,10 +135,8 @@ All three accept an `Idempotency-Key` header. Same key + same body within 24h re
 | --- | --- |
 | `400` | Schema validation failed — error body lists field paths |
 | `401` | Missing / invalid bearer key |
-| `403` | Scope `brain:write` required |
-| `409` | Idempotency-Key reused with a different body |
-| `422` | Vocabulary unknown predicate — register it first or use one from the standard set |
-| `429` | Per-tenant rate limit hit |
+| `403` | Scope `brain:write` required, or a user-bound token asserted a different `userId` |
+| `429` | Per-tenant rate limit hit — mention ingest runs the extractor and sits in the tight `expensive` bucket |
 
 ## Related
 

--- a/brain-landing/content/docs/en/getting-started.mdx
+++ b/brain-landing/content/docs/en/getting-started.mdx
@@ -18,7 +18,39 @@ export BRAIN_URL="https://brain.inite.ai"
 
 These examples store personal memory for `user_42`. Use your own stable user ID on both writes and reads. Omit `userId` on both only for tenant-global memory.
 
-## 1. Ingest one fact
+## 1. Remember something
+
+Text in. Brain captures the turn, extracts the entities and claims, and
+runs each one through the conflict resolver:
+
+```bash
+curl -X POST "$BRAIN_URL/v1/ingest/mention" \
+  -H "Authorization: Bearer $BRAIN_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "text": "Maria moved to Berlin in June and prefers morning appointments.",
+    "userId": "user_42"
+  }'
+```
+
+The response lists what was written: `extractedEntityIds`, `extractedFactIds`. `skipped: true` means the extractor found nothing worth recording — a normal outcome for a greeting, not an error.
+
+## 2. Ask about it
+
+```bash
+curl -X POST "$BRAIN_URL/v1/search" \
+  -H "Authorization: Bearer $BRAIN_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{ "query": "where does Maria live", "userId": "user_42", "limit": 5 }'
+```
+
+Returns ranked entity-hits with their matching facts and per-leg score breakdown.
+
+### When you already know the claim
+
+Extraction is for prose. If the write comes from a CRM field or an event
+stream, state it directly and skip the LLM — the response then names what
+the resolver *decided* (`INSERTED`, `SUPERSEDED`, `COMPETING`…):
 
 ```bash
 curl -X POST "$BRAIN_URL/v1/ingest/fact" \
@@ -33,19 +65,6 @@ curl -X POST "$BRAIN_URL/v1/ingest/fact" \
     "source": { "vertical": "rent", "messageId": "msg_1" }
   }'
 ```
-
-Response carries the `factId` and the conflict-resolver outcome (`INSERTED` on first ingest).
-
-## 2. Search for it
-
-```bash
-curl -X POST "$BRAIN_URL/v1/search" \
-  -H "Authorization: Bearer $BRAIN_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{ "query": "maintenance issues", "userId": "user_42", "limit": 5 }'
-```
-
-Returns ranked entity-hits with their matching facts and per-leg score breakdown.
 
 ## 3. Stand up an MCP client
 

--- a/brain-landing/content/docs/ru/api/ingest.mdx
+++ b/brain-landing/content/docs/ru/api/ingest.mdx
@@ -4,9 +4,69 @@
 
 | Эндпоинт | Вход | Когда использовать |
 | --- | --- | --- |
+| `POST /v1/ingest/mention` | сырой текст (обязателен только `text`) | Самая простая запись. Реплики чата, сообщения inbox, транскрипты, отзывы — всё, где на руках проза, а не готовое утверждение. |
 | `POST /v1/ingest/fact` | один структурный `{entityRef, predicate, object, validFrom, …}` | Ты уже знаешь пару предикат / объект. Структурные потоки событий, выгрузки из CRM, программные записи. |
-| `POST /v1/ingest/mention` | сырой текст + `sourceVertical` | NLU-извлечение сущностей и фактов из естественного языка. Сообщения inbox, транскрипты, отзывы. |
 | `POST /v1/ingest/link` | типизированное ребро `{from, to, kind}` | Кросс-вертикальные слияния (`identity_of`), связи графа (`paid_for`, `mentioned_in`). |
+
+## POST /v1/ingest/mention
+
+Самая маленькая запись, которую brain принимает:
+
+```bash
+curl -X POST "$BRAIN_URL/v1/ingest/mention" \
+  -H "Authorization: Bearer $BRAIN_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "text": "Мария переехала в Берлин в июне и предпочитает утренние слоты.",
+    "userId": "user_42"
+  }'
+```
+
+Полная форма:
+
+```ts
+{
+  text: string                  // обязательно, ≤16 000 символов
+  userId?: string               // скоуп персональной памяти (0055)
+  contextRef?: {                // по умолчанию: { vertical: 'chat' }
+    vertical: string
+    conversationId?: string
+    messageId?: string
+    eventId?: string
+    recorder?: string           // по умолчанию: id модели-экстрактора
+  }
+  knownEntities?: Array<{       // якорит кореференцию на участников
+    vertical: string
+    id: string
+    role?: 'speaker' | 'addressee'
+    name?: string
+  }>
+  emittedAt?: string            // ISO-8601 время события, по умолчанию: сейчас
+  timezone?: string             // IANA-зона, якорит относительные даты
+}
+```
+
+`contextRef` и `emittedAt` необязательны, потому что у агента, который пишет разговор, есть текст и пользователь — и больше ничего, что он мог бы честно заполнить. А тот, кто проигрывает историю (единственный случай, где время события действительно важно), таймстемп всегда знает и передаёт.
+
+Ответ называет то, что записано:
+
+```ts
+{
+  skipped: boolean                  // true = экстрактор ничего не нашёл
+  reason?: string                   // какая проверка его остановила
+  extractedEntityIds: string[]
+  extractedFactIds: string[]
+  extractedEdgeIds?: string[]
+}
+```
+
+`skipped: true` — нормальный исход, а не ошибка: в приветствии нет фактов.
+
+Извлечение намеренно шумное: каждый извлечённый факт проходит через тот же битемпоральный resolver, что и `/v1/ingest/fact`, поэтому дубликаты корроборируют, а противоречия всплывают как competing-факты, а не отфильтровываются на входе. Исходный текст остаётся эпизодом за этими фактами — каждый из них прослеживается до реплики, из которой взялся.
+
+Модель экстрактора задаётся переменной `OPENAI_CHAT_MODEL` (по умолчанию `gpt-4o-mini`, настраивается оператором). Стоимость считается на каждый вызов; алерты по бюджету на тенанта — в оператор-плейбуке.
+
+Для всего, что достаточно длинное, чтобы требовать чанкинга, есть [`POST /v1/ingest/document`](/ru/docs/platform/document-pipeline).
 
 ## POST /v1/ingest/fact
 
@@ -23,40 +83,26 @@
 }
 ```
 
-В ответе — `factId` и исход resolver:
+В ответе — `factId` и исход resolver: что он **решил**, а не просто «ок»:
 
 ```ts
 {
-  factId: string
-  outcome: 'INSERTED' | 'SUPERSEDED' | 'COMPETING' | 'REJECTED'
-  margin?: number
-  contradicting?: string[]   // factIds of the rivals
+  factId: string | null              // null, если утверждение REJECTED
+  outcome:
+    | 'INSERTED'
+    | 'INSERTED_HISTORICAL'          // задним числом: подшит за более новую строку
+    | 'CORROBORATED'                 // то же утверждение, другой источник
+    | 'SUPERSEDED'
+    | 'COMPETING'
+    | 'REJECTED'
+  supersededFactIds?: string[]
+  competingFactIds?: string[]
+  supersededByFactId?: string        // только INSERTED_HISTORICAL
+  corroboratedFactId?: string        // только CORROBORATED
+  reason?: string
+  conflictExplanation?: object       // только при `explain: true`
 }
 ```
-
-## POST /v1/ingest/mention
-
-```ts
-{
-  text: string
-  sourceVertical: string
-  source: { messageId?: string, ... }
-  entityHints?: Array<{ vertical: string, id: string }>  // anchor extraction
-  asOf?: string  // when the mention happened (default: now)
-}
-```
-
-Возвращает батч-результат — каждую сущность, что нашла NLU, каждый выпущенный факт и исход resolver на факт:
-
-```ts
-{
-  entities: Array<{ entityId: string, externalRefs: [...] }>
-  facts: Array<{ factId: string, outcome: ... }>
-  cost: { promptTokens: number, completionTokens: number }
-}
-```
-
-Модель экстрактора задаётся переменной `OPENAI_CHAT_MODEL` (по умолчанию `gpt-4o-mini`, настраивается оператором). Стоимость считается на каждый вызов; алерты по бюджету на тенанта — в оператор-плейбуке.
 
 ## POST /v1/ingest/link
 
@@ -72,9 +118,16 @@
 
 `kind=identity_of` — примитив кросс-вертикального слияния: когда у вертикали rent и у вертикали inbox есть один `alice@example.com`, это один человек. Установка ребра запускает реатрибуцию: существующие факты сливаются на каноническую сущность.
 
-## Идемпотентность
+## Повторная запись
 
-Все три принимают заголовок `Idempotency-Key`. Тот же ключ + то же тело в течение 24 ч вернут исходный исход и не перезапустят resolver. Другое тело с тем же ключом вернёт 409.
+Заголовка `Idempotency-Key` нет. Безопасным повтор делает resolver: то же
+утверждение, пришедшее дважды из того же источника, идёт как
+`CORROBORATED` к стоящему факту, а не дублируется; из **другого**
+источника — поднимает счётчик корроборации у действующего. Поэтому
+ретрай после таймаута — правильное действие.
+
+Предикаты — открытый словарь: незарегистрированный предикат это новация,
+а не ошибка, и разрешается в собственном слоте.
 
 ## Ошибки
 
@@ -82,10 +135,8 @@
 | --- | --- |
 | `400` | Не прошла валидация схемы — в теле ошибки пути полей |
 | `401` | Нет / неверный bearer-ключ |
-| `403` | Нужен scope `brain:write` |
-| `409` | `Idempotency-Key` переиспользован с другим телом |
-| `422` | Предикат не из словаря — зарегистрируй его или возьми из стандартного набора |
-| `429` | Упёрся в rate limit тенанта |
+| `403` | Нужен scope `brain:write`, либо user-bound токен заявил чужой `userId` |
+| `429` | Упёрся в rate limit тенанта — mention-ингест запускает экстрактор и живёт в тесном бакете `expensive` |
 
 ## Связанное
 

--- a/brain-landing/content/docs/ru/getting-started.mdx
+++ b/brain-landing/content/docs/ru/getting-started.mdx
@@ -18,7 +18,39 @@ export BRAIN_URL="https://brain.inite.ai"
 
 Примеры используют личную память `user_42`. Передавайте свой постоянный ID пользователя при записи и чтении. Для общей памяти организации не передавайте `userId` в обоих запросах.
 
-## 1. Заингестить один факт
+## 1. Что-нибудь запомнить
+
+На вход — текст. Brain сохраняет реплику, извлекает сущности и утверждения
+и прогоняет каждое через conflict-resolver:
+
+```bash
+curl -X POST "$BRAIN_URL/v1/ingest/mention" \
+  -H "Authorization: Bearer $BRAIN_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "text": "Мария переехала в Берлин в июне и предпочитает утренние слоты.",
+    "userId": "user_42"
+  }'
+```
+
+В ответе — что записано: `extractedEntityIds`, `extractedFactIds`. `skipped: true` значит, что экстрактор не нашёл ничего, что стоило бы записать — нормальный исход для приветствия, а не ошибка.
+
+## 2. Спросить про это
+
+```bash
+curl -X POST "$BRAIN_URL/v1/search" \
+  -H "Authorization: Bearer $BRAIN_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{ "query": "где живёт Мария", "userId": "user_42", "limit": 5 }'
+```
+
+Вернёт ранжированные попадания по сущностям с подходящими фактами и разбивкой score по этапам.
+
+### Когда утверждение уже известно
+
+Извлечение нужно для прозы. Если запись идёт из поля CRM или потока
+событий — заявляй напрямую и не трать LLM: в ответе тогда придёт то, что
+**решил** resolver (`INSERTED`, `SUPERSEDED`, `COMPETING`…):
 
 ```bash
 curl -X POST "$BRAIN_URL/v1/ingest/fact" \
@@ -33,19 +65,6 @@ curl -X POST "$BRAIN_URL/v1/ingest/fact" \
     "source": { "vertical": "rent", "messageId": "msg_1" }
   }'
 ```
-
-В ответе придёт `factId` и исход работы conflict-resolver (`INSERTED` на первом ингесте).
-
-## 2. Найти его
-
-```bash
-curl -X POST "$BRAIN_URL/v1/search" \
-  -H "Authorization: Bearer $BRAIN_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{ "query": "maintenance issues", "userId": "user_42", "limit": 5 }'
-```
-
-Вернёт ранжированные попадания по сущностям с подходящими фактами и разбивкой score по этапам.
 
 ## 3. Поднять MCP-клиент
 

--- a/brain-landing/lib/quickstart.ts
+++ b/brain-landing/lib/quickstart.ts
@@ -12,10 +12,34 @@ export const MCP_CONFIG = JSON.stringify({
   },
 }, null, 2)
 
+/**
+ * Order matters: the first write a reader sees should be the smallest
+ * one that works. `/v1/ingest/mention` takes text and a user and does
+ * the extraction; the typed `/v1/ingest/fact` path is the precision
+ * route for callers that already have a structured claim, and it earns
+ * its own tab rather than being the first hurdle.
+ */
 export const QUICKSTART_EXAMPLES = [
   { id: 'mcp', label: 'MCP', filename: 'claude_desktop_config.json', code: MCP_CONFIG },
   {
     id: 'curl', label: 'REST', filename: 'terminal',
+    code: `export BRAIN_KEY="brain_YOUR_API_KEY"
+
+curl -X POST https://brain.inite.ai/v1/ingest/mention \\
+  -H "Authorization: Bearer $BRAIN_KEY" \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "text": "Maria moved to Berlin in June and prefers morning appointments.",
+    "userId": "user_42"
+  }'
+
+curl -X POST https://brain.inite.ai/v1/search \\
+  -H "Authorization: Bearer $BRAIN_KEY" \\
+  -H "Content-Type: application/json" \\
+  -d '{ "query": "where does Maria live", "userId": "user_42", "limit": 5 }'`,
+  },
+  {
+    id: 'typed', label: 'REST · typed', filename: 'terminal',
     code: `export BRAIN_KEY="brain_YOUR_API_KEY"
 
 curl -X POST https://brain.inite.ai/v1/ingest/fact \\
@@ -42,15 +66,11 @@ curl -X POST https://brain.inite.ai/v1/search \\
   'Content-Type': 'application/json',
 }
 
-const write = await fetch('https://brain.inite.ai/v1/ingest/fact', {
+const write = await fetch('https://brain.inite.ai/v1/ingest/mention', {
   method: 'POST', headers,
   body: JSON.stringify({
-    entityRef: { vertical: 'rent', id: 'cust_42' },
-    predicate: 'complained_about',
-    object: 'late maintenance',
-    validFrom: '2026-09-01T10:00:00Z',
+    text: 'Maria moved to Berlin in June and prefers morning appointments.',
     userId: 'user_42',
-    source: { vertical: 'rent', messageId: 'msg_1' },
   }),
 })
 if (!write.ok) throw new Error(\`Ingest failed: \${write.status}\`)
@@ -58,7 +78,7 @@ if (!write.ok) throw new Error(\`Ingest failed: \${write.status}\`)
 const response = await fetch('https://brain.inite.ai/v1/search', {
   method: 'POST', headers,
   body: JSON.stringify({
-    query: 'maintenance issues', userId: 'user_42', limit: 5,
+    query: 'where does Maria live', userId: 'user_42', limit: 5,
   }),
 })
 if (!response.ok) throw new Error(\`Search failed: \${response.status}\`)

--- a/brain-landing/public/openapi.json
+++ b/brain-landing/public/openapi.json
@@ -3125,6 +3125,74 @@
         ],
         "type": "object"
       },
+      "IngestMentionRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "contextRef": {
+            "$ref": "#/components/schemas/MentionContextRef"
+          },
+          "emittedAt": {
+            "type": "string"
+          },
+          "knownEntities": {
+            "items": {
+              "$ref": "#/components/schemas/KnownEntity"
+            },
+            "type": "array"
+          },
+          "text": {
+            "maxLength": 16000,
+            "type": "string"
+          },
+          "timezone": {
+            "maxLength": 64,
+            "type": "string"
+          },
+          "userId": {
+            "maxLength": 200,
+            "type": "string"
+          }
+        },
+        "required": [
+          "text"
+        ],
+        "type": "object"
+      },
+      "IngestMentionResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "extractedEdgeIds": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "extractedEntityIds": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "extractedFactIds": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "reason": {
+            "type": "string"
+          },
+          "skipped": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "skipped",
+          "extractedEntityIds",
+          "extractedFactIds"
+        ],
+        "type": "object"
+      },
       "InstallFromRegistryRequest": {
         "additionalProperties": false,
         "properties": {
@@ -3363,6 +3431,52 @@
           "keys",
           "issuingEnabled",
           "issuableScopes"
+        ],
+        "type": "object"
+      },
+      "KnownEntity": {
+        "additionalProperties": {},
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "role": {
+            "type": "string"
+          },
+          "vertical": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "vertical",
+          "id"
+        ],
+        "type": "object"
+      },
+      "MentionContextRef": {
+        "additionalProperties": {},
+        "properties": {
+          "conversationId": {
+            "type": "string"
+          },
+          "eventId": {
+            "type": "string"
+          },
+          "messageId": {
+            "type": "string"
+          },
+          "recorder": {
+            "type": "string"
+          },
+          "vertical": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "vertical"
         ],
         "type": "object"
       },
@@ -8325,6 +8439,47 @@
           }
         },
         "summary": "Record a declared structured fact",
+        "tags": [
+          "Ingest"
+        ]
+      }
+    },
+    "/v1/ingest/mention": {
+      "post": {
+        "description": "The simplest write, and the one to reach for when the caller has prose rather than a structured claim: a chat turn, a meeting note, an email body. The text is captured as an episode, an LLM extracts entities, facts and edges from it, and each extracted fact goes through the same bitemporal resolver as `POST /v1/ingest/fact` — so extraction is noisy by design and conflict resolution cleans up at read time. Only `text` is required: `contextRef` defaults to the `chat` vertical and `emittedAt` to the moment the request arrives. `userId` stamps the per-user memory scope on the episode and every extracted fact. `skipped: true` means the extractor found nothing worth recording (`reason` says which check stopped it) — that is a normal outcome, not an error. Prefer `POST /v1/ingest/document` for anything long enough to need chunking. Source: src/ingest/ingest.controller.ts.\n\nRequired scope: `brain:write`.",
+        "operationId": "ingestMention",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IngestMentionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IngestMentionResponse"
+                }
+              }
+            },
+            "description": "What the extractor wrote."
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        },
+        "summary": "Record free text and let brain extract the facts",
         "tags": [
           "Ingest"
         ]

--- a/docs/api.md
+++ b/docs/api.md
@@ -38,8 +38,8 @@ at the discovery document below.
 
 | Endpoint | Notes |
 |---|---|
-| `POST /v1/ingest/fact` | Declared structured fact ingest. Optional `userId` stamps a per-user memory scope (0055): scope-local conflict resolution, invisible outside that user. |
-| `POST /v1/ingest/mention` | NLU extraction → entities + facts. With `INGEST_MENTION_VIA_DOCUMENT=1`, routed through the document pipeline (same response shape; `userId` scope preserved end-to-end — 0127). |
+| `POST /v1/ingest/mention` | The simplest write: free text → entities + facts. `text` is the only required field — `contextRef` defaults to the `chat` vertical, `emittedAt` to request time. With `INGEST_MENTION_VIA_DOCUMENT=1`, routed through the document pipeline (same response shape; `userId` scope preserved end-to-end — 0127). |
+| `POST /v1/ingest/fact` | Declared structured fact ingest — the precision route when the claim is already known. Optional `userId` stamps a per-user memory scope (0055): scope-local conflict resolution, invisible outside that user. |
 | `POST /v1/ingest/link` | Typed edge between entities (incl. `identity_of` for cross-vertical merge). |
 
 ## Documents (Source → Indexer → Candidates → Brain)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -48,7 +48,19 @@ BRAIN_API_KEYS=[{"keyHash":"sha256:abc...","companyId":"co_demo","scopes":["brai
 ## Smoke test
 
 ```bash
-# Ingest one fact
+# Remember something — text in, extraction handled
+curl -X POST http://localhost:3000/v1/ingest/mention \
+  -H "Authorization: Bearer local-dev-key" \
+  -H "Content-Type: application/json" \
+  -d '{ "text": "Maria moved to Berlin in June and prefers morning appointments." }'
+
+# Ask about it
+curl -X POST http://localhost:3000/v1/search \
+  -H "Authorization: Bearer local-dev-key" \
+  -H "Content-Type: application/json" \
+  -d '{ "query": "where does Maria live", "limit": 5 }'
+
+# Or state a claim you already know, and read the resolver's decision
 curl -X POST http://localhost:3000/v1/ingest/fact \
   -H "Authorization: Bearer local-dev-key" \
   -H "Content-Type: application/json" \
@@ -59,12 +71,6 @@ curl -X POST http://localhost:3000/v1/ingest/fact \
     "validFrom": "2026-05-05T10:00:00Z",
     "source": { "vertical": "rent", "messageId": "msg_1" }
   }'
-
-# Search
-curl -X POST http://localhost:3000/v1/search \
-  -H "Authorization: Bearer local-dev-key" \
-  -H "Content-Type: application/json" \
-  -d '{ "query": "maintenance issues", "limit": 5 }'
 ```
 
 ## Docker (compose)

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -3125,6 +3125,74 @@
         ],
         "type": "object"
       },
+      "IngestMentionRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "contextRef": {
+            "$ref": "#/components/schemas/MentionContextRef"
+          },
+          "emittedAt": {
+            "type": "string"
+          },
+          "knownEntities": {
+            "items": {
+              "$ref": "#/components/schemas/KnownEntity"
+            },
+            "type": "array"
+          },
+          "text": {
+            "maxLength": 16000,
+            "type": "string"
+          },
+          "timezone": {
+            "maxLength": 64,
+            "type": "string"
+          },
+          "userId": {
+            "maxLength": 200,
+            "type": "string"
+          }
+        },
+        "required": [
+          "text"
+        ],
+        "type": "object"
+      },
+      "IngestMentionResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "extractedEdgeIds": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "extractedEntityIds": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "extractedFactIds": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "reason": {
+            "type": "string"
+          },
+          "skipped": {
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "skipped",
+          "extractedEntityIds",
+          "extractedFactIds"
+        ],
+        "type": "object"
+      },
       "InstallFromRegistryRequest": {
         "additionalProperties": false,
         "properties": {
@@ -3363,6 +3431,52 @@
           "keys",
           "issuingEnabled",
           "issuableScopes"
+        ],
+        "type": "object"
+      },
+      "KnownEntity": {
+        "additionalProperties": {},
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "role": {
+            "type": "string"
+          },
+          "vertical": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "vertical",
+          "id"
+        ],
+        "type": "object"
+      },
+      "MentionContextRef": {
+        "additionalProperties": {},
+        "properties": {
+          "conversationId": {
+            "type": "string"
+          },
+          "eventId": {
+            "type": "string"
+          },
+          "messageId": {
+            "type": "string"
+          },
+          "recorder": {
+            "type": "string"
+          },
+          "vertical": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "vertical"
         ],
         "type": "object"
       },
@@ -8325,6 +8439,47 @@
           }
         },
         "summary": "Record a declared structured fact",
+        "tags": [
+          "Ingest"
+        ]
+      }
+    },
+    "/v1/ingest/mention": {
+      "post": {
+        "description": "The simplest write, and the one to reach for when the caller has prose rather than a structured claim: a chat turn, a meeting note, an email body. The text is captured as an episode, an LLM extracts entities, facts and edges from it, and each extracted fact goes through the same bitemporal resolver as `POST /v1/ingest/fact` — so extraction is noisy by design and conflict resolution cleans up at read time. Only `text` is required: `contextRef` defaults to the `chat` vertical and `emittedAt` to the moment the request arrives. `userId` stamps the per-user memory scope on the episode and every extracted fact. `skipped: true` means the extractor found nothing worth recording (`reason` says which check stopped it) — that is a normal outcome, not an error. Prefer `POST /v1/ingest/document` for anything long enough to need chunking. Source: src/ingest/ingest.controller.ts.\n\nRequired scope: `brain:write`.",
+        "operationId": "ingestMention",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IngestMentionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IngestMentionResponse"
+                }
+              }
+            },
+            "description": "What the extractor wrote."
+          },
+          "400": {
+            "$ref": "#/components/responses/BadRequest"
+          },
+          "401": {
+            "$ref": "#/components/responses/Unauthorized"
+          },
+          "403": {
+            "$ref": "#/components/responses/Forbidden"
+          }
+        },
+        "summary": "Record free text and let brain extract the facts",
         "tags": [
           "Ingest"
         ]

--- a/scripts/build-openapi.ts
+++ b/scripts/build-openapi.ts
@@ -179,6 +179,10 @@ import {
   FactSourceSchema,
   IngestFactRequestSchema,
   IngestFactResponseSchema,
+  IngestMentionRequestSchema,
+  IngestMentionResponseSchema,
+  KnownEntitySchema,
+  MentionContextRefSchema,
   SourceEvidenceSchema,
 } from '../src/contracts/ingest/ingest.schema';
 import {
@@ -367,6 +371,11 @@ const ZOD_COMPONENTS: Record<string, z.ZodType> = {
   IngestFactRequest: IngestFactRequestSchema,
   IngestFactResponse: IngestFactResponseSchema,
   ConflictExplanation: ConflictExplanationSchema,
+  // --- free-text ingest (src/contracts/ingest/ingest.schema.ts)
+  MentionContextRef: MentionContextRefSchema,
+  KnownEntity: KnownEntitySchema,
+  IngestMentionRequest: IngestMentionRequestSchema,
+  IngestMentionResponse: IngestMentionResponseSchema,
   // --- search (src/contracts/search/search.schema.ts)
   SearchRequest: SearchRequestSchema,
   SearchFact: SearchFactSchema,
@@ -972,6 +981,37 @@ function memoryCorePaths(): Json {
         requestBody: jsonBody(ref('IngestFactRequest')),
         responses: {
           '201': jsonResponse("The resolver's decision.", ref('IngestFactResponse')),
+          '400': errorRef('BadRequest'),
+          ...AUTH_ERRORS,
+        },
+      }),
+    },
+    '/v1/ingest/mention': {
+      post: operation({
+        operationId: 'ingestMention',
+        tag: 'Ingest',
+        summary: 'Record free text and let brain extract the facts',
+        description:
+          'The simplest write, and the one to reach for when the caller ' +
+          'has prose rather than a structured claim: a chat turn, a ' +
+          'meeting note, an email body. The text is captured as an ' +
+          'episode, an LLM extracts entities, facts and edges from it, ' +
+          'and each extracted fact goes through the same bitemporal ' +
+          'resolver as `POST /v1/ingest/fact` — so extraction is noisy ' +
+          'by design and conflict resolution cleans up at read time. ' +
+          'Only `text` is required: `contextRef` defaults to the `chat` ' +
+          'vertical and `emittedAt` to the moment the request arrives. ' +
+          '`userId` stamps the per-user memory scope on the episode and ' +
+          'every extracted fact. `skipped: true` means the extractor ' +
+          'found nothing worth recording (`reason` says which check ' +
+          'stopped it) — that is a normal outcome, not an error. ' +
+          'Prefer `POST /v1/ingest/document` for anything long enough ' +
+          'to need chunking. ' +
+          'Source: src/ingest/ingest.controller.ts.',
+        scope: 'brain:write',
+        requestBody: jsonBody(ref('IngestMentionRequest')),
+        responses: {
+          '201': jsonResponse('What the extractor wrote.', ref('IngestMentionResponse')),
           '400': errorRef('BadRequest'),
           ...AUTH_ERRORS,
         },

--- a/src/contracts/ingest/ingest.schema.ts
+++ b/src/contracts/ingest/ingest.schema.ts
@@ -110,5 +110,66 @@ export const IngestFactResponseSchema = z.object({
   conflictExplanation: ConflictExplanationSchema.optional(),
 });
 
+/**
+ * Where a mention came from. Optional as a whole — a conversational
+ * capture has text and a user and nothing else it can honestly fill in
+ * — and defaulted to the `chat` vertical at the surface.
+ */
+export const MentionContextRefSchema = z.looseObject({
+  vertical: z.string(),
+  conversationId: z.string().optional(),
+  messageId: z.string().optional(),
+  eventId: z.string().optional(),
+  /**
+   * The producer of the mention, keyed into source trust as
+   * `vertical:recorder`. Absent defaults to the extraction model id, so
+   * LLM-extracted facts get a per-model trust bucket.
+   */
+  recorder: z.string().optional(),
+});
+
+/** A participant already known to the caller, for coreference anchoring. */
+export const KnownEntitySchema = z.looseObject({
+  vertical: z.string(),
+  id: z.string(),
+  /** `speaker` resolves first person, `addressee` resolves second. */
+  role: z.string().optional(),
+  name: z.string().optional(),
+});
+
+/**
+ * The simplest write: free text in, facts out. Only `text` is required —
+ * everything else has a surface default — which is what makes the
+ * two-line quickstart honest rather than a trimmed example.
+ */
+export const IngestMentionRequestSchema = z.strictObject({
+  /** ≤16 000 chars; the extractor truncates server-side as a backstop. */
+  text: z.string().max(16_000),
+  /** Defaults to `{ vertical: 'chat' }`. */
+  contextRef: MentionContextRefSchema.optional(),
+  knownEntities: z.array(KnownEntitySchema).optional(),
+  /**
+   * Per-user memory scope (migration 0055) — stamps the captured episode
+   * turn and every extracted fact. A user-bound token pins it to its own
+   * user; a mismatch is 403.
+   */
+  userId: z.string().max(200).optional(),
+  /** ISO-8601 event time. Defaults to the moment the request arrives. */
+  emittedAt: z.string().optional(),
+  /** IANA zone of the speaker's session, anchoring relative dates. */
+  timezone: z.string().max(64).optional(),
+});
+
+export const IngestMentionResponseSchema = z.object({
+  /** true when nothing was extracted — `reason` says why. */
+  skipped: z.boolean(),
+  reason: z.string().optional(),
+  extractedEntityIds: z.array(z.string()),
+  extractedFactIds: z.array(z.string()),
+  extractedEdgeIds: z.array(z.string()).optional(),
+});
+
 export type IngestFactRequest = z.infer<typeof IngestFactRequestSchema>;
 export type IngestFactResponse = z.infer<typeof IngestFactResponseSchema>;
+export type IngestMentionRequest = z.infer<typeof IngestMentionRequestSchema>;
+export type IngestMentionResponse = z.infer<typeof IngestMentionResponseSchema>;

--- a/src/ingest/dto/ingest-mention.dto.ts
+++ b/src/ingest/dto/ingest-mention.dto.ts
@@ -43,8 +43,21 @@ export class IngestMentionDto {
   @MaxLength(16_000)
   text!: string;
 
+  /**
+   * Where the text came from. Optional since the two-line quickstart:
+   * an agent capturing a conversation has a `text` and a user, and
+   * nothing else it can honestly fill in. Absent means the `chat`
+   * vertical, which is what a conversational mention is.
+   *
+   * The default is a property initializer rather than a service-side
+   * `??`: the global ValidationPipe runs with `transform: true`, so
+   * class-transformer constructs the DTO (running initializers) and
+   * then assigns the supplied keys over it. An absent key keeps the
+   * default, a supplied one wins, and every downstream reader still
+   * sees a required field — no optionality leaks past the surface.
+   */
   @IsObject()
-  contextRef!: MentionContextRef;
+  contextRef: MentionContextRef = { vertical: 'chat' };
 
   @IsOptional()
   @IsArray()
@@ -66,8 +79,14 @@ export class IngestMentionDto {
   @MaxLength(200)
   userId?: string | undefined;
 
+  /**
+   * Event time of the mention. Optional: "now" is right for anything
+   * captured live, and a caller replaying history — the case where this
+   * genuinely matters — always knows the timestamp and passes it.
+   * Evaluated per request, at DTO construction.
+   */
   @IsISO8601()
-  emittedAt!: string;
+  emittedAt: string = new Date().toISOString();
 
   /**
    * IANA timezone of the speaker's session (e.g. 'Asia/Tokyo'). Multilingual

--- a/test/ingest-mention-defaults.unit-spec.ts
+++ b/test/ingest-mention-defaults.unit-spec.ts
@@ -1,0 +1,89 @@
+/**
+ * The two-line write.
+ *
+ * `POST /v1/ingest/mention` used to demand `contextRef` and `emittedAt`
+ * on top of the text — five domain concepts before a first success,
+ * against a category norm of `add("text", user_id=…)`. They are now
+ * defaulted at the surface.
+ *
+ * The mechanism is a property initializer on the DTO, which only works
+ * because the global ValidationPipe runs with `transform: true`:
+ * class-transformer constructs the instance (running initializers) and
+ * then assigns the supplied keys over it. That is a load-bearing
+ * assumption about someone else's library, so it is tested through the
+ * real pipe rather than by constructing the class directly.
+ */
+import { ValidationPipe, BadRequestException } from '@nestjs/common';
+import { IngestMentionDto } from '../src/ingest/dto/ingest-mention.dto';
+
+const pipe = new ValidationPipe({
+  whitelist: true,
+  forbidNonWhitelisted: true,
+  transform: true,
+});
+
+const metadata = { type: 'body' as const, metatype: IngestMentionDto };
+const run = (body: unknown): Promise<IngestMentionDto> =>
+  pipe.transform(body, metadata) as Promise<IngestMentionDto>;
+
+describe('POST /v1/ingest/mention — surface defaults', () => {
+  it('accepts text alone', async () => {
+    const dto = await run({ text: 'Maria moved to Berlin in June.' });
+    expect(dto.contextRef).toEqual({ vertical: 'chat' });
+    expect(Number.isNaN(Date.parse(dto.emittedAt))).toBe(false);
+  });
+
+  it('accepts text plus a user, which is the whole quickstart', async () => {
+    const dto = await run({ text: 'Maria prefers morning appointments.', userId: 'user_42' });
+    expect(dto.userId).toBe('user_42');
+    expect(dto.contextRef.vertical).toBe('chat');
+  });
+
+  it('lets a caller that knows better win', async () => {
+    const dto = await run({
+      text: 'Maria moved to Berlin.',
+      contextRef: { vertical: 'rent', conversationId: 'conv_1', recorder: 'crm-sync' },
+      emittedAt: '2026-06-01T10:00:00Z',
+    });
+    expect(dto.contextRef).toEqual({
+      vertical: 'rent',
+      conversationId: 'conv_1',
+      recorder: 'crm-sync',
+    });
+    expect(dto.emittedAt).toBe('2026-06-01T10:00:00Z');
+  });
+
+  it('stamps the arrival time, not a fixed date', async () => {
+    const before = Date.now();
+    const dto = await run({ text: 'Anything at all, long enough to be a mention.' });
+    const stamped = Date.parse(dto.emittedAt);
+    expect(stamped).toBeGreaterThanOrEqual(before - 1000);
+    expect(stamped).toBeLessThanOrEqual(Date.now() + 1000);
+  });
+
+  it('gives each request its own default object, not a shared one', async () => {
+    // A default shared across requests would let one tenant's mutation
+    // leak into the next request's contextRef.
+    const a = await run({ text: 'First mention, long enough to pass validation.' });
+    const b = await run({ text: 'Second mention, long enough to pass validation.' });
+    expect(a.contextRef).not.toBe(b.contextRef);
+  });
+
+  it('still rejects a mention with no text', async () => {
+    await expect(run({ userId: 'user_42' })).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('still rejects a malformed emittedAt rather than silently defaulting it', async () => {
+    // Defaulting an absent value is a convenience; defaulting a WRONG
+    // value would be brain quietly recording the wrong event time.
+    await expect(run({ text: 'Maria moved.', emittedAt: 'last tuesday' })).rejects.toBeInstanceOf(
+      BadRequestException,
+    );
+  });
+
+  it('still rejects unknown keys', async () => {
+    await expect(run({ text: 'Maria moved.', vertical: 'rent' })).rejects.toBeInstanceOf(
+      BadRequestException,
+    );
+  });
+});

--- a/test/ingest-mention-minimal.e2e-spec.ts
+++ b/test/ingest-mention-minimal.e2e-spec.ts
@@ -1,0 +1,95 @@
+/**
+ * The two-line write, end to end.
+ *
+ * `test/ingest-mention-defaults.unit-spec.ts` proves the ValidationPipe
+ * fills the defaults. This proves nothing downstream trips over them:
+ * the episode, the extracted facts and their source key all have to
+ * come out right from a body that carried only `text` and `userId`.
+ */
+import type { AppFixture } from './app-fixture';
+import { createApp } from './app-fixture';
+import { SurrealService } from '../src/db/surreal.service';
+
+describe('POST /v1/ingest/mention with text alone', () => {
+  let f: AppFixture;
+  let surreal: SurrealService;
+
+  beforeAll(async () => {
+    f = await createApp({ companyId: `co_minmention_${Date.now()}` });
+    surreal = f.app.get(SurrealService);
+    f.extractor.setScript({
+      entities: [{ name: 'Maria', type: 'customer' }],
+      facts: [
+        {
+          entityIndex: 0,
+          predicate: 'lives_in',
+          object: 'Berlin',
+          confidence: 0.9,
+        },
+      ],
+      edges: [],
+    });
+  });
+
+  afterAll(async () => {
+    if (f) await f.close();
+  });
+
+  it('accepts the body the quickstart shows and writes a fact', async () => {
+    const before = Date.now();
+    const res = await f.http
+      .post('/v1/ingest/mention')
+      .set({ Authorization: `Bearer ${f.apiKey}` })
+      .send({
+        text: 'Maria moved to Berlin in June and prefers morning appointments.',
+        userId: 'user_42',
+      });
+
+    expect(res.status).toBe(201);
+    expect(res.body.skipped).toBe(false);
+    expect(res.body.extractedFactIds?.length).toBeGreaterThan(0);
+
+    const factId = String(res.body.extractedFactIds[0]);
+    const row = await surreal.withCompany(f.companyId, async (db) => {
+      const tail = factId.includes(':') ? factId.split(':')[1] : factId;
+      const [rows] = await db.query<Record<string, unknown>[][]>(
+        `SELECT source, userId, validFrom FROM type::record('knowledge_fact', $t)`,
+        { t: tail },
+      );
+      return rows?.[0] ?? null;
+    });
+
+    expect(row).not.toBeNull();
+    // The default vertical rides all the way into the stored source, so
+    // source trust keys on `chat:<model>` rather than on nothing.
+    expect((row?.source as { vertical?: string })?.vertical).toBe('chat');
+    // The per-user fence still applies — the one field the caller did send.
+    expect(row?.userId).toBe('user_42');
+    // emittedAt defaulted to request time, and validFrom follows it.
+    const validFrom = Date.parse(String(row?.validFrom));
+    expect(validFrom).toBeGreaterThanOrEqual(before - 60_000);
+    expect(validFrom).toBeLessThanOrEqual(Date.now() + 60_000);
+  });
+
+  it('still fences the read: the fact is invisible without the same userId', async () => {
+    const mine = await f.http
+      .post('/v1/search')
+      .set({ Authorization: `Bearer ${f.apiKey}` })
+      .send({ query: 'Maria Berlin', userId: 'user_42', limit: 5 });
+    expect(mine.status).toBe(201);
+    const mineFacts = (mine.body.results ?? []).flatMap(
+      (hit: { facts?: unknown[] }) => hit.facts ?? [],
+    );
+    expect(mineFacts.length).toBeGreaterThan(0);
+
+    const global = await f.http
+      .post('/v1/search')
+      .set({ Authorization: `Bearer ${f.apiKey}` })
+      .send({ query: 'Maria Berlin', limit: 5 });
+    expect(global.status).toBe(201);
+    const globalFacts = (global.body.results ?? []).flatMap(
+      (hit: { facts?: unknown[] }) => hit.facts ?? [],
+    );
+    expect(globalFacts).toHaveLength(0);
+  });
+});

--- a/test/openapi-doc.unit-spec.ts
+++ b/test/openapi-doc.unit-spec.ts
@@ -21,6 +21,10 @@ const PLATFORM_OPERATIONS: Array<[string, string]> = [
   // The memory core — the README quick start's two calls plus the two
   // reasoning surfaces on the same retrieval stack. No feature flag.
   ['/v1/ingest/fact', 'post'],
+  // The simplest write — free text in, extraction handled. The quick
+  // start's first call, so it belongs in the published contract next to
+  // the typed path it fronts.
+  ['/v1/ingest/mention', 'post'],
   ['/v1/search', 'post'],
   ['/v1/search/multi-hop', 'post'],
   ['/v1/synthesize', 'post'],


### PR DESCRIPTION
Wave 1 item 12 (P2-8) of the [onboarding research](docs/roadmap/onboarding-research-2026-09.md), plus a documentation defect found while writing it.

## The first write was five concepts deep

The category norm is `add("text", user_id=…)`. Ours was `entityRef.vertical`, `predicate`, `object`, `validFrom`, `source.messageId` before a first success — and the endpoint that already does the easy thing, `/v1/ingest/mention`, appeared in neither the README quickstart nor the landing tabs.

`contextRef` and `emittedAt` are now defaulted at the surface:

```bash
curl -X POST "$BRAIN_URL/v1/ingest/mention" \
  -H "Authorization: Bearer $BRAIN_KEY" \
  -H "Content-Type: application/json" \
  -d '{ "text": "Maria moved to Berlin in June.", "userId": "user_42" }'
```

### How the defaults work, and why that needed testing

Property initializers on the DTO, not a service-side `??`. The global ValidationPipe runs with `transform: true`, so class-transformer constructs the instance (running initializers) and assigns supplied keys over it. Absent keeps the default, supplied wins, and **every downstream reader still sees a required field** — no optionality leaks past the surface.

That is a load-bearing assumption about someone else's library, so `test/ingest-mention-defaults.unit-spec.ts` drives the real pipe, including:

- each request gets its **own** default object (a shared one would let one tenant's mutation reach the next request)
- a **malformed** `emittedAt` is still a 400 — defaulting an absent value is a convenience, defaulting a wrong one would be brain quietly recording the wrong event time

`test/ingest-mention-minimal.e2e-spec.ts` then proves nothing downstream trips: the default `chat` vertical reaches the stored `source` (so source trust keys on `chat:<model>` rather than on nothing), the per-user fence still holds, and `validFrom` follows the defaulted event time.

`/v1/ingest/mention` also joins the published OpenAPI contract — it was missing while being the simplest write brain has.

## The ingest docs page described a different API

Found while rewriting the quickstart. `content/docs/{en,ru}/api/ingest.mdx` documented:

| Documented | Reality |
|---|---|
| `sourceVertical`, `source`, `entityHints`, `asOf` | `contextRef`, `knownEntities`, `emittedAt`, `timezone` |
| response `{entities, facts, cost}` | `{skipped, reason, extractedEntityIds, extractedFactIds, extractedEdgeIds}` |
| "All three accept an `Idempotency-Key` header" | implemented nowhere near `/v1/ingest/*` |
| `409` on key reuse, `422` on unregistered predicate | neither exists; predicates are open vocabulary by design |
| fact `outcome` with 4 values, `margin`, `contradicting` | 6 values, `supersededFactIds` / `competingFactIds` / `corroboratedFactId` |

All corrected in both locales, with the real mechanism written down: repeats are safe because the resolver **corroborates** them, which is also why retrying a timed-out write is the right move.

## Also updated

README, `docs/getting-started.md`, `docs/api.md`, both locales of the getting-started page, and the landing Quickstart tabs — which now lead with the mention path and keep the typed one as a `REST · typed` tab rather than as the first hurdle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB