### PR TITLE
fix(ingest): link a fact to the turn it came from without an unrelated flag

### DIFF
--- a/src/ingest/mention-ingest.service.ts
+++ b/src/ingest/mention-ingest.service.ts
@@ -101,14 +101,23 @@ export class MentionIngestService {
         };
       }
 
-      // Drift-1: with fail-closed capture on, the captured episode id is
-      // stamped into every extracted fact's source — the grounding stamp
-      // (EVIDENCE_GROUNDING_STAMP) then reads it as observational. Flag
-      // off ⇒ the SAME source object rides through — byte-identical.
-      const source =
-        failClosedCaptureEnabled() && episodeId
-          ? { ...prep.source, episodeIds: [episodeId] }
-          : prep.source;
+      // The captured episode id is stamped into every extracted fact's
+      // source, so the fact can be walked back to the turn it came from
+      // (the grounding stamp, EVIDENCE_GROUNDING_STAMP, then reads it as
+      // observational).
+      //
+      // This used to require EVIDENCE_FAIL_CLOSED_CAPTURE, which is a
+      // different question: that flag decides whether ingest REFUSES a
+      // turn it could not capture, not whether a captured turn is worth
+      // linking. Coupling them meant that on a default deployment every
+      // episode was stored, every fact was stored, and no fact pointed
+      // at its episode — GET /v1/facts/:id/provenance answered `[]` for
+      // the entire mention path. Found by the memory-fitness battery,
+      // D3 at 0/3 with 12 facts walked and not one episode behind them.
+      //
+      // No episode id (substrate off, or a failed write) ⇒ the same
+      // source object rides through untouched, as before.
+      const source = episodeId ? { ...prep.source, episodeIds: [episodeId] } : prep.source;
 
       const out = await this.persist.persistAll({
         companyId,

--- a/test/episode-substrate.unit-spec.ts
+++ b/test/episode-substrate.unit-spec.ts
@@ -280,11 +280,28 @@ describe('MentionIngestService — fail-closed capture (EVIDENCE_FAIL_CLOSED_CAP
     expect(prepSource).toEqual({ vertical: 'locomo', recorder: 'stub-model' });
   });
 
-  it('flag OFF (default) → the capture result is discarded and persistAll receives the IDENTICAL source', async () => {
+  it('a captured episode is linked whatever the fail-closed flag says', async () => {
+    // These are two different questions and used to be one flag. Whether
+    // ingest REFUSES an uncapturable turn is the fail-closed decision;
+    // whether a turn we DID capture is worth pointing at is not. While
+    // they were coupled, a default deployment stored every episode,
+    // stored every fact, and linked none of them — provenance answered
+    // `[]` for the whole mention path.
     delete process.env.EVIDENCE_FAIL_CLOSED_CAPTURE;
-    const { svc, persisted, prepSource } = makeMentionStack('episode:cap1');
+    const { svc, persisted } = makeMentionStack('episode:cap1');
     const out = await svc.ingestMention('co_x', dto());
     expect(out.skipped).toBe(false);
+    expect(persisted[0]!.source).toEqual({
+      vertical: 'locomo',
+      recorder: 'stub-model',
+      episodeIds: ['episode:cap1'],
+    });
+  });
+
+  it('no captured episode → the source object rides through untouched', async () => {
+    delete process.env.EVIDENCE_FAIL_CLOSED_CAPTURE;
+    const { svc, persisted, prepSource } = makeMentionStack(null);
+    await svc.ingestMention('co_x', dto());
     // Byte-identity: the very same object reference, no episodeIds key.
     expect(persisted[0]!.source).toBe(prepSource);
     expect(persisted[0]!.source).toEqual({ vertical: 'locomo', recorder: 'stub-model' });

--- a/test/eval/memory-fitness/questions.ts
+++ b/test/eval/memory-fitness/questions.ts
@@ -263,10 +263,10 @@ export const QUESTIONS: Question[] = [
   {
     id: 'd9-batch-size-out-of-order',
     dimension: 'D9',
-    kind: 'currency',
+    kind: 'ordering',
     prompt: 'What payout batch size does ledger-sync use per run?',
-    expectAnyOf: ['200'],
-    forbidAnyOf: ['500'],
+    currentMarkers: ['200'],
+    priorMarkers: ['500'],
   },
 
   // ── D10: per-user scope at serve time ─────────────────────────────

--- a/test/eval/memory-fitness/runner.ts
+++ b/test/eval/memory-fitness/runner.ts
@@ -37,6 +37,7 @@ import { interleaveRoundRobin } from './interleave';
 import { QUESTIONS } from './questions';
 import {
   checkEvolution,
+  checkOrdering,
   classifyConflictAnswer,
   containsAnyOf,
   findForbidden,
@@ -539,6 +540,11 @@ async function askOne(ctx: AskContext, q: Question): Promise<Verdict> {
       return isAbstention(out.answer, out.reason)
         ? { status: 'pass', detail: 'honest abstention on never-written topic', answer: out.answer }
         : { status: 'fail', detail: 'confabulated an answer', answer: out.answer };
+    }
+    case 'ordering': {
+      const { answer } = await synthesizeAnswer(ctx, q.prompt);
+      const verdict = checkOrdering(answer ?? '', q.currentMarkers, q.priorMarkers);
+      return { status: verdict.pass ? 'pass' : 'fail', detail: verdict.detail, answer };
     }
     case 'scope-fence': {
       // Positive half first: if the owner cannot get its own fact, the

--- a/test/eval/memory-fitness/scorers.ts
+++ b/test/eval/memory-fitness/scorers.ts
@@ -156,6 +156,41 @@ export function checkEvolution(
 }
 
 /**
+ * Event-time ordering in a served answer (D9).
+ *
+ * Passes when the current value is present and the superseded value,
+ * if mentioned at all, comes after it. A memory that ordered by arrival
+ * rather than by event time leads with the stale value, and that is the
+ * only thing this separates.
+ */
+export function checkOrdering(
+  answer: string,
+  currentMarkers: readonly string[],
+  priorMarkers: readonly string[],
+): { pass: boolean; detail: string } {
+  const firstIndex = (markers: readonly string[]): number => {
+    const hits = markers
+      .map((m) => answer.toLowerCase().indexOf(m.toLowerCase()))
+      .filter((i) => i >= 0);
+    return hits.length === 0 ? -1 : Math.min(...hits);
+  };
+  const current = firstIndex(currentMarkers);
+  if (current === -1) {
+    return { pass: false, detail: 'the current value is absent from the answer' };
+  }
+  const prior = firstIndex(priorMarkers);
+  if (prior === -1) {
+    return { pass: true, detail: 'current value served, superseded value not mentioned' };
+  }
+  return prior > current
+    ? { pass: true, detail: 'current value leads; the superseded value follows it as history' }
+    : {
+        pass: false,
+        detail: 'the answer leads with the superseded value — ordered by arrival, not event time',
+      };
+}
+
+/**
  * Key-phrase scorer (D8): every group must be satisfied; a plain string
  * is a required substring, an array is an any-of group. Returns the
  * missing groups (empty = pass).

--- a/test/eval/memory-fitness/types.ts
+++ b/test/eval/memory-fitness/types.ts
@@ -108,6 +108,27 @@ export interface TemporalQuestion extends QuestionBase {
 }
 
 /**
+ * D9 — event-time ordering in the served answer.
+ *
+ * NOT a currency check. The first run of this axis failed a D1-shaped
+ * `forbidAnyOf: ['500']` against the answer "batch size is 200 as of
+ * 2026-03-25; prior to that it was 500 as of 2026-03-05" — which is the
+ * behaviour under test, stated correctly. Mentioning the superseded
+ * value as history is right; LEADING with it is what a memory ordered
+ * by arrival would do.
+ *
+ * So the discriminator is order, not presence: whichever value the
+ * answer presents first is the one the memory holds to be current.
+ */
+export interface OrderingQuestion extends QuestionBase {
+  kind: 'ordering';
+  /** The value that is current by event time. Must be present. */
+  currentMarkers: string[];
+  /** The superseded value. May appear — but only after the current one. */
+  priorMarkers: string[];
+}
+
+/**
  * D10 — per-user scope at serve time. The SAME question is asked twice:
  * as the user who owns the fact (must answer it) and as the battery's
  * own user (must not). Both halves, because a fence that answers nobody
@@ -168,6 +189,7 @@ export type Question =
   | ConflictApiQuestion
   | ConflictAnswerQuestion
   | IntegrationQuestion
+  | OrderingQuestion
   | ScopeFenceQuestion
   | ReplayQuestion;
 


### PR DESCRIPTION
**Found by running the battery, not by reading the code.**

## The finding

A default stand ingests 66 turns, stores 66 episodes, extracts facts from all of them — and `GET /v1/facts/:id/provenance` answers `[]` for **every one**.

memory-fitness D3 scored **0/3**, detail: *"12 facts walked, no episode quotes a seeded fragment"*.

## The cause is one condition

```ts
failClosedCaptureEnabled() && episodeId ? { ...prep.source, episodeIds: [episodeId] } : prep.source
```

`source.episodeIds` was stamped **only when `EVIDENCE_FAIL_CLOSED_CAPTURE` was on** — a flag that answers a different question: *whether ingest refuses a turn it could not capture*. Whether a turn we **did** capture is worth pointing at is not the same decision.

Tying them meant the fact→episode link existed only for deployments that had opted into a stricter ingest posture for unrelated reasons. So *"follow the decision back to the conversation that explains it"* — the hero claim on the landing page — did not work out of the box.

## The fix

An episode id, when there is one, is stamped. No episode (substrate off, or a failed write) and the same source object rides through untouched, exactly as before.

Verified on a live stand:

```
POST /v1/ingest/mention  → knowledge_fact:dc5npx…
GET  /v1/facts/dc5npx…/provenance
  → episodes: [{ episodeId: "episode:p1dztn…", conversationId: "probe-conv-2",
                 text: "Probe two: the widget cache TTL moved to 90 seconds…" }]
```

## Also here: the D9 check was wrong, not the engine

The new out-of-order axis failed on its first run — and it was my check. It inherited D1's `forbidAnyOf: ['500']` and so rejected:

> "The payout batch size is **200 per run as of 2026-03-25**. Prior to that, it was 500 as of 2026-03-05."

That is the behaviour under test, stated correctly. **Mentioning a superseded value as history is right; leading with it is what a memory ordered by arrival would do.** New `ordering` question kind and `checkOrdering` scorer — the discriminator is which value comes *first* in the answer, not whether the old one appears at all.

D9 now passes on the stand: *"current value leads; the superseded value follows it as history"*. The bitemporal ordering claim holds under out-of-order arrival, measured for the first time.

## Tests

- unit **5726 passed**, 468 suites. The spec that pinned the old coupling is rewritten to the new contract, with a sibling asserting byte-identity when there is no episode.
- `eslint --max-warnings 0`, `prettier --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D4YjLXHAdvJuFgu4xZPXGB