### PR TITLE
fix(ci): the pinned MinIO image vanished from Docker Hub

### DIFF
--- a/test/evidence-storage-adapter-contract.e2e-spec.ts
+++ b/test/evidence-storage-adapter-contract.e2e-spec.ts
@@ -26,7 +26,16 @@ import type { EvidenceStorageAdapter } from '../src/evidence/storage/storage-ada
 
 // Pinned: an object store's compatibility surface is exactly what this
 // suite is measuring, so `latest` would make a green run unrepeatable.
-const MINIO_IMAGE = 'minio/minio:RELEASE.2025-01-20T14-49-07Z';
+//
+// From quay.io, MinIO's own registry, and pinned BY DIGEST. The tag alone
+// on Docker Hub stopped resolving mid-2026-09 — `pull access denied for
+// minio/minio, repository does not exist` on a tag that had been pulling
+// for months, which failed every PR that touched this shard. quay.io
+// still serves the identical image; the digest means a tag that is moved
+// or withdrawn again fails loudly at pull time instead of silently
+// changing what this contract is measured against.
+const MINIO_IMAGE =
+  'quay.io/minio/minio:RELEASE.2025-01-20T14-49-07Z@sha256:ed9be66eb5f2636c18289c34c3b725ddf57815f2777c77b5938543b78a44f144';
 const ACCESS_KEY = 'minioadmin';
 const SECRET_KEY = 'minioadmin';
 const BUCKET = 'brain-evidence-contract';


### PR DESCRIPTION
**Blocking every PR that touches e2e shard 1**, including #583 — this is not that PR's change.

`minio/minio:RELEASE.2025-01-20T14-49-07Z` stopped resolving mid-2026-09:

```
(HTTP code 404) unexpected - pull access denied for minio/minio,
repository does not exist or may require 'docker login'
```

A tag that had been pulling for months. A rerun of the failed jobs reproduces it exactly, so it is not a Docker Hub rate limit — the repository is gone.

Repointed at **quay.io**, MinIO's own registry, which still serves the identical image, and pinned **by digest** so a tag that is moved or withdrawn again fails loudly at pull time instead of quietly changing the object store this contract is measured against.

```
$ docker pull minio/minio:RELEASE.2025-01-20T14-49-07Z
  → pull access denied, repository does not exist

$ docker pull quay.io/minio/minio:RELEASE.2025-01-20T14-49-07Z
  → sha256:ed9be66eb5f2636c18289c34c3b725ddf57815f2777c77b5938543b78a44f144
```

All 27 tests in the storage-adapter contract pass locally against the quay image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB