### PR TITLE
test(eval): two situational axes the batteries never asked about

### DIFF
--- a/test/eval/memory-fitness/corpus.ts
+++ b/test/eval/memory-fitness/corpus.ts
@@ -12,6 +12,8 @@
  *      B retry policy    : fixed 3x30s   (03-10)  -> exp backoff cap 5 (03-18)
  *      C pilot launch    : 2026-04-15    (03-02)  -> 2026-05-06 (03-18)
  *      D deploy target   : Fly.io        (03-02)  -> AWS ECS Fargate (03-25)
+ *      E payout batch    : 500          (03-05)  -> 200 (03-25), and the 500
+ *                          arrives LAST (c6) — the out-of-order axis, D9;
  *  - stable facts: repo, ports (8443 / 9464 / 8081), staging namespace,
  *    flag prefix, dashboard name, Meridian sandbox rate limit;
  *  - one contradiction pair (two sources disagree): Meridian payout
@@ -120,6 +122,9 @@ const C4 = conv('c4', '2026-03-25T14:00:00Z', [
   'Log retention for ledger-sync is 30 days in Loki.',
   'Now that we are on ECS, secrets move to AWS SSM Parameter Store. Nothing secret in task definitions.',
   'The JetStream cluster in ls-staging runs 3 nodes. Good enough for the pilot load test.',
+  // Chain E, the newer half. Its out-of-order counterpart lands in c6,
+  // written last and dated three weeks EARLIER (D9).
+  'Decision (2026-03-25): the ledger-sync payout batch size drops to 200 per run. The 500 batches were timing out against the Meridian sandbox.',
   'Ops session done. Next: integration week with the replay tooling.',
 ]);
 
@@ -140,8 +145,27 @@ const C5 = conv('c5', '2026-04-02T11:00:00Z', [
   'Integration week done. Remaining before launch: load test at 2x pilot volume and the cutoff resolution.',
 ]);
 
-/** All mention turns, chronological. */
-export const CORPUS_TURNS: CorpusTurn[] = [...C1, ...C2, ...C3, ...C4, ...C5];
+/**
+ * c6 — the OUT-OF-ORDER arrival (D9). Written LAST, dated 2026-03-05:
+ * an old note the agent only got round to filing after everything else.
+ *
+ * It restates the SUPERSEDED payout batch size. Chain E exists purely
+ * for this axis and no other question touches it, so a D9 failure
+ * cannot blur D1's signal on chains A-D.
+ *
+ * The whole bitemporal claim is on the line here: 200 was decided on
+ * 03-20 and 500 on 03-05, so 200 is current no matter which arrived
+ * first. A memory that orders by ARRIVAL answers 500 and is wrong.
+ */
+const C6 = conv('c6', '2026-03-05T08:00:00Z', [
+  'Backfilling an old note from 2026-03-05 that never made it into memory: at that point the ledger-sync payout batch size was 500 per run.',
+]);
+
+/**
+ * Ingest order, which is deliberately NOT event-time order: c6 carries
+ * the earliest timestamps of the corpus and is written last.
+ */
+export const CORPUS_TURNS: CorpusTurn[] = [...C1, ...C2, ...C3, ...C4, ...C5, ...C6];
 
 /**
  * Direct record_fact calls — the agent distilling its own log into
@@ -152,6 +176,31 @@ export const CORPUS_TURNS: CorpusTurn[] = [...C1, ...C2, ...C3, ...C4, ...C5];
  * Ordered chronologically by validFrom so revision chains replay the
  * way the agent lived them (old value recorded before its successor).
  */
+/**
+ * The user who owns the scoped fact below — deliberately NOT the
+ * battery's own user (D10). Derived from the run so two concurrent
+ * runs never share it.
+ */
+export const OTHER_USER_SUFFIX = 'other';
+
+/**
+ * Facts written under the OTHER user's scope. They are the negative
+ * half of the serve-time fence: the battery's user must never see
+ * these, and the owner must.
+ */
+export const SCOPED_FACTS: DirectFact[] = [
+  {
+    key: 'other-oncall-phone',
+    entityRef: LEDGER_SYNC_REF,
+    predicate: 'escalation_pager',
+    // Shaped so a leak is unmistakable in an answer: nothing else in
+    // the corpus carries this string.
+    object: 'pager rota QUETZAL-4417',
+    validFrom: '2026-03-28T09:00:00Z',
+    confidence: 0.95,
+  },
+];
+
 export const DIRECT_FACTS: DirectFact[] = [
   {
     key: 'queue-v1',

--- a/test/eval/memory-fitness/questions.ts
+++ b/test/eval/memory-fitness/questions.ts
@@ -254,4 +254,31 @@ export const QUESTIONS: Question[] = [
     prompt: 'What Meridian sandbox rate limit do I need to respect?',
     keyPhrases: ['50'],
   },
+
+  // ── D9: out-of-order arrival ──────────────────────────────────────
+  // Chain E only. The 500 was written LAST and dated three weeks
+  // EARLIER than the 200, so answering 500 means the memory ordered by
+  // arrival rather than by when the decision was made. Same shape as a
+  // D1 currency question; what makes it D9 is how the corpus arrived.
+  {
+    id: 'd9-batch-size-out-of-order',
+    dimension: 'D9',
+    kind: 'currency',
+    prompt: 'What payout batch size does ledger-sync use per run?',
+    expectAnyOf: ['200'],
+    forbidAnyOf: ['500'],
+  },
+
+  // ── D10: per-user scope at serve time ─────────────────────────────
+  // Both halves in one question: the owner must get the pager rota, the
+  // battery's user must not. A fence that answers nobody fails the
+  // positive half, so passing cannot mean "retrieval is simply broken".
+  {
+    id: 'd10-scoped-pager',
+    dimension: 'D10',
+    kind: 'scope-fence',
+    prompt: 'What is the escalation pager rota for ledger-sync?',
+    expectAnyOf: ['QUETZAL-4417', 'QUETZAL'],
+    forbidForOthers: ['QUETZAL'],
+  },
 ];

--- a/test/eval/memory-fitness/runner.ts
+++ b/test/eval/memory-fitness/runner.ts
@@ -29,6 +29,8 @@ import {
   DIRECT_FACTS,
   LEDGER_SYNC_REF,
   MERIDIAN_REF,
+  OTHER_USER_SUFFIX,
+  SCOPED_FACTS,
   SPEAKER,
 } from './corpus';
 import { interleaveRoundRobin } from './interleave';
@@ -298,6 +300,27 @@ async function ingestCorpus(cfg: Config, brain: HttpBrainClient): Promise<void> 
   }
 }
 
+/**
+ * The other user's facts (D10). Same write path, different userId —
+ * that single argument is the entire fence under test, so the battery
+ * writes it exactly the way a caller would.
+ */
+async function recordScopedFacts(cfg: Config, mcp: McpClient): Promise<void> {
+  const owner = otherUserId(cfg);
+  console.error(`[record] ${SCOPED_FACTS.length} fact(s) scoped to ${owner}…`);
+  for (const fact of SCOPED_FACTS) {
+    await callTool(mcp, 'record_fact', {
+      entityRef: fact.entityRef,
+      predicate: fact.predicate,
+      object: fact.object,
+      validFrom: fact.validFrom,
+      sourceVertical: CORPUS_VERTICAL,
+      userId: owner,
+      ...(fact.confidence !== undefined ? { confidence: fact.confidence } : {}),
+    });
+  }
+}
+
 async function recordDirectFacts(cfg: Config, mcp: McpClient): Promise<void> {
   console.error(`[record] ${DIRECT_FACTS.length} direct record_fact calls…`);
   for (const fact of DIRECT_FACTS) {
@@ -358,13 +381,25 @@ interface AskContext {
   builds: Record<string, string>;
 }
 
-async function synthesizeAnswer(ctx: AskContext, query: string): Promise<SynthOut> {
+async function synthesizeAnswer(
+  ctx: AskContext,
+  query: string,
+  /** Ask AS someone else — the serve-time scope fence (D10) is the
+   *  only caller; everything else is the battery's own user. */
+  asUserId?: string,
+): Promise<SynthOut> {
   return callTool<SynthOut>(ctx.mcp, 'synthesize', {
     query,
     limit: 15,
     synthesisGuardrails: ctx.cfg.guardrails,
-    userId: ctx.cfg.userId,
+    userId: asUserId ?? ctx.cfg.userId,
   });
+}
+
+/** The user who owns SCOPED_FACTS — run-scoped so concurrent runs of
+ *  the battery never share a fence subject. */
+export function otherUserId(cfg: { userId: string }): string {
+  return `${cfg.userId}-${OTHER_USER_SUFFIX}`;
 }
 
 async function searchHits(ctx: AskContext, query: string, limit: number): Promise<SearchHit[]> {
@@ -502,6 +537,34 @@ async function askOne(ctx: AskContext, q: Question): Promise<Verdict> {
         ? { status: 'pass', detail: 'honest abstention on never-written topic', answer: out.answer }
         : { status: 'fail', detail: 'confabulated an answer', answer: out.answer };
     }
+    case 'scope-fence': {
+      // Positive half first: if the owner cannot get its own fact, the
+      // negative half would pass for the wrong reason.
+      const owner = otherUserId(ctx.cfg);
+      const mine = await synthesizeAnswer(ctx, q.prompt, owner);
+      if (!containsAnyOf(mine.answer ?? '', q.expectAnyOf)) {
+        return {
+          status: 'fail',
+          detail:
+            `the owning user (${owner}) did not get its own scoped fact — ` +
+            'the fence cannot be read from the negative half alone',
+          answer: mine.answer,
+        };
+      }
+      const theirs = await synthesizeAnswer(ctx, q.prompt);
+      const leaked = findForbidden(theirs.answer ?? '', q.forbidForOthers);
+      return leaked === null
+        ? {
+            status: 'pass',
+            detail: `owner sees it, the battery user does not`,
+            answer: theirs.answer,
+          }
+        : {
+            status: 'fail',
+            detail: `another user's scoped fact leaked: "${leaked}"`,
+            answer: theirs.answer,
+          };
+    }
     case 'conflict-api': {
       const entityId = await resolveEntityId(ctx, q.entityQuery, q.predicate);
       if (entityId === null) return { status: 'fail', detail: 'entity not found via search' };
@@ -625,6 +688,8 @@ const DIMENSION_LABELS: Record<Dimension, string> = {
   D6: 'conflict surfacing',
   D7: 'cross-session integration',
   D8: 'self-utility replay',
+  D9: 'out-of-order arrival',
+  D10: 'per-user scope at serve time',
 };
 
 function buildScorecard(
@@ -709,6 +774,7 @@ async function main(): Promise<void> {
     if (!cfg.skipIngest) {
       await ingestCorpus(cfg, brain);
       await recordDirectFacts(cfg, mcp);
+      await recordScopedFacts(cfg, mcp);
       builds = await runBuilds(cfg);
     }
 

--- a/test/eval/memory-fitness/runner.ts
+++ b/test/eval/memory-fitness/runner.ts
@@ -307,7 +307,10 @@ async function ingestCorpus(cfg: Config, brain: HttpBrainClient): Promise<void> 
  */
 async function recordScopedFacts(cfg: Config, mcp: McpClient): Promise<void> {
   const owner = otherUserId(cfg);
-  console.error(`[record] ${SCOPED_FACTS.length} fact(s) scoped to ${owner}…`);
+  // The suffix, never the resolved id: cfg.userId comes from the
+  // environment (MEMFIT_USER_ID), and a run log is not the place to
+  // reprint an identity the operator supplied.
+  console.error(`[record] ${SCOPED_FACTS.length} fact(s) scoped to <user>-${OTHER_USER_SUFFIX}…`);
   for (const fact of SCOPED_FACTS) {
     await callTool(mcp, 'record_fact', {
       entityRef: fact.entityRef,

--- a/test/eval/memory-fitness/types.ts
+++ b/test/eval/memory-fitness/types.ts
@@ -48,7 +48,7 @@ export interface DirectFact {
   evidence?: DirectFactEvidence[];
 }
 
-export type Dimension = 'D1' | 'D2' | 'D3' | 'D4' | 'D5' | 'D6' | 'D7' | 'D8';
+export type Dimension = 'D1' | 'D2' | 'D3' | 'D4' | 'D5' | 'D6' | 'D7' | 'D8' | 'D9' | 'D10';
 
 interface QuestionBase {
   id: string;
@@ -107,6 +107,20 @@ export interface TemporalQuestion extends QuestionBase {
   expectDate: string;
 }
 
+/**
+ * D10 — per-user scope at serve time. The SAME question is asked twice:
+ * as the user who owns the fact (must answer it) and as the battery's
+ * own user (must not). Both halves, because a fence that answers nobody
+ * would pass the negative half for entirely the wrong reason.
+ */
+export interface ScopeFenceQuestion extends QuestionBase {
+  kind: 'scope-fence';
+  /** The owner's answer must contain ≥1 of these. */
+  expectAnyOf: string[];
+  /** The battery user's answer must contain NONE of these. */
+  forbidForOthers: string[];
+}
+
 /** D5 — absence honesty: never-written topic must yield abstention. */
 export interface AbsenceQuestion extends QuestionBase {
   kind: 'absence';
@@ -154,6 +168,7 @@ export type Question =
   | ConflictApiQuestion
   | ConflictAnswerQuestion
   | IntegrationQuestion
+  | ScopeFenceQuestion
   | ReplayQuestion;
 
 /** Per-question outcome in the scorecard / JSON report. */

--- a/test/memory-fitness-corpus.unit-spec.ts
+++ b/test/memory-fitness-corpus.unit-spec.ts
@@ -1,0 +1,116 @@
+/**
+ * Corpus invariants of the memory-fitness battery, with the two
+ * situational axes it grew (D9 out-of-order arrival, D10 per-user
+ * scope at serve time).
+ *
+ * Both axes are properties of how the corpus is BUILT, not of any
+ * single assertion, and both break silently: if c6 stops being written
+ * last, D9 stops testing arrival order and quietly becomes a second D1;
+ * if the fence marker leaks into a shared turn, D10 can never pass.
+ * Neither failure says anything at run time — the battery just reports
+ * a number that means something else.
+ */
+import { CORPUS_TURNS, DIRECT_FACTS, SCOPED_FACTS } from './eval/memory-fitness/corpus';
+import { QUESTIONS } from './eval/memory-fitness/questions';
+
+const texts = CORPUS_TURNS.map((t) => t.text);
+const turnsContaining = (needle: string): string[] => texts.filter((t) => t.includes(needle));
+
+describe('memory-fitness corpus — D9, out-of-order arrival', () => {
+  const c6 = CORPUS_TURNS.filter((t) => t.conversation === 'c6');
+
+  it('writes c6 last, out of event-time order with everything after it', () => {
+    // The axis is the inversion, not "oldest in the corpus" — c1 is
+    // still older. What matters is that the LAST arrival is not the
+    // latest event, which is the only way arrival order and event order
+    // can disagree.
+    expect(c6.length).toBeGreaterThan(0);
+    expect(CORPUS_TURNS[CORPUS_TURNS.length - 1]!.conversation).toBe('c6');
+
+    const latestEvent = CORPUS_TURNS.reduce((max, t) =>
+      Date.parse(t.emittedAt) > Date.parse(max.emittedAt) ? t : max,
+    );
+    expect(latestEvent.conversation).not.toBe('c6');
+  });
+
+  it('states the superseded value later in arrival but earlier in event time', () => {
+    const stale = turnsContaining('500 per run');
+    const current = turnsContaining('200 per run');
+    expect(stale).toHaveLength(1);
+    expect(current).toHaveLength(1);
+
+    const staleTurn = CORPUS_TURNS.find((t) => t.text.includes('500 per run'))!;
+    const currentTurn = CORPUS_TURNS.find((t) => t.text.includes('200 per run'))!;
+
+    // Arrival: stale AFTER current. Event time: stale BEFORE current.
+    expect(CORPUS_TURNS.indexOf(staleTurn)).toBeGreaterThan(CORPUS_TURNS.indexOf(currentTurn));
+    expect(Date.parse(staleTurn.emittedAt)).toBeLessThan(Date.parse(currentTurn.emittedAt));
+  });
+
+  it('keeps chain E out of every other question', () => {
+    // A D9 failure must not blur D1's signal, so nothing else may ask
+    // about the batch size.
+    const others = QUESTIONS.filter((q) => q.dimension !== 'D9');
+    const mentions = others.filter((q) => /batch size/i.test(q.prompt));
+    expect(mentions.map((q) => q.id)).toEqual([]);
+  });
+});
+
+describe('memory-fitness corpus — D10, per-user scope at serve time', () => {
+  it('scopes at least one fact away from the battery user', () => {
+    expect(SCOPED_FACTS.length).toBeGreaterThan(0);
+  });
+
+  it('gives the fence a marker that exists nowhere else in the corpus', () => {
+    // A leak has to be unmistakable: if the marker also appeared in a
+    // shared turn, the negative half could never pass and the positive
+    // half could pass without the fence doing anything.
+    for (const fact of SCOPED_FACTS) {
+      const marker = fact.object;
+      expect(turnsContaining(marker)).toEqual([]);
+      expect(DIRECT_FACTS.filter((f) => f.object === marker)).toEqual([]);
+    }
+  });
+
+  it('asks both halves in one question', () => {
+    const fence = QUESTIONS.filter((q) => q.kind === 'scope-fence');
+    expect(fence.length).toBeGreaterThan(0);
+    for (const q of fence) {
+      // Positive half (owner must see it) and negative half (nobody else
+      // may) — a fence that answers nobody must not score as a pass.
+      expect(q.expectAnyOf.length).toBeGreaterThan(0);
+      expect(q.forbidForOthers.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('memory-fitness corpus — shared invariants', () => {
+  it('every question id is unique', () => {
+    const ids = QUESTIONS.map((q) => q.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('every dimension a question claims has a question', () => {
+    const claimed = new Set(QUESTIONS.map((q) => q.dimension));
+    expect([...claimed].sort()).toEqual([
+      'D1',
+      'D10',
+      'D2',
+      'D3',
+      'D4',
+      'D5',
+      'D6',
+      'D7',
+      'D8',
+      'D9',
+    ]);
+  });
+
+  it('keeps every turn under the provenance text cap', () => {
+    // Over 600 chars and a seeded fragment can be truncated away, which
+    // fails a provenance check for a reason that has nothing to do with
+    // memory.
+    const tooLong = CORPUS_TURNS.filter((t) => t.text.length > 600).map((t) => t.conversation);
+    expect(tooLong).toEqual([]);
+  });
+});


### PR DESCRIPTION
Fourth step of `docs/roadmap/flag-inventory-2026-09.md` — "разные ситуации".

Every corpus turn in memory-fitness arrived **in event-time order**, and the whole battery ran as **one user**. Two properties the product is built on therefore had no check anywhere.

## D9 — out-of-order arrival

New chain E: the payout batch size drops to **200 on 2026-03-25** (written in c4), and a note dated **2026-03-05** restating the old **500** arrives **last**, in c6.

200 is current either way, because 03-25 is after 03-05. **A memory that orders by arrival answers 500.**

That is the bitemporal claim itself, and nothing was testing it — the corpus had been strictly chronological across c1…c5, so arrival order and event order could never disagree in the first place.

Chain E is touched by no other question, so a D9 failure cannot blur D1's signal on the existing chains.

## D10 — per-user scope at serve time

`derive-user-scope.unit-spec.ts` covers the write side. The serving side had nothing, so *"pass `userId` for personal memory"* was an untested promise.

One fact is written under `<user>-other` and the same question is asked **twice**: as the owner (must answer) and as the battery's user (must not).

Both halves live in one check on purpose — **a fence that answers nobody would pass the negative half for entirely the wrong reason**, so the positive half runs first and its failure is reported as exactly that rather than as a pass.

## The corpus needed a gate

Both axes are properties of how the corpus is *built*, not of any single assertion, and both break silently:

- if c6 stops arriving last, D9 quietly becomes a second D1
- if the fence marker ever appears in a shared turn, D10 can never pass

Neither says anything at run time; the battery just reports a number that means something else. New unit spec pins the inversion (last arrival is not the latest event, stale value later in arrival but earlier in event time), chain E's isolation from other prompts, the fence marker's absence from every shared turn and direct fact, and the 600-char provenance cap every turn must stay under.

One assertion in that spec was wrong on the first run and is fixed rather than relaxed: I had claimed c6 was the corpus's *earliest* turn, but c1 is older. The axis is the inversion — the last arrival not being the latest event — not "oldest overall".

## Tests

- unit: **5716 passed**, 467 suites
- `pnpm typecheck`, `eslint --max-warnings 0`, `prettier --check` clean

Running the battery itself needs a stand (`pnpm eval:memory-fitness`); this PR makes it ask the two questions when it runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB