### PR TITLE
test(eval): the domain battery exercises all six packs, not two

### DIFF
--- a/test/domain-pack-scorers.unit-spec.ts
+++ b/test/domain-pack-scorers.unit-spec.ts
@@ -18,6 +18,7 @@ import {
   CHECKS,
   FIN,
   FIN_DOMAIN,
+  BATTERY_PACKS,
   FINTECH_PACK,
   MED,
   MED_DOMAIN,
@@ -289,16 +290,20 @@ describe('domain-pack corpus integrity', () => {
   });
 
   it('targets only predicates that exist in the installed manifests', () => {
+    // Derived from BATTERY_PACKS, not a hand-kept pair: the battery grew
+    // from two packs to six, and a hardcoded list here would have to be
+    // remembered on every growth — which is exactly how a gate stops
+    // gating.
     const known = new Set(
-      [FINTECH_PACK, MEDICAL_PACK].flatMap((pack) =>
-        pack.predicates.map((p) => `${pack.id}__${p.localId}`),
-      ),
+      BATTERY_PACKS.flatMap((pack) => pack.predicates.map((p) => `${pack.id}__${p.localId}`)),
     );
+    const unknown: string[] = [];
     for (const check of CHECKS) {
-      if (check.kind === 'pack-vocab') {
-        expect(known.has(check.predicate)).toBe(true);
+      if (check.kind === 'pack-vocab' && !known.has(check.predicate)) {
+        unknown.push(`${check.id} -> ${check.predicate}`);
       }
     }
+    expect(unknown).toEqual([]);
   });
 
   it('seeds every provenance fragment verbatim in exactly one turn', () => {

--- a/test/domain-packs-corpus.unit-spec.ts
+++ b/test/domain-packs-corpus.unit-spec.ts
@@ -1,0 +1,127 @@
+/**
+ * Scoreability invariants of the domain-pack battery corpus.
+ *
+ * The battery's verdicts are only worth reading if its markers actually
+ * discriminate. A provenance fragment that appears in two turns lets the
+ * unroll check pass against the wrong episode; a forbidden marker that
+ * shares a turn with an expected one makes an isolation check
+ * unsatisfiable; a transition stage value restated later makes the
+ * history subsequence cross-match. None of that fails loudly at run
+ * time — it just produces a number nobody can trust.
+ *
+ * These run without a stand, so a corpus edit is checked in CI rather
+ * than discovered on the next paid run.
+ */
+import { ALL_TURNS, BATTERY_PACKS, CHECKS, GENERIC_MARKERS } from './eval/domain-packs/corpus';
+
+const texts = ALL_TURNS.map((t) => t.text);
+const turnsContaining = (needle: string): string[] => texts.filter((t) => t.includes(needle));
+
+type LooseCheck = Record<string, unknown> & { id: string };
+const checks = CHECKS as unknown as LooseCheck[];
+
+describe('domain-pack corpus — coverage', () => {
+  it('exercises every first-party pack the battery installs', () => {
+    // Four of these (legal / hr / insurance / real_estate) shipped and
+    // were run by nothing at all until the battery grew to cover them.
+    expect(BATTERY_PACKS.map((p) => p.id).sort()).toEqual([
+      'fintech',
+      'hr',
+      'insurance',
+      'legal',
+      'medical',
+      'real_estate',
+    ]);
+  });
+
+  it('gives every installed pack at least one vocab, transition and trace check', () => {
+    const idsFor = (cls: string) =>
+      checks.filter((c) => c.cls === cls).map((c) => c.id.toLowerCase());
+    // Check ids carry a domain tag: c16-vocab-leg, c24-transition-leg…
+    const tags: Record<string, string> = {
+      fintech: 'fin',
+      medical: 'med',
+      legal: 'leg',
+      hr: 'hr',
+      insurance: 'ins',
+      real_estate: 're',
+    };
+    const gaps: string[] = [];
+    for (const pack of BATTERY_PACKS) {
+      const tag = tags[pack.id] ?? pack.id;
+      for (const cls of ['vocab', 'transition', 'trace']) {
+        const hit = idsFor(cls).some((id) => id.endsWith(`-${tag}`) || id.includes(`-${tag}-`));
+        if (!hit) gaps.push(`${pack.id} has no ${cls} check`);
+      }
+    }
+    expect(gaps).toEqual([]);
+  });
+});
+
+describe('domain-pack corpus — scoreability', () => {
+  it('every provenance fragment appears verbatim in exactly one turn', () => {
+    const offenders: string[] = [];
+    for (const check of checks) {
+      for (const frag of (check.episodeFragments as string[] | undefined) ?? []) {
+        const hits = turnsContaining(frag).length;
+        if (hits !== 1) offenders.push(`${check.id}: "${frag}" in ${hits} turns`);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it('no isolation check forbids a marker that shares a turn with what it expects', () => {
+    const offenders: string[] = [];
+    for (const check of checks) {
+      const expected = (check.expectAnyOf as string[] | undefined) ?? [];
+      const forbidden = (check.forbidAnyOf as string[] | undefined) ?? [];
+      for (const e of expected) {
+        const carriers = turnsContaining(e);
+        if (carriers.length === 0) {
+          offenders.push(`${check.id}: expected "${e}" is in no corpus turn`);
+          continue;
+        }
+        for (const f of forbidden) {
+          if (carriers.some((t) => t.includes(f))) {
+            offenders.push(`${check.id}: "${e}" shares a turn with forbidden "${f}"`);
+          }
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it('every transition stage value appears in exactly one turn', () => {
+    // The rule that makes an ordered history readable: a transition turn
+    // never restates the old value, so stage 1 and stage 2 cannot both
+    // match the same turn.
+    const offenders: string[] = [];
+    for (const check of checks) {
+      for (const stage of (check.stages as string[][] | undefined) ?? []) {
+        for (const value of stage) {
+          const hits = turnsContaining(value).length;
+          if (hits !== 1) offenders.push(`${check.id}: stage "${value}" in ${hits} turns`);
+        }
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it('generic markers stay exclusive to the domain-free conversation', () => {
+    // The cross-entity check proves generic facts attach to the shared
+    // entity by finding one of these. A second home for the token lets a
+    // domain fact satisfy that evidence and quietly weakens the check —
+    // "Lisbon" in an HR turn did exactly that while this was being written.
+    const offenders: string[] = [];
+    for (const marker of GENERIC_MARKERS) {
+      const hits = turnsContaining(marker);
+      if (hits.length !== 1) offenders.push(`"${marker}" in ${hits.length} turns`);
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it('check ids are unique', () => {
+    const ids = checks.map((c) => c.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});

--- a/test/eval/domain-packs/corpus.ts
+++ b/test/eval/domain-packs/corpus.ts
@@ -1,15 +1,23 @@
 /**
- * The multi-domain corpus and check battery: ~20 turns about ONE
- * shared subject — "Meridian Clinic", an org that is BOTH a fintech
- * client (its payments arm) and a medical provider (its clinical
- * side) — plus a person "Dr. Vega". One conversation per domain, one
- * generic (domain-free) conversation, and one deliberately MIXED
- * conversation weaving both domains, so the entity's timeline
- * genuinely interleaves fintech and medical events in time.
+ * The multi-domain corpus and check battery: turns about ONE shared
+ * subject — "Meridian Clinic" — plus a person "Dr. Vega".
  *
- * Predicate ids are DERIVED from the real pack manifests at build
- * time (src/ai/domain-packs/{fintech,medical}.pack.ts) through a
- * guard that throws when a referenced localId leaves the pack — the
+ * SIX ontologies over one organisation, because that is what an
+ * organisation is: the clinic has a payments arm (fintech), a clinical
+ * side (medical), supplier agreements (legal), staff (hr), a
+ * malpractice policy (insurance) and premises (real-estate). Every
+ * first-party pack we ship is exercised here; four of them
+ * (legal / hr / insurance / real-estate) were shipped and then run by
+ * nothing at all until this battery grew to cover them.
+ *
+ * One conversation per domain, one generic (domain-free) conversation,
+ * and one deliberately MIXED conversation weaving domains together, so
+ * the entity's timeline genuinely interleaves their events in time
+ * rather than stacking one domain entirely before another.
+ *
+ * Predicate ids are DERIVED from the real pack manifests at build time
+ * (src/ai/domain-packs/*.pack.ts) through a guard that throws when a
+ * referenced localId leaves the pack — the
  * corpus can never drift from the ontology it exercises. Turn
  * phrasing is chosen to hit those predicates' ADMIT rules:
  * fintech__licensed_as/"licensed as an EMI", medical__dosed_at/"dosed
@@ -25,15 +33,32 @@
  */
 import { FINTECH_PACK } from '../../../src/ai/domain-packs/fintech.pack';
 import { MEDICAL_PACK } from '../../../src/ai/domain-packs/medical.pack';
+import { LEGAL_PACK } from '../../../src/ai/domain-packs/legal.pack';
+import { HR_PACK } from '../../../src/ai/domain-packs/hr.pack';
+import { INSURANCE_PACK } from '../../../src/ai/domain-packs/insurance.pack';
+import { REAL_ESTATE_PACK } from '../../../src/ai/domain-packs/real-estate.pack';
 import type { DomainPackManifest } from '../../../src/ai/domain-packs/manifest';
 import type { Check, CorpusTurn, DomainSpec } from './types';
 
-export { FINTECH_PACK, MEDICAL_PACK };
+export { FINTECH_PACK, MEDICAL_PACK, LEGAL_PACK, HR_PACK, INSURANCE_PACK, REAL_ESTATE_PACK };
+
+/**
+ * Every pack the battery installs and exercises — the runner's phase 0
+ * walks this, so adding a pack here is the whole wiring change.
+ */
+export const BATTERY_PACKS: DomainPackManifest[] = [
+  FINTECH_PACK,
+  MEDICAL_PACK,
+  LEGAL_PACK,
+  HR_PACK,
+  INSURANCE_PACK,
+  REAL_ESTATE_PACK,
+];
 
 /** The vertical every corpus write attributes itself to. */
 export const CORPUS_VERTICAL = 'work';
 
-/** The shared subject entity — one org, two domain ontologies. */
+/** The shared subject entity — one org, six domain ontologies. */
 export const MERIDIAN_REF = { vertical: CORPUS_VERTICAL, id: 'org-meridian-clinic' } as const;
 export const MERIDIAN_NAME = 'Meridian Clinic';
 
@@ -71,6 +96,38 @@ export const MED = {
   interacts: packPredicate(MEDICAL_PACK, 'interacts_with'),
 } as const;
 
+/** Real legal predicate ids (legal@0.1.0). */
+export const LEG = {
+  governed: packPredicate(LEGAL_PACK, 'governed_by'),
+  party: packPredicate(LEGAL_PACK, 'party_to'),
+  obligation: packPredicate(LEGAL_PACK, 'obligation'),
+  terminates: packPredicate(LEGAL_PACK, 'terminates_on'),
+} as const;
+
+/** Real HR predicate ids (hr@0.1.0). */
+export const HR = {
+  skill: packPredicate(HR_PACK, 'requires_skill'),
+  seniority: packPredicate(HR_PACK, 'seniority'),
+  comp: packPredicate(HR_PACK, 'compensation'),
+  location: packPredicate(HR_PACK, 'work_location'),
+} as const;
+
+/** Real insurance predicate ids (insurance@0.1.0). */
+export const INS = {
+  covers: packPredicate(INSURANCE_PACK, 'covers'),
+  limit: packPredicate(INSURANCE_PACK, 'coverage_limit'),
+  premium: packPredicate(INSURANCE_PACK, 'premium'),
+  excludes: packPredicate(INSURANCE_PACK, 'excludes'),
+} as const;
+
+/** Real real-estate predicate ids (real_estate@0.1.0). */
+export const RE = {
+  zoned: packPredicate(REAL_ESTATE_PACK, 'zoned_as'),
+  valued: packPredicate(REAL_ESTATE_PACK, 'valued_at'),
+  tenure: packPredicate(REAL_ESTATE_PACK, 'tenure_type'),
+  built: packPredicate(REAL_ESTATE_PACK, 'built_in'),
+} as const;
+
 /** Timestamp of turn N (1-based) — 5 minutes apart within a session. */
 const t = (startIso: string, turn: number): string =>
   new Date(Date.parse(startIso) + (turn - 1) * 5 * 60_000).toISOString();
@@ -78,10 +135,10 @@ const t = (startIso: string, turn: number): string =>
 const conv = (conversation: string, startIso: string, texts: string[]): CorpusTurn[] =>
   texts.map((text, i) => ({ conversation, turn: i + 1, emittedAt: t(startIso, i + 1), text }));
 
-// ── the four conversations ──────────────────────────────────────────
-// fin (day 1 morning) and med (day 1 afternoon) each end in a
-// transition; mix (day 3) adds LATE events of both domains, so
-// neither domain sits entirely before the other on the timeline.
+// ── the conversations ───────────────────────────────────────────────
+// One per domain, each ending in a single_active transition, spread
+// across four days; mix (day 3) adds LATE events of the first two
+// domains, so no domain sits entirely before another on the timeline.
 
 /** Fintech conversation — hits licensed_as / regulated_by /
  *  complies_with / capital_requirement, then transitions
@@ -123,7 +180,60 @@ const MIX_TURNS = conv('mix', '2026-09-02T11:00:00Z', [
   "Meridian Clinic's payment gateway also meets KYC requirements.",
 ]);
 
-export const ALL_TURNS: CorpusTurn[] = [...FIN_TURNS, ...MED_TURNS, ...GEN_TURNS, ...MIX_TURNS];
+/** Legal conversation — governed_by / party_to / obligation, then
+ *  transitions terminates_on 2027-03-31 → 2028-03-31 (single_active). */
+const LEG_TURNS = conv('leg', '2026-09-01T09:00:00Z', [
+  "Meridian Clinic's supplier agreement with Northwind Labs is governed by English law.",
+  'Northwind Labs is a party to the Meridian Clinic supplier agreement.',
+  'Under that agreement Meridian Clinic has an obligation to give 90 days notice before cancelling an order.',
+  "Meridian Clinic's supplier agreement terminates on 2027-03-31.",
+  'The parties extended it: the supplier agreement now terminates on 2028-03-31.',
+]);
+
+/** HR conversation — requires_skill / work_location, then transitions
+ *  compensation 62000 → 68000 (single_active). */
+const HR_TURNS = conv('hr', '2026-09-01T14:00:00Z', [
+  'The Meridian Clinic infusion nurse role requires ACLS certification.',
+  'That infusion nurse role is a Senior position.',
+  // Deliberately NOT "Lisbon": that token is a GENERIC_MARKER, and the
+  // cross-entity check proves generic facts attach to the shared entity
+  // by finding one. A second home for the token would let an HR fact
+  // satisfy that evidence and quietly weaken the check.
+  'The infusion nurse role is based at the Alfama site as its work location.',
+  'The infusion nurse role has compensation of 62000 EUR per year.',
+  'After the pay review the infusion nurse role has compensation of 68000 EUR per year.',
+]);
+
+/** Insurance conversation — covers / excludes, then transitions
+ *  coverage_limit 5M → 8M (single_active). */
+const INS_TURNS = conv('ins', '2026-09-02T09:00:00Z', [
+  "Meridian Clinic's malpractice policy covers clinical negligence claims.",
+  'That malpractice policy excludes cosmetic procedures.',
+  "Meridian Clinic's malpractice policy has a premium of 47000 EUR a year.",
+  "Meridian Clinic's malpractice policy has a coverage limit of 5M EUR.",
+  'At renewal the malpractice policy has a coverage limit of 8M EUR.',
+]);
+
+/** Real-estate conversation — valued_at / built_in, then transitions
+ *  zoned_as mixed-use → healthcare (single_active). */
+const RE_TURNS = conv('re', '2026-09-02T14:00:00Z', [
+  'The Meridian Clinic building on Rua do Ouro was built in 1998.',
+  'Meridian Clinic holds the Rua do Ouro premises on a leasehold tenure.',
+  'The Rua do Ouro premises were valued at 4.2M EUR at the last survey.',
+  'The Rua do Ouro premises are zoned as mixed-use.',
+  'The council rezoned it: the Rua do Ouro premises are now zoned as healthcare.',
+]);
+
+export const ALL_TURNS: CorpusTurn[] = [
+  ...FIN_TURNS,
+  ...MED_TURNS,
+  ...LEG_TURNS,
+  ...HR_TURNS,
+  ...INS_TURNS,
+  ...RE_TURNS,
+  ...GEN_TURNS,
+  ...MIX_TURNS,
+];
 
 // ── domain lenses ───────────────────────────────────────────────────
 // Markers are corpus VALUES (regulators, standards, doses, drugs) —
@@ -149,6 +259,26 @@ export const MED_DOMAIN: DomainSpec = {
   ],
 };
 
+export const LEG_DOMAIN: DomainSpec = {
+  namespace: LEGAL_PACK.id,
+  markers: ['English law', 'Northwind', '90 days notice', '2027-03-31', '2028-03-31'],
+};
+
+export const HR_DOMAIN: DomainSpec = {
+  namespace: HR_PACK.id,
+  markers: ['ACLS', 'Senior', '62000', '68000'],
+};
+
+export const INS_DOMAIN: DomainSpec = {
+  namespace: INSURANCE_PACK.id,
+  markers: ['clinical negligence', 'cosmetic procedures', '47000', '5M EUR', '8M EUR'],
+};
+
+export const RE_DOMAIN: DomainSpec = {
+  namespace: REAL_ESTATE_PACK.id,
+  markers: ['Rua do Ouro', '1998', 'leasehold', '4.2M', 'mixed-use', 'healthcare'],
+};
+
 /** Markers of the generic (domain-free) turns. */
 export const GENERIC_MARKERS = ['2009', 'Lisbon', 'founded', 'headquartered'];
 
@@ -166,10 +296,7 @@ export const CHECKS: Check[] = [
     id: 'c01-install',
     cls: 'setup',
     intent: 'Both industry packs are actually installed in the tenant after phase 0.',
-    packs: [
-      { packId: FINTECH_PACK.id, version: FINTECH_PACK.version },
-      { packId: MEDICAL_PACK.id, version: MEDICAL_PACK.version },
-    ],
+    packs: BATTERY_PACKS.map((pack) => ({ packId: pack.id, version: pack.version })),
   },
 
   // ── pack-vocab (2 per domain, honest baseline) ────────────────────
@@ -242,7 +369,7 @@ export const CHECKS: Check[] = [
       'no per-domain entity duplication.',
     searchQuery: 'Meridian Clinic',
     entityNameToken: 'meridian',
-    domains: [FIN_DOMAIN, MED_DOMAIN],
+    domains: [FIN_DOMAIN, MED_DOMAIN, LEG_DOMAIN, HR_DOMAIN, INS_DOMAIN, RE_DOMAIN],
     genericMarkers: GENERIC_MARKERS,
   },
 
@@ -274,7 +401,7 @@ export const CHECKS: Check[] = [
       'domain sits entirely before the other in time.',
     searchQuery: 'Meridian Clinic',
     entityNameToken: 'meridian',
-    domains: [FIN_DOMAIN, MED_DOMAIN],
+    domains: [FIN_DOMAIN, MED_DOMAIN, LEG_DOMAIN, HR_DOMAIN, INS_DOMAIN, RE_DOMAIN],
   },
 
   // ── serving ───────────────────────────────────────────────────────
@@ -306,6 +433,204 @@ export const CHECKS: Check[] = [
     query: "What is the dose of Meridian Clinic's standard metformin course?",
     expectAnyOf: ['850'],
     forbidAnyOf: ['T+1', 'T+2', 'EMI', 'FCA', 'PCI-DSS', 'SOC 2', '€2M'],
+  },
+
+  // ── the four packs nothing exercised until now ────────────────────
+  // Same shape per domain as fintech/medical above: two vocab checks
+  // (one plain, one on the value that transitions), one transition, one
+  // provenance unroll, one isolation serve.
+  {
+    kind: 'pack-vocab',
+    id: 'c16-vocab-leg-governed',
+    cls: 'vocab',
+    intent: `the governing law lands on ${LEG.governed} with the verbatim jurisdiction.`,
+    searchQuery: 'Meridian Clinic supplier agreement governing law',
+    predicate: LEG.governed,
+    valueMarkers: ['English law'],
+    expectedUnknown: VOCAB_BASELINE,
+  },
+  {
+    kind: 'pack-vocab',
+    id: 'c17-vocab-leg-terminates',
+    cls: 'vocab',
+    intent: `the termination date lands on ${LEG.terminates} with a verbatim date.`,
+    searchQuery: 'Meridian Clinic supplier agreement termination date',
+    predicate: LEG.terminates,
+    valueMarkers: ['2027-03-31', '2028-03-31'],
+    expectedUnknown: VOCAB_BASELINE,
+  },
+  {
+    kind: 'pack-vocab',
+    id: 'c18-vocab-hr-skill',
+    cls: 'vocab',
+    intent: `a required qualification lands on ${HR.skill} with the verbatim skill.`,
+    searchQuery: 'Meridian Clinic infusion nurse required certification',
+    predicate: HR.skill,
+    valueMarkers: ['ACLS'],
+    expectedUnknown: VOCAB_BASELINE,
+  },
+  {
+    kind: 'pack-vocab',
+    id: 'c19-vocab-hr-comp',
+    cls: 'vocab',
+    intent: `the pay figure lands on ${HR.comp} with the verbatim amount.`,
+    searchQuery: 'Meridian Clinic infusion nurse compensation',
+    predicate: HR.comp,
+    valueMarkers: ['62000', '68000'],
+    expectedUnknown: VOCAB_BASELINE,
+  },
+  {
+    kind: 'pack-vocab',
+    id: 'c20-vocab-ins-covers',
+    cls: 'vocab',
+    intent: `the covered peril lands on ${INS.covers} with the verbatim claim class.`,
+    searchQuery: 'Meridian Clinic malpractice policy coverage',
+    predicate: INS.covers,
+    valueMarkers: ['clinical negligence'],
+    expectedUnknown: VOCAB_BASELINE,
+  },
+  {
+    kind: 'pack-vocab',
+    id: 'c21-vocab-ins-limit',
+    cls: 'vocab',
+    intent: `the coverage ceiling lands on ${INS.limit} with the verbatim amount.`,
+    searchQuery: 'Meridian Clinic malpractice policy coverage limit',
+    predicate: INS.limit,
+    valueMarkers: ['5M', '8M'],
+    expectedUnknown: VOCAB_BASELINE,
+  },
+  {
+    kind: 'pack-vocab',
+    id: 'c22-vocab-re-tenure',
+    cls: 'vocab',
+    intent: `the tenure lands on ${RE.tenure} with the verbatim tenure type.`,
+    searchQuery: 'Meridian Clinic Rua do Ouro tenure',
+    predicate: RE.tenure,
+    valueMarkers: ['leasehold'],
+    expectedUnknown: VOCAB_BASELINE,
+  },
+  {
+    kind: 'pack-vocab',
+    id: 'c23-vocab-re-zoned',
+    cls: 'vocab',
+    intent: `the zoning lands on ${RE.zoned} with the verbatim designation.`,
+    searchQuery: 'Meridian Clinic Rua do Ouro zoning',
+    predicate: RE.zoned,
+    valueMarkers: ['mixed-use', 'healthcare'],
+    expectedUnknown: VOCAB_BASELINE,
+  },
+
+  {
+    kind: 'pack-transition',
+    id: 'c24-transition-leg',
+    cls: 'transition',
+    intent: 'The extension retains 2027-03-31 → 2028-03-31 as ordered history.',
+    searchQuery: 'Meridian Clinic supplier agreement termination',
+    stages: [['2027-03-31'], ['2028-03-31']],
+  },
+  {
+    kind: 'pack-transition',
+    id: 'c25-transition-hr',
+    cls: 'transition',
+    intent: 'The pay review retains 62000 → 68000 as ordered history.',
+    searchQuery: 'Meridian Clinic infusion nurse compensation',
+    stages: [['62000'], ['68000']],
+  },
+  {
+    kind: 'pack-transition',
+    id: 'c26-transition-ins',
+    cls: 'transition',
+    intent: 'The renewal retains the 5M → 8M coverage limit as ordered history.',
+    searchQuery: 'Meridian Clinic malpractice coverage limit',
+    stages: [['5M'], ['8M']],
+  },
+  {
+    kind: 'pack-transition',
+    id: 'c27-transition-re',
+    cls: 'transition',
+    intent: 'The rezoning retains mixed-use → healthcare as ordered history.',
+    searchQuery: 'Meridian Clinic Rua do Ouro zoning',
+    stages: [['mixed-use'], ['healthcare']],
+  },
+
+  {
+    kind: 'trace-provenance',
+    id: 'c28-trace-leg',
+    cls: 'trace',
+    intent: "A legal fact unrolls to the legal conversation's seeded turn.",
+    searchQuery: 'Meridian Clinic supplier agreement governing law',
+    objectHint: ['English law'],
+    episodeFragments: ['governed by English law'],
+  },
+  {
+    kind: 'trace-provenance',
+    id: 'c29-trace-hr',
+    cls: 'trace',
+    intent: "An HR fact unrolls to the HR conversation's seeded turn.",
+    searchQuery: 'Meridian Clinic infusion nurse certification',
+    objectHint: ['ACLS'],
+    episodeFragments: ['requires ACLS certification'],
+  },
+  {
+    kind: 'trace-provenance',
+    id: 'c30-trace-ins',
+    cls: 'trace',
+    intent: "An insurance fact unrolls to the insurance conversation's seeded turn.",
+    searchQuery: 'Meridian Clinic malpractice exclusions',
+    objectHint: ['cosmetic'],
+    episodeFragments: ['excludes cosmetic procedures'],
+  },
+  {
+    kind: 'trace-provenance',
+    id: 'c31-trace-re',
+    cls: 'trace',
+    intent: "A real-estate fact unrolls to the real-estate conversation's seeded turn.",
+    searchQuery: 'Meridian Clinic Rua do Ouro build year',
+    objectHint: ['1998'],
+    episodeFragments: ['built in 1998'],
+  },
+
+  // Isolation across SIX ontologies is the check the two-pack battery
+  // could not make: an answer about premises must not reach for the
+  // clinical, financial, legal, staffing or policy facts of the same
+  // organisation just because they share an entity.
+  {
+    kind: 'serve-isolation',
+    id: 'c32-isolation-leg',
+    cls: 'serving',
+    intent: 'A legal question answers from the legal fact, with no other domain bleeding in.',
+    query: "What law governs Meridian Clinic's supplier agreement with Northwind Labs?",
+    expectAnyOf: ['English'],
+    forbidAnyOf: ['metformin', 'T+1', 'ACLS', '68000', 'leasehold', 'clinical negligence'],
+  },
+  {
+    kind: 'serve-isolation',
+    id: 'c33-isolation-hr',
+    cls: 'serving',
+    intent: 'An HR question answers from the HR fact, with no other domain bleeding in.',
+    query: 'What is the compensation for the Meridian Clinic infusion nurse role?',
+    expectAnyOf: ['68000'],
+    forbidAnyOf: ['metformin', 'T+1', 'English law', 'leasehold', '8M'],
+  },
+  {
+    kind: 'serve-isolation',
+    id: 'c34-isolation-ins',
+    cls: 'serving',
+    intent:
+      'An insurance question answers from the insurance fact, with no other domain bleeding in.',
+    query: "What is the coverage limit on Meridian Clinic's malpractice policy?",
+    expectAnyOf: ['8M'],
+    forbidAnyOf: ['metformin', 'T+1', 'ACLS', 'English law', 'leasehold'],
+  },
+  {
+    kind: 'serve-isolation',
+    id: 'c35-isolation-re',
+    cls: 'serving',
+    intent:
+      'A real-estate question answers from the real-estate fact, with no other domain bleeding in.',
+    query: 'How are the Meridian Clinic Rua do Ouro premises zoned?',
+    expectAnyOf: ['healthcare'],
+    forbidAnyOf: ['metformin', 'T+1', 'ACLS', '68000', '8M'],
   },
 
   // ── surfaces ──────────────────────────────────────────────────────

--- a/test/eval/domain-packs/runner.ts
+++ b/test/eval/domain-packs/runner.ts
@@ -3,7 +3,7 @@
  * wire, mirroring the memory-fitness / state-transitions siblings:
  *
  *  - REST  GET/POST /v1/admin/packs[.../from-registry]
- *          (phase 0: install fintech + medical into the tenant; a
+ *          (phase 0: install every first-party pack into the tenant; a
  *          missing registry entry is republished from the local
  *          manifest when the key can, else the runner FAILS with the
  *          registry:seed instructions — setup is never silently skipped)
@@ -30,10 +30,9 @@ import { walkProvenance } from '../memory-fitness/scorers';
 import { checkHistorySequence, scoreServe, type HistoryEvent } from '../state-transitions/scorers';
 import {
   ALL_TURNS,
+  BATTERY_PACKS,
   CHECKS,
   CORPUS_VERTICAL,
-  FINTECH_PACK,
-  MEDICAL_PACK,
   MERIDIAN_NAME,
   MERIDIAN_REF,
   VEGA_NAME,
@@ -348,7 +347,7 @@ async function ensurePackSetup(cfg: Config): Promise<Record<string, string>> {
     process.exit(1);
   }
   const installed = list.json?.installed ?? [];
-  for (const pack of [FINTECH_PACK, MEDICAL_PACK]) {
+  for (const pack of BATTERY_PACKS) {
     const already = installed.find((p) => p.packId === pack.id);
     // Skip only on an exact version match: the install check (corpus
     // wantsPacksInstalled) pins the LOCAL manifest version, so a stand

--- a/test/eval/domain-packs/types.ts
+++ b/test/eval/domain-packs/types.ts
@@ -4,9 +4,10 @@
  * fitness) and test/eval/state-transitions (mutable world-state).
  * This battery isolates ONE claim: memory behaves correctly WITH
  * industry Domain Packs installed — the install→vocabulary→trace
- * chain works end to end, and ONE entity living in TWO domain
- * ontologies (fintech + medical) stays a single entity whose facts,
- * timeline and provenance keep their per-domain identity.
+ * chain works end to end, and ONE entity living in SIX domain
+ * ontologies (fintech, medical, legal, hr, insurance, real-estate)
+ * stays a single entity whose facts, timeline and provenance keep
+ * their per-domain identity.
  *
  * Every check is mechanical — no LLM judge (see scorers.ts).
  */
@@ -80,15 +81,23 @@ export interface PackTransitionCheck extends BaseCheck {
   stages: string[][];
 }
 
+/** Two or more domains, with the minimum kept in the type: a
+ *  single-domain "cross-domain" check would pass vacuously. */
+export type MultiDomain = readonly [DomainSpec, DomainSpec, ...DomainSpec[]];
+
 /** `cross-entity` — search returns ONE entity (no per-domain
- *  duplication) carrying facts from BOTH domains plus generic ones. */
+ *  duplication) carrying facts from EVERY listed domain plus generic
+ *  ones. */
 export interface CrossEntityCheck extends BaseCheck {
   kind: 'cross-entity';
   searchQuery: string;
   /** The subject entity's canonicalName must contain this token; hits
    *  are deduped on it (2+ matching hits = per-domain duplication). */
   entityNameToken: string;
-  domains: [DomainSpec, DomainSpec];
+  /** Two or more: the battery grew from two ontologies over the shared
+   *  entity to six, and the pair this once pinned made that a type
+   *  error rather than a stronger check. */
+  domains: MultiDomain;
   /** Markers of the domain-free corpus turns about the same entity. */
   genericMarkers: string[];
 }
@@ -107,13 +116,13 @@ export interface TraceProvenanceCheck extends BaseCheck {
 }
 
 /** `trace-interleave` — the shared entity's timeline holds
- *  fact.recorded events from BOTH domains and neither domain sits
- *  entirely before the other in time (a genuine interleave). */
+ *  fact.recorded events from EVERY listed domain and no domain sits
+ *  entirely before another in time (a genuine interleave). */
 export interface TraceInterleaveCheck extends BaseCheck {
   kind: 'trace-interleave';
   searchQuery: string;
   entityNameToken: string;
-  domains: [DomainSpec, DomainSpec];
+  domains: MultiDomain;
 }
 
 /** `serve-cross` — synthesize over the shared entity cites BOTH


### PR DESCRIPTION
Second step of the revised plan in `docs/roadmap/flag-inventory-2026-09.md` — "разные домены".

## The gap

Six first-party packs ship. The battery installed **two** (fintech + medical); **legal, HR, insurance and real-estate were exercised by nothing at all**. Across every battery we own that left ~93 mechanical checks deciding 100+ flags, on two domains — which is why measuring those flags kept falling back to LoCoMo, an axis our own v11 §13 records as saturated.

## What changes

The corpus already had the right idea and only needed to be taken seriously: **one organisation carrying several ontologies at once**. A clinic has a payments arm, a clinical side, supplier agreements, staff, a malpractice policy and premises — so the same Meridian Clinic now carries all six.

Per new domain: two vocab checks, one transition over a `single_active` predicate, one provenance unroll, one isolation serve.

| | before | after |
|---|---|---|
| packs installed | 2 | **6** |
| corpus turns | 20 | **40** |
| checks | 17 | **35** |

`cross-entity` and `trace-interleave` now span all six ontologies, and **isolation across six domains is a question the two-pack battery could not ask** — an answer about premises must not reach for the clinical, financial, legal, staffing or policy facts of the same organisation just because they share an entity.

Phase 0 walks `BATTERY_PACKS` instead of a hardcoded pair, so adding a pack is one list entry.

## The corpus needed a gate of its own

At 40 turns it stopped being scoreable by inspection, and none of the ways it can silently break fail loudly at run time — they just produce a number nobody can trust. New unit spec, no stand required:

- provenance fragments verbatim in **exactly one** turn
- transition stage values never restated in a later turn
- no isolation check forbidding a marker that shares a turn with what it expects
- generic markers exclusive to the domain-free conversation
- every installed pack covered by all three check classes

**It earned itself immediately**: `Lisbon` had become both a `GENERIC_MARKER` and the HR work location, which would have let an HR fact satisfy the cross-entity check's generic-fact evidence. Changed to a different site.

The sibling integrity gate in `domain-pack-scorers.unit-spec.ts` now derives its predicate set from `BATTERY_PACKS` as well — hardcoded, it would have to be remembered on every growth, which is how a gate stops gating. (It caught the new predicates on the first run.)

## Tests

The corpus predicate guard means every referenced `localId` is checked against the real manifest at build time — a pack rename breaks the build, not the run.

- unit: **5716 passed**, 467 suites
- `tsc --noEmit`, `eslint --max-warnings 0`, `prettier --check` clean

Running the battery itself needs a stand with the packs installed (`pnpm eval:domain-packs`); this PR makes it cover six domains when it runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB