### PR TITLE
feat(outcomes): give the decision stream a reader, and switch capture on

### DIFF
--- a/src/admin/admin-memory-decisions.controller.ts
+++ b/src/admin/admin-memory-decisions.controller.ts
@@ -1,0 +1,67 @@
+import { Controller, Get, Query, Req, UseGuards } from '@nestjs/common';
+import { ApiKeyGuard, RequireScopes } from '../auth/api-key.guard';
+import type { AuthenticatedRequest } from '../auth/api-key.types';
+import { MemoryDecisionsReadService } from '../outcomes/memory-decisions-read.service';
+import type {
+  MemoryDecisionsResponse,
+  MemoryDecisionsStatsResponse,
+} from '../contracts/admin/memory-decisions.schema';
+
+/**
+ * Read side of the serving-path decision stream (0119): the trace feed
+ * (filterable, cursor-paginated, `?requestId=` pulls one request's whole
+ * decision chain) and the aggregates that make it a statistic rather
+ * than a log.
+ *
+ * The sibling of /v1/admin/policy/decisions, over a different question.
+ * That one answers "who was allowed to see what"; this one answers "why
+ * did the engine abstain, escalate or zoom, under which policy version,
+ * and what did it cost".
+ *
+ * Not gated by its own flag: the rows either exist (capture on) or the
+ * feed is empty, and an empty feed is the honest answer — a 404 here
+ * would only repeat the mistake the rest of this wave undid.
+ */
+@Controller('v1/admin/memory/decisions')
+@UseGuards(ApiKeyGuard)
+export class AdminMemoryDecisionsController {
+  constructor(private readonly decisions: MemoryDecisionsReadService) {}
+
+  @Get()
+  @RequireScopes('brain:admin')
+  async feed(
+    @Req() req: AuthenticatedRequest,
+    @Query()
+    q: {
+      decisionKind?: string;
+      chosenAction?: string;
+      policyVersion?: string;
+      requestId?: string;
+      limit?: string;
+      before?: string;
+    },
+  ): Promise<MemoryDecisionsResponse> {
+    const parsedLimit = q.limit ? parseInt(q.limit, 10) : undefined;
+    return await this.decisions.feed(req.brainAuth.companyId, {
+      ...(q.decisionKind ? { decisionKind: q.decisionKind } : {}),
+      ...(q.chosenAction ? { chosenAction: q.chosenAction } : {}),
+      ...(q.policyVersion ? { policyVersion: q.policyVersion } : {}),
+      ...(q.requestId ? { requestId: q.requestId } : {}),
+      ...(parsedLimit !== undefined && Number.isFinite(parsedLimit) ? { limit: parsedLimit } : {}),
+      ...(q.before ? { before: q.before } : {}),
+    });
+  }
+
+  @Get('stats')
+  @RequireScopes('brain:admin')
+  async stats(
+    @Req() req: AuthenticatedRequest,
+    @Query('windowDays') windowDays?: string,
+  ): Promise<MemoryDecisionsStatsResponse> {
+    const days = windowDays ? parseInt(windowDays, 10) : 7;
+    return await this.decisions.stats(
+      req.brainAuth.companyId,
+      Number.isFinite(days) && days > 0 ? days : 7,
+    );
+  }
+}

--- a/src/admin/admin.module.ts
+++ b/src/admin/admin.module.ts
@@ -31,6 +31,8 @@ import { AdminPacksController } from './admin-packs.controller';
 import { AdminPoliciesController } from './admin-policies.controller';
 import { AdminPolicyController } from './admin-policy.controller';
 import { AdminPolicyDecisionsController } from './admin-policy-decisions.controller';
+import { AdminMemoryDecisionsController } from './admin-memory-decisions.controller';
+import { MemoryDecisionsReadService } from '../outcomes/memory-decisions-read.service';
 import { AdminKeysController } from './admin-keys.controller';
 import { AdminCodeMemoryController } from './admin-code-memory.controller';
 import { AdminHnswController } from './admin-hnsw.controller';
@@ -116,6 +118,7 @@ import { ConfigInspectorService } from './config-inspector.service';
     AdminPoliciesController,
     AdminPolicyController,
     AdminPolicyDecisionsController,
+    AdminMemoryDecisionsController,
     AdminKeysController,
     AdminCodeMemoryController,
     AdminHnswController,
@@ -128,6 +131,7 @@ import { ConfigInspectorService } from './config-inspector.service';
   ],
   providers: [
     AdminService,
+    MemoryDecisionsReadService,
     HnswMaintenanceService,
     HnswProvisionService,
     VectorCorpusService,

--- a/src/admin/config-catalog.data.ts
+++ b/src/admin/config-catalog.data.ts
@@ -265,11 +265,11 @@ export const CONFIG_CATALOG: ConfigCatalogSpec[] = [
   {
     key: 'OUTCOME_DECISION_CAPTURE',
     category: 'audit',
-    defaultValue: '0',
+    defaultValue: '1',
     runtimeMutable: true,
     isBooleanFlag: true,
     description:
-      'Decision-context telemetry (0119): content-free memory_decision rows at the abstain gate and the L3 escalation trigger, plus the decisionId join columns on memory_outcome / focus_signal_sample and the nightly decision prune leg. Independent master — not coupled to OUTCOME_TELEMETRY_ENABLED.',
+      'Decision-context telemetry (0119): content-free memory_decision rows at the abstain gate and the L3 escalation trigger, plus the decisionId join columns on memory_outcome / focus_signal_sample and the nightly decision prune leg. Independent master — not coupled to OUTCOME_TELEMETRY_ENABLED. On by default since the read side landed (GET /v1/admin/memory/decisions + /stats); rows are content-free, one per decision seam per request, bounded by the nightly prune.',
   },
   {
     key: 'OUTCOME_DECISION_RETENTION_DAYS',

--- a/src/common/outcome-flags.ts
+++ b/src/common/outcome-flags.ts
@@ -1,4 +1,4 @@
-import { envFlagEnabled } from './env-validation';
+import { envFlagEnabled, envFlagNotDisabled } from './env-validation';
 
 /**
  * Outcome telemetry (0107) master flag — OUTCOME_TELEMETRY_ENABLED.
@@ -63,11 +63,19 @@ export function outcomeTxWritesEnabled(): boolean {
  * or without the outcome stream. The env read lives here in the common
  * layer, NOT inside the engine dirs (engine-gates S5.2); engine callers
  * reach it via the MemoryDecisionService static. Read at call time so a
- * flip is runtime-mutable. Default off ⇒ no decision row is ever
- * written and no join column is ever stamped — serving byte-identical.
+ * flip is runtime-mutable.
+ *
+ * DEFAULT ON, now that there is somewhere to read it
+ * (GET /v1/admin/memory/decisions). It shipped off and stayed off, which
+ * meant the only record of WHY the engine abstained or escalated was
+ * written nowhere — and the flags that would be judged by that record
+ * had to be judged by a benchmark instead. The rows are content-free by
+ * contract, one per decision seam per request, bounded by the nightly
+ * prune. Set `OUTCOME_DECISION_CAPTURE=0` and no decision row is written
+ * and no join column is stamped — serving byte-identical.
  */
 export function outcomeDecisionCaptureEnabled(): boolean {
-  return envFlagEnabled(process.env.OUTCOME_DECISION_CAPTURE);
+  return envFlagNotDisabled(process.env.OUTCOME_DECISION_CAPTURE);
 }
 
 /** Default raw-event retention window for the nightly prune (days). */

--- a/src/contracts/admin/memory-decisions.schema.ts
+++ b/src/contracts/admin/memory-decisions.schema.ts
@@ -1,0 +1,72 @@
+import { z } from 'zod';
+
+/**
+ * Wire contracts for the serving-path decision stream (migration 0119):
+ *   GET /v1/admin/memory/decisions (+ /stats)
+ *
+ * The sibling of the ABAC feed in policy-tools.schema.ts, over a
+ * different question. That one answers "who was allowed to see what";
+ * this one answers "why did the engine abstain, escalate or zoom" —
+ * with the policy version that decided it, the alternatives it turned
+ * down, and what the choice cost.
+ *
+ * Rows are content-free by contract (0119): ids, enums and numbers, no
+ * query text, no fact text, no answer text. Nothing in these responses
+ * can widen that.
+ */
+
+export const DecisionKindSchema = z.enum(['l3_escalation', 'abstain', 'lane_route', 'zoom']);
+
+/** One decision as served. Optional fields are absent, never null. */
+export const MemoryDecisionSchema = z.object({
+  decisionId: z.string(),
+  decisionKind: DecisionKindSchema,
+  policyVersion: z.string(),
+  chosenAction: z.string(),
+  createdAt: z.string(),
+  requestId: z.string().optional(),
+  actionScore: z.number().optional(),
+  /** Whitelisted signal numbers plus queryClass — the writer's contract. */
+  observedState: z.record(z.string(), z.union([z.number(), z.string()])).optional(),
+  alternatives: z.array(z.object({ action: z.string(), score: z.number() })).optional(),
+  costs: z.record(z.string(), z.number()).optional(),
+});
+
+export const MemoryDecisionsResponseSchema = z.object({
+  decisions: z.array(MemoryDecisionSchema),
+  /** Cursor for the next page: the last row's createdAt. */
+  nextCursor: z.string().optional(),
+});
+
+/**
+ * The aggregate the feed exists for. A decision stream read one row at a
+ * time answers nothing; the questions are "how often does the abstain
+ * gate fire, under which policy version, and what does escalation cost".
+ */
+export const MemoryDecisionsStatsResponseSchema = z.object({
+  windowDays: z.number(),
+  /** Rows scanned — reported so a truncated window is never read as a trend. */
+  sampled: z.number(),
+  truncated: z.boolean(),
+  /** Per (kind, chosenAction): how often, and what it cost on average. */
+  byAction: z.array(
+    z.object({
+      decisionKind: DecisionKindSchema,
+      chosenAction: z.string(),
+      count: z.number(),
+      avgLatencyMs: z.number().optional(),
+      avgPromptTokens: z.number().optional(),
+      avgCompletionTokens: z.number().optional(),
+    }),
+  ),
+  /** Per policy version: the A/B axis a policy change is read on. */
+  byPolicyVersion: z.array(
+    z.object({ policyVersion: z.string(), count: z.number(), kinds: z.array(DecisionKindSchema) }),
+  ),
+  /** Per day, per kind — the shape that shows a regression arriving. */
+  series: z.array(z.object({ day: z.string(), counts: z.record(z.string(), z.number()) })),
+});
+
+export type MemoryDecision = z.infer<typeof MemoryDecisionSchema>;
+export type MemoryDecisionsResponse = z.infer<typeof MemoryDecisionsResponseSchema>;
+export type MemoryDecisionsStatsResponse = z.infer<typeof MemoryDecisionsStatsResponseSchema>;

--- a/src/outcomes/memory-decisions-read.service.ts
+++ b/src/outcomes/memory-decisions-read.service.ts
@@ -1,0 +1,272 @@
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { SurrealService, queryRows } from '../db/surreal.service';
+import type {
+  MemoryDecision,
+  MemoryDecisionsResponse,
+  MemoryDecisionsStatsResponse,
+} from '../contracts/admin/memory-decisions.schema';
+
+/**
+ * Read side of the serving-path decision stream (migration 0119).
+ *
+ * 0119 shipped a writer, three indexes (`createdAt`, `requestId`,
+ * `decisionId`) and a retention cron — and no reader. Outside
+ * MemoryDecisionService, every query against the table was the GDPR
+ * forget cascade or the nightly prune: it wrote rows that existed only
+ * to be deleted. This is the consumer the schema was built for.
+ *
+ * Shape follows PolicyDecisionsService deliberately — feed + stats,
+ * cursor on the ordering column, aggregates computed in-process over a
+ * capped scan. Two surfaces answering "why did the engine decide that"
+ * should not have two idioms.
+ */
+
+/** SurrealDB returns datetimes as a Date on 3.x and an ISO string via JSON. */
+type RawDateTime = string | number | Date;
+
+interface DecisionReadRow {
+  decisionId: unknown;
+  decisionKind: MemoryDecision['decisionKind'];
+  policyVersion: unknown;
+  chosenAction: unknown;
+  createdAt: RawDateTime;
+  requestId?: unknown;
+  actionScore?: unknown;
+  observedState?: Record<string, unknown> | null;
+  alternatives?: Array<{ action?: unknown; score?: unknown }> | null;
+  costs?: Record<string, unknown> | null;
+}
+
+const FEED_MAX_LIMIT = 200;
+const FEED_DEFAULT_LIMIT = 50;
+
+/**
+ * Ceiling on the stats scan. A tenant serving steadily produces one row
+ * per abstain/escalate/zoom decision, so a 30-day window is unbounded in
+ * principle; the response reports `sampled` and `truncated` so a capped
+ * scan is never silently read as the whole window.
+ */
+const STATS_ROW_CAP = 20_000;
+
+const KINDS = ['l3_escalation', 'abstain', 'lane_route', 'zoom'] as const;
+
+function isoOf(value: RawDateTime): string {
+  return value instanceof Date ? value.toISOString() : new Date(value).toISOString();
+}
+
+/** Numbers only, finite only — the row is content-free and stays that way. */
+function numberRecord(raw: Record<string, unknown> | null | undefined): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const [k, v] of Object.entries(raw ?? {})) {
+    if (typeof v === 'number' && Number.isFinite(v)) out[k] = v;
+  }
+  return out;
+}
+
+function mapRow(row: DecisionReadRow): MemoryDecision {
+  // observedState is FLEXIBLE in 0119, so the read side cannot assume the
+  // writer's whitelist held for every row already stored: admit finite
+  // numbers and strings, drop everything else rather than serve an object
+  // the content-free contract never promised.
+  const observed: Record<string, number | string> = {};
+  for (const [k, v] of Object.entries(row.observedState ?? {})) {
+    const keep = typeof v === 'string' || (typeof v === 'number' && Number.isFinite(v));
+    if (keep) observed[k] = v as number | string;
+  }
+  const alternatives = (row.alternatives ?? [])
+    .filter((a) => typeof a.action === 'string' && typeof a.score === 'number')
+    .map((a) => ({ action: String(a.action), score: Number(a.score) }));
+  const costs = numberRecord(row.costs);
+
+  return {
+    decisionId: String(row.decisionId),
+    decisionKind: row.decisionKind,
+    policyVersion: String(row.policyVersion),
+    chosenAction: String(row.chosenAction),
+    createdAt: isoOf(row.createdAt),
+    ...(typeof row.requestId === 'string' ? { requestId: row.requestId } : {}),
+    ...(typeof row.actionScore === 'number' ? { actionScore: row.actionScore } : {}),
+    ...(Object.keys(observed).length > 0 ? { observedState: observed } : {}),
+    ...(alternatives.length > 0 ? { alternatives } : {}),
+    ...(Object.keys(costs).length > 0 ? { costs } : {}),
+  };
+}
+
+/** Running mean that never divides by zero and never carries a NaN out. */
+function mean(total: number, n: number): number | undefined {
+  return n > 0 ? Math.round((total / n) * 100) / 100 : undefined;
+}
+
+interface ActionTally {
+  count: number;
+  latency: { total: number; n: number };
+  prompt: { total: number; n: number };
+  completion: { total: number; n: number };
+}
+
+function addCost(tally: { total: number; n: number }, value: unknown): void {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    tally.total += value;
+    tally.n += 1;
+  }
+}
+
+@Injectable()
+export class MemoryDecisionsReadService {
+  constructor(private readonly surreal: SurrealService) {}
+
+  async feed(
+    companyId: string,
+    filters: {
+      decisionKind?: string;
+      chosenAction?: string;
+      policyVersion?: string;
+      requestId?: string;
+      limit?: number;
+      before?: string;
+    },
+  ): Promise<MemoryDecisionsResponse> {
+    const limit = Math.min(Math.max(filters.limit ?? FEED_DEFAULT_LIMIT, 1), FEED_MAX_LIMIT);
+    const clauses: string[] = [];
+    const params: Record<string, unknown> = { limit: limit + 1 };
+
+    if (filters.decisionKind !== undefined) {
+      if (!KINDS.includes(filters.decisionKind as (typeof KINDS)[number])) {
+        throw new BadRequestException(
+          `Unknown decisionKind '${filters.decisionKind}' — expected one of ${KINDS.join(', ')}`,
+        );
+      }
+      clauses.push('decisionKind = $decisionKind');
+      params.decisionKind = filters.decisionKind;
+    }
+    if (filters.chosenAction !== undefined) {
+      clauses.push('chosenAction = $chosenAction');
+      params.chosenAction = filters.chosenAction;
+    }
+    if (filters.policyVersion !== undefined) {
+      clauses.push('policyVersion = $policyVersion');
+      params.policyVersion = filters.policyVersion;
+    }
+    if (filters.requestId !== undefined) {
+      // The whole point of the requestId index: pull every decision one
+      // request made, in order, as one trace.
+      clauses.push('requestId = $requestId');
+      params.requestId = filters.requestId;
+    }
+    if (filters.before !== undefined) {
+      const before = new Date(filters.before);
+      if (Number.isNaN(before.getTime())) {
+        throw new BadRequestException('before must be an ISO datetime');
+      }
+      clauses.push('createdAt < $before');
+      params.before = before;
+    }
+
+    const where = clauses.length > 0 ? `WHERE ${clauses.join(' AND ')}` : '';
+    const rows = await this.surreal.withCompany(companyId, (db) =>
+      queryRows<DecisionReadRow>(
+        db,
+        `SELECT decisionId, decisionKind, policyVersion, chosenAction, createdAt,
+                requestId, actionScore, observedState, alternatives, costs
+           FROM memory_decision ${where}
+          ORDER BY createdAt DESC LIMIT $limit`,
+        params,
+      ),
+    );
+
+    const page = rows.slice(0, limit);
+    const decisions = page.map(mapRow);
+    return {
+      decisions,
+      ...(rows.length > limit && decisions.length > 0
+        ? { nextCursor: decisions[decisions.length - 1]!.createdAt }
+        : {}),
+    };
+  }
+
+  async stats(companyId: string, windowDays = 7): Promise<MemoryDecisionsStatsResponse> {
+    const days = Math.min(Math.max(windowDays, 1), 30);
+    const rows = await this.surreal.withCompany(companyId, (db) =>
+      queryRows<DecisionReadRow>(
+        db,
+        `SELECT decisionKind, policyVersion, chosenAction, createdAt, costs
+           FROM memory_decision
+          WHERE createdAt > time::now() - ${days}d
+          ORDER BY createdAt DESC
+          LIMIT ${STATS_ROW_CAP}`,
+      ),
+    );
+
+    const byAction = new Map<
+      string,
+      ActionTally & { kind: MemoryDecision['decisionKind']; action: string }
+    >();
+    const byVersion = new Map<string, { count: number; kinds: Set<string> }>();
+    const series = new Map<string, Record<string, number>>();
+
+    for (const row of rows) {
+      const kind = row.decisionKind;
+      const action = String(row.chosenAction);
+      // JSON, not a delimiter character: chosenAction is a caller-shaped
+      // string ('skip:<reason>'), so any literal separator is a guess about
+      // what cannot appear inside it.
+      const key = JSON.stringify([kind, action]);
+      const tally = byAction.get(key) ?? {
+        kind,
+        action,
+        count: 0,
+        latency: { total: 0, n: 0 },
+        prompt: { total: 0, n: 0 },
+        completion: { total: 0, n: 0 },
+      };
+      tally.count += 1;
+      addCost(tally.latency, row.costs?.latencyMs);
+      addCost(tally.prompt, row.costs?.promptTokens);
+      addCost(tally.completion, row.costs?.completionTokens);
+      byAction.set(key, tally);
+
+      const version = String(row.policyVersion);
+      const v = byVersion.get(version) ?? { count: 0, kinds: new Set<string>() };
+      v.count += 1;
+      v.kinds.add(kind);
+      byVersion.set(version, v);
+
+      const day = isoOf(row.createdAt).slice(0, 10);
+      const bucket = series.get(day) ?? {};
+      bucket[kind] = (bucket[kind] ?? 0) + 1;
+      series.set(day, bucket);
+    }
+
+    return {
+      windowDays: days,
+      sampled: rows.length,
+      truncated: rows.length >= STATS_ROW_CAP,
+      byAction: [...byAction.values()]
+        .sort((a, b) => b.count - a.count)
+        .map((t) => ({
+          decisionKind: t.kind,
+          chosenAction: t.action,
+          count: t.count,
+          ...(mean(t.latency.total, t.latency.n) !== undefined
+            ? { avgLatencyMs: mean(t.latency.total, t.latency.n)! }
+            : {}),
+          ...(mean(t.prompt.total, t.prompt.n) !== undefined
+            ? { avgPromptTokens: mean(t.prompt.total, t.prompt.n)! }
+            : {}),
+          ...(mean(t.completion.total, t.completion.n) !== undefined
+            ? { avgCompletionTokens: mean(t.completion.total, t.completion.n)! }
+            : {}),
+        })),
+      byPolicyVersion: [...byVersion.entries()]
+        .sort((a, b) => b[1].count - a[1].count)
+        .map(([policyVersion, v]) => ({
+          policyVersion,
+          count: v.count,
+          kinds: [...v.kinds] as MemoryDecision['decisionKind'][],
+        })),
+      series: [...series.entries()]
+        .sort((a, b) => (a[0] < b[0] ? -1 : 1))
+        .map(([day, counts]) => ({ day, counts })),
+    };
+  }
+}

--- a/test/lease-guard-sweeps.unit-spec.ts
+++ b/test/lease-guard-sweeps.unit-spec.ts
@@ -103,9 +103,13 @@ function prune(guard?: DistributedLeaseGuard) {
 describe('OutcomePruneService — nightly prune under the distributed lease', () => {
   beforeEach(() => {
     process.env.OUTCOME_TELEMETRY_ENABLED = '1';
+    // The decision leg (0119) is default-on; this suite isolates the
+    // other legs, so it says so rather than relying on a default.
+    process.env.OUTCOME_DECISION_CAPTURE = '0';
   });
   afterEach(() => {
     delete process.env.OUTCOME_TELEMETRY_ENABLED;
+    delete process.env.OUTCOME_DECISION_CAPTURE;
   });
 
   it('walks the roster under outcome_prune with an hour of TTL', async () => {

--- a/test/memory-decision.e2e-spec.ts
+++ b/test/memory-decision.e2e-spec.ts
@@ -277,7 +277,7 @@ describe('memory_decision — decision-context capture, joins and cascade', () =
   });
 
   it('(e) capture off ⇒ zero decision rows (byte-identical)', async () => {
-    delete process.env.OUTCOME_DECISION_CAPTURE;
+    process.env.OUTCOME_DECISION_CAPTURE = '0';
     process.env.RETRIEVAL_ABSTENTION_CALIBRATION = 'coverage';
     try {
       await purgeDecisions();

--- a/test/memory-decision.unit-spec.ts
+++ b/test/memory-decision.unit-spec.ts
@@ -159,7 +159,7 @@ describe('MemoryDecisionService.record', () => {
   });
 
   it('is a no-op returning undefined with the flag off', async () => {
-    delete process.env.OUTCOME_DECISION_CAPTURE;
+    process.env.OUTCOME_DECISION_CAPTURE = '0';
     const captured: CapturedQuery[] = [];
     const svc = new MemoryDecisionService(makeSurreal(captured));
     expect(svc.record('co_x', baseInput)).toBeUndefined();

--- a/test/memory-decisions-read.unit-spec.ts
+++ b/test/memory-decisions-read.unit-spec.ts
@@ -1,0 +1,187 @@
+/**
+ * Read side of the 0119 decision stream.
+ *
+ * The table shipped with a writer, three indexes and a retention cron,
+ * and no reader — so these gates are about the two things that make a
+ * reader worth having: it must not widen the content-free contract, and
+ * its aggregate must be honest about a truncated scan.
+ */
+import { BadRequestException } from '@nestjs/common';
+import { MemoryDecisionsReadService } from '../src/outcomes/memory-decisions-read.service';
+import type { SurrealService } from '../src/db/surreal.service';
+
+interface Captured {
+  sql: string;
+  params: Record<string, unknown>;
+}
+
+function makeSurreal(captured: Captured[], rows: unknown[] = []): SurrealService {
+  return {
+    withCompany: async <T>(_c: string, fn: (db: unknown) => Promise<T>): Promise<T> =>
+      fn({
+        query: async (sql: string, params: Record<string, unknown> = {}) => {
+          captured.push({ sql, params });
+          return [rows];
+        },
+      }),
+  } as unknown as SurrealService;
+}
+
+const row = (over: Record<string, unknown> = {}) => ({
+  decisionId: 'd1',
+  decisionKind: 'abstain',
+  policyVersion: 'static',
+  chosenAction: 'abstain',
+  createdAt: new Date('2026-09-10T12:00:00.000Z'),
+  ...over,
+});
+
+describe('MemoryDecisionsReadService.feed', () => {
+  it('orders by createdAt and pages with a cursor only when more rows exist', async () => {
+    const captured: Captured[] = [];
+    const rows = [row({ decisionId: 'a' }), row({ decisionId: 'b' }), row({ decisionId: 'c' })];
+    const svc = new MemoryDecisionsReadService(makeSurreal(captured, rows));
+
+    const res = await svc.feed('co', { limit: 2 });
+
+    expect(captured[0]!.sql).toContain('ORDER BY createdAt DESC');
+    // limit + 1 is how "is there another page" is answered without a count.
+    expect(captured[0]!.params.limit).toBe(3);
+    expect(res.decisions.map((d) => d.decisionId)).toEqual(['a', 'b']);
+    expect(res.nextCursor).toBe('2026-09-10T12:00:00.000Z');
+  });
+
+  it('omits the cursor on the last page', async () => {
+    const svc = new MemoryDecisionsReadService(makeSurreal([], [row()]));
+    const res = await svc.feed('co', { limit: 5 });
+    expect(res.decisions).toHaveLength(1);
+    expect(res.nextCursor).toBeUndefined();
+  });
+
+  it('pulls one request whole decision chain through the requestId index', async () => {
+    const captured: Captured[] = [];
+    const svc = new MemoryDecisionsReadService(makeSurreal(captured, [row()]));
+    await svc.feed('co', { requestId: 'req-7' });
+    expect(captured[0]!.sql).toContain('requestId = $requestId');
+    expect(captured[0]!.params.requestId).toBe('req-7');
+  });
+
+  it('refuses a decisionKind outside the migration enum instead of querying', async () => {
+    const captured: Captured[] = [];
+    const svc = new MemoryDecisionsReadService(makeSurreal(captured));
+    await expect(svc.feed('co', { decisionKind: 'made_up' })).rejects.toThrow(BadRequestException);
+    expect(captured).toEqual([]);
+  });
+
+  it('refuses a non-ISO cursor instead of querying', async () => {
+    const captured: Captured[] = [];
+    const svc = new MemoryDecisionsReadService(makeSurreal(captured));
+    await expect(svc.feed('co', { before: 'yesterday' })).rejects.toThrow(BadRequestException);
+    expect(captured).toEqual([]);
+  });
+
+  it('never carries a non-number, non-string value out of observedState', async () => {
+    // 0119 declares observedState FLEXIBLE, so the read side cannot
+    // assume the writer's whitelist held for every row already stored.
+    const svc = new MemoryDecisionsReadService(
+      makeSurreal(
+        [],
+        [
+          row({
+            observedState: {
+              topScore: 0.4,
+              queryClass: 'temporal',
+              leaked: { note: 'free text' },
+              alsoLeaked: ['a'],
+              nan: Number.NaN,
+            },
+          }),
+        ],
+      ),
+    );
+    const [d] = (await svc.feed('co', {})).decisions;
+    expect(d!.observedState).toEqual({ topScore: 0.4, queryClass: 'temporal' });
+  });
+
+  it('drops malformed alternatives rather than serving half a pair', async () => {
+    const svc = new MemoryDecisionsReadService(
+      makeSurreal(
+        [],
+        [
+          row({
+            alternatives: [
+              { action: 'escalate', score: 0.7 },
+              { action: 'proceed' },
+              { score: 0.1 },
+            ],
+          }),
+        ],
+      ),
+    );
+    const [d] = (await svc.feed('co', {})).decisions;
+    expect(d!.alternatives).toEqual([{ action: 'escalate', score: 0.7 }]);
+  });
+});
+
+describe('MemoryDecisionsReadService.stats', () => {
+  it('groups by (kind, action) and averages only the costs that are present', async () => {
+    const rows = [
+      row({ chosenAction: 'abstain', costs: { latencyMs: 100 } }),
+      row({ chosenAction: 'abstain', costs: { latencyMs: 200, promptTokens: 50 } }),
+      row({ decisionKind: 'l3_escalation', chosenAction: 'escalate' }),
+    ];
+    const svc = new MemoryDecisionsReadService(makeSurreal([], rows));
+    const res = await svc.stats('co', 7);
+
+    const abstain = res.byAction.find((a) => a.chosenAction === 'abstain');
+    expect(abstain).toMatchObject({ count: 2, avgLatencyMs: 150, avgPromptTokens: 50 });
+    // Averaged over the rows that HAVE the cost, not over all rows —
+    // otherwise a partially-instrumented seam reads as cheaper than it is.
+    const escalate = res.byAction.find((a) => a.chosenAction === 'escalate');
+    expect(escalate!.avgLatencyMs).toBeUndefined();
+  });
+
+  it('reports the sample size and says when the scan was truncated', async () => {
+    const svc = new MemoryDecisionsReadService(makeSurreal([], [row(), row()]));
+    const res = await svc.stats('co', 7);
+    expect(res.sampled).toBe(2);
+    // A capped scan read as a whole window is how a "trend" gets invented.
+    expect(res.truncated).toBe(false);
+  });
+
+  it('clamps the window to the retention range', async () => {
+    const captured: Captured[] = [];
+    const svc = new MemoryDecisionsReadService(makeSurreal(captured));
+    await svc.stats('co', 9999);
+    expect(captured[0]!.sql).toContain('time::now() - 30d');
+  });
+
+  it('buckets the series by day and counts per kind', async () => {
+    const rows = [
+      row({ createdAt: new Date('2026-09-10T01:00:00Z') }),
+      row({ createdAt: new Date('2026-09-10T23:00:00Z'), decisionKind: 'zoom' }),
+      row({ createdAt: new Date('2026-09-11T01:00:00Z') }),
+    ];
+    const svc = new MemoryDecisionsReadService(makeSurreal([], rows));
+    const res = await svc.stats('co', 7);
+    expect(res.series).toEqual([
+      { day: '2026-09-10', counts: { abstain: 1, zoom: 1 } },
+      { day: '2026-09-11', counts: { abstain: 1 } },
+    ]);
+  });
+
+  it('counts policy versions — the axis a policy change is read on', async () => {
+    const rows = [
+      row({ policyVersion: 'static' }),
+      row({ policyVersion: 'adaptive@thr=0.5', decisionKind: 'l3_escalation' }),
+      row({ policyVersion: 'adaptive@thr=0.5' }),
+    ];
+    const svc = new MemoryDecisionsReadService(makeSurreal([], rows));
+    const res = await svc.stats('co', 7);
+    expect(res.byPolicyVersion[0]).toMatchObject({
+      policyVersion: 'adaptive@thr=0.5',
+      count: 2,
+    });
+    expect(res.byPolicyVersion[0]!.kinds.sort()).toEqual(['abstain', 'l3_escalation']);
+  });
+});

--- a/test/memory-outcome.unit-spec.ts
+++ b/test/memory-outcome.unit-spec.ts
@@ -521,9 +521,13 @@ describe('OUTCOME_TX_WRITES', () => {
 describe('OutcomePruneService', () => {
   beforeEach(() => {
     process.env.OUTCOME_TELEMETRY_ENABLED = '1';
+    // The decision leg (0119) is default-on; this suite isolates the
+    // other legs, so it says so rather than relying on a default.
+    process.env.OUTCOME_DECISION_CAPTURE = '0';
   });
   afterAll(() => {
     delete process.env.OUTCOME_TELEMETRY_ENABLED;
+    delete process.env.OUTCOME_DECISION_CAPTURE;
   });
 
   const apiKeys = (ids: string[]) => ({ fanOutRoster: () => ids }) as unknown as ApiKeyService;

--- a/test/synthesize-outcome-writers.unit-spec.ts
+++ b/test/synthesize-outcome-writers.unit-spec.ts
@@ -452,7 +452,7 @@ describe('SynthesizeService — OUTCOME_DECISION_CAPTURE abstain seam', () => {
   });
 
   it('capture flag off: no decision rows, no decisionId on events (byte-identical)', async () => {
-    delete process.env.OUTCOME_DECISION_CAPTURE;
+    process.env.OUTCOME_DECISION_CAPTURE = '0';
     const decisionCalls: DecisionCall[] = [];
     const { svc, calls } = makeSvc('supported', { decisionCalls });
     await svc.synthesize({

--- a/test/tool-observation.unit-spec.ts
+++ b/test/tool-observation.unit-spec.ts
@@ -188,9 +188,16 @@ describe('ToolObservationService.verifyRef', () => {
 describe('OutcomePruneService — tool_observation leg', () => {
   const apiKeys = (ids: string[]) => ({ fanOutRoster: () => ids }) as unknown as ApiKeyService;
 
+  beforeEach(() => {
+    // The decision leg (0119) is default-on; this suite isolates the
+    // other legs, so it says so rather than relying on a default.
+    process.env.OUTCOME_DECISION_CAPTURE = '0';
+  });
+
   afterEach(() => {
     delete process.env.TOOL_OBSERVATIONS_ENABLED;
     delete process.env.OUTCOME_TELEMETRY_ENABLED;
+    delete process.env.OUTCOME_DECISION_CAPTURE;
     delete process.env.TOOL_OBSERVATION_RETENTION_DAYS;
   });
 


### PR DESCRIPTION
First step of the revised measurement plan from #584 — and the reason that plan changed order.

## The gap

Migration 0119 shipped a writer for `memory_decision`, **three indexes** (`createdAt`, `requestId`, `decisionId`) and a retention cron — and no reader. Outside `MemoryDecisionService`, every query against that table is the GDPR forget cascade or the nightly prune. It wrote rows that existed only to be deleted, and the indexes say plainly what was intended.

Those rows are the record of **why the engine decided what it decided** — the abstain gate, the L3 escalation trigger, the fragment-zoom step — carrying `policyVersion`, the chosen action, the alternatives it turned down, the observed signals and what the choice cost. Content-free by contract, correlated by request id.

With no reader and capture off, the only way to judge a serving lane was a benchmark. That is why #584's first draft reached for LoCoMo, and why it was wrong to: v11 §13 records that axis as saturated for this stack (63% of the residual miss is dataset-capped).

## What lands

`GET /v1/admin/memory/decisions` — the trace feed. `?requestId=` pulls one request's whole decision chain through the index 0119 built for it; also filterable by kind / action / policy version, cursor-paginated on `createdAt`.

`GET /v1/admin/memory/decisions/stats` — the aggregate that makes it a statistic rather than a log: by (kind, action) with average latency and tokens, by policy version (the axis a policy change is read on), and per day per kind.

Shape follows `PolicyDecisionsService` deliberately — two surfaces answering "why did it decide that" should not have two idioms.

`OUTCOME_DECISION_CAPTURE` becomes **default-on**, now that there is somewhere to read it.

## Details worth reviewing

- **Costs are averaged over the rows that have the cost**, not over all rows — otherwise a partially-instrumented seam reads as cheaper than it is.
- `sampled` + `truncated` are in the response, so a capped 20k scan is never read as a whole window. A capped scan mistaken for a trend is how numbers get invented.
- `observedState` is `FLEXIBLE` in 0119, so the reader re-filters to finite numbers and strings rather than trusting that the writer's whitelist held for every row already stored.
- Three prune suites now say "off" out loud: `OutcomePruneService` runs three legs with the decision leg on, so "both flags off ⇒ no queries at all" became a three-flag statement.
- The repo's NUL-byte hygiene gate earned its keep — it caught a literal NUL I wrote into a map key.

## Tests

12 new unit tests on the reader (paging, the requestId trace pull, enum and cursor rejection, the content-free re-filter, the cost-averaging rule, window clamping, day buckets).

- unit: **5709 passed**, 466 suites
- e2e: **856 passed**, 167 suites (full local suite, SurrealDB 3.2.4)
- `tsc --noEmit`, `eslint --max-warnings 0`, `prettier --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB