### PR TITLE
fix(config): the catalogue told operators the strict-space guard was off

### DIFF
--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -1090,11 +1090,11 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
     key: 'EMBEDDING_SPACE_STRICT',
     category: 'embedder',
     // Read per-call in EmbedderService.serveProvider(), not the constructor.
-    defaultValue: '0',
+    defaultValue: '1',
     runtimeMutable: true,
     isBooleanFlag: true,
     description:
-      'Strict-space serving guard: when on, EmbedderService refuses (503) to serve a query embedded in a space INCOMPATIBLE (different dim / model / norm) with the primary configured space — the warmup-window failover from bge-m3 (1024) to the OpenAI fallback (1536) is the canonical case — instead of silently cross-space-comparing against the target rows. Off (default) → the existing warmup failover is byte-identical.',
+      'Strict-space serving guard: when on, EmbedderService refuses (503) to serve a query embedded in a space INCOMPATIBLE (different dim / model / norm) with the primary configured space — the warmup-window failover from bge-m3 (1024) to the OpenAI fallback (1536) is the canonical case — instead of silently cross-space-comparing against the target rows. On by default since the 2026-09-08 runtime audit made it the P1 fix for search taking foreign vectors during warmup. Set `0` to restore the old unsafe read path; writes stay guarded either way.',
   },
   {
     key: 'EMBEDDING_SPACE_DUAL_WRITE',

--- a/test/config-catalog-truth.unit-spec.ts
+++ b/test/config-catalog-truth.unit-spec.ts
@@ -159,6 +159,19 @@ describe('config catalogue truth gates (W6)', () => {
       for (const text of SOURCES.values()) {
         if (text.includes(`envFlagEnabled(process.env.${entry.key})`)) offUnlessSet = true;
         if (text.includes(`envFlagNotDisabled(process.env.${entry.key})`)) onUnlessCleared = true;
+        // Same two idioms reached through Nest's ConfigService instead of
+        // process.env — the DREAMS_* family and the embedder read that way,
+        // and matching only `process.env.` let EMBEDDING_SPACE_STRICT sit
+        // catalogued `0` for a month after it was made default-on as a P1.
+        for (const m of text.matchAll(
+          new RegExp(
+            `envFlag(Enabled|NotDisabled)\\(\\s*(?:this\\.)?configService\\.get(?:<[^>]*>)?\\(\\s*'${entry.key}'`,
+            'g',
+          ),
+        )) {
+          if (m[1] === 'Enabled') offUnlessSet = true;
+          else onUnlessCleared = true;
+        }
         if (
           text.includes(`process.env.${entry.key} ==`) ||
           text.includes(`process.env.${entry.key} ??`)


### PR DESCRIPTION
Found while answering "why are we still carrying flags that measure negative" — a different defect, in the other direction.

`EMBEDDING_SPACE_STRICT` was made default-on on 2026-09-08 as the P1 fix for search taking foreign vectors during the bge-m3 warmup window ([audit](../blob/main/docs/audits/runtime-auth-embedding-2026-09-08.md)). The catalogue still declared `0`, and the description still ended *"Off (default) → the existing warmup failover is byte-identical"*. So `GET /v1/admin/config` and the admin config screen reported a security-relevant guard as disabled while it was enforcing — the same class of lie as the surfaces in #582, pointing the other way.

**Why the new gate missed it:** #582's derivation matched `envFlagEnabled(process.env.KEY)` only. This flag is read as `envFlagNotDisabled(this.configService.get<string>('EMBEDDING_SPACE_STRICT'))`. Widened to both idioms through ConfigService; the `DREAMS_*` family reads the same way and is now covered.

**Verified the gate actually fires:** put `'0'` back and the suite fails with

```
EMBEDDING_SPACE_STRICT: catalogue says 0, code reads it with envFlagNotDisabled (default on)
```

A gate that cannot fail is not a gate, so this is checked rather than assumed.

5697 unit tests pass, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB